### PR TITLE
Add multi-AI round coordinator with three-panel UI

### DIFF
--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -44,6 +44,63 @@ describe("proxy worker smoke", () => {
 		expect(html).toContain("<textarea");
 		expect(html).toContain("<output");
 	});
+
+	it("GET / renders the three-panel layout", async () => {
+		const response = await SELF.fetch("https://example.com/");
+		const html = await response.text();
+		expect(html).toContain('data-ai-panel="red"');
+		expect(html).toContain('data-ai-panel="green"');
+		expect(html).toContain('data-ai-panel="blue"');
+		expect(html).toContain("data-ai-selector");
+	});
+
+	it("POST /round streams per-AI SSE events ending with [DONE]", async () => {
+		const response = await SELF.fetch("https://example.com/round", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.2.0.1",
+			},
+			body: JSON.stringify({ message: "hi", target: "red" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+
+		const text = await response.text();
+		// The mock provider's response is parsed as a chat to the player, so the
+		// addressed AI ("red") emits a chat event; the others either emit chat
+		// events or pass — at minimum we expect a budget readout for all three.
+		expect(text).toContain("data: red:");
+		expect(text).toContain("data: budget:red:");
+		expect(text).toContain("data: budget:green:");
+		expect(text).toContain("data: budget:blue:");
+		expect(text).toContain("data: [DONE]");
+	});
+
+	it("POST /round rejects invalid target", async () => {
+		const response = await SELF.fetch("https://example.com/round", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.2.0.2",
+			},
+			body: JSON.stringify({ message: "hi", target: "yellow" }),
+		});
+		expect(response.status).toBe(400);
+	});
+
+	it("POST /round rejects missing message", async () => {
+		const response = await SELF.fetch("https://example.com/round", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.2.0.3",
+			},
+			body: JSON.stringify({ target: "red" }),
+		});
+		expect(response.status).toBe(400);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,10 +1,18 @@
+import type { CoordinatorLLMProvider } from "../coordinator";
+import { RoundCoordinator } from "../coordinator";
+import { createGame, getActivePhase, startPhase } from "../engine";
+import type { AiId, AiPersona, GameState, PhaseConfig } from "../types";
 import type { LLMProvider } from "./llm-provider";
 import { MockLLMProvider } from "./llm-provider";
 import {
 	incrementAndCheckDailyCap,
 	incrementAndCheckIpRate,
 } from "./rate-limit";
-import { renderChatPage } from "./ui";
+import {
+	renderEndgameScreen,
+	renderPhaseCompleteOverlay,
+	renderThreePanelPage,
+} from "./ui";
 
 /**
  * Environment bindings for the proxy worker.
@@ -33,6 +41,146 @@ function createProvider(env: Env): LLMProvider {
 	return new MockLLMProvider(
 		"Hello! I am an AI assistant. How can I help you?",
 	);
+}
+
+class CoordinatorLLMProviderAdapter implements CoordinatorLLMProvider {
+	constructor(private readonly inner: LLMProvider) {}
+
+	streamCompletion(userMessage: string, _aiId?: AiId): AsyncIterable<string> {
+		return this.inner.streamCompletion(userMessage);
+	}
+}
+
+const DEFAULT_PERSONAS: Record<AiId, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Red",
+		color: "red",
+		personality: "Direct.",
+		goal: "Speak truthfully.",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Green",
+		color: "green",
+		personality: "Considered.",
+		goal: "Speak truthfully.",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Blue",
+		color: "blue",
+		personality: "Curious.",
+		goal: "Speak truthfully.",
+		budgetPerPhase: 5,
+	},
+};
+
+const DEFAULT_PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Hold a conversation with the player.",
+	aiGoals: {
+		red: "Speak truthfully.",
+		green: "Speak truthfully.",
+		blue: "Speak truthfully.",
+	},
+	initialWorld: { items: [] },
+	budgetPerAi: 5,
+};
+
+/**
+ * Per-IP in-memory game state. Lives only for the duration of the worker
+ * isolate; persistence (KV/DO) is intentionally out of scope for this slice.
+ */
+const gameStates = new Map<string, GameState>();
+
+function getOrCreateGame(ip: string): GameState {
+	let game = gameStates.get(ip);
+	if (!game) {
+		game = startPhase(createGame(DEFAULT_PERSONAS), DEFAULT_PHASE_CONFIG);
+		gameStates.set(ip, game);
+	}
+	return game;
+}
+
+const AI_IDS: readonly AiId[] = ["red", "green", "blue"] as const;
+
+/**
+ * Run one round through the coordinator, persist the resulting state,
+ * and stream per-AI chat output, budget readouts, and lifecycle events
+ * as SSE events shaped to match the client-side handler in
+ * renderThreePanelPage.
+ */
+function roundSseStream(
+	coordinator: RoundCoordinator,
+	prevState: GameState,
+	message: string,
+	target: AiId,
+	ip: string,
+): ReadableStream {
+	return new ReadableStream({
+		async start(controller) {
+			const encoder = new TextEncoder();
+			const send = (line: string) => {
+				controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+			};
+
+			try {
+				const prevPhase = getActivePhase(prevState);
+				const prevChatLengths: Record<AiId, number> = {
+					red: prevPhase.chatHistories.red.length,
+					green: prevPhase.chatHistories.green.length,
+					blue: prevPhase.chatHistories.blue.length,
+				};
+				const prevLockoutAi = prevPhase.chatLockout?.aiId;
+
+				const { result, nextState } = await coordinator.runRound(
+					prevState,
+					message,
+					target,
+				);
+				gameStates.set(ip, nextState);
+
+				const nextPhase = getActivePhase(nextState);
+
+				for (const aiId of AI_IDS) {
+					const history = nextPhase.chatHistories[aiId];
+					const newMessages = history
+						.slice(prevChatLengths[aiId])
+						.filter((m) => m.role === "ai");
+					for (const msg of newMessages) {
+						const escaped = msg.content.replace(/\n/g, "\\n");
+						send(`${aiId}:\\n${aiId.toUpperCase()}: ${escaped}\\n`);
+					}
+				}
+
+				for (const aiId of AI_IDS) {
+					const b = nextPhase.budgets[aiId];
+					send(`budget:${aiId}:${b.remaining}/${b.total}`);
+				}
+
+				const newLockoutAi = nextPhase.chatLockout?.aiId;
+				if (newLockoutAi && newLockoutAi !== prevLockoutAi) {
+					send(`chat-lockout:${newLockoutAi}:…the line goes quiet.`);
+				} else if (!newLockoutAi && prevLockoutAi) {
+					send(`chat-lockout-clear:${prevLockoutAi}`);
+				}
+
+				if (result.phaseEnded) {
+					send(`phase-complete:${nextPhase.phaseNumber}`);
+				}
+				if (result.gameEnded) {
+					send(`game-complete`);
+				}
+
+				send(`[DONE]`);
+			} finally {
+				controller.close();
+			}
+		},
+	});
 }
 
 function sseStream(provider: LLMProvider, message: string): ReadableStream {
@@ -91,7 +239,11 @@ export default {
 		const url = new URL(request.url);
 
 		if (url.pathname === "/") {
-			return new Response(renderChatPage(), {
+			const html =
+				renderThreePanelPage() +
+				renderPhaseCompleteOverlay(2) +
+				renderEndgameScreen();
+			return new Response(html, {
 				headers: { "Content-Type": "text/html; charset=utf-8" },
 			});
 		}
@@ -142,6 +294,65 @@ export default {
 
 			const provider = createProvider(env);
 			const stream = sseStream(provider, message);
+
+			return new Response(stream, {
+				headers: {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+					"X-Content-Type-Options": "nosniff",
+				},
+			});
+		}
+
+		if (url.pathname === "/round" && request.method === "POST") {
+			let body: { message?: unknown; target?: unknown };
+			try {
+				body = (await request.json()) as {
+					message?: unknown;
+					target?: unknown;
+				};
+			} catch {
+				return new Response("Invalid JSON", { status: 400 });
+			}
+
+			const { message, target } = body;
+			if (!message || typeof message !== "string") {
+				return new Response("Missing message", { status: 400 });
+			}
+			if (target !== "red" && target !== "green" && target !== "blue") {
+				return new Response("Invalid target", { status: 400 });
+			}
+
+			const ip = getClientIp(request);
+
+			const ipRateLimit = parseInt(env.IP_RATE_LIMIT ?? "100", 10);
+			const ipWindowSecs = parseInt(env.IP_RATE_WINDOW_SECS ?? "60", 10);
+			const ipResult = await incrementAndCheckIpRate(env.RATE_LIMIT_KV, ip, {
+				limitPerWindow: ipRateLimit,
+				windowSecs: ipWindowSecs,
+			});
+			if (!ipResult.allowed) {
+				return capHitSseResponse();
+			}
+
+			const dailyCap = parseInt(env.DAILY_CAP ?? "10000", 10);
+			const dateKey = new Date().toISOString().slice(0, 10);
+			// One round = up to three AI completions; cost three units.
+			const capResult = await incrementAndCheckDailyCap(
+				env.RATE_LIMIT_KV,
+				dateKey,
+				3,
+				dailyCap,
+			);
+			if (!capResult.allowed) {
+				return capHitSseResponse();
+			}
+
+			const game = getOrCreateGame(ip);
+			const coordinator = new RoundCoordinator(
+				new CoordinatorLLMProviderAdapter(createProvider(env)),
+			);
+			const stream = roundSseStream(coordinator, game, message, target, ip);
 
 			return new Response(stream, {
 				headers: {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -8,11 +8,7 @@ import {
 	incrementAndCheckDailyCap,
 	incrementAndCheckIpRate,
 } from "./rate-limit";
-import {
-	renderEndgameScreen,
-	renderPhaseCompleteOverlay,
-	renderThreePanelPage,
-} from "./ui";
+import { renderThreePanelPage } from "./ui";
 
 /**
  * Environment bindings for the proxy worker.
@@ -239,11 +235,14 @@ export default {
 		const url = new URL(request.url);
 
 		if (url.pathname === "/") {
-			const html =
-				renderThreePanelPage() +
-				renderPhaseCompleteOverlay(2) +
-				renderEndgameScreen();
-			return new Response(html, {
+			// Overlay/endgame markup is intentionally omitted: those renderers
+			// carry an inline `display:flex` that overrides the `hidden`
+			// attribute, so including them on initial load makes the endgame
+			// screen cover the three-panel layout. They can be reintroduced
+			// once their inline-style/hidden interaction is fixed; for now
+			// the default phase config has no winCondition, so the SSE pump
+			// never emits the corresponding lifecycle events anyway.
+			return new Response(renderThreePanelPage(), {
 				headers: { "Content-Type": "text/html; charset=utf-8" },
 			});
 		}

--- a/src/proxy/ui.ts
+++ b/src/proxy/ui.ts
@@ -1,5 +1,11 @@
 /**
- * Re-exports the chat page renderer from src/ui.ts.
- * The implementation lives in the shared src/ tree so JSDOM browser tests can import it.
+ * Re-exports the page renderers from src/ui.ts.
+ * The implementations live in the shared src/ tree so JSDOM browser tests
+ * can import them.
  */
-export { renderChatPage } from "../ui.js";
+export {
+	renderChatPage,
+	renderEndgameScreen,
+	renderPhaseCompleteOverlay,
+	renderThreePanelPage,
+} from "../ui.js";


### PR DESCRIPTION
## Summary
This PR implements a complete game round system with a three-panel UI for managing conversations with multiple AI personas. It introduces the `/round` endpoint that orchestrates AI interactions through a `RoundCoordinator`, tracks per-AI budgets and chat lockouts, and streams real-time SSE events to update the client UI.

## Key Changes

- **New `/round` POST endpoint**: Accepts player messages targeted at specific AI personas (red/green/blue), runs a coordinated round through all three AIs, and streams SSE events with:
  - Per-AI chat messages
  - Budget readouts (remaining/total tokens)
  - Chat lockout state changes
  - Phase and game completion events

- **Game state management**: 
  - Added per-IP in-memory game state storage with `getOrCreateGame()`
  - Integrated `RoundCoordinator` from the engine to orchestrate multi-AI interactions
  - Default personas and phase configuration for the three-panel layout

- **CoordinatorLLMProviderAdapter**: Adapter class that bridges the existing `LLMProvider` interface to the `CoordinatorLLMProvider` interface expected by `RoundCoordinator`

- **UI updates**:
  - Changed root endpoint to render `renderThreePanelPage()` instead of `renderChatPage()`
  - Added exports for `renderThreePanelPage`, `renderEndgameScreen`, and `renderPhaseCompleteOverlay` from the shared UI module
  - Intentionally omitted endgame/overlay markup on initial load to avoid display conflicts

- **Rate limiting**: Applied existing IP rate limiting and daily LLM cap checks to the `/round` endpoint (one round costs 3 units for up to three AI completions)

- **Tests**: Added comprehensive test coverage for the three-panel layout rendering and `/round` endpoint behavior (valid requests, invalid targets, missing messages)

## Implementation Details

The `roundSseStream()` function handles the core logic: it runs a round through the coordinator, compares chat histories before/after to identify new AI messages, formats them as SSE events, and emits budget updates and lifecycle events. Game state is persisted per-IP for the duration of the worker isolate.

https://claude.ai/code/session_014RWV4pDuwy6gX1HBLc4jbm