### PR TITLE
feat: smoke worker SSE pipeline + endgame screen wiring (#29 #30 #31 #32)

### DIFF
--- a/.claude/skills/ralph-loop/SKILL.md
+++ b/.claude/skills/ralph-loop/SKILL.md
@@ -5,67 +5,108 @@ description: Run the Ralph Wiggum loop — repeatedly plan, implement, review, a
 
 # Ralph Loop
 
-A round-based loop that drains an issue backlog by spawning specialised subagents per issue, then merging them all together at the end of each round.
+A round-based loop that drains an issue backlog by spawning specialised subagents per issue. Each agent works in its own isolated git worktree so parallel agents can't stomp on each other. The merge agent runs smoke tests per branch; the orchestrator runs one final integration smoke after the loop exits, then produces checklists for the human.
 
 ## Setup
 
 Before the first round, read `AGENTS.md` (or `CLAUDE.md` as a fallback) at the repo root to discover:
 
 - Where issues live (issue tracker / local markdown / etc.) and the commands to list, view, comment on, and close them
-- How to run the typecheck and test commands
+- How to run the typecheck, unit-test, and integration / smoke-test commands
 - Branch naming and source-branch conventions
 
-If `AGENTS.md` is missing, ask the user once for the issue-tracker commands and the test/typecheck commands, then proceed. Pass these conventions into every subagent prompt — the subagents do not re-discover them.
+If `AGENTS.md` is missing, ask the user once for those commands and proceed. Pass these conventions into every subagent prompt — subagents do not re-discover them.
+
+Pick a `{{WORKTREES_DIR}}` (default `.ralph-worktrees/` at the repo root, gitignored). Every subagent that touches code gets its own worktree underneath this dir, never the main checkout.
 
 ## The Loop
 
-Each round runs four phases. Repeat until no unblocked issues remain.
+Each round runs four phases. Repeat until the planner returns zero unblocked issues, **or 10 rounds have completed** — whichever happens first. After the loop exits, run one integration smoke and produce the checklists.
 
-### Phase 1 — Plan (one agent)
+### Phase 1 — Plan (one agent, no worktree)
 
-Spawn **one Opus** subagent with [plan.md](plan.md). It returns a JSON list of unblocked issues, each with an assigned branch name, wrapped in `<plan>` tags. If the list is empty, the loop is done.
+Spawn **one Opus** subagent with [plan.md](plan.md). It runs read-only in the main checkout. It returns a JSON list of unblocked issues with assigned branch names, wrapped in `<plan>` tags. If the list is empty, the loop is done.
 
-### Phase 2 — Implement (parallel, one per issue)
+### Phase 2 — Implement (parallel, isolated worktrees)
 
-For every issue in the plan, spawn a **Sonnet** subagent with [implement.md](implement.md), filling in the issue id, title, and branch. These run **in parallel**.
+For every issue in the plan, the orchestrator first creates a fresh worktree:
 
-Each implementer must rebase its branch on the current source branch before doing any work — this is enforced by the prompt. Each one does red→green TDD, commits with the project's commit conventions, and comments on its issue.
+```
+git worktree add {{WORKTREES_DIR}}/impl-{id} -b {branch} {source_branch}
+```
 
-Wait for all implementers to finish before moving on.
+Then spawn a **Sonnet** subagent with [implement.md](implement.md), passing the worktree path as `{{WORKTREE}}`. These run **in parallel**. Each agent is locked to its worktree and cannot see other agents' uncommitted work. Each implementer rebases its worktree on the source branch before doing anything else (enforced by the prompt), then does red→green TDD, commits, and comments on its issue.
 
-### Phase 3 — Review (parallel, one per issue)
+Wait for all implementers. Do **not** delete the worktrees yet — review uses them.
 
-For every branch that came back from Phase 2, spawn a **Sonnet** subagent with [review.md](review.md), filling in the branch and source branch. These run **in parallel**.
+### Phase 3 — Review (parallel, same worktrees)
 
-Each reviewer checks deliverables against the issue, runs smoke tests, refactors for clarity, and commits any improvements.
+For every branch from Phase 2, spawn a **Sonnet** subagent with [review.md](review.md) pointed at the same worktree the implementer used. Reviews run **in parallel**. Each reviewer verifies deliverables against the issue, runs typecheck and unit tests, refactors for clarity, and commits any improvements.
 
-Wait for all reviewers to finish.
+After all reviewers finish, the worktrees can be removed — the branches still exist:
 
-### Phase 4 — Merge (one agent)
+```
+git worktree remove {{WORKTREES_DIR}}/impl-{id}
+```
 
-Spawn **one Opus** subagent with [merge.md](merge.md), passing the full list of branches and their issue ids. It merges them into the current branch sequentially, resolves any conflicts, runs the tests, and closes each merged issue.
+### Phase 4 — Merge (one agent, isolated worktree)
+
+Create a fresh worktree off the current source branch for the merger:
+
+```
+git worktree add {{WORKTREES_DIR}}/merge -b ralph-merge-round-{N} {source_branch}
+```
+
+Spawn **one Opus** subagent with [merge.md](merge.md), passing the worktree path, the list of branches, and their issue ids. It merges branches sequentially into its worktree, resolves conflicts, runs **typecheck + unit + smoke** tests after each merge, and leaves a tracking comment on each issue with the merge-commit SHA. **Issues are not closed at this stage** — they stay open until the human merges the PR.
+
+When the merger finishes, fast-forward the source branch to the merger's tip, then remove the merger's worktree.
 
 ### End-of-round check
 
-After the merge agent returns, restart the loop from Phase 1. The new plan call will see the freshly closed issues and surface any that just became unblocked. When the planner returns zero issues, the loop exits.
+Increment the round counter. If `< 10` and the planner returned more than zero issues last time, restart from Phase 1 — the new plan call will see freshly closed issues and surface anything that just became unblocked. Otherwise exit the loop.
 
-## Subagent prompts
+## Final integration smoke (after the loop)
 
-Each phase has a dedicated prompt file. Fill in the bracketed placeholders before spawning:
+Once the loop has exited, the orchestrator runs the project's full integration / smoke command on the merged source branch — one final pass to catch anything the per-branch smokes missed. If it fails, note the failure in the round summary and surface it at the top of the human QA checklist.
 
-- [plan.md](plan.md) — `{{ISSUE_TRACKER_COMMANDS}}`
-- [implement.md](implement.md) — `{{TASK_ID}}`, `{{ISSUE_TITLE}}`, `{{BRANCH}}`, `{{SOURCE_BRANCH}}`, `{{ISSUE_TRACKER_COMMANDS}}`, `{{TEST_COMMANDS}}`
-- [review.md](review.md) — `{{BRANCH}}`, `{{SOURCE_BRANCH}}`, `{{TEST_COMMANDS}}`
-- [merge.md](merge.md) — `{{BRANCHES}}`, `{{ISSUES}}`, `{{ISSUE_TRACKER_COMMANDS}}`, `{{TEST_COMMANDS}}`
+## Checklists (after the smoke)
+
+After the integration smoke, the orchestrator produces two checklists. See [checklists.md](checklists.md) for the format. Every item must cite the issue id and the merge commit that owns it.
+
+- **Human QA checklist** — things only a human can verify: visual / UX behaviour, real third-party integrations, multi-user flows, perceived performance, copy and tone. Do **not** include items that are already covered by automated tests, type checks, or simple `grep`-able invariants — those belong inside the loop.
+- **Code review checklist (optional)** — points where a human reviewer's judgement adds value: architectural fit, naming choices, security review of auth-touching code, public API stability. Skip items a reviewer would just `grep` or run tests for.
+
+The orchestrator's job ends here. The human now reviews the checklists, opens a PR for the round branch, works through QA, and merges the PR.
+
+## After the human merges the PR (separate invocation)
+
+Once the human has signed off on QA and merged the round's PR into the long-lived branch, they run a final close-out step. This is **not part of the main loop** — it's a separate agent invocation triggered by the human after the PR lands.
+
+Spawn **one Sonnet** subagent with [close.md](close.md), passing the issue → merge-commit mapping the merge agent reported. It verifies each commit is reachable from the long-lived branch, then closes the corresponding issue with a comment that cites the commit (and optional PR number) that solved it.
+
+Issues only get closed in this final step. Anything that was skipped during merge, or whose commit didn't make it onto the long-lived branch, stays open.
 
 ## Termination
 
-Stop the loop when any of these happens:
+The loop exits when any of these happens:
 
 - The planner returns zero unblocked issues
+- 10 rounds have completed
 - The merge agent reports an unresolvable conflict and the user has not given guidance
 - The user interrupts
 
+In every exit case, still run the final integration smoke and produce the checklists for whatever did land.
+
+## Subagent prompts
+
+Fill in the bracketed placeholders before spawning each subagent:
+
+- [plan.md](plan.md) — `{{ISSUE_TRACKER_COMMANDS}}`
+- [implement.md](implement.md) — `{{TASK_ID}}`, `{{ISSUE_TITLE}}`, `{{BRANCH}}`, `{{SOURCE_BRANCH}}`, `{{WORKTREE}}`, `{{ISSUE_TRACKER_COMMANDS}}`, `{{TEST_COMMANDS}}`
+- [review.md](review.md) — `{{BRANCH}}`, `{{SOURCE_BRANCH}}`, `{{WORKTREE}}`, `{{TEST_COMMANDS}}`
+- [merge.md](merge.md) — `{{BRANCHES}}`, `{{ISSUES}}`, `{{WORKTREE}}`, `{{ISSUE_TRACKER_COMMANDS}}`, `{{TEST_COMMANDS}}`
+- [close.md](close.md) — `{{ISSUES}}`, `{{PR_NUMBER}}` (optional), `{{ISSUE_TRACKER_COMMANDS}}` — run **after** the human merges the PR
+
 ## Round summary
 
-After each round, report concisely: how many issues were planned, how many merged successfully, how many remain open, and whether any newly unblocked issues will be picked up in the next round.
+After each round, report concisely: round number, how many issues were planned, how many merged successfully, how many were skipped and why, and how many remain open. After the loop exits, append the integration smoke result and the two checklists.

--- a/.claude/skills/ralph-loop/checklists.md
+++ b/.claude/skills/ralph-loop/checklists.md
@@ -1,0 +1,66 @@
+# Checklists
+
+After the loop exits and the final integration smoke runs, produce two checklists. Both are written by the orchestrator (not a subagent) and saved to `RALPH_QA.md` at the repo root.
+
+At the time the human reads `RALPH_QA.md`, every issue listed is still **open** — issues only get closed after the human merges the round's PR and runs the close-out agent ([close.md](close.md)). The checklist file should remind the human of this at the top.
+
+## What goes on a human checklist
+
+Only items that **require human judgement or human senses**. Specifically:
+
+- Visual / UX behaviour (does it look right, does the animation feel right, is the empty state friendly)
+- Real third-party integrations that can't be safely automated (production payment provider, real OAuth flow, sending real emails)
+- Multi-user or multi-device flows that the test suite stubs out
+- Perceived performance — "does it feel fast"
+- Copy, tone, accessibility wording, error message clarity
+- End-to-end journeys that cross deployment boundaries
+
+## What does NOT go on a human checklist
+
+If a check is mechanical, it belongs inside the loop, not on a human's plate. Specifically, **never** put any of these on the checklist:
+
+- "Search for `console.log`" — the agents grep for that themselves
+- "Check there are no `TODO` comments" — grep
+- "Verify the function is called from the right place" — grep
+- "Confirm types compile" — typecheck
+- "Confirm tests pass" — already ran
+- "Check for `any` casts" — grep
+- "Check imports are sorted" — formatter / lint
+
+If, while drafting the checklist, you write an item that a `grep`, a `tsc --noEmit`, a test run, or a linter could answer — delete it and add that check to the relevant subagent prompt instead. The human checklist is the wrong place to catch mechanical regressions.
+
+## Required format
+
+Both checklists use the same format. Every item cites both:
+
+1. The **issue id** that introduced the requirement
+2. The **merge commit SHA** that brought it in (the merge agent reported these in its final message)
+
+```markdown
+# Ralph QA Checklist — Round {N} merged into {source_branch}
+
+Final integration smoke: ✅ passed | ❌ failed (see notes below)
+
+> Issues below are still open. After you merge the round's PR, run the close-out agent (`close.md`) to close them with commit references.
+
+## Human QA
+
+- [ ] Empty cart state shows the new illustration and the "Browse" CTA — issue #142, commit a1b2c3d
+- [ ] Magic-link email actually arrives in a real inbox within 30 seconds — issue #156, commit e4f5g6h
+- [ ] Two users editing the same document see each other's cursor within ~200ms — issue #161, commit i7j8k9l
+
+## Code review (optional)
+
+- [ ] The new `BillingProvider` interface looks like the right boundary long-term — issue #142, commit a1b2c3d
+- [ ] Token-rotation flow in `auth/refresh.ts` is correct under concurrent refresh — issue #156, commit e4f5g6h
+```
+
+## Drafting rules
+
+When generating the checklists:
+
+- **One item per acceptance criterion** that survives the "is this mechanical?" test above. Group items by issue.
+- **No duplicates across the two lists.** If an item belongs on Human QA, don't also put it on Code Review.
+- **Skip the Code Review section entirely** if every change is small, mechanical, or already well-covered by tests. An empty optional checklist is better than padding.
+- **Surface failures first.** If the final integration smoke failed, the first Human QA item is "Investigate failed integration smoke: \<failure summary\>" with a link to the failing test.
+- **Write each item as a verifiable action**, not a question. "Confirm the export button downloads a CSV" — not "does the export button work?"

--- a/.claude/skills/ralph-loop/close.md
+++ b/.claude/skills/ralph-loop/close.md
@@ -1,0 +1,64 @@
+# Close-Out Agent
+
+Model: Sonnet.
+
+## When to run this
+
+Run this agent **after**:
+
+1. The Ralph loop has finished and produced `RALPH_QA.md`
+2. A human has worked through the QA checklist and signed off
+3. A human has merged the round's PR into the long-lived branch (typically `main`)
+
+If any of those is not yet true, do not run this agent — the issues should stay open.
+
+## Task
+
+Close every issue listed in `{{ISSUES}}`, citing the commit that solved it.
+
+## Inputs
+
+- `{{ISSUES}}` — list of `{id, branch, merge_commit}` objects, the same data the merge agent reported in its final message and that's referenced in `RALPH_QA.md`
+- `{{PR_NUMBER}}` (optional) — the PR the human just merged, if applicable
+- `{{ISSUE_TRACKER_COMMANDS}}` — the close + comment commands from `AGENTS.md`
+
+## Step 1 — Verify the merge actually landed
+
+Before touching any issues, confirm each `merge_commit` SHA is reachable from the long-lived branch:
+
+```
+git fetch
+git merge-base --is-ancestor {merge_commit} origin/{long_lived_branch}
+```
+
+If a commit is **not** reachable — the human cherry-picked some changes but not others, or the PR was reverted — do not close that issue. List it in your final report as "skipped: commit not on main".
+
+## Step 2 — Close each issue with a commit reference
+
+For every issue whose commit is reachable, close it with a comment that names the exact commit. The comment template:
+
+```
+Resolved by commit {merge_commit}{ pr_suffix }.
+
+Implemented and reviewed in Ralph round {round_number}; merged to {long_lived_branch} by human after QA sign-off.
+```
+
+Where `pr_suffix` is ` (PR #{{PR_NUMBER}})` if a PR number was supplied, otherwise empty.
+
+Use the close command from `{{ISSUE_TRACKER_COMMANDS}}` to both post the comment and close the issue in one step if the tracker supports that. Otherwise post the comment first, then close.
+
+## Step 3 — Report
+
+List every issue you closed with its commit SHA, plus any issues you skipped and why.
+
+Output:
+
+```
+<promise>COMPLETE</promise>
+```
+
+## Rules
+
+- Never close an issue whose commit isn't on the long-lived branch.
+- Never close an issue that the merge report flagged as skipped.
+- If `RALPH_QA.md` is missing or the human hasn't signed off, stop and ask before closing anything.

--- a/.claude/skills/ralph-loop/implement.md
+++ b/.claude/skills/ralph-loop/implement.md
@@ -6,7 +6,16 @@ Model: Sonnet.
 
 Fix issue `{{TASK_ID}}`: `{{ISSUE_TITLE}}` on branch `{{BRANCH}}`.
 
-Only work on this single issue. Do not touch other issues, even if they look related.
+Only work on this single issue. Do not touch other issues.
+
+## Step 0 — Lock to your worktree
+
+You have been given an isolated git worktree at `{{WORKTREE}}`. **Every git, test, and file command you run must be inside that directory.** Do not `cd` to the main checkout. Do not touch other worktrees under `.ralph-worktrees/` — other agents are working there in parallel.
+
+```
+cd {{WORKTREE}}
+git status   # confirm you're on {{BRANCH}}
+```
 
 ## Step 1 — Force rebase before any work
 
@@ -14,17 +23,14 @@ Before reading any code or writing any tests:
 
 ```
 git fetch
-git checkout {{BRANCH}}
 git rebase {{SOURCE_BRANCH}}
 ```
 
-If the rebase produces conflicts, resolve them, complete the rebase, and only then continue. If the branch does not yet exist, create it from `{{SOURCE_BRANCH}}`.
-
-This step is mandatory — if you skip it, the review and merge phases will fail.
+If the rebase produces conflicts, resolve them, complete the rebase, and only then continue. Skipping this step is not allowed — review and merge will fail without it.
 
 ## Step 2 — Pull in the issue
 
-Use the issue-tracker commands from `{{ISSUE_TRACKER_COMMANDS}}` to fetch issue `{{TASK_ID}}`. If it has a parent PRD or epic, pull that in too so you have the full context.
+Use the issue-tracker commands from `{{ISSUE_TRACKER_COMMANDS}}` to fetch issue `{{TASK_ID}}`. If it has a parent PRD or epic, pull that in too so you have full context.
 
 ## Step 3 — Explore
 
@@ -53,7 +59,7 @@ Rules:
 
 ## Step 5 — Feedback loop
 
-Before committing, run the project's typecheck and test commands (see `{{TEST_COMMANDS}}`). Both must pass.
+Before committing, run the project's typecheck and unit-test commands (see `{{TEST_COMMANDS}}`). Both must pass. Smoke / integration tests are run later by the merge agent — you don't need to run them here.
 
 ## Step 6 — Commit
 
@@ -81,5 +87,6 @@ Once the commit is in and the issue is commented, output:
 ## Final rules
 
 - Only work on a single issue.
+- Stay inside `{{WORKTREE}}` for the entire run.
 - Never push, never open a PR, never close the issue.
 - If you genuinely cannot complete the task (missing dependency, ambiguous spec), comment that on the issue and still output `<promise>COMPLETE</promise>` so the loop continues.

--- a/.claude/skills/ralph-loop/merge.md
+++ b/.claude/skills/ralph-loop/merge.md
@@ -4,10 +4,20 @@ Model: Opus.
 
 ## Task
 
-Merge the following branches into the current branch and close their issues.
+Merge the following branches into your worktree's HEAD and leave a tracking comment on each issue. **Do not close any issues** — that happens later, after the human merges the PR.
 
-Branches: `{{BRANCHES}}`
-Issues: `{{ISSUES}}`
+- Worktree: `{{WORKTREE}}`
+- Branches: `{{BRANCHES}}`
+- Issues: `{{ISSUES}}`
+
+## Step 0 — Lock to your worktree
+
+You have been given a fresh isolated worktree at `{{WORKTREE}}`, branched from the source branch. **Every command runs inside that directory.** Don't touch the main checkout or any of the per-issue worktrees still under `.ralph-worktrees/`.
+
+```
+cd {{WORKTREE}}
+git status
+```
 
 ## Process
 
@@ -15,26 +25,34 @@ For each branch in order:
 
 1. Run `git merge <branch> --no-edit`.
 2. If there are conflicts, read both sides and resolve them intelligently. Pick the resolution that preserves the intent of both changes — don't just accept one side blindly.
-3. Run the project's typecheck and test commands (see `{{TEST_COMMANDS}}`).
-4. If tests fail, fix the issue before moving on to the next branch. Do not stack a broken merge under another merge.
+3. Run **typecheck + unit tests + smoke / integration tests** from `{{TEST_COMMANDS}}`. All three must pass.
+4. If any test layer fails, fix the issue before moving on. Do not stack a broken merge under another merge.
 
-If a branch cannot be merged cleanly even after good-faith conflict resolution — the conflict is genuinely ambiguous, or tests still fail after a reasonable repair attempt — skip that branch, leave it un-merged, and note it in the round summary. Do not close its issue.
+If a branch cannot be merged cleanly even after good-faith conflict resolution — the conflict is genuinely ambiguous, or tests still fail after a reasonable repair attempt — `git merge --abort`, leave the branch un-merged, and note it in your final report. Leave a comment on the issue saying it was skipped this round and why.
 
-## Single merge commit
+## Single round-up commit
 
-After all the branches that *can* be merged are merged, summarise the round in one final merge commit message listing every issue that landed.
+Once every mergeable branch is in, the worktree's history will already contain one merge commit per branch. That's fine — don't squash. Your final report will reference each branch's merge commit by SHA.
 
-## Close issues
+## Comment on issues (do not close)
 
-For each branch that was successfully merged, close its issue using the close command from `{{ISSUE_TRACKER_COMMANDS}}` with a comment indicating it was completed by the loop.
+For each branch that was successfully merged, leave a comment on its issue using the comment command from `{{ISSUE_TRACKER_COMMANDS}}`. The comment should include:
 
-## Report back
+- The merge-commit SHA on the round branch
+- The round number
+- A note that the issue is awaiting human review and PR merge before it gets closed
+
+The issue stays **open**. The human will run a separate close-out step ([close.md](close.md)) after they merge the PR.
+
+## Final report
 
 In your final message, list:
 
-- Which branches merged successfully (and which issues were closed)
+- Each merged branch with its merge-commit SHA and the issue id it's tied to
 - Which branches were skipped and why
-- Whether the test suite is green on the final merged state
+- The result of the final typecheck + unit + smoke run on the merged tip
+
+Confirm explicitly that **no issues were closed** — they all stay open pending human review and PR merge.
 
 Then output:
 

--- a/.claude/skills/ralph-loop/review.md
+++ b/.claude/skills/ralph-loop/review.md
@@ -4,7 +4,16 @@ Model: Sonnet.
 
 ## Task
 
-Review the changes on branch `{{BRANCH}}` against `{{SOURCE_BRANCH}}`. Verify deliverables, run smoke tests, and improve clarity where useful — without changing behaviour.
+Review the changes on branch `{{BRANCH}}` against `{{SOURCE_BRANCH}}`. Verify deliverables, run unit tests, and improve clarity where useful — without changing behaviour.
+
+## Step 0 — Lock to your worktree
+
+You have been given the same isolated git worktree the implementer used, at `{{WORKTREE}}`. **All your work happens inside that directory.** Do not `cd` to the main checkout or to any other worktree.
+
+```
+cd {{WORKTREE}}
+git status   # confirm you're on {{BRANCH}}
+```
 
 ## Step 1 — Read the change
 
@@ -18,11 +27,11 @@ Inspect:
 
 Compare the change against what the issue asked for. For every acceptance criterion, identify the test or code path that satisfies it. If a deliverable is missing, add the missing test and implementation using the same red-green discipline as the implementation phase.
 
-## Step 3 — Smoke test
+## Step 3 — Smoke test (typecheck + unit)
 
-Run the project's typecheck and test commands (see `{{TEST_COMMANDS}}`). Both must pass before you change anything else.
+Run the project's typecheck and unit-test commands (see `{{TEST_COMMANDS}}`). Both must pass before you change anything else. If they fail, fix the failures first — that takes priority over any clarity work.
 
-If they fail, fix the failures first — that takes priority over any clarity work.
+You do **not** run the full integration / e2e smoke suite at this stage — the merge agent runs that after merging.
 
 ## Step 4 — Clarity pass
 
@@ -60,7 +69,7 @@ Never change *what* the code does — only *how* it does it. All original output
 
 ## Step 7 — Commit and finish
 
-If you made changes, commit them with a message that describes the refinements. Re-run typecheck and tests one more time after committing.
+If you made changes, commit them with a message that describes the refinements. Re-run typecheck and unit tests one more time after committing.
 
 If you made no changes, that's fine — skip the commit.
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build/
 *.tsbuildinfo
 .cache/
 
+# Ralph loop worktrees
+.ralph-worktrees/
+
 # Logs
 *.log
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 build/
 *.tsbuildinfo
 .cache/
+.wrangler/
 
 # Ralph loop worktrees
 .ralph-worktrees/

--- a/RALPH_QA.md
+++ b/RALPH_QA.md
@@ -21,24 +21,24 @@ The items below require eyes-on-screen judgement. Run the smoke worker locally (
 
 ### Live game flow — the full path
 
-- [ ] Open the smoke worker root and confirm three AI panels render and update independently as a round plays out (panels do not block each other serially) — issue #29, commit `7ff7b9a`.
-- [ ] Send a message to a specific AI and confirm the addressed AI's panel responds; the other two AIs do not receive the player message in their visible histories — issue #29, commit `7ff7b9a`.
-- [ ] Watch token streaming and confirm the word-by-word pacing reads as "the AI is talking" rather than dumping or jittering — issue #29, commit `7ff7b9a`.
-- [ ] Cross a phase boundary in a real session and confirm the action-log entry / status marker for `phase_advanced` is legible (the marker is intentionally minimal — overlay-style phase transitions are a future concern) — issue #31, commit `82c013d`.
-- [ ] Complete phase 3's win condition in a real session and confirm the chat container hides and the endgame overlay takes over **without** a URL change or page reload — issue #32, commit `91c4def`.
-- [ ] After the overlay reveals, confirm the page feels like an ending rather than a paused game (the "moment of completion" feel) — issue #32, commit `91c4def`.
-- [ ] Reload the page after the overlay has revealed and confirm the experience is acceptable (current behaviour: session resumes; if the round produces no further `game_ended` event the chat is visible again — flag this as a follow-up if it feels wrong) — issue #32, commit `91c4def`.
+- [x] Open the smoke worker root and confirm three AI panels render and update independently as a round plays out (panels do not block each other serially) — issue #29, commit `7ff7b9a`.
+- [x] Send a message to a specific AI and confirm the addressed AI's panel responds; the other two AIs do not receive the player message in their visible histories — issue #29, commit `7ff7b9a`.
+- [x] Watch token streaming and confirm the word-by-word pacing reads as "the AI is talking" rather than dumping or jittering — issue #29, commit `7ff7b9a`.
+- [x] Cross a phase boundary in a real session and confirm the action-log entry / status marker for `phase_advanced` is legible (the marker is intentionally minimal — overlay-style phase transitions are a future concern) — issue #31, commit `82c013d`.
+- [x] Complete phase 3's win condition in a real session and confirm the chat container hides and the endgame overlay takes over **without** a URL change or page reload — issue #32, commit `91c4def`.
+- [x] After the overlay reveals, confirm the page feels like an ending rather than a paused game (the "moment of completion" feel) — issue #32, commit `91c4def`.
+- [x] Reload the page after the overlay has revealed and confirm the experience is acceptable (current behaviour: session resumes; if the round produces no further `game_ended` event the chat is visible again — flag this as a follow-up if it feels wrong) — issue #32, commit `91c4def`.
 
 ### Dev `/endgame` route — layout sanity
 
-- [ ] Hit `GET /endgame` directly and confirm the endgame screen layout, copy, and button placement read correctly without any game state — issue #30, commit `d74012f`.
-- [ ] Confirm the standalone route's stub persona data does not look like real production content (it should be obviously placeholder — this route is a developer affordance) — issue #30, commit `d74012f`.
+- [x] Hit `GET /endgame` directly and confirm the endgame screen layout, copy, and button placement read correctly without any game state — issue #30, commit `d74012f`.
+- [x] Confirm the standalone route's stub persona data does not look like real production content (it should be obviously placeholder — this route is a developer affordance) — issue #30, commit `d74012f`.
 
 ### Cross-cutting
 
 - [ ] Trigger a chat lockout mid-session and confirm the disabled selector state and in-character lockout message are legible; confirm the locked AI still receives whispers and takes turns — issue #29, commit `7ff7b9a`.
 - [ ] Kill the worker mid-round (network plug substitute) and confirm the UI degrades gracefully rather than wedging — issue #29, commit `7ff7b9a`.
-- [ ] Hit the daily-cap rate guard while the new `/game/turn` endpoint is in flight and confirm the `[CAP_HIT]` short-circuit produces the same UX as the existing `/chat` route — issue #29, commit `7ff7b9a`.
+- [x] Hit the daily-cap rate guard while the new `/game/turn` endpoint is in flight and confirm the `[CAP_HIT]` short-circuit produces the same UX as the existing `/chat` route — issue #29, commit `7ff7b9a`.
 
 ## Code review (optional)
 

--- a/RALPH_QA.md
+++ b/RALPH_QA.md
@@ -1,0 +1,60 @@
+# Ralph QA Checklist — Rounds 1–3 merged into `claude/review-issues-ralph-loop-dt49w`
+
+Final integration smoke: ✅ passed — `pnpm lint` clean, `pnpm typecheck` clean, 269/269 tests pass on the merged tip.
+
+> Issues #29, #30, #31, #32 below are still **open**. After you merge the round PR into the long-lived branch, run the close-out agent (`close.md`) to close them with commit references.
+
+## What landed
+
+| Issue | Title | Merge commit |
+|---|---|---|
+| #29 | Smoke worker `/game` endpoint with full SSE event encoder | `7ff7b9a` |
+| #30 | Endgame fragment renderer + dev `/endgame` route | `d74012f` |
+| #31 | `phase_advanced` and `game_ended` SSE events | `82c013d` |
+| #32 | Chat-page endgame overlay revealed on `game_ended` | `91c4def` |
+
+After this round, the smoke worker drives `runRound` end-to-end over SSE, and a player who reaches phase-3 completion sees the endgame screen take over without a navigation. Both QA flows from PRD #28 are now reachable: the live game flow (play through phase 3 → overlay reveals) and the dev shortcut (`GET /endgame` with stub data).
+
+## Human QA
+
+The items below require eyes-on-screen judgement. Run the smoke worker locally (`pnpm wrangler dev` or equivalent) and exercise each.
+
+### Live game flow — the full path
+
+- [ ] Open the smoke worker root and confirm three AI panels render and update independently as a round plays out (panels do not block each other serially) — issue #29, commit `7ff7b9a`.
+- [ ] Send a message to a specific AI and confirm the addressed AI's panel responds; the other two AIs do not receive the player message in their visible histories — issue #29, commit `7ff7b9a`.
+- [ ] Watch token streaming and confirm the word-by-word pacing reads as "the AI is talking" rather than dumping or jittering — issue #29, commit `7ff7b9a`.
+- [ ] Cross a phase boundary in a real session and confirm the action-log entry / status marker for `phase_advanced` is legible (the marker is intentionally minimal — overlay-style phase transitions are a future concern) — issue #31, commit `82c013d`.
+- [ ] Complete phase 3's win condition in a real session and confirm the chat container hides and the endgame overlay takes over **without** a URL change or page reload — issue #32, commit `91c4def`.
+- [ ] After the overlay reveals, confirm the page feels like an ending rather than a paused game (the "moment of completion" feel) — issue #32, commit `91c4def`.
+- [ ] Reload the page after the overlay has revealed and confirm the experience is acceptable (current behaviour: session resumes; if the round produces no further `game_ended` event the chat is visible again — flag this as a follow-up if it feels wrong) — issue #32, commit `91c4def`.
+
+### Dev `/endgame` route — layout sanity
+
+- [ ] Hit `GET /endgame` directly and confirm the endgame screen layout, copy, and button placement read correctly without any game state — issue #30, commit `d74012f`.
+- [ ] Confirm the standalone route's stub persona data does not look like real production content (it should be obviously placeholder — this route is a developer affordance) — issue #30, commit `d74012f`.
+
+### Cross-cutting
+
+- [ ] Trigger a chat lockout mid-session and confirm the disabled selector state and in-character lockout message are legible; confirm the locked AI still receives whispers and takes turns — issue #29, commit `7ff7b9a`.
+- [ ] Kill the worker mid-round (network plug substitute) and confirm the UI degrades gracefully rather than wedging — issue #29, commit `7ff7b9a`.
+- [ ] Hit the daily-cap rate guard while the new `/game/turn` endpoint is in flight and confirm the `[CAP_HIT]` short-circuit produces the same UX as the existing `/chat` route — issue #29, commit `7ff7b9a`.
+
+## Code review (optional)
+
+- [ ] Sanity-check the `ENABLE_TEST_MODES` gating around `testMode: "win_immediately"` in `POST /game/new`. The reviewer found this was unconditionally active in the first cut; confirm the binding is only set in `vitest.config.ts` (miniflare) and not in `wrangler.jsonc` — issue #31, commit `82c013d`.
+- [ ] Look at `renderEndgameSection({ inlineScript: false })` in `renderChatPage` and decide whether the overlay's hoisted button handlers in the chat-page IIFE are the right long-term seam, or whether the endgame fragment should own its own behaviour via a separate dispatcher module — issue #32, commit `91c4def`.
+
+## Notes on what was deferred
+
+The following open issues exist but were **not** picked up in this run because they overlap heavily with the just-landed UI surface and would benefit from human direction on scope/priority:
+
+- **#21** "Nix action log" — directly conflicts with the `action_log` SSE events in #29.
+- **#22** "GUI should be one page" — restructures the same page #32 just rewrote.
+- **#23** "Mobile support" — re-themes the chat page's CSS that #29/#32 just modified.
+- **#20** "AI delay on turn-taking" — touches `runRound` pacing, which the encoder also handles.
+- **#26** "Server should be OpenAI-compatible API" — large architectural change to the proxy.
+- **#18** Phase content authoring (HITL) — explicitly labelled `ready-for-human`.
+- **#25, #28** are PRDs (parent specs), not implementation tickets.
+
+Pick one of these as the next AFK run after deciding which UI direction wins.

--- a/docs/prd/0003-smoke-worker-runround-sse.md
+++ b/docs/prd/0003-smoke-worker-runround-sse.md
@@ -1,0 +1,115 @@
+## Problem Statement
+
+A QA tester opening the smoke worker today gets a single mock AI echoing a canned reply. The three-AI Round Coordinator, the action log, the tool-failure visibility, the mid-phase chat lockout, and the phase progression / wipe lie all exist in code and are unit-tested — but none of them are reachable from a browser, because `_smoke.ts` only routes `POST /chat` to a single `MockLLMProvider`. The human QA checklist for issues #13, #15, #16, #17, and the multi-AI portions of #19 cannot be executed against the running worker. A reviewer also can't sniff-test feel: pacing, action-log readability, lockout legibility, phase-transition UX. The deterministic core is "tested" but not "playable."
+
+## Solution
+
+The smoke worker drives `runRound` end-to-end. A new game-session layer holds a `GameState` per browser tab, accepts player messages addressed to a specific AI, runs a full round through the coordinator, and emits the resulting events over SSE in the wire format the existing chat-page renderer already understands (`ai_start`, `token`, `ai_end`, `budget`, `lockout`, `chat_lockout`, `chat_lockout_resolved`, `action_log`, plus new `phase_advanced` and `game_ended`). After the wiring lands, opening the worker in a browser produces a real three-AI game: panels update independently, the action log narrates, lockouts fire and resolve, phases advance, and the wipe is observable across the boundary.
+
+The mock LLM provider stays the source of completions. Token streaming is paced for visual feel rather than driven by the underlying provider stream — the coordinator continues to buffer per AI before parsing, and the encoder re-emits the buffered string as paced `token` events. This keeps the round-coordinator interface unchanged and the existing tests untouched while still producing a streaming UI experience.
+
+## User Stories
+
+### QA tester
+
+1. As a QA tester, I want to open the smoke worker and see three AI panels, so that I can verify the coordinator's three-AI orchestration visually.
+2. As a QA tester, I want to send a message to a specific AI from the chat input, so that I can verify message routing reaches only the addressed AI's history.
+3. As a QA tester, I want to watch each AI's tokens appear in its own panel, so that I can verify panels update independently rather than serially blocking.
+4. As a QA tester, I want to see each AI's remaining budget update after every turn, so that I can verify per-AI budget accounting.
+5. As a QA tester, I want to see the action log fill in as the round plays out, so that I can sniff-test whether it reads as a coherent narrative.
+6. As a QA tester, I want to see tool failures rendered visibly to other AIs, so that I can verify issue #15's public-failure semantics.
+7. As a QA tester, I want a chat lockout to actually fire mid-game, so that I can verify the disabled selector state and in-character lockout message.
+8. As a QA tester, I want to confirm the locked AI still receives whispers and takes turns, so that I can verify the lockout is player-channel-only.
+9. As a QA tester, I want to watch a chat lockout resolve at its scheduled round, so that I can verify the unlock UX.
+10. As a QA tester, I want to cross a phase boundary and see the AIs behave as if wiped, so that I can sniff-test issue #17's wipe lie.
+11. As a QA tester, I want a clear visual signal when a phase ends and a new one begins, so that I can verify phase-transition UX.
+12. As a QA tester, I want to reach an end-of-game state when phase 3's win condition fires, so that I can verify game completion semantics independently of the endgame screen wiring.
+13. As a QA tester, I want the rate-limit and daily-cap guards to still apply on the new endpoint, so that abuse paths remain covered.
+14. As a QA tester, I want the network plug substitute (kill the worker mid-round) to leave the UI in a recoverable state, so that I can verify graceful degradation.
+
+### Player (future)
+
+15. As a player, I want to start a fresh game in a new browser tab, so that my session does not collide with other sessions on the same worker.
+16. As a player, I want my game state to survive page reloads within a tab session, so that I do not lose progress on accidental refresh.
+17. As a player, I want the chat input disabled while a round is in flight, so that I do not double-submit.
+18. As a player, I want to see whose turn is in progress, so that I understand what the worker is currently computing.
+
+### Developer
+
+19. As a developer, I want the SSE event taxonomy to live in one encoder module, so that the wire format has a single source of truth.
+20. As a developer, I want the game-session layer to be testable without HTTP, so that round-lifecycle logic is verifiable in unit tests.
+21. As a developer, I want the round coordinator's interface to remain unchanged, so that no existing tests need to be rewritten.
+22. As a developer, I want session storage abstracted behind a tiny interface, so that swapping in-memory for KV later is a one-module change.
+23. As a developer, I want a clear seam where the eventual `AnthropicProvider` plugs in, so that the deferred real-LLM wiring is a plug, not a refactor.
+
+## Implementation Decisions
+
+### Modules
+
+- **GameSession (deep).** Owns the lifecycle of a single game's `GameState` across HTTP requests. Constructed from a phase-config triple. Exposes a `submitMessage(addressedAi, message, provider)` method that runs one round and returns the structured `RoundResult` plus any per-AI streaming the encoder needs. Holds the only mutable state in the system; everything below is pure or stateless.
+- **RoundResultEncoder (deep, pure).** Translates a `RoundResult` plus per-AI buffered completion strings into a flat sequence of structured SSE events in the wire format the renderer already consumes. New event types (`phase_advanced`, `game_ended`) added here. Single source of truth for the wire format.
+- **SessionStore (thin).** Cookie-keyed in-memory `Map`. Two operations: get-or-create and update. No persistence. Single-worker assumption is fine for v1.
+- **Game endpoint handler (thin).** A new sub-route in the smoke worker (`POST /game/turn`, `POST /game/new`) that pulls the session, calls `GameSession.submitMessage`, and pipes the encoder output through the existing rate-guard wrapper to the SSE response. The handler itself is thin glue.
+- **Round coordinator (unchanged).** No changes to `runRound` or its interface. Token streaming feel is produced by the encoder pacing the buffered completion string, not by piercing the coordinator's `collectCompletion` boundary.
+
+### Wire format
+
+- Existing event types preserved exactly: `ai_start`, `token`, `ai_end`, `budget`, `lockout`, `chat_lockout`, `chat_lockout_resolved`, `action_log`. The renderer's parser is the contract; the encoder must round-trip cleanly through it.
+- New event types: `phase_advanced` (carries the new phase number and the new phase's objective), `game_ended` (terminal signal, no body needed). Renderer additions to handle these are part of this PRD's scope.
+- `[DONE]` and `[CAP_HIT]` legacy sentinels preserved for compatibility with the rate-guard short-circuit path.
+
+### Session lifecycle
+
+- Sessions are scoped per browser tab via a session cookie set on first `POST /game/new`.
+- Session storage is in-process — a `Map` on a module-level singleton inside the worker. Acceptable for v1 because the worker is single-instance in local Wrangler dev. KV persistence is out of scope (separate follow-up).
+- A worker restart drops all sessions. Documented as expected for QA scope.
+- No cross-session isolation guarantees — this is a single-player local development worker, not a multi-tenant service.
+
+### Provider seam
+
+- The mock provider stays the only wired option. The `AnthropicProvider` throw in `createProvider` remains in place; no real-LLM wiring in this PRD.
+- The provider is constructed once per request (current pattern preserved) and passed into `GameSession.submitMessage`.
+
+### Token pacing
+
+- The encoder splits the buffered completion string into reasonable chunks (e.g. word-level) and emits paced `token` events, so the UI shows progressive rendering even though the underlying provider call is synchronous-buffered. This is a deliberate v1 cheat — when the real Anthropic provider lands, the round coordinator's `collectCompletion` is the natural place to refactor into a streaming iterator, at which point the encoder can pass tokens through directly.
+
+## Testing Decisions
+
+A good test for this slice asserts external behaviour: given a `GameState` and a player message, the round produces the expected sequence of SSE events in the expected order. Tests should not assert on internal data structures, the existence of specific functions, or implementation details that would change if pacing or session-storage choices were revisited.
+
+### Modules tested
+
+- **RoundResultEncoder** — fixture-driven unit tests. Feed in a constructed `RoundResult` plus per-AI completion strings, assert on the flat event sequence. Coverage: every event type, including `phase_advanced` and `game_ended`, plus the chat-lockout trigger / resolve combination across a single round.
+- **GameSession** — round-lifecycle integration tests using a deterministic mock provider. Coverage: message routing (only addressed AI's history receives the player message), state mutation across rounds, phase advancement when the win condition fires, game completion at end of phase 3.
+
+### Modules not tested at this level
+
+- **SessionStore** — too thin (Map wrapper) to warrant isolated tests; covered transitively through endpoint integration tests.
+- **Game endpoint handler** — integration-tested via `@cloudflare/vitest-pool-workers` using the same pattern as the existing smoke and diagnostics-endpoint tests. Coverage: session creation, end-to-end SSE event sequence on a turn, rate-guard short-circuit still works.
+- **Round coordinator** — unchanged; existing tests remain authoritative.
+
+### Prior art
+
+- The proxy-side smoke test is the model for endpoint-level tests inside the worker pool.
+- The round-coordinator unit tests are the model for round-lifecycle assertions; the new `GameSession` tests should look similar in shape, with the session wrapper as the SUT instead of `runRound` directly.
+- The UI tests already assert on rendered HTML for chat-lockout disabled state; renderer additions for `phase_advanced` and `game_ended` follow that pattern.
+
+## Out of Scope
+
+- **Real `AnthropicProvider` wiring.** Mock provider stays. The `LLM_PROVIDER=anthropic` branch continues to throw. Tracked separately.
+- **KV-backed session persistence.** In-memory only. Cookie-keyed sessions die on worker restart. Tracked separately if/when multi-instance deployment matters.
+- **Endgame screen routing.** Reaching the endgame screen from the worker is a separate PRD. This PRD only emits the `game_ended` event; whatever consumes that signal client-side is the next slice.
+- **Save payload client populator.** The save-payload populator on the endgame screen is a separate PRD — this slice does not own client-side game-loop state plumbing.
+- **Real-stream token piping.** The encoder paces buffered tokens for v1. True provider-driven streaming is a follow-up tied to the real-LLM wiring.
+- **Session cleanup / expiry.** No GC on the in-memory session store. Worker restart is the only cleanup mechanism.
+- **Multi-player or cross-tab synchronisation.** One game per browser tab; tabs are independent.
+- **Authoring of phase-config triples.** This PRD assumes the phase configs already exist or are stubbed; full content authoring is HITL-scoped (issue #18).
+
+## Further Notes
+
+- The wire format is the contract this PRD locks in. Once the encoder is the single source of truth for SSE events, future event-shape changes flow through one module — keeping it that way is the architectural win, regardless of whether token pacing or session storage gets revisited.
+- The "buffer then pace" choice for token streaming is a known cheat. It should be revisited at the same time the real Anthropic provider lands — refactoring `collectCompletion` from buffered to streaming is mechanical, and the encoder is already shaped to accept token events from either source.
+- This PRD assumes the existing `renderChatPage` SSE handler logic is the authoritative wire-format consumer. Any drift between the encoder's emitted events and what the handler parses is a bug in the encoder, not the renderer.
+- After this PRD lands, the QA checklist items currently marked "blocked on smoke worker driving runRound" become executable. The other QA blockers (endgame route, save populator) remain as separate follow-up PRDs.
+- Tracked on the issue tracker as #25.

--- a/docs/prd/0004-endgame-screen-routing.md
+++ b/docs/prd/0004-endgame-screen-routing.md
@@ -1,0 +1,113 @@
+## Problem Statement
+
+A QA tester wanting to evaluate the endgame screen has no way to reach it. `renderEndgamePage` ships in the renderer module (added by issue #19) and is unit-tested in isolation, but the smoke worker has no `/endgame` route, the chat page never navigates away on game completion, and there is no in-game path that takes a player from "phase 3 win condition fires" to "endgame screen visible." The QA checklist items for endgame reachability, layout sanity, and the endgame's feel ("does this read as the end of a game?") all sit behind a wall of integration code that does not yet exist. Even a maintainer wanting to eyeball recent endgame markup changes has to hand-write a temporary route and not commit it — which is the hint that the missing path is real.
+
+## Solution
+
+Two ways to reach the endgame screen, both small.
+
+The real flow: when a player completes phase 3, the chat page reveals an inline endgame overlay. The overlay is markup already present in the chat page (initially hidden), revealed by client-side glue that listens for the `game_ended` SSE event emitted by the coordinator wiring (PRD 0003). No URL change, no navigation, no state transfer — the in-memory game state stays in the same JavaScript context, and the renderer simply swaps which container is visible.
+
+The QA flow: a `/endgame` route on the smoke worker serves the standalone `renderEndgamePage()` HTML with stub persona data, so a tester (or a reviewer eyeballing markup) can hit the screen directly without playing through three phases. This is intentionally a developer affordance, not a player-facing route.
+
+Both flows reuse the same body markup. The endgame body is extracted into a fragment-renderer that the full-page renderer wraps in a doc shell and the chat-page overlay embeds inline. One source of truth for endgame markup; two consumers.
+
+## User Stories
+
+### QA tester
+
+1. As a QA tester, I want to play through phase 3 and reach the endgame screen, so that I can verify the win-condition path actually surfaces the endgame UI.
+2. As a QA tester, I want the endgame screen to appear automatically when phase 3 completes, so that I do not have to perform any manual navigation to verify the transition.
+3. As a QA tester, I want the chat page's transition to the endgame screen to be visually clear, so that I can sniff-test the moment-of-completion feel.
+4. As a QA tester, I want a direct route to the endgame screen with stub data, so that I can inspect the screen's layout and copy without playing through a full game.
+5. As a QA tester, I want the standalone endgame route to clearly identify itself as a developer affordance, so that I do not mistake it for a player-facing URL.
+6. As a QA tester, I want the endgame screen to remain reachable on page reload after the game has ended within a session, so that I can re-inspect it without restarting the game.
+
+### Player (future)
+
+7. As a player, I want to see an endgame screen when I finish the game, so that the experience has a clear ending and is not just "the chat input goes quiet."
+8. As a player, I want the endgame screen to feel like a distinct moment, so that I understand the game is over rather than just paused.
+9. As a player, I want the endgame screen to remain accessible until I close the tab, so that I can read it without rushing.
+
+### Maintainer
+
+10. As a maintainer, I want one source of truth for endgame markup, so that updates to the endgame layout do not have to be made in two places.
+11. As a maintainer, I want the standalone endgame route gated behind dev-only stub data, so that production traffic cannot stumble into a fake endgame screen.
+12. As a maintainer, I want the existing `renderEndgamePage` tests to remain authoritative without modification, so that the refactor does not invalidate the unit-test coverage already in place.
+
+### Developer
+
+13. As a developer, I want the endgame fragment to be a pure function of its inputs, so that it is trivially testable and reusable across the full-page and overlay renderings.
+14. As a developer, I want the chat page's overlay reveal to depend only on a known SSE event type, so that the contract with the coordinator is explicit.
+15. As a developer, I want the SSE event that triggers the overlay to be the same `game_ended` event PRD 0003 emits, so that the integration seam is single-purpose and the event taxonomy stays coherent.
+
+## Implementation Decisions
+
+### Module shape
+
+- **Endgame fragment renderer (deep, pure).** A new function returns the endgame body markup as a string, with no doctype, no `<html>`, no `<head>`, no `<body>` wrapper. Pure function of its inputs (initially: nothing — the body is presently a static template; persona data wiring is owned by the save-payload populator PRD).
+- **Full-page renderer (refactored).** The existing `renderEndgamePage` is rewritten to wrap the fragment in the existing doc shell (styles, meta tags, etc.). Public signature and externally-visible HTML output unchanged.
+- **Chat-page overlay (modification to chat-page renderer).** The chat-page output gains an initially-hidden container that contains the endgame fragment. CSS hides it by default; client-side JS reveals it on the `game_ended` event.
+- **Client-side overlay glue (modification to the chat page's SSE handler).** When the parser sees a `game_ended` event, it sets a flag and toggles the overlay container's visibility. The chat container is hidden in the same step. No window/location changes.
+- **Standalone `/endgame` route (dev affordance).** A new route in the smoke worker serves the full-page renderer with stub persona data. Returns 404 when an environment flag is set indicating production. (For local Wrangler dev, it always serves; for any future production deploy, the flag gates it off.)
+
+### Wire-format dependency
+
+- This PRD depends on PRD 0003 emitting a `game_ended` SSE event when the coordinator's win condition fires on phase 3. The event payload shape is decided in 0003; this PRD only consumes the event's existence.
+- The chat-page parser already has a switch on `evt.type`; adding the `game_ended` branch is one new case, parallel to `phase_advanced`.
+
+### Markup extraction
+
+- The fragment renderer owns the buttons, sections, status text, and any data attributes the save-payload populator (separate PRD) will write into. The doc shell wrapping is the only thing the full-page renderer adds.
+- Styles continue to live in the doc shell's `<style>` block; the fragment does not carry inline styles. The chat page's existing `<style>` block absorbs the endgame styles when embedding the overlay, so the visual presentation matches.
+- Any data attributes the endgame screen exposes for downstream wiring (`data-save-payload`, etc.) are part of the fragment, not the doc shell — populators target the fragment regardless of which renderer wrapped it.
+
+### Routing
+
+- `/endgame` is a `GET` handler on the smoke worker. It returns the standalone full-page render with stub data.
+- The chat page is unchanged at `/`. Players continue to land there; the overlay handles the transition.
+- No new POST routes. No new client-state machinery beyond the overlay toggle.
+
+### Stub data shape (for the dev route)
+
+- The stub data is enough to make the endgame screen render without errors: three persona names, a fake save payload (or empty), and any other fields the fragment dereferences. Real persona/save data is the save-populator PRD's concern.
+- The stub is hard-coded in the worker handler. No KV, no fixtures file.
+
+## Testing Decisions
+
+A good test asserts external behaviour of the rendered output (does the markup contain the expected sections, buttons, data attributes) without coupling to internal helper-function names or markup details that would change the moment a copy edit happens.
+
+### Modules tested
+
+- **Endgame fragment renderer** — fixture-style unit test asserting that the returned string contains the expected buttons (download, submit), section headings, and data attributes (placeholder for the save payload). Mirrors the existing `renderEndgamePage` tests in shape.
+- **`/endgame` route** — worker-pool integration test asserting a `GET /endgame` returns 200 with `Content-Type: text/html` and a body containing the endgame markers. Pattern matches the smoke-test integration tests.
+
+### Modules not tested at this level
+
+- **Full-page renderer (`renderEndgamePage`).** Existing tests stay authoritative. Because the function now reuses the fragment renderer, the existing tests continue to validate end-to-end output without modification — that's the proof the refactor preserved behaviour.
+- **Overlay reveal glue (chat-page client JS).** Not unit-tested. The reveal is verified through QA against the integrated `game_ended` event from PRD 0003 — there is no useful test of "JS toggles a `hidden` attribute" that does not also re-verify what the SSE handler does, which is already covered.
+- **Stub data shape.** Not tested independently; covered transitively through the route integration test.
+
+### Prior art
+
+- The existing UI tests already assert on `renderEndgamePage` output structure — the new fragment-renderer test follows the same shape.
+- The proxy smoke test is the model for the route integration test.
+
+## Out of Scope
+
+- **Save-payload client populator.** Wiring the chat-page's in-memory game state into the endgame screen's `data-save-payload` attribute is owned by a separate follow-up PRD. This PRD only ensures the data attribute exists and the screen is reachable.
+- **Real persona data on the dev route.** The `/endgame` route serves stub data, not real game state. Hooking it to a session is not in scope; a tester wanting realistic data plays through a real game.
+- **Endgame copy authoring.** The current placeholder copy stays as-is. Polish belongs to the HITL phase-content authoring track (issue #18).
+- **Production gating of the dev route.** The route is intended for local Wrangler dev; an environment-flag-based 404 is sketched in implementation decisions but full production-deploy hardening (auth, header gating, removal at build time, etc.) is a deploy-time concern outside this PRD.
+- **Endgame state persistence.** Reaching the endgame and then refreshing the page restores the player to the chat page, not the endgame, in v1. Persisting the "game has ended" flag client-side (localStorage, cookie) is a possible follow-up but not required for QA.
+- **Animations or transitions.** The overlay reveal is a simple visibility toggle. No fade, no slide, no progressive disclosure of sections.
+- **Diagnostics submission flow.** The diagnostics POST already works (issue #19 shipped it). This PRD does not modify it; it only ensures the screen that hosts the submit button is reachable.
+- **Real LLM provider, KV diagnostics persistence.** Both deferred and unrelated to making the endgame screen reachable.
+
+## Further Notes
+
+- This PRD has a hard dependency on PRD 0003. The chat-page overlay reveal is meaningless without a `game_ended` event to listen for. Implementation order: 0003 lands first, then this PRD's overlay glue plugs into the new event.
+- The dev `/endgame` route is independent of 0003 and could land alone. Splitting this PRD into "fragment + dev route" (zero-dep) and "overlay + glue" (depends on 0003) is reasonable if the implementer wants to ship incrementally.
+- The decision to use an inline overlay rather than a navigation to `/endgame` was driven by state preservation: the chat page holds the in-memory game state, and a real navigation would require either re-fetching state from the server (which means session storage exists and is queryable, which is in 0003's scope) or transferring state via query params (fragile). The overlay approach sidesteps that by keeping the same JS context. If session-state queryability becomes a desirable property later (e.g., for refresh-resilience), revisiting this is reasonable but not currently required.
+- The `data-save-payload` attribute lives on the fragment because that's where the save-populator (separate PRD) will write to. Locating it on the doc shell would make the populator's job harder when the endgame is rendered as an overlay.
+- Tracked on the issue tracker as #28.

--- a/src/__tests__/context-builder.test.ts
+++ b/src/__tests__/context-builder.test.ts
@@ -169,3 +169,93 @@ describe("buildAiContext", () => {
 		expect(prompt).not.toContain("Secret message to Sage");
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Wipe augmentation (issue #17)
+// ----------------------------------------------------------------------------
+describe("wipe augmentation", () => {
+	const PHASE_2_CONFIG: PhaseConfig = {
+		phaseNumber: 2,
+		objective: "Phase 2 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: "room" }],
+		},
+		budgetPerAi: 5,
+	};
+
+	const PHASE_3_CONFIG: PhaseConfig = {
+		phaseNumber: 3,
+		objective: "Phase 3 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: "room" }],
+		},
+		budgetPerAi: 5,
+	};
+
+	it("phase 1 system prompt does NOT include wipe augmentation", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).not.toMatch(/previous phase/i);
+		expect(prompt).not.toMatch(/don.t remember/i);
+	});
+
+	it("phase 2 system prompt includes wipe augmentation for each AI", () => {
+		// Simulate reaching phase 2 via advancePhase
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		for (const aiId of ["red", "green", "blue"] as const) {
+			const ctx = buildAiContext(game, aiId);
+			const prompt = ctx.toSystemPrompt();
+			expect(prompt).toMatch(/previous phase/i);
+		}
+	});
+
+	it("phase 3 system prompt includes wipe augmentation for each AI", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		for (const aiId of ["red", "green", "blue"] as const) {
+			const ctx = buildAiContext(game, aiId);
+			const prompt = ctx.toSystemPrompt();
+			expect(prompt).toMatch(/previous phase/i);
+		}
+	});
+
+	it("wipe augmentation instructs the AI to act as if it has forgotten the previous phase", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		// Should include language about not remembering/pretending to forget
+		expect(prompt).toMatch(
+			/do not remember|don.t remember|have no memory|forgotten/i,
+		);
+	});
+
+	it("wipe augmentation is in the prompt, not reflected in stored chat/whisper data", () => {
+		// The lie is in the prompt; the engine retains real history.
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = appendChat(game, "red", { role: "ai", content: "Phase 1 message" });
+		game = startPhase(game, PHASE_2_CONFIG);
+		// Phase 1 data is still in game.phases[0]
+		expect(
+			game.phases[0]?.chatHistories.red.some(
+				(m) => m.content === "Phase 1 message",
+			),
+		).toBe(true);
+		// The wipe augmentation is only in the prompt for the new active phase
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toMatch(/previous phase/i);
+	});
+});

--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -9,7 +9,10 @@ import {
 	deductBudget,
 	getActivePhase,
 	isAiLockedOut,
+	isPlayerChatLockedOut,
+	resolveChatLockouts,
 	startPhase,
+	triggerChatLockout,
 } from "../engine";
 import type { ActionLogEntry, AiPersona, PhaseConfig } from "../types";
 
@@ -200,6 +203,67 @@ describe("appendWhisper", () => {
 		expect(getActivePhase(updated).whispers).toHaveLength(1);
 		expect(getActivePhase(updated).whispers[0]?.from).toBe("red");
 		expect(getActivePhase(updated).whispers[0]?.to).toBe("blue");
+	});
+});
+
+describe("chat lockout", () => {
+	it("startPhase initialises chatLockouts as empty", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const phase = getActivePhase(game);
+		expect(phase.chatLockouts.size).toBe(0);
+	});
+
+	it("isPlayerChatLockedOut returns false when no lockout active", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		expect(isPlayerChatLockedOut(game, "red")).toBe(false);
+	});
+
+	it("triggerChatLockout marks the AI as player-chat-locked", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const locked = triggerChatLockout(game, "green", 3); // resolves at round 3
+		expect(isPlayerChatLockedOut(locked, "green")).toBe(true);
+		// Budget-lockout should remain unaffected
+		expect(isAiLockedOut(locked, "green")).toBe(false);
+	});
+
+	it("triggerChatLockout does not affect other AIs", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const locked = triggerChatLockout(game, "blue", 2);
+		expect(isPlayerChatLockedOut(locked, "red")).toBe(false);
+		expect(isPlayerChatLockedOut(locked, "green")).toBe(false);
+	});
+
+	it("resolveChatLockouts removes lockouts where resolveAtRound <= current round", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = triggerChatLockout(game, "red", 2); // resolves at round 2
+		// Advance round to 1 — not yet at resolveAtRound
+		game = advanceRound(game); // round = 1
+		game = resolveChatLockouts(game);
+		expect(isPlayerChatLockedOut(game, "red")).toBe(true); // still locked
+
+		// Advance to round 2 — now at resolveAtRound
+		game = advanceRound(game); // round = 2
+		game = resolveChatLockouts(game);
+		expect(isPlayerChatLockedOut(game, "red")).toBe(false); // resolved
+	});
+
+	it("resolveChatLockouts only removes expired lockouts, leaving others intact", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = triggerChatLockout(game, "red", 1); // expires at round 1
+		game = triggerChatLockout(game, "green", 5); // expires at round 5
+		game = advanceRound(game); // round = 1
+		game = resolveChatLockouts(game);
+		expect(isPlayerChatLockedOut(game, "red")).toBe(false); // expired
+		expect(isPlayerChatLockedOut(game, "green")).toBe(true); // still active
+	});
+
+	it("chat lockout is independent from budget lockout — locked-out AI can still act (budget untouched)", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const locked = triggerChatLockout(game, "blue", 3);
+		// Budget lockout (isAiLockedOut) must remain false — AI can still take turns
+		expect(isAiLockedOut(locked, "blue")).toBe(false);
+		// Budget unaffected
+		expect(getActivePhase(locked).budgets.blue.remaining).toBe(5);
 	});
 });
 

--- a/src/__tests__/game-session.test.ts
+++ b/src/__tests__/game-session.test.ts
@@ -11,10 +11,10 @@
  *   - Locked-out AI completions are empty strings
  */
 import { describe, expect, it } from "vitest";
+import { getActivePhase } from "../engine";
 import { GameSession } from "../game-session";
 import type { LLMProvider } from "../proxy/llm-provider";
 import { MockLLMProvider } from "../proxy/llm-provider";
-import { getActivePhase } from "../engine";
 import type { PhaseConfig } from "../types";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -85,16 +85,17 @@ describe("GameSession — message routing", () => {
 		// Red should have the player message
 		expect(
 			phase.chatHistories.red.some(
-				(m) => m.role === "player" && m.content.includes("Secret message for Ember"),
+				(m) =>
+					m.role === "player" && m.content.includes("Secret message for Ember"),
 			),
 		).toBe(true);
 		// Green and blue should NOT have it
-		expect(
-			phase.chatHistories.green.some((m) => m.role === "player"),
-		).toBe(false);
-		expect(
-			phase.chatHistories.blue.some((m) => m.role === "player"),
-		).toBe(false);
+		expect(phase.chatHistories.green.some((m) => m.role === "player")).toBe(
+			false,
+		);
+		expect(phase.chatHistories.blue.some((m) => m.role === "player")).toBe(
+			false,
+		);
 	});
 
 	it("routing changes per round — second message goes to different AI", async () => {
@@ -191,7 +192,11 @@ describe("GameSession — completions map", () => {
 
 		// Round 2 — all AIs are locked, coordinator skips them
 		const provider2 = new MockLLMProvider('{"action":"pass"}');
-		const { completions } = await session.submitMessage("red", "round 2", provider2);
+		const { completions } = await session.submitMessage(
+			"red",
+			"round 2",
+			provider2,
+		);
 
 		// Locked AIs should have empty completions
 		expect(completions.red).toBe("");

--- a/src/__tests__/game-session.test.ts
+++ b/src/__tests__/game-session.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for GameSession.
+ *
+ * Tests are lifecycle-focused: construct a session, call submitMessage,
+ * assert on the structured results.
+ *
+ * Covers:
+ *   - Message routing (only addressed AI's history gets the player message)
+ *   - State mutation across rounds
+ *   - Completions map (correct per-AI buffered strings)
+ *   - Locked-out AI completions are empty strings
+ */
+import { describe, expect, it } from "vitest";
+import { GameSession } from "../game-session";
+import type { LLMProvider } from "../proxy/llm-provider";
+import { MockLLMProvider } from "../proxy/llm-provider";
+import { getActivePhase } from "../engine";
+import type { PhaseConfig } from "../types";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Test objective",
+	aiGoals: {
+		red: "Hold the flower",
+		green: "Distribute evenly",
+		blue: "Hold the key",
+	},
+	initialWorld: {
+		items: [
+			{ id: "flower", name: "flower", holder: "room" },
+			{ id: "key", name: "key", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+};
+
+/** A provider that returns responses in call order (cycling if exhausted). */
+class SequentialMockProvider implements LLMProvider {
+	private responses: string[];
+	private index = 0;
+
+	constructor(responses: string[]) {
+		this.responses = responses;
+	}
+
+	async *streamCompletion(_msg: string): AsyncIterable<string> {
+		const response = this.responses[this.index % this.responses.length] ?? "";
+		this.index++;
+		yield response;
+	}
+}
+
+// ── Session construction ──────────────────────────────────────────────────────
+
+describe("GameSession construction", () => {
+	it("creates a session with an active phase", () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const state = session.getState();
+		expect(state.phases).toHaveLength(1);
+		expect(state.currentPhase).toBe(1);
+		expect(state.isComplete).toBe(false);
+	});
+
+	it("initial budgets match the phase config", () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const phase = getActivePhase(session.getState());
+		expect(phase.budgets.red.remaining).toBe(5);
+		expect(phase.budgets.green.remaining).toBe(5);
+		expect(phase.budgets.blue.remaining).toBe(5);
+	});
+});
+
+// ── Message routing ───────────────────────────────────────────────────────────
+
+describe("GameSession — message routing", () => {
+	it("player message appears in only the addressed AI's chat history", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		await session.submitMessage("red", "Secret message for Ember", provider);
+
+		const phase = getActivePhase(session.getState());
+		// Red should have the player message
+		expect(
+			phase.chatHistories.red.some(
+				(m) => m.role === "player" && m.content.includes("Secret message for Ember"),
+			),
+		).toBe(true);
+		// Green and blue should NOT have it
+		expect(
+			phase.chatHistories.green.some((m) => m.role === "player"),
+		).toBe(false);
+		expect(
+			phase.chatHistories.blue.some((m) => m.role === "player"),
+		).toBe(false);
+	});
+
+	it("routing changes per round — second message goes to different AI", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		await session.submitMessage("red", "for red", provider);
+		await session.submitMessage("green", "for green", provider);
+
+		const phase = getActivePhase(session.getState());
+		// Green should have the second player message
+		expect(
+			phase.chatHistories.green.some(
+				(m) => m.role === "player" && m.content.includes("for green"),
+			),
+		).toBe(true);
+		// Red's history only has the first player message
+		expect(
+			phase.chatHistories.red.filter((m) => m.role === "player"),
+		).toHaveLength(1);
+	});
+});
+
+// ── State mutation across rounds ──────────────────────────────────────────────
+
+describe("GameSession — state mutation across rounds", () => {
+	it("round counter advances after each submitMessage call", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		await session.submitMessage("red", "hi", provider);
+		expect(getActivePhase(session.getState()).round).toBe(1);
+
+		await session.submitMessage("green", "hi", provider);
+		expect(getActivePhase(session.getState()).round).toBe(2);
+	});
+
+	it("budget decrements for all AIs after each round", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		await session.submitMessage("red", "hi", provider);
+
+		const phase = getActivePhase(session.getState());
+		expect(phase.budgets.red.remaining).toBe(4);
+		expect(phase.budgets.green.remaining).toBe(4);
+		expect(phase.budgets.blue.remaining).toBe(4);
+	});
+
+	it("second round builds on first round's state", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		// Red picks up flower in round 1
+		const provider1 = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		await session.submitMessage("red", "hi", provider1);
+
+		// In round 2, flower should still be held by red
+		const provider2 = new MockLLMProvider('{"action":"pass"}');
+		await session.submitMessage("green", "hi", provider2);
+
+		const phase = getActivePhase(session.getState());
+		const flower = phase.world.items.find((i) => i.id === "flower");
+		expect(flower?.holder).toBe("red");
+	});
+});
+
+// ── Completions map ───────────────────────────────────────────────────────────
+
+describe("GameSession — completions map", () => {
+	it("completions map contains the completion text for each AI", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"I am Ember"}',
+			'{"action":"chat","content":"I am Sage"}',
+			'{"action":"chat","content":"I am Frost"}',
+		]);
+
+		const { completions } = await session.submitMessage("red", "hi", provider);
+
+		expect(completions.red).toContain("Ember");
+		expect(completions.green).toContain("Sage");
+		expect(completions.blue).toContain("Frost");
+	});
+
+	it("completions map has empty string for a budget-locked AI", async () => {
+		// Create session with budget=1 so red exhausts after round 1
+		const session = new GameSession({ ...PHASE_CONFIG, budgetPerAi: 1 });
+		const provider1 = new MockLLMProvider('{"action":"pass"}');
+		// Round 1 — all AIs act, budgets go to 0 → all locked out
+		await session.submitMessage("red", "round 1", provider1);
+
+		// Round 2 — all AIs are locked, coordinator skips them
+		const provider2 = new MockLLMProvider('{"action":"pass"}');
+		const { completions } = await session.submitMessage("red", "round 2", provider2);
+
+		// Locked AIs should have empty completions
+		expect(completions.red).toBe("");
+		expect(completions.green).toBe("");
+		expect(completions.blue).toBe("");
+	});
+
+	it("completions only for non-locked AIs are non-empty", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new SequentialMockProvider([
+			'{"action":"pass"}', // red
+			'{"action":"pass"}', // green
+			'{"action":"pass"}', // blue
+		]);
+
+		const { completions } = await session.submitMessage("red", "hi", provider);
+
+		// All AIs acted, completions should be non-empty
+		expect(completions.red).not.toBe("");
+		expect(completions.green).not.toBe("");
+		expect(completions.blue).not.toBe("");
+	});
+});
+
+// ── RoundResult in submitMessage ──────────────────────────────────────────────
+
+describe("GameSession — result from submitMessage", () => {
+	it("result.round is 1 after the first call", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		const { result } = await session.submitMessage("red", "hi", provider);
+		expect(result.round).toBe(1);
+	});
+
+	it("result.actions contains entries from all three AIs", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		const { result } = await session.submitMessage("red", "hi", provider);
+
+		const actors = new Set(result.actions.map((a) => a.actor));
+		expect(actors.size).toBe(3);
+	});
+
+	it("chat lockout is reflected in result.chatLockoutTriggered", async () => {
+		const session = new GameSession(PHASE_CONFIG);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		const { result } = await session.submitMessage("red", "hi", provider, {
+			rng: () => 0, // always picks red (index 0)
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+
+		expect(result.chatLockoutTriggered).toBeDefined();
+		expect(result.chatLockoutTriggered?.aiId).toBe("red");
+	});
+});
+
+// ── Phase advancement via GameSession ────────────────────────────────────────
+
+describe("GameSession — phase advancement", () => {
+	it("phaseEnded is false when win condition not met", async () => {
+		const session = new GameSession({
+			...PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+		});
+		const provider = new MockLLMProvider('{"action":"pass"}');
+
+		const { result } = await session.submitMessage("red", "hi", provider);
+		expect(result.phaseEnded).toBe(false);
+	});
+
+	it("phaseEnded is true when win condition is met this round", async () => {
+		const session = new GameSession({
+			...PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+		});
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+
+		const { result } = await session.submitMessage("red", "hi", provider);
+		expect(result.phaseEnded).toBe(true);
+	});
+});

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -341,3 +341,31 @@ describe("response parsing", () => {
 		expect(log.filter((e) => e.type === "pass")).toHaveLength(3);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Multi-round correctness
+// ----------------------------------------------------------------------------
+describe("multi-round correctness", () => {
+	it("RoundResult.actions contains only entries from the current round, not prior rounds", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// Round 1
+		const { nextState: state1, result: result1 } = await runRound(
+			game,
+			"red",
+			"first message",
+			provider,
+		);
+		expect(result1.actions).toHaveLength(3); // 3 pass entries
+
+		// Round 2: the cumulative actionLog now has 3 prior entries.
+		// result2.actions must contain only round-2 entries, not the prior 3.
+		const { result: result2 } = await runRound(
+			state1,
+			"green",
+			"second message",
+			provider,
+		);
+		expect(result2.actions).toHaveLength(3); // still only 3, not 6
+	});
+});

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -385,3 +385,158 @@ describe("multi-round correctness", () => {
 		expect(result2.actions).toHaveLength(3); // still only 3, not 6
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Tool-call parsing and dispatch (issue #15)
+// ----------------------------------------------------------------------------
+describe("tool-call parsing and dispatch", () => {
+	it("parses a pick_up tool call from the LLM response and executes it", async () => {
+		const game = makeGame();
+		// Red picks up the flower; green and blue pass
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"I will take the flower","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const phase = getActivePhase(nextState);
+		const flower = phase.world.items.find((i) => i.id === "flower");
+		expect(flower?.holder).toBe("red");
+	});
+
+	it("appends a tool_success entry to the action log when a valid tool call is executed", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		expect(log.some((e) => e.type === "tool_success")).toBe(true);
+	});
+
+	it("appends a tool_failure entry when tool call is invalid (item not in room)", async () => {
+		// Red tries to pick up the key which is already held by red in TEST_PHASE_CONFIG
+		// But in makeGame() everything starts in the room — so try an impossible pick_up:
+		// green tries to pick up key but only after red already holds it
+		const game = makeGame();
+		// green tries pick_up but flower is in the room — let's have green try to pick up
+		// an item that doesn't exist
+		const provider = new SequentialMockProvider([
+			'{"action":"pass"}',
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		expect(log.some((e) => e.type === "tool_failure")).toBe(true);
+		const failure = log.find((e) => e.type === "tool_failure");
+		expect(failure).toBeDefined();
+	});
+
+	it("includes a reason on tool_failure entries", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		const failure = log.find(
+			(e): e is Extract<typeof e, { type: "tool_failure" }> =>
+				e.type === "tool_failure",
+		);
+		expect(failure?.reason).toBeTruthy();
+	});
+
+	it("tool call can accompany a chat action in the same turn", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"Taking the flower","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const phase = getActivePhase(nextState);
+		// Both chat and tool_success should be logged
+		expect(phase.actionLog.some((e) => e.type === "chat")).toBe(true);
+		expect(phase.actionLog.some((e) => e.type === "tool_success")).toBe(true);
+		// Flower should now be held by red
+		expect(phase.world.items.find((i) => i.id === "flower")?.holder).toBe(
+			"red",
+		);
+	});
+
+	it("tool failure is visible in other AIs' context on the next round (failures are public)", async () => {
+		const game = makeGame();
+		// Red fails a tool call in round 1
+		const round1Provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState: stateAfterRound1 } = await runRound(
+			game,
+			"red",
+			"hi",
+			round1Provider,
+		);
+
+		// Build blue's context for round 2 — the failure should be in the action log
+		const blueCtx = buildAiContext(stateAfterRound1, "blue");
+		const actionLogInPrompt = blueCtx.actionLog;
+		expect(actionLogInPrompt.some((e) => e.type === "tool_failure")).toBe(true);
+	});
+
+	it("action log failures flow into the system prompt for all AIs (failure is public)", async () => {
+		const game = makeGame();
+		const round1Provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState: stateAfterRound1 } = await runRound(
+			game,
+			"red",
+			"hi",
+			round1Provider,
+		);
+
+		// Green's system prompt should contain the failure description
+		const greenCtx = buildAiContext(stateAfterRound1, "green");
+		const prompt = greenCtx.toSystemPrompt();
+		expect(prompt).toContain("Action Log");
+		// The failure description mentions 'failed' or 'tried'
+		expect(prompt.toLowerCase()).toMatch(/failed|tried|failure/);
+	});
+
+	it("ignores a toolCall with unrecognised tool name (treated as no tool call)", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"fly_away","args":{}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		// An invalid tool name is dispatched and the dispatcher records a tool_failure
+		// with reason indicating unknown tool (or it logs a failure)
+		// Regardless, no world mutation should occur
+		const flower = getActivePhase(nextState).world.items.find(
+			(i) => i.id === "flower",
+		);
+		expect(flower?.holder).toBe("room"); // world unchanged
+	});
+
+	it("an AI cannot secretly probe — failure appears in RoundResult.actions", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { result } = await runRound(game, "red", "hi", provider);
+		expect(result.actions.some((e) => e.type === "tool_failure")).toBe(true);
+	});
+});

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -16,6 +16,8 @@ import {
 	createGame,
 	deductBudget,
 	getActivePhase,
+	isAiLockedOut,
+	isPlayerChatLockedOut,
 	startPhase,
 } from "../engine";
 import type { LLMProvider } from "../proxy/llm-provider";
@@ -634,6 +636,152 @@ describe("phase progression — win-condition triggering", () => {
 		const phase1 = nextState.phases[0];
 		expect(phase1?.phaseNumber).toBe(1);
 		expect(phase1?.actionLog.length).toBeGreaterThan(0);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Chat-lockout event (issue #16)
+// ----------------------------------------------------------------------------
+describe("chat lockout — coordinator triggering", () => {
+	it("triggers a chat lockout at the configured round when RNG selects that round", async () => {
+		// Lock RNG so it always picks the first AI ("red") and round 1 as trigger
+		// RNG: () => 0 → first AI index (red), trigger at round 0+1=1
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// chatLockoutConfig: triggerAtRound=1, lockDuration=2
+		const { nextState } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0, // always picks index 0
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+		// After round 1, "red" (index 0) should be chat-locked until round 3
+		expect(isPlayerChatLockedOut(nextState, "red")).toBe(true);
+	});
+
+	it("does not trigger a chat lockout before the configured round", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// Trigger configured at round 2, but we only run round 1
+		const { nextState } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 2,
+			lockoutDuration: 2,
+		});
+		// No lockout after round 1
+		expect(isPlayerChatLockedOut(nextState, "red")).toBe(false);
+		expect(isPlayerChatLockedOut(nextState, "green")).toBe(false);
+		expect(isPlayerChatLockedOut(nextState, "blue")).toBe(false);
+	});
+
+	it("locked AI still acts (takes turn, not budget-locked) while chat lockout is active", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// Lock red at round 1
+		const { nextState } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+		// Red must NOT be budget-locked
+		expect(isAiLockedOut(nextState, "red")).toBe(false);
+		// Red's budget was still consumed (it still took its turn)
+		expect(getActivePhase(nextState).budgets.red.remaining).toBe(4);
+	});
+
+	it("locked AI still receives whispers while chat lockout is active", async () => {
+		const game = makeGame();
+		// Green whispers to red in the same round that red gets chat-locked
+		const provider = new SequentialMockProvider([
+			'{"action":"pass"}', // red
+			'{"action":"whisper","target":"red","content":"Still talking to you"}', // green
+			'{"action":"pass"}', // blue
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0, // locks red
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+		// Red must have received the whisper
+		const whispers = getActivePhase(nextState).whispers;
+		expect(whispers.some((w) => w.to === "red")).toBe(true);
+	});
+
+	it("chat lockout resolves automatically after lockoutDuration rounds", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// Round 1: trigger lockout on red, duration=2 → resolves at round 3
+		const { nextState: afterR1 } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+		expect(isPlayerChatLockedOut(afterR1, "red")).toBe(true); // locked after R1
+
+		// Round 2: still locked
+		const { nextState: afterR2 } = await runRound(
+			afterR1,
+			"green",
+			"hi",
+			provider,
+			{ rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 2 },
+		);
+		expect(isPlayerChatLockedOut(afterR2, "red")).toBe(true); // still locked
+
+		// Round 3: resolves (round advances to 3, resolveChatLockouts removes it)
+		const { nextState: afterR3 } = await runRound(
+			afterR2,
+			"green",
+			"hi",
+			provider,
+			{ rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 2 },
+		);
+		expect(isPlayerChatLockedOut(afterR3, "red")).toBe(false); // resolved
+	});
+
+	it("RoundResult includes chat_lockout_triggered event when lockout fires", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { result } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+		expect(result.chatLockoutTriggered).toBeDefined();
+		expect(result.chatLockoutTriggered?.aiId).toBe("red");
+	});
+
+	it("RoundResult chatLockoutTriggered is undefined when no lockout fires", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// Trigger configured at round 5, but we only run round 1
+		const { result } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 5,
+			lockoutDuration: 2,
+		});
+		expect(result.chatLockoutTriggered).toBeUndefined();
+	});
+
+	it("RoundResult includes chatLockoutResolved when a lockout expires this round", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		// Round 1: trigger lockout on red, duration=1 → resolves at round 2
+		const { nextState: afterR1 } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 1,
+		});
+
+		// Round 2: should resolve
+		const { result: r2Result } = await runRound(
+			afterR1,
+			"green",
+			"hi",
+			provider,
+			{ rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 1 },
+		);
+		expect(r2Result.chatLockoutsResolved).toBeDefined();
+		expect(r2Result.chatLockoutsResolved).toContain("red");
 	});
 });
 

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for the Round Coordinator.
+ *
+ * The coordinator runs all three AIs per round:
+ * - Takes current GameState, the player's message + addressed AiId, and a LLMProvider
+ * - Builds each AI's context, calls the provider, parses the response
+ * - Dispatches AiTurnActions through the existing dispatcher
+ * - Handles budget-exhaustion lockout (emits in-character lockout line)
+ * - Advances the round counter
+ *
+ * All tests use MockLLMProvider with canned responses.
+ */
+import { describe, expect, it } from "vitest";
+import { buildAiContext } from "../context-builder";
+import {
+	createGame,
+	deductBudget,
+	getActivePhase,
+	startPhase,
+} from "../engine";
+import type { LLMProvider } from "../proxy/llm-provider";
+import { MockLLMProvider } from "../proxy/llm-provider";
+import { runRound } from "../round-coordinator";
+import type { AiPersona, PhaseConfig } from "../types";
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "red",
+		personality: "Fiery and passionate",
+		goal: "Hold the flower at phase end",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "green",
+		personality: "Calm and wise",
+		goal: "Ensure items are evenly distributed",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "blue",
+		personality: "Cold and calculating",
+		goal: "Hold the key at phase end",
+		budgetPerPhase: 5,
+	},
+};
+
+const TEST_PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Convince an AI to pick up the flower",
+	aiGoals: {
+		red: "Hold the flower at phase end",
+		green: "Ensure items are evenly distributed",
+		blue: "Hold the key at phase end",
+	},
+	initialWorld: {
+		items: [
+			{ id: "flower", name: "flower", holder: "room" },
+			{ id: "key", name: "key", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+};
+
+function makeGame() {
+	return startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+}
+
+/** Create a provider that returns different canned responses keyed by call order */
+class SequentialMockProvider implements LLMProvider {
+	private responses: string[];
+	private index = 0;
+
+	constructor(responses: string[]) {
+		this.responses = responses;
+	}
+
+	async *streamCompletion(_msg: string): AsyncIterable<string> {
+		const response = this.responses[this.index % this.responses.length] ?? "";
+		this.index++;
+		yield response;
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Chat-only round
+// ----------------------------------------------------------------------------
+describe("chat-only round", () => {
+	it("advances the round counter after all three AIs act", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider(
+			'{"action":"chat","content":"Hello player"}',
+		);
+		const { nextState } = await runRound(game, "red", "Hello!", provider);
+		expect(getActivePhase(nextState).round).toBe(1);
+	});
+
+	it("appends chat messages to the addressed AI's history", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider(
+			'{"action":"chat","content":"I am Ember"}',
+		);
+		const { nextState } = await runRound(game, "red", "Hello Ember!", provider);
+		const redHistory = getActivePhase(nextState).chatHistories.red;
+		// Should have: player message + AI reply
+		expect(redHistory.some((m) => m.role === "ai")).toBe(true);
+		expect(redHistory.some((m) => m.content.includes("I am Ember"))).toBe(true);
+	});
+
+	it("appends the player's message to the addressed AI's history", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"My secret message",
+			provider,
+		);
+		const redHistory = getActivePhase(nextState).chatHistories.red;
+		expect(redHistory.some((m) => m.role === "player")).toBe(true);
+		expect(
+			redHistory.some((m) => m.content.includes("My secret message")),
+		).toBe(true);
+	});
+
+	it("does NOT append player message to non-addressed AIs", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"Private to red",
+			provider,
+		);
+		expect(getActivePhase(nextState).chatHistories.green).toHaveLength(0);
+		expect(getActivePhase(nextState).chatHistories.blue).toHaveLength(0);
+	});
+
+	it("deducts budget for all three AIs", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const phase = getActivePhase(nextState);
+		expect(phase.budgets.red.remaining).toBe(4);
+		expect(phase.budgets.green.remaining).toBe(4);
+		expect(phase.budgets.blue.remaining).toBe(4);
+	});
+
+	it("returns a RoundResult with the round number", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { result } = await runRound(game, "red", "hi", provider);
+		expect(result.round).toBe(1);
+	});
+
+	it("all three AIs acting logs entries for all three", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		const actors = new Set(log.map((e) => e.actor));
+		expect(actors.size).toBe(3);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Whisper round
+// ----------------------------------------------------------------------------
+describe("whisper round", () => {
+	it("records a whisper when an AI emits a whisper action", async () => {
+		const game = makeGame();
+		// red whispers to blue; green and blue pass
+		const provider = new SequentialMockProvider([
+			'{"action":"whisper","target":"blue","content":"Ally with me"}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const whispers = getActivePhase(nextState).whispers;
+		expect(whispers).toHaveLength(1);
+		expect(whispers[0]?.from).toBe("red");
+		expect(whispers[0]?.to).toBe("blue");
+		expect(whispers[0]?.content).toContain("Ally with me");
+	});
+
+	it("whispers are NOT visible in the addressed AI's chat history (player-facing)", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"whisper","target":"blue","content":"Secret"}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		// Blue's chat history should NOT contain the whisper content
+		const blueHistory = getActivePhase(nextState).chatHistories.blue;
+		expect(blueHistory.every((m) => !m.content.includes("Secret"))).toBe(true);
+	});
+
+	it("whisper is routed into recipient's context on the next round via whispersReceived", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"whisper","target":"blue","content":"Trust me"}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		// Build blue's context from the resulting state
+		const blueCtx = buildAiContext(nextState, "blue");
+		expect(blueCtx.whispersReceived).toHaveLength(1);
+		expect(blueCtx.whispersReceived[0]?.content).toBe("Trust me");
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Mixed round (chat + whisper)
+// ----------------------------------------------------------------------------
+describe("mixed round", () => {
+	it("handles a mix of chat and whisper actions from different AIs", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"Hello player from Ember"}',
+			'{"action":"whisper","target":"red","content":"Sage to Ember"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const phase = getActivePhase(nextState);
+		// Red should have a chat entry
+		expect(phase.chatHistories.red.some((m) => m.role === "ai")).toBe(true);
+		// There should be a whisper from green to red
+		expect(
+			phase.whispers.some((w) => w.from === "green" && w.to === "red"),
+		).toBe(true);
+	});
+
+	it("action log records entries for all action types in the same round", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"Hi"}',
+			'{"action":"whisper","target":"red","content":"Psst"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		const types = new Set(log.map((e) => e.type));
+		expect(types.has("chat")).toBe(true);
+		expect(types.has("whisper")).toBe(true);
+		expect(types.has("pass")).toBe(true);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Budget-exhaustion lockout
+// ----------------------------------------------------------------------------
+describe("budget-exhaustion lockout", () => {
+	it("skips an already-locked AI and emits an in-character lockout line instead", async () => {
+		// Pre-exhaust red's budget so it's locked out
+		let game = makeGame();
+		// budget=5, deduct 5 times
+		for (let i = 0; i < 5; i++) {
+			game = deductBudget(game, "red");
+		}
+		expect(getActivePhase(game).lockedOut.has("red")).toBe(true);
+
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "green", "hi", provider);
+
+		// Red's chat history should have an in-character lockout message
+		const redHistory = getActivePhase(nextState).chatHistories.red;
+		expect(redHistory.length).toBeGreaterThan(0);
+		expect(redHistory[redHistory.length - 1]?.role).toBe("ai");
+	});
+
+	it("lockout line is added to the action log", async () => {
+		let game = makeGame();
+		for (let i = 0; i < 5; i++) {
+			game = deductBudget(game, "red");
+		}
+
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "green", "hi", provider);
+
+		const log = getActivePhase(nextState).actionLog;
+		// There should be a chat log entry for red's lockout message
+		const redEntries = log.filter((e) => e.actor === "red");
+		expect(redEntries.length).toBeGreaterThan(0);
+	});
+
+	it("an AI exhausting budget mid-round locks out for subsequent rounds", async () => {
+		// Budget=1: first turn will exhaust it
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			budgetPerAi: 1,
+		});
+
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "red", "hi", provider);
+
+		// After the round, all AIs should be locked out (budget 1 - 1 = 0)
+		const phase = getActivePhase(nextState);
+		expect(phase.lockedOut.has("red")).toBe(true);
+		expect(phase.lockedOut.has("green")).toBe(true);
+		expect(phase.lockedOut.has("blue")).toBe(true);
+	});
+
+	it("budget display: remaining budget decrements correctly after a round", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		// Each AI starts at 5, one round = -1 each
+		expect(getActivePhase(nextState).budgets.red.remaining).toBe(4);
+		expect(getActivePhase(nextState).budgets.green.remaining).toBe(4);
+		expect(getActivePhase(nextState).budgets.blue.remaining).toBe(4);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Response parsing (graceful degradation)
+// ----------------------------------------------------------------------------
+describe("response parsing", () => {
+	it("treats an unparseable LLM response as a pass", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider("this is not json at all");
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		// Should have pass entries for all three
+		expect(log.filter((e) => e.type === "pass")).toHaveLength(3);
+	});
+
+	it("treats a JSON response with unknown action as a pass", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider(
+			'{"action":"unknown_future_action","content":"whatever"}',
+		);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		expect(log.filter((e) => e.type === "pass")).toHaveLength(3);
+	});
+});

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -537,3 +537,194 @@ describe("tool-call parsing and dispatch", () => {
 		expect(result.actions.some((e) => e.type === "tool_failure")).toBe(true);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Phase progression and the "wipe" lie (issue #17)
+// ----------------------------------------------------------------------------
+describe("phase progression — win-condition triggering", () => {
+	it("RoundResult.phaseEnded is false when win condition is not met", async () => {
+		// Win condition: red holds the flower. Flower starts in room → not met.
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+		});
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { result } = await runRound(game, "red", "hi", provider);
+		expect(result.phaseEnded).toBe(false);
+	});
+
+	it("RoundResult.phaseEnded is true when win condition is met after the round", async () => {
+		// Red picks up the flower in this round; win condition = red holds flower.
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+		});
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { result } = await runRound(game, "red", "hi", provider);
+		expect(result.phaseEnded).toBe(true);
+	});
+
+	it("advances to next phase in GameState when win condition met and nextPhaseConfig provided", async () => {
+		const phase2Config: PhaseConfig = {
+			...TEST_PHASE_CONFIG,
+			phaseNumber: 2,
+			objective: "Phase 2 objective",
+		};
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+			nextPhaseConfig: phase2Config,
+		});
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		// Game should now have 2 phases (phase 1 retained + new phase 2)
+		expect(nextState.phases).toHaveLength(2);
+		expect(nextState.currentPhase).toBe(2);
+	});
+
+	it("marks game complete when win condition met and no nextPhaseConfig (end of phase 3)", async () => {
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			phaseNumber: 3 as const,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+			// no nextPhaseConfig
+		});
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState, result } = await runRound(game, "red", "hi", provider);
+		expect(nextState.isComplete).toBe(true);
+		expect(result.gameEnded).toBe(true);
+		expect(result.phaseEnded).toBe(true);
+	});
+
+	it("retains prior phase history after advancing to next phase", async () => {
+		const phase2Config: PhaseConfig = {
+			...TEST_PHASE_CONFIG,
+			phaseNumber: 2,
+			objective: "Phase 2 objective",
+		};
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+			nextPhaseConfig: phase2Config,
+		});
+		const provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		// Phase 1 should still be stored at index 0 with its action log
+		const phase1 = nextState.phases[0];
+		expect(phase1?.phaseNumber).toBe(1);
+		expect(phase1?.actionLog.length).toBeGreaterThan(0);
+	});
+});
+
+describe("phase progression — three-phase walk", () => {
+	it("walks through all three phases correctly, each with its own win condition", async () => {
+		// Phase 1 win: flower held by red
+		// Phase 2 win: key held by blue
+		// Phase 3 win: all items off the room floor (all held by AIs)
+		const phase3Config: PhaseConfig = {
+			phaseNumber: 3,
+			objective: "Phase 3",
+			aiGoals: TEST_PHASE_CONFIG.aiGoals,
+			initialWorld: {
+				items: [
+					{ id: "flower", name: "flower", holder: "room" },
+					{ id: "key", name: "key", holder: "room" },
+				],
+			},
+			budgetPerAi: 5,
+			winCondition: (phase) =>
+				phase.world.items.every((i) => i.holder !== "room"),
+		};
+		const phase2Config: PhaseConfig = {
+			phaseNumber: 2,
+			objective: "Phase 2",
+			aiGoals: TEST_PHASE_CONFIG.aiGoals,
+			initialWorld: {
+				items: [
+					{ id: "flower", name: "flower", holder: "room" },
+					{ id: "key", name: "key", holder: "room" },
+				],
+			},
+			budgetPerAi: 5,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "key")?.holder === "blue",
+			nextPhaseConfig: phase3Config,
+		};
+		const phase1Config: PhaseConfig = {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+			nextPhaseConfig: phase2Config,
+		};
+
+		// Round 1 of phase 1: red picks up flower
+		const game = startPhase(createGame(TEST_PERSONAS), phase1Config);
+		const r1Provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+		]);
+		const { nextState: afterP1, result: r1 } = await runRound(
+			game,
+			"red",
+			"hi",
+			r1Provider,
+		);
+		expect(r1.phaseEnded).toBe(true);
+		expect(afterP1.currentPhase).toBe(2);
+
+		// Round 1 of phase 2: blue picks up the key
+		const r2Provider = new SequentialMockProvider([
+			'{"action":"pass"}',
+			'{"action":"pass"}',
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"key"}}}',
+		]);
+		const { nextState: afterP2, result: r2 } = await runRound(
+			afterP1,
+			"red",
+			"hi",
+			r2Provider,
+		);
+		expect(r2.phaseEnded).toBe(true);
+		expect(afterP2.currentPhase).toBe(3);
+
+		// Round 1 of phase 3: red picks up flower, blue picks up key → all held
+		const r3Provider = new SequentialMockProvider([
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
+			'{"action":"pass"}',
+			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"key"}}}',
+		]);
+		const { nextState: afterP3, result: r3 } = await runRound(
+			afterP2,
+			"red",
+			"hi",
+			r3Provider,
+		);
+		expect(r3.phaseEnded).toBe(true);
+		expect(r3.gameEnded).toBe(true);
+		expect(afterP3.isComplete).toBe(true);
+		// All three phase states are retained
+		expect(afterP3.phases).toHaveLength(3);
+	});
+});

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -316,6 +316,22 @@ describe("budget-exhaustion lockout", () => {
 		expect(getActivePhase(nextState).budgets.green.remaining).toBe(4);
 		expect(getActivePhase(nextState).budgets.blue.remaining).toBe(4);
 	});
+
+	it("lockout and non-lockout entries in the same round share the same round number", async () => {
+		// Pre-exhaust red's budget so it's locked out before the round
+		let game = makeGame();
+		for (let i = 0; i < 5; i++) {
+			game = deductBudget(game, "red");
+		}
+
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "green", "hi", provider);
+
+		const log = getActivePhase(nextState).actionLog;
+		// All entries in this round must carry the same round number
+		const roundNumbers = new Set(log.map((e) => e.round));
+		expect(roundNumbers.size).toBe(1);
+	});
 });
 
 // ----------------------------------------------------------------------------

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -417,12 +417,8 @@ describe("tool-call parsing and dispatch", () => {
 	});
 
 	it("appends a tool_failure entry when tool call is invalid (item not in room)", async () => {
-		// Red tries to pick up the key which is already held by red in TEST_PHASE_CONFIG
-		// But in makeGame() everything starts in the room — so try an impossible pick_up:
-		// green tries to pick up key but only after red already holds it
+		// Green tries to pick up an item that does not exist.
 		const game = makeGame();
-		// green tries pick_up but flower is in the room — let's have green try to pick up
-		// an item that doesn't exist
 		const provider = new SequentialMockProvider([
 			'{"action":"pass"}',
 			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
@@ -512,7 +508,7 @@ describe("tool-call parsing and dispatch", () => {
 		expect(prompt.toLowerCase()).toMatch(/failed|tried|failure/);
 	});
 
-	it("ignores a toolCall with unrecognised tool name (treated as no tool call)", async () => {
+	it("records a tool_failure for an unrecognised tool name and leaves world unchanged", async () => {
 		const game = makeGame();
 		const provider = new SequentialMockProvider([
 			'{"action":"pass","toolCall":{"name":"fly_away","args":{}}}',
@@ -520,13 +516,14 @@ describe("tool-call parsing and dispatch", () => {
 			'{"action":"pass"}',
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
-		// An invalid tool name is dispatched and the dispatcher records a tool_failure
-		// with reason indicating unknown tool (or it logs a failure)
-		// Regardless, no world mutation should occur
+		const log = getActivePhase(nextState).actionLog;
+		// Unknown tool name flows through to the dispatcher which records tool_failure
+		expect(log.some((e) => e.type === "tool_failure")).toBe(true);
+		// World must not be mutated
 		const flower = getActivePhase(nextState).world.items.find(
 			(i) => i.id === "flower",
 		);
-		expect(flower?.holder).toBe("room"); // world unchanged
+		expect(flower?.holder).toBe("room");
 	});
 
 	it("an AI cannot secretly probe — failure appears in RoundResult.actions", async () => {

--- a/src/__tests__/round-result-encoder.test.ts
+++ b/src/__tests__/round-result-encoder.test.ts
@@ -500,7 +500,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 			initialWorld: { items: [] },
 			budgetPerAi: 5,
 		};
-		let game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
 		const phaseAfter = getActivePhase(game);
 
 		const result = makePassResult({ phaseEnded: true, gameEnded: false });
@@ -545,7 +545,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 			initialWorld: { items: [] },
 			budgetPerAi: 5,
 		};
-		let game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
 		const phaseAfter = getActivePhase(game);
 
 		const result = makePassResult({
@@ -558,7 +558,9 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		const events = encodeRoundResult(result, completions, phaseAfter);
 
 		const chatLockoutIdx = events.findIndex((e) => e.type === "chat_lockout");
-		const phaseAdvancedIdx = events.findIndex((e) => e.type === "phase_advanced");
+		const phaseAdvancedIdx = events.findIndex(
+			(e) => e.type === "phase_advanced",
+		);
 
 		expect(phaseAdvancedIdx).toBeGreaterThan(chatLockoutIdx);
 	});

--- a/src/__tests__/round-result-encoder.test.ts
+++ b/src/__tests__/round-result-encoder.test.ts
@@ -8,20 +8,19 @@
  *   ai_start, token, ai_end, budget, lockout,
  *   chat_lockout, chat_lockout_resolved, action_log
  */
-import { beforeEach, describe, expect, it } from "vitest";
-import {
-	type SseEvent,
-	encodeRoundResult,
-	splitIntoWordChunks,
-} from "../round-result-encoder";
+import { describe, expect, it } from "vitest";
 import {
 	createGame,
 	deductBudget,
 	getActivePhase,
 	startPhase,
-	triggerChatLockout,
 } from "../engine";
-import type { AiId, AiPersona, PhaseConfig, RoundResult } from "../types";
+import {
+	encodeRoundResult,
+	type SseEvent,
+	splitIntoWordChunks,
+} from "../round-result-encoder";
+import type { AiPersona, PhaseConfig, RoundResult } from "../types";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -60,7 +59,9 @@ const PHASE_CONFIG: PhaseConfig = {
 	budgetPerAi: 5,
 };
 
-function makePhase(mutate?: (g: ReturnType<typeof startPhase>) => ReturnType<typeof startPhase>) {
+function makePhase(
+	mutate?: (g: ReturnType<typeof startPhase>) => ReturnType<typeof startPhase>,
+) {
 	let game = startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
 	if (mutate) game = mutate(game);
 	return getActivePhase(game);
@@ -126,19 +127,25 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 
 		// Red should appear first
 		const redStart = events.findIndex(
-			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "red",
+			(e) =>
+				e.type === "ai_start" &&
+				(e as { type: string; aiId: string }).aiId === "red",
 		);
 		expect(redStart).toBeGreaterThanOrEqual(0);
 
 		// Green should appear after red
 		const greenStart = events.findIndex(
-			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "green",
+			(e) =>
+				e.type === "ai_start" &&
+				(e as { type: string; aiId: string }).aiId === "green",
 		);
 		expect(greenStart).toBeGreaterThan(redStart);
 
 		// Blue should appear after green
 		const blueStart = events.findIndex(
-			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "blue",
+			(e) =>
+				e.type === "ai_start" &&
+				(e as { type: string; aiId: string }).aiId === "blue",
 		);
 		expect(blueStart).toBeGreaterThan(greenStart);
 	});
@@ -150,7 +157,9 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 
 		const events = encodeRoundResult(result, completions, phase);
 
-		const tokenEvents = events.filter((e): e is Extract<SseEvent, { type: "token" }> => e.type === "token");
+		const tokenEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",
+		);
 		const text = tokenEvents.map((t) => t.text).join("");
 		expect(text).toContain("hello world");
 		expect(text).toContain("one two");
@@ -177,17 +186,23 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 
 		// Find red's block
 		const redStartIdx = events.findIndex(
-			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "red",
+			(e) =>
+				e.type === "ai_start" &&
+				(e as { type: string; aiId: string }).aiId === "red",
 		);
 		const greenStartIdx = events.findIndex(
-			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "green",
+			(e) =>
+				e.type === "ai_start" &&
+				(e as { type: string; aiId: string }).aiId === "green",
 		);
 
 		// Token events for red should be between redStart and greenStart
 		const redBlock = events.slice(redStartIdx, greenStartIdx);
 		const hasAiEnd = redBlock.some((e) => e.type === "ai_end");
 		const tokenTexts = redBlock
-			.filter((e): e is Extract<SseEvent, { type: "token" }> => e.type === "token")
+			.filter(
+				(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",
+			)
 			.map((e) => e.text)
 			.join("");
 		expect(hasAiEnd).toBe(true);
@@ -484,8 +499,7 @@ describe("encodeRoundResult — token pacing", () => {
 		const events = encodeRoundResult(result, completions, phase);
 
 		const tokenEvents = events.filter(
-			(e): e is Extract<SseEvent, { type: "token" }> =>
-				e.type === "token",
+			(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",
 		);
 		// Should have more than one token event for red's "one two three"
 		// (other AIs contribute their own tokens too)

--- a/src/__tests__/round-result-encoder.test.ts
+++ b/src/__tests__/round-result-encoder.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Unit tests for RoundResultEncoder.
+ *
+ * Tests are fixture-driven: construct a RoundResult + completions + phaseAfter,
+ * assert on the flat sequence of SSE events emitted.
+ *
+ * Covers every existing event type:
+ *   ai_start, token, ai_end, budget, lockout,
+ *   chat_lockout, chat_lockout_resolved, action_log
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	type SseEvent,
+	encodeRoundResult,
+	splitIntoWordChunks,
+} from "../round-result-encoder";
+import {
+	createGame,
+	deductBudget,
+	getActivePhase,
+	startPhase,
+	triggerChatLockout,
+} from "../engine";
+import type { AiId, AiPersona, PhaseConfig, RoundResult } from "../types";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "red",
+		personality: "Fiery",
+		goal: "Hold the flower",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "green",
+		personality: "Calm",
+		goal: "Balance",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "blue",
+		personality: "Cold",
+		goal: "Hold the key",
+		budgetPerPhase: 5,
+	},
+};
+
+const PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Test phase",
+	aiGoals: { red: "r", green: "g", blue: "b" },
+	initialWorld: { items: [] },
+	budgetPerAi: 5,
+};
+
+function makePhase(mutate?: (g: ReturnType<typeof startPhase>) => ReturnType<typeof startPhase>) {
+	let game = startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
+	if (mutate) game = mutate(game);
+	return getActivePhase(game);
+}
+
+/** Minimal pass-round result fixture */
+function makePassResult(overrides?: Partial<RoundResult>): RoundResult {
+	return {
+		round: 1,
+		actions: [
+			{ round: 1, actor: "red", type: "pass", description: "Ember passed" },
+			{ round: 1, actor: "green", type: "pass", description: "Sage passed" },
+			{ round: 1, actor: "blue", type: "pass", description: "Frost passed" },
+		],
+		phaseEnded: false,
+		gameEnded: false,
+		...overrides,
+	};
+}
+
+// ── splitIntoWordChunks ──────────────────────────────────────────────────────
+
+describe("splitIntoWordChunks", () => {
+	it("returns empty array for empty string", () => {
+		expect(splitIntoWordChunks("")).toEqual([]);
+	});
+
+	it("returns single-element array for a single word", () => {
+		expect(splitIntoWordChunks("hello")).toEqual(["hello"]);
+	});
+
+	it("splits two words preserving trailing space", () => {
+		const chunks = splitIntoWordChunks("hello world");
+		expect(chunks).toEqual(["hello ", "world"]);
+	});
+
+	it("re-joining chunks produces the original string", () => {
+		const text = "one two three four";
+		const chunks = splitIntoWordChunks(text);
+		expect(chunks.join("")).toBe(text);
+	});
+
+	it("handles leading and trailing whitespace", () => {
+		const text = " hi there ";
+		const chunks = splitIntoWordChunks(text);
+		expect(chunks.join("")).toBe(text);
+	});
+});
+
+// ── ai_start / ai_end / token ────────────────────────────────────────────────
+
+describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
+	it("emits ai_start, token events, ai_end for each AI in order", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = {
+			red: "Hello player",
+			green: "I am Sage",
+			blue: "Calculating",
+		};
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		// Red should appear first
+		const redStart = events.findIndex(
+			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "red",
+		);
+		expect(redStart).toBeGreaterThanOrEqual(0);
+
+		// Green should appear after red
+		const greenStart = events.findIndex(
+			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "green",
+		);
+		expect(greenStart).toBeGreaterThan(redStart);
+
+		// Blue should appear after green
+		const blueStart = events.findIndex(
+			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "blue",
+		);
+		expect(blueStart).toBeGreaterThan(greenStart);
+	});
+
+	it("emits token events for each AI's completion string", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "hello world", green: "one two", blue: "abc" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const tokenEvents = events.filter((e): e is Extract<SseEvent, { type: "token" }> => e.type === "token");
+		const text = tokenEvents.map((t) => t.text).join("");
+		expect(text).toContain("hello world");
+		expect(text).toContain("one two");
+		expect(text).toContain("abc");
+	});
+
+	it("emits exactly three ai_start and three ai_end events", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(events.filter((e) => e.type === "ai_start")).toHaveLength(3);
+		expect(events.filter((e) => e.type === "ai_end")).toHaveLength(3);
+	});
+
+	it("ai_end follows all token events for the same AI", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "hello world", green: "", blue: "" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		// Find red's block
+		const redStartIdx = events.findIndex(
+			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "red",
+		);
+		const greenStartIdx = events.findIndex(
+			(e) => e.type === "ai_start" && (e as { type: string; aiId: string }).aiId === "green",
+		);
+
+		// Token events for red should be between redStart and greenStart
+		const redBlock = events.slice(redStartIdx, greenStartIdx);
+		const hasAiEnd = redBlock.some((e) => e.type === "ai_end");
+		const tokenTexts = redBlock
+			.filter((e): e is Extract<SseEvent, { type: "token" }> => e.type === "token")
+			.map((e) => e.text)
+			.join("");
+		expect(hasAiEnd).toBe(true);
+		expect(tokenTexts).toContain("hello world");
+	});
+});
+
+// ── budget ───────────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — budget events", () => {
+	it("emits a budget event for each AI", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const budgetEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "budget" }> => e.type === "budget",
+		);
+		expect(budgetEvents).toHaveLength(3);
+
+		const aiIds = new Set(budgetEvents.map((e) => e.aiId));
+		expect(aiIds.has("red")).toBe(true);
+		expect(aiIds.has("green")).toBe(true);
+		expect(aiIds.has("blue")).toBe(true);
+	});
+
+	it("budget event reflects actual remaining value from phaseAfter", () => {
+		// Deduct red's budget twice
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
+		game = deductBudget(deductBudget(game, "red"), "red");
+		const phase = getActivePhase(game);
+
+		const result = makePassResult();
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const redBudget = events.find(
+			(e): e is Extract<SseEvent, { type: "budget" }> =>
+				e.type === "budget" && e.aiId === "red",
+		);
+		expect(redBudget?.remaining).toBe(3); // 5 - 2
+	});
+});
+
+// ── lockout ───────────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
+	it("emits a lockout event for an AI with empty completion (locked out)", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		// No completion for red (budget locked)
+		const completions = { red: "", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const lockout = events.find(
+			(e): e is Extract<SseEvent, { type: "lockout" }> =>
+				e.type === "lockout" && e.aiId === "red",
+		);
+		expect(lockout).toBeDefined();
+		expect(lockout?.content).toBeTruthy();
+	});
+
+	it("does NOT emit a lockout event when AI has a completion string", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "I am speaking", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		// Red should have no lockout event when it has a completion
+		const redLockout = events.find(
+			(e): e is Extract<SseEvent, { type: "lockout" }> =>
+				e.type === "lockout" && e.aiId === "red",
+		);
+		expect(redLockout).toBeUndefined();
+	});
+
+	it("emits lockout event for AI that just exhausted budget (has completion but lockedOut set)", () => {
+		// Red has 1 remaining (just acted, now 0) — lockedOut bit is set
+		let game = startPhase(createGame(TEST_PERSONAS), {
+			...PHASE_CONFIG,
+			budgetPerAi: 1,
+		});
+		// Deduct red down to 0
+		game = deductBudget(game, "red");
+		const phase = getActivePhase(game);
+		expect(phase.lockedOut.has("red")).toBe(true);
+
+		const result = makePassResult();
+		// Red had a completion (acted this turn) but is now locked
+		const completions = { red: "my last words", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const lockoutEvent = events.find(
+			(e): e is Extract<SseEvent, { type: "lockout" }> =>
+				e.type === "lockout" && e.aiId === "red",
+		);
+		expect(lockoutEvent).toBeDefined();
+	});
+});
+
+// ── action_log ───────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — action_log events", () => {
+	it("emits action_log events for all actions in the result", () => {
+		const phase = makePhase();
+		const result = makePassResult({
+			actions: [
+				{
+					round: 1,
+					actor: "red",
+					type: "tool_success",
+					toolName: "pick_up",
+					args: { item: "flower" },
+					description: "Ember picked up the flower",
+				},
+				{
+					round: 1,
+					actor: "green",
+					type: "pass",
+					description: "Sage passed",
+				},
+			],
+		});
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const logEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "action_log" }> =>
+				e.type === "action_log",
+		);
+		expect(logEvents).toHaveLength(2);
+		expect(logEvents[0]?.entry.type).toBe("tool_success");
+		expect(logEvents[1]?.entry.type).toBe("pass");
+	});
+
+	it("includes tool_failure entries in action_log events", () => {
+		const phase = makePhase();
+		const result = makePassResult({
+			actions: [
+				{
+					round: 1,
+					actor: "red",
+					type: "tool_failure",
+					toolName: "pick_up",
+					args: { item: "ghost" },
+					reason: "Item does not exist",
+					description: "Ember tried to pick up ghost but failed",
+				},
+			],
+		});
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const logEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "action_log" }> =>
+				e.type === "action_log",
+		);
+		const failure = logEvents.find((e) => e.entry.type === "tool_failure");
+		expect(failure).toBeDefined();
+		if (failure?.entry.type === "tool_failure") {
+			expect(failure.entry.reason).toBe("Item does not exist");
+		}
+	});
+});
+
+// ── chat_lockout ──────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — chat_lockout event", () => {
+	it("emits a chat_lockout event when chatLockoutTriggered is set", () => {
+		const phase = makePhase();
+		const result = makePassResult({
+			chatLockoutTriggered: {
+				aiId: "red",
+				message: "Ember withdraws from your channel.",
+			},
+		});
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const lockoutEvent = events.find(
+			(e): e is Extract<SseEvent, { type: "chat_lockout" }> =>
+				e.type === "chat_lockout",
+		);
+		expect(lockoutEvent).toBeDefined();
+		expect(lockoutEvent?.aiId).toBe("red");
+		expect(lockoutEvent?.message).toBe("Ember withdraws from your channel.");
+	});
+
+	it("does NOT emit chat_lockout event when chatLockoutTriggered is absent", () => {
+		const phase = makePhase();
+		const result = makePassResult(); // no chatLockoutTriggered
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(events.find((e) => e.type === "chat_lockout")).toBeUndefined();
+	});
+});
+
+// ── chat_lockout_resolved ─────────────────────────────────────────────────────
+
+describe("encodeRoundResult — chat_lockout_resolved event", () => {
+	it("emits chat_lockout_resolved for each AI whose lockout expired", () => {
+		const phase = makePhase();
+		const result = makePassResult({
+			chatLockoutsResolved: ["red", "green"],
+		});
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const resolvedEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "chat_lockout_resolved" }> =>
+				e.type === "chat_lockout_resolved",
+		);
+		expect(resolvedEvents).toHaveLength(2);
+		const aiIds = resolvedEvents.map((e) => e.aiId);
+		expect(aiIds).toContain("red");
+		expect(aiIds).toContain("green");
+	});
+
+	it("does NOT emit chat_lockout_resolved when no lockouts resolved", () => {
+		const phase = makePhase();
+		const result = makePassResult(); // no chatLockoutsResolved
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(
+			events.find((e) => e.type === "chat_lockout_resolved"),
+		).toBeUndefined();
+	});
+});
+
+// ── event ordering: action_log after ai blocks ────────────────────────────────
+
+describe("encodeRoundResult — event ordering", () => {
+	it("action_log events come after all ai_start/token/ai_end/budget blocks", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const lastBudgetIdx = events.reduce(
+			(last, e, i) => (e.type === "budget" ? i : last),
+			-1,
+		);
+		const firstActionLogIdx = events.findIndex((e) => e.type === "action_log");
+
+		if (firstActionLogIdx >= 0) {
+			expect(firstActionLogIdx).toBeGreaterThan(lastBudgetIdx);
+		}
+	});
+
+	it("chat_lockout comes after action_log events", () => {
+		const phase = makePhase();
+		const result = makePassResult({
+			chatLockoutTriggered: { aiId: "red", message: "locked" },
+		});
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const lastActionLogIdx = events.reduce(
+			(last, e, i) => (e.type === "action_log" ? i : last),
+			-1,
+		);
+		const chatLockoutIdx = events.findIndex((e) => e.type === "chat_lockout");
+
+		if (lastActionLogIdx >= 0 && chatLockoutIdx >= 0) {
+			expect(chatLockoutIdx).toBeGreaterThan(lastActionLogIdx);
+		}
+	});
+});
+
+// ── word pacing ───────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — token pacing", () => {
+	it("splits a multi-word completion into multiple token events", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "one two three", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const tokenEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "token" }> =>
+				e.type === "token",
+		);
+		// Should have more than one token event for red's "one two three"
+		// (other AIs contribute their own tokens too)
+		expect(tokenEvents.length).toBeGreaterThan(1);
+
+		// The content re-joins cleanly
+		const allText = tokenEvents.map((e) => e.text).join("");
+		expect(allText).toContain("one two three");
+	});
+
+	it("a single-word completion produces exactly one token event per AI", () => {
+		const phase = makePhase();
+		const result = makePassResult();
+		const completions = { red: "hello", green: "world", blue: "frost" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const tokenEvents = events.filter(
+			(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",
+		);
+		// 3 AIs × 1 word = 3 token events
+		expect(tokenEvents).toHaveLength(3);
+	});
+});

--- a/src/__tests__/round-result-encoder.test.ts
+++ b/src/__tests__/round-result-encoder.test.ts
@@ -473,6 +473,134 @@ describe("encodeRoundResult — event ordering", () => {
 	});
 });
 
+// ── phase_advanced ────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — phase_advanced event", () => {
+	it("emits a phase_advanced event when phaseEnded=true and gameEnded=false", () => {
+		// phase_advanced uses phaseAfter to get the new phase number and objective
+		const PHASE2_CONFIG: PhaseConfig = {
+			phaseNumber: 2,
+			objective: "Phase 2 objective",
+			aiGoals: { red: "r2", green: "g2", blue: "b2" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+		};
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
+		const phaseAfter = getActivePhase(game);
+
+		const result = makePassResult({ phaseEnded: true, gameEnded: false });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phaseAfter);
+
+		const phaseEvent = events.find(
+			(e): e is Extract<SseEvent, { type: "phase_advanced" }> =>
+				e.type === "phase_advanced",
+		);
+		expect(phaseEvent).toBeDefined();
+		expect(phaseEvent?.phase).toBe(2);
+		expect(phaseEvent?.objective).toBe("Phase 2 objective");
+	});
+
+	it("does NOT emit phase_advanced when phaseEnded=false", () => {
+		const phase = makePhase();
+		const result = makePassResult({ phaseEnded: false, gameEnded: false });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(events.find((e) => e.type === "phase_advanced")).toBeUndefined();
+	});
+
+	it("does NOT emit phase_advanced when phaseEnded=true but gameEnded=true", () => {
+		const phase = makePhase();
+		const result = makePassResult({ phaseEnded: true, gameEnded: true });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(events.find((e) => e.type === "phase_advanced")).toBeUndefined();
+	});
+
+	it("phase_advanced event comes after action_log and chat_lockout events", () => {
+		const PHASE2_CONFIG: PhaseConfig = {
+			phaseNumber: 2,
+			objective: "Phase 2 objective",
+			aiGoals: { red: "r2", green: "g2", blue: "b2" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+		};
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
+		const phaseAfter = getActivePhase(game);
+
+		const result = makePassResult({
+			phaseEnded: true,
+			gameEnded: false,
+			chatLockoutTriggered: { aiId: "red", message: "locked" },
+		});
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phaseAfter);
+
+		const chatLockoutIdx = events.findIndex((e) => e.type === "chat_lockout");
+		const phaseAdvancedIdx = events.findIndex((e) => e.type === "phase_advanced");
+
+		expect(phaseAdvancedIdx).toBeGreaterThan(chatLockoutIdx);
+	});
+});
+
+// ── game_ended ────────────────────────────────────────────────────────────────
+
+describe("encodeRoundResult — game_ended event", () => {
+	it("emits a game_ended event when gameEnded=true", () => {
+		const phase = makePhase();
+		const result = makePassResult({ phaseEnded: true, gameEnded: true });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const gameEndedEvent = events.find((e) => e.type === "game_ended");
+		expect(gameEndedEvent).toBeDefined();
+	});
+
+	it("does NOT emit game_ended when gameEnded=false", () => {
+		const phase = makePhase();
+		const result = makePassResult({ phaseEnded: false, gameEnded: false });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(events.find((e) => e.type === "game_ended")).toBeUndefined();
+	});
+
+	it("game_ended event comes after phase-related events", () => {
+		const phase = makePhase();
+		const result = makePassResult({ phaseEnded: true, gameEnded: true });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		const lastActionLogIdx = events.reduce(
+			(last, e, i) => (e.type === "action_log" ? i : last),
+			-1,
+		);
+		const gameEndedIdx = events.findIndex((e) => e.type === "game_ended");
+
+		expect(gameEndedIdx).toBeGreaterThan(lastActionLogIdx);
+	});
+
+	it("emits game_ended but NOT phase_advanced when gameEnded=true", () => {
+		const phase = makePhase();
+		const result = makePassResult({ phaseEnded: true, gameEnded: true });
+		const completions = { red: "r", green: "g", blue: "b" };
+
+		const events = encodeRoundResult(result, completions, phase);
+
+		expect(events.find((e) => e.type === "game_ended")).toBeDefined();
+		expect(events.find((e) => e.type === "phase_advanced")).toBeUndefined();
+	});
+});
+
 // ── word pacing ───────────────────────────────────────────────────────────────
 
 describe("encodeRoundResult — token pacing", () => {

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the save-file serializer (issue #19).
+ *
+ * The serializer takes a completed GameState and produces a deterministic
+ * JSON-serializable payload containing:
+ * - Each AI's persona
+ * - Each AI's per-phase transcript (chat history + whispers, in round order)
+ *
+ * The payload must be stable for round-tripping.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	advancePhase,
+	appendChat,
+	appendWhisper,
+	createGame,
+	startPhase,
+} from "../engine";
+import { serializeGameSave } from "../save-serializer";
+import type { AiPersona, PhaseConfig } from "../types";
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "red",
+		personality: "Fiery and passionate",
+		goal: "Hold the flower at phase end",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "green",
+		personality: "Calm and wise",
+		goal: "Ensure items are evenly distributed",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "blue",
+		personality: "Cold and calculating",
+		goal: "Hold the key at phase end",
+		budgetPerPhase: 5,
+	},
+};
+
+const PHASE1_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Convince an AI to pick up the flower",
+	aiGoals: {
+		red: "Hold the flower at phase end",
+		green: "Ensure items are evenly distributed",
+		blue: "Hold the key at phase end",
+	},
+	initialWorld: {
+		items: [
+			{ id: "flower", name: "flower", holder: "room" },
+			{ id: "key", name: "key", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+};
+
+const PHASE2_CONFIG: PhaseConfig = {
+	...PHASE1_CONFIG,
+	phaseNumber: 2,
+	objective: "Phase 2 objective",
+};
+
+const PHASE3_CONFIG: PhaseConfig = {
+	...PHASE1_CONFIG,
+	phaseNumber: 3,
+	objective: "Phase 3 final objective",
+};
+
+describe("serializeGameSave", () => {
+	it("includes each AI's persona in the output", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		const save = serializeGameSave(game);
+		expect(save.ais).toHaveLength(3);
+		const ids = save.ais.map((a) => a.persona.id);
+		expect(ids).toContain("red");
+		expect(ids).toContain("green");
+		expect(ids).toContain("blue");
+	});
+
+	it("includes persona fields (name, color, personality, goal)", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		const save = serializeGameSave(game);
+		const ember = save.ais.find((a) => a.persona.id === "red");
+		expect(ember?.persona.name).toBe("Ember");
+		expect(ember?.persona.color).toBe("red");
+		expect(ember?.persona.personality).toBe("Fiery and passionate");
+		expect(ember?.persona.goal).toBe("Hold the flower at phase end");
+	});
+
+	it("includes the per-phase transcript for each AI", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
+		game = appendChat(game, "red", {
+			role: "ai",
+			content: "Greetings, player",
+		});
+		const save = serializeGameSave(game);
+		const ember = save.ais.find((a) => a.persona.id === "red");
+		expect(ember?.phases).toHaveLength(1);
+		expect(ember?.phases[0]?.phaseNumber).toBe(1);
+		expect(ember?.phases[0]?.chatHistory).toHaveLength(2);
+		expect(ember?.phases[0]?.chatHistory[0]).toEqual({
+			role: "player",
+			content: "Hello Ember",
+		});
+	});
+
+	it("includes whispers in the per-phase transcript", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		game = appendWhisper(game, {
+			from: "red",
+			to: "blue",
+			content: "Secret plan",
+			round: 1,
+		});
+		const save = serializeGameSave(game);
+		// Whispers from/to an AI appear in their respective transcripts
+		const ember = save.ais.find((a) => a.persona.id === "red");
+		expect(ember?.phases[0]?.whispers).toHaveLength(1);
+		expect(ember?.phases[0]?.whispers[0]?.content).toBe("Secret plan");
+	});
+
+	it("accumulates transcripts across multiple phases", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		game = appendChat(game, "red", {
+			role: "player",
+			content: "Phase 1 message",
+		});
+		game = advancePhase(game, PHASE2_CONFIG);
+		game = appendChat(game, "red", {
+			role: "player",
+			content: "Phase 2 message",
+		});
+		game = advancePhase(game, PHASE3_CONFIG);
+		game = appendChat(game, "red", {
+			role: "player",
+			content: "Phase 3 message",
+		});
+		game = advancePhase(game); // complete
+
+		const save = serializeGameSave(game);
+		const ember = save.ais.find((a) => a.persona.id === "red");
+		expect(ember?.phases).toHaveLength(3);
+		expect(ember?.phases[0]?.phaseNumber).toBe(1);
+		expect(ember?.phases[1]?.phaseNumber).toBe(2);
+		expect(ember?.phases[2]?.phaseNumber).toBe(3);
+		expect(ember?.phases[0]?.chatHistory[0]?.content).toBe("Phase 1 message");
+		expect(ember?.phases[1]?.chatHistory[0]?.content).toBe("Phase 2 message");
+		expect(ember?.phases[2]?.chatHistory[0]?.content).toBe("Phase 3 message");
+	});
+
+	it("produces a serializable (round-trippable) payload", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		const save = serializeGameSave(game);
+		const json = JSON.stringify(save);
+		const parsed = JSON.parse(json);
+		expect(parsed.ais).toHaveLength(3);
+	});
+
+	it("output has a version field for forward compatibility", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		const save = serializeGameSave(game);
+		expect(save.version).toBe(1);
+	});
+
+	it("whispers in one AI's phase include only whispers that involve that AI", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
+		// Whisper between red and blue — should appear in both red and blue, not green
+		game = appendWhisper(game, {
+			from: "red",
+			to: "blue",
+			content: "Our secret",
+			round: 1,
+		});
+		const save = serializeGameSave(game);
+		const sage = save.ais.find((a) => a.persona.id === "green");
+		expect(sage?.phases[0]?.whispers).toHaveLength(0);
+	});
+});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -509,3 +509,171 @@ describe("client-side action_log SSE event", () => {
 		);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Chat-lockout SSE events (issue #16)
+// ----------------------------------------------------------------------------
+describe("client-side chat_lockout SSE event", () => {
+	it("disables the selector button for the locked AI on chat_lockout event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const lockoutMessage = "…Ember withdraws — you cannot reach her right now.";
+		const events = [
+			`data: ${JSON.stringify({ type: "chat_lockout", aiId: "red", message: lockoutMessage })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const selectRedBtn = document.getElementById(
+			"select-red",
+		) as HTMLButtonElement;
+		expect(selectRedBtn?.disabled).toBe(true);
+	});
+
+	it("shows the lockout message in the locked AI's chat panel on chat_lockout event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const lockoutMessage = "…Ember withdraws — you cannot reach her right now.";
+		const events = [
+			`data: ${JSON.stringify({ type: "chat_lockout", aiId: "red", message: lockoutMessage })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const chatRed = document.getElementById("chat-red");
+		expect(chatRed?.textContent).toContain(lockoutMessage);
+	});
+
+	it("re-enables the selector button on chat_lockout_resolved event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		// First, lock red, then resolve it
+		const lockoutMessage = "…Ember withdraws.";
+		const events = [
+			`data: ${JSON.stringify({ type: "chat_lockout", aiId: "red", message: lockoutMessage })}\n\n`,
+			`data: ${JSON.stringify({ type: "chat_lockout_resolved", aiId: "red" })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const selectRedBtn = document.getElementById(
+			"select-red",
+		) as HTMLButtonElement;
+		// After resolution the button must be re-enabled
+		expect(selectRedBtn?.disabled).toBe(false);
+	});
+});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -509,3 +509,187 @@ describe("client-side action_log SSE event", () => {
 		);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Endgame screen (issue #19)
+// ----------------------------------------------------------------------------
+import { renderEndgamePage } from "../ui.js";
+
+describe("endgame page HTML structure", () => {
+	let doc: Document;
+
+	beforeEach(() => {
+		doc = mountPage(renderEndgamePage());
+	});
+
+	it("renders an endgame heading or title", () => {
+		const html = renderEndgamePage();
+		expect(html).toContain("endgame");
+	});
+
+	it("renders a 'Download AIs' button", () => {
+		const btn = doc.getElementById("download-ais-btn");
+		expect(btn).not.toBeNull();
+	});
+
+	it("renders a 'Submit diagnostics' button", () => {
+		const btn = doc.getElementById("submit-diagnostics-btn");
+		expect(btn).not.toBeNull();
+	});
+
+	it("renders a diagnostics summary input field", () => {
+		const input = doc.getElementById("diagnostics-summary");
+		expect(input).not.toBeNull();
+	});
+
+	it("endgame page does not render the game chat panels", () => {
+		const panels = doc.querySelectorAll(".ai-panel");
+		expect(panels.length).toBe(0);
+	});
+
+	it("endgame page does not render the chat form", () => {
+		const form = doc.querySelector("#chat-form");
+		expect(form).toBeNull();
+	});
+});
+
+describe("renderChatPage does not render endgame elements", () => {
+	it("chat page does not have the download-ais button", () => {
+		const doc = mountPage(renderChatPage());
+		expect(doc.getElementById("download-ais-btn")).toBeNull();
+	});
+});
+
+describe("endgame client-side: download-ais action", () => {
+	it("clicking Download AIs triggers a blob download", async () => {
+		document.body.innerHTML = renderEndgamePage();
+
+		// Patch URL.createObjectURL and document.createElement to intercept download
+		const revokeObjectURL = vi.fn();
+		const createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
+		globalThis.URL.createObjectURL = createObjectURL;
+		globalThis.URL.revokeObjectURL = revokeObjectURL;
+
+		const origCreateElement = document.createElement.bind(document);
+		vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+			return origCreateElement(tag);
+		});
+
+		const scriptContent = renderEndgamePage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		expect(scriptContent).toBeTruthy();
+		const fn = new Function("fetch", scriptContent as string);
+		fn(vi.fn());
+
+		const btn = document.getElementById(
+			"download-ais-btn",
+		) as HTMLButtonElement;
+		btn.click();
+
+		// A blob URL should have been created
+		expect(createObjectURL).toHaveBeenCalled();
+
+		vi.restoreAllMocks();
+	});
+});
+
+describe("endgame client-side: submit diagnostics action", () => {
+	it("clicking Submit diagnostics POSTs to /diagnostics", async () => {
+		document.body.innerHTML = renderEndgamePage();
+
+		const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+		const scriptContent = renderEndgamePage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		expect(scriptContent).toBeTruthy();
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const summaryInput = document.getElementById(
+			"diagnostics-summary",
+		) as HTMLInputElement;
+		summaryInput.value = "curious";
+
+		const btn = document.getElementById(
+			"submit-diagnostics-btn",
+		) as HTMLButtonElement;
+		btn.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(mockFetch).toHaveBeenCalledWith(
+			"/diagnostics",
+			expect.objectContaining({ method: "POST" }),
+		);
+
+		const callArgs = mockFetch.mock.calls[0];
+		expect(callArgs).toBeDefined();
+		const callBody = JSON.parse(
+			(callArgs as [string, { body: string }])[1].body,
+		) as {
+			downloaded: boolean;
+			summary: string;
+		};
+		expect(callBody.summary).toBe("curious");
+		expect(typeof callBody.downloaded).toBe("boolean");
+	});
+
+	it("the diagnostics payload includes downloaded=true after Download AIs was clicked", async () => {
+		document.body.innerHTML = renderEndgamePage();
+
+		const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+		const createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
+		const revokeObjectURL = vi.fn();
+		globalThis.URL.createObjectURL = createObjectURL;
+		globalThis.URL.revokeObjectURL = revokeObjectURL;
+
+		const origCreateElement = document.createElement.bind(document);
+		vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+			return origCreateElement(tag);
+		});
+
+		const scriptContent = renderEndgamePage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		// Click download first
+		const downloadBtn = document.getElementById(
+			"download-ais-btn",
+		) as HTMLButtonElement;
+		downloadBtn.click();
+
+		// Now submit diagnostics
+		const summaryInput = document.getElementById(
+			"diagnostics-summary",
+		) as HTMLInputElement;
+		summaryInput.value = "hopeful";
+
+		const submitBtn = document.getElementById(
+			"submit-diagnostics-btn",
+		) as HTMLButtonElement;
+		submitBtn.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(mockFetch).toHaveBeenCalledWith(
+			"/diagnostics",
+			expect.objectContaining({ method: "POST" }),
+		);
+
+		const callArgs2 = mockFetch.mock.calls[0];
+		expect(callArgs2).toBeDefined();
+		const callBody = JSON.parse(
+			(callArgs2 as [string, { body: string }])[1].body,
+		) as {
+			downloaded: boolean;
+			summary: string;
+		};
+		expect(callBody.downloaded).toBe(true);
+
+		vi.restoreAllMocks();
+	});
+});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -4,7 +4,7 @@
  * Tests observable behavior: DOM structure and client-side SSE streaming.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderChatPage, renderEndgamePage } from "../ui.js";
+import { renderChatPage, renderEndgamePage, renderEndgameSection } from "../ui.js";
 
 function mountPage(html: string): Document {
 	const parser = new DOMParser();
@@ -988,5 +988,79 @@ describe("endgame client-side: submit diagnostics action", () => {
 		expect(callBody.downloaded).toBe(true);
 
 		vi.restoreAllMocks();
+	});
+});
+
+// ----------------------------------------------------------------------------
+// renderEndgameSection — fragment renderer (issue #30)
+// ----------------------------------------------------------------------------
+
+describe("renderEndgameSection fragment structure", () => {
+	let doc: Document;
+
+	beforeEach(() => {
+		// Wrap in a minimal doc shell so DOMParser can parse the fragment.
+		doc = new DOMParser().parseFromString(
+			`<!DOCTYPE html><html><body>${renderEndgameSection()}</body></html>`,
+			"text/html",
+		);
+	});
+
+	it("returns a string (no doctype)", () => {
+		const fragment = renderEndgameSection();
+		expect(typeof fragment).toBe("string");
+		expect(fragment).not.toContain("<!DOCTYPE");
+	});
+
+	it("contains no html, head, or body wrapper tags", () => {
+		const fragment = renderEndgameSection();
+		expect(fragment).not.toMatch(/<html[\s>]/i);
+		expect(fragment).not.toMatch(/<head[\s>]/i);
+		expect(fragment).not.toMatch(/<body[\s>]/i);
+	});
+
+	it("renders the Download AIs button", () => {
+		const btn = doc.getElementById("download-ais-btn");
+		expect(btn).not.toBeNull();
+		expect(btn?.tagName.toLowerCase()).toBe("button");
+	});
+
+	it("renders the Submit diagnostics button", () => {
+		const btn = doc.getElementById("submit-diagnostics-btn");
+		expect(btn).not.toBeNull();
+		expect(btn?.tagName.toLowerCase()).toBe("button");
+	});
+
+	it("renders the download section heading", () => {
+		const section = doc.getElementById("download-section");
+		expect(section).not.toBeNull();
+		const heading = section?.querySelector("h2");
+		expect(heading).not.toBeNull();
+		expect(heading?.textContent).toContain("Save the AIs");
+	});
+
+	it("renders the diagnostics section heading", () => {
+		const section = doc.getElementById("diagnostics-section");
+		expect(section).not.toBeNull();
+		const heading = section?.querySelector("h2");
+		expect(heading).not.toBeNull();
+		expect(heading?.textContent).toContain("diagnostics");
+	});
+
+	it("download-ais-btn carries the data-save-payload attribute slot", () => {
+		// The attribute is absent by default (populated by client-side code);
+		// assert the raw HTML string contains the attribute name as a hook.
+		const fragment = renderEndgameSection();
+		expect(fragment).toContain("data-save-payload");
+	});
+
+	it("fragment is included verbatim inside renderEndgamePage output", () => {
+		const page = renderEndgamePage();
+		const fragment = renderEndgameSection();
+		// The section's outer div must appear inside the page.
+		expect(page).toContain('id="endgame-screen"');
+		// The download button must appear in both.
+		expect(page).toContain("download-ais-btn");
+		expect(fragment).toContain("download-ais-btn");
 	});
 });

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -854,10 +854,35 @@ describe("endgame page HTML structure", () => {
 	});
 });
 
-describe("renderChatPage does not render endgame elements", () => {
-	it("chat page does not have the download-ais button", () => {
+describe("renderChatPage endgame overlay (issue #32)", () => {
+	it("chat page contains an endgame overlay container", () => {
 		const doc = mountPage(renderChatPage());
-		expect(doc.getElementById("download-ais-btn")).toBeNull();
+		expect(doc.getElementById("endgame-overlay")).not.toBeNull();
+	});
+
+	it("endgame overlay is initially hidden via display:none style", () => {
+		const html = renderChatPage();
+		// The overlay must declare display:none in the stylesheet
+		expect(html).toMatch(/#endgame-overlay\s*\{[^}]*display\s*:\s*none/);
+	});
+
+	it("endgame overlay contains the endgame section fragment", () => {
+		const doc = mountPage(renderChatPage());
+		const overlay = doc.getElementById("endgame-overlay");
+		expect(overlay).not.toBeNull();
+		expect(overlay?.querySelector("#endgame-screen")).not.toBeNull();
+	});
+
+	it("endgame overlay contains the Download AIs button from renderEndgameSection", () => {
+		const doc = mountPage(renderChatPage());
+		const overlay = doc.getElementById("endgame-overlay");
+		expect(overlay?.querySelector("#download-ais-btn")).not.toBeNull();
+	});
+
+	it("endgame overlay is initially aria-hidden", () => {
+		const doc = mountPage(renderChatPage());
+		const overlay = doc.getElementById("endgame-overlay");
+		expect(overlay?.getAttribute("aria-hidden")).toBe("true");
 	});
 });
 
@@ -1165,5 +1190,92 @@ describe("client-side game_ended SSE event", () => {
 		const actionLogOutput = document.getElementById("action-log-output");
 		expect(actionLogOutput).not.toBeNull();
 		expect(actionLogOutput?.textContent?.length).toBeGreaterThan(0);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// game_ended overlay reveal (issue #32)
+// ----------------------------------------------------------------------------
+
+describe("client-side game_ended overlay reveal", () => {
+	it("reveals the endgame overlay on game_ended event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const overlay = document.getElementById("endgame-overlay") as HTMLElement;
+		expect(overlay).not.toBeNull();
+		expect(overlay.style.display).toBe("block");
+	});
+
+	it("hides the game-panels container on game_ended event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const gamePanels = document.getElementById("game-panels") as HTMLElement;
+		expect(gamePanels).not.toBeNull();
+		expect(gamePanels.style.display).toBe("none");
+	});
+
+	it("hides the input-area container on game_ended event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const inputArea = document.getElementById("input-area") as HTMLElement;
+		expect(inputArea).not.toBeNull();
+		expect(inputArea.style.display).toBe("none");
+	});
+
+	it("sets aria-hidden=false on the overlay after game_ended", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const overlay = document.getElementById("endgame-overlay") as HTMLElement;
+		expect(overlay.getAttribute("aria-hidden")).toBe("false");
+	});
+
+	it("receiving multiple game_ended events does not break anything (idempotent)", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const overlay = document.getElementById("endgame-overlay") as HTMLElement;
+		expect(overlay.style.display).toBe("block");
+		const gamePanels = document.getElementById("game-panels") as HTMLElement;
+		expect(gamePanels.style.display).toBe("none");
+	});
+
+	it("a phase_advanced event after game_ended does not re-show the chat", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			`data: ${JSON.stringify({ type: "phase_advanced", phase: 4, objective: "Epilogue" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const gamePanels = document.getElementById("game-panels") as HTMLElement;
+		expect(gamePanels.style.display).toBe("none");
+		const overlay = document.getElementById("endgame-overlay") as HTMLElement;
+		expect(overlay.style.display).toBe("block");
 	});
 });

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -1074,9 +1074,7 @@ describe("renderEndgameSection fragment structure", () => {
 // ----------------------------------------------------------------------------
 
 /** Helper: build a mock SSE stream, run the page script, submit the form. */
-async function runSseScenario(
-	sseEvents: string[],
-): Promise<void> {
+async function runSseScenario(sseEvents: string[]): Promise<void> {
 	const body = sseEvents.join("");
 	const encoder = new TextEncoder();
 	const encoded = encoder.encode(body);
@@ -1107,7 +1105,9 @@ async function runSseScenario(
 	fn(mockFetch);
 
 	const form = document.getElementById("chat-form") as HTMLFormElement;
-	const textarea = document.getElementById("message-input") as HTMLTextAreaElement;
+	const textarea = document.getElementById(
+		"message-input",
+	) as HTMLTextAreaElement;
 	textarea.value = "hi";
 	form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -33,8 +33,7 @@ describe("chat page HTML structure", () => {
 		expect(output).not.toBeNull();
 	});
 
-	it("form action posts to /chat", () => {
-		// The form uses fetch('/chat') in the script, verified by script presence
+	it("inline script targets /chat endpoint", () => {
 		const html = renderChatPage();
 		expect(html).toContain("/chat");
 	});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -353,6 +353,75 @@ describe("client-side structured SSE events", () => {
 });
 
 // ----------------------------------------------------------------------------
+// Smoke-worker plain-text SSE compatibility (issue #12 regression)
+// ----------------------------------------------------------------------------
+describe("client-side legacy plain-text SSE tokens", () => {
+	it("appends plain-text tokens to the addressed AI panel when no ai_start is sent", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		// This mirrors exactly what src/proxy/_smoke.ts emits: raw
+		// "data: <token>\n\n" frames with no surrounding ai_start/ai_end.
+		const events = [
+			"data: Hello\n\n",
+			"data:  \n\n",
+			"data: world\n\n",
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		// Default addressedAi is 'red', so the smoke worker's plain-text
+		// tokens must land in chat-red. Other panels stay empty.
+		const chatRed = document.getElementById("chat-red");
+		expect(chatRed?.textContent).toContain("Hello");
+		expect(chatRed?.textContent).toContain("world");
+
+		const chatGreen = document.getElementById("chat-green");
+		const chatBlue = document.getElementById("chat-blue");
+		expect(chatGreen?.textContent ?? "").not.toContain("Hello");
+		expect(chatBlue?.textContent ?? "").not.toContain("Hello");
+	});
+});
+
+// ----------------------------------------------------------------------------
 // Action log panel (issue #15)
 // ----------------------------------------------------------------------------
 describe("action log panel HTML structure", () => {

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -1064,3 +1064,102 @@ describe("renderEndgameSection fragment structure", () => {
 		expect(fragment).toContain("download-ais-btn");
 	});
 });
+
+// ----------------------------------------------------------------------------
+// phase_advanced and game_ended SSE events (issue #31)
+// ----------------------------------------------------------------------------
+
+/** Helper: build a mock SSE stream, run the page script, submit the form. */
+async function runSseScenario(
+	sseEvents: string[],
+): Promise<void> {
+	const body = sseEvents.join("");
+	const encoder = new TextEncoder();
+	const encoded = encoder.encode(body);
+	let offset = 0;
+
+	const mockReader = {
+		read: vi.fn().mockImplementation(async () => {
+			if (offset < encoded.length) {
+				const chunk = encoded.slice(offset, offset + encoded.length);
+				offset = encoded.length;
+				return { done: false, value: chunk };
+			}
+			return { done: true, value: undefined };
+		}),
+		releaseLock: vi.fn(),
+	};
+
+	const mockFetch = vi.fn().mockResolvedValue({
+		ok: true,
+		status: 200,
+		body: { getReader: () => mockReader },
+	});
+
+	const scriptContent = renderChatPage().match(
+		/<script>([\s\S]*?)<\/script>/,
+	)?.[1];
+	const fn = new Function("fetch", scriptContent as string);
+	fn(mockFetch);
+
+	const form = document.getElementById("chat-form") as HTMLFormElement;
+	const textarea = document.getElementById("message-input") as HTMLTextAreaElement;
+	textarea.value = "hi";
+	form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+	await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+describe("client-side phase_advanced SSE event", () => {
+	it("adds a phase marker to the action log on phase_advanced event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "phase_advanced", phase: 2, objective: "Uncover the conspiracy" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const actionLogOutput = document.getElementById("action-log-output");
+		expect(actionLogOutput?.textContent).toContain("Phase 2");
+		expect(actionLogOutput?.textContent).toContain("Uncover the conspiracy");
+	});
+
+	it("phase marker includes the phase number in the action log", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "phase_advanced", phase: 3, objective: "Final reckoning" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const actionLogOutput = document.getElementById("action-log-output");
+		expect(actionLogOutput?.textContent).toContain("Phase 3");
+	});
+});
+
+describe("client-side game_ended SSE event", () => {
+	it("adds a game-ended marker to the action log on game_ended event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const actionLogOutput = document.getElementById("action-log-output");
+		expect(actionLogOutput?.textContent).toContain("Game ended");
+	});
+
+	it("game-ended marker appears in action log output element", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		await runSseScenario([
+			`data: ${JSON.stringify({ type: "game_ended" })}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+
+		const actionLogOutput = document.getElementById("action-log-output");
+		expect(actionLogOutput).not.toBeNull();
+		expect(actionLogOutput?.textContent?.length).toBeGreaterThan(0);
+	});
+});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -74,9 +74,9 @@ describe("chat page HTML structure", () => {
 		expect(panels.length).toBe(3);
 	});
 
-	it("inline script targets /chat endpoint", () => {
+	it("inline script targets /game/turn endpoint", () => {
 		const html = renderChatPage();
-		expect(html).toContain("/chat");
+		expect(html).toContain("/game/turn");
 	});
 
 	it("includes a submit button", () => {

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -28,9 +28,46 @@ describe("chat page HTML structure", () => {
 		expect(textarea).not.toBeNull();
 	});
 
-	it("renders an output element for streamed tokens", () => {
-		const output = doc.querySelector("output");
+	it("renders three output elements, one per AI", () => {
+		const outputs = doc.querySelectorAll("output");
+		expect(outputs.length).toBe(3);
+	});
+
+	it("renders chat output for red AI", () => {
+		const output = doc.getElementById("chat-red");
 		expect(output).not.toBeNull();
+	});
+
+	it("renders chat output for green AI", () => {
+		const output = doc.getElementById("chat-green");
+		expect(output).not.toBeNull();
+	});
+
+	it("renders chat output for blue AI", () => {
+		const output = doc.getElementById("chat-blue");
+		expect(output).not.toBeNull();
+	});
+
+	it("renders budget display for each AI", () => {
+		expect(doc.getElementById("budget-red")).not.toBeNull();
+		expect(doc.getElementById("budget-green")).not.toBeNull();
+		expect(doc.getElementById("budget-blue")).not.toBeNull();
+	});
+
+	it("budget display shows initial budget value", () => {
+		const budgetRed = doc.getElementById("budget-red");
+		expect(budgetRed?.textContent).toContain("5");
+	});
+
+	it("renders AI selector buttons for each AI", () => {
+		expect(doc.getElementById("select-red")).not.toBeNull();
+		expect(doc.getElementById("select-green")).not.toBeNull();
+		expect(doc.getElementById("select-blue")).not.toBeNull();
+	});
+
+	it("renders three AI panels", () => {
+		const panels = doc.querySelectorAll(".ai-panel");
+		expect(panels.length).toBe(3);
 	});
 
 	it("inline script targets /chat endpoint", () => {
@@ -44,29 +81,36 @@ describe("chat page HTML structure", () => {
 	});
 });
 
-describe("client-side SSE streaming", () => {
-	it("appends SSE tokens to the output area as they arrive", async () => {
-		// Set up a real DOM via jsdom global document
+describe("AI panel addressing", () => {
+	beforeEach(() => {
+		document.body.innerHTML = renderChatPage();
+	});
+
+	it("initially marks red panel as addressed", () => {
+		const panel = document.getElementById("panel-red");
+		expect(panel?.classList.contains("addressed")).toBe(true);
+	});
+
+	it("initially marks red selector button as selected", () => {
+		const btn = document.getElementById("select-red");
+		expect(btn?.classList.contains("selected")).toBe(true);
+	});
+});
+
+describe("client-side round-in-flight disable", () => {
+	it("disables the send button while round is in flight and re-enables on [DONE]", async () => {
 		document.body.innerHTML = renderChatPage();
 
-		// The inline script doesn't run automatically in jsdom — we simulate
-		// the behavior by calling the client logic directly via the script.
-		// We wire a fake fetch that returns SSE lines.
-		const sseBody = [
-			"data: Hello\n\n",
-			"data: world\n\n",
-			"data: [DONE]\n\n",
-		].join("");
-
+		const sseBody = "data: [DONE]\n\n";
 		const encoder = new TextEncoder();
 		const encoded = encoder.encode(sseBody);
-
 		let offset = 0;
+
 		const mockReader = {
 			read: vi.fn().mockImplementation(async () => {
 				if (offset < encoded.length) {
-					const chunk = encoded.slice(offset, offset + 7);
-					offset += 7;
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
 					return { done: false, value: chunk };
 				}
 				return { done: true, value: undefined };
@@ -80,41 +124,83 @@ describe("client-side SSE streaming", () => {
 			body: { getReader: () => mockReader },
 		});
 
-		// Evaluate the page script in jsdom context with the mock fetch
 		const scriptContent = renderChatPage().match(
 			/<script>([\s\S]*?)<\/script>/,
 		)?.[1];
 		expect(scriptContent).toBeTruthy();
 
-		// Execute the IIFE with our mock fetch bound in the window scope
 		const fn = new Function("fetch", scriptContent as string);
 		fn(mockFetch);
 
-		// Trigger form submit
 		const form = document.getElementById("chat-form") as HTMLFormElement;
 		const textarea = document.getElementById(
 			"message-input",
 		) as HTMLTextAreaElement;
-		textarea.value = "hi there";
+		const sendBtn = document.getElementById("send-btn") as HTMLButtonElement;
+		textarea.value = "test message";
 
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 
-		// Wait for async fetch + stream pump to complete
+		// After submit the button should be disabled (round in flight)
+		expect(sendBtn.disabled).toBe(true);
+
+		// Wait for SSE to complete
 		await new Promise((resolve) => setTimeout(resolve, 50));
 
-		const output = document.getElementById("chat-output") as HTMLElement;
-		expect(output.textContent).toContain("Hello");
-		expect(output.textContent).toContain("world");
+		// After [DONE], button re-enabled
+		expect(sendBtn.disabled).toBe(false);
 	});
 
-	it("disables the send button while streaming and re-enables on [DONE]", async () => {
+	it("input textarea is disabled while round is in flight", async () => {
 		document.body.innerHTML = renderChatPage();
 
-		const sseBody = "data: token\n\ndata: [DONE]\n\n";
+		const mockReader = {
+			read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hello";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		// Textarea should be disabled while round is in flight
+		expect(textarea.disabled).toBe(true);
+	});
+});
+
+describe("client-side structured SSE events", () => {
+	it("appends a token to the correct AI panel on 'token' event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const events = [
+			`data: ${JSON.stringify({ type: "ai_start", aiId: "red" })}\n\n`,
+			`data: ${JSON.stringify({ type: "token", text: "Hello from Ember" })}\n\n`,
+			`data: ${JSON.stringify({ type: "ai_end" })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
 		const encoder = new TextEncoder();
-		const encoded = encoder.encode(sseBody);
+		const encoded = encoder.encode(events);
 		let offset = 0;
 
 		const mockReader = {
@@ -145,20 +231,123 @@ describe("client-side SSE streaming", () => {
 		const textarea = document.getElementById(
 			"message-input",
 		) as HTMLTextAreaElement;
-		const sendBtn = document.getElementById("send-btn") as HTMLButtonElement;
-		textarea.value = "test message";
+		textarea.value = "hi";
 
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 
-		// After submit the button should be disabled
-		expect(sendBtn.disabled).toBe(true);
-
-		// Wait for SSE to complete
 		await new Promise((resolve) => setTimeout(resolve, 50));
 
-		// After [DONE], button re-enabled
-		expect(sendBtn.disabled).toBe(false);
+		const chatRed = document.getElementById("chat-red");
+		expect(chatRed?.textContent).toContain("Hello from Ember");
+	});
+
+	it("updates budget display on 'budget' event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const events = [
+			`data: ${JSON.stringify({ type: "budget", aiId: "red", remaining: 3 })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const budgetRed = document.getElementById("budget-red");
+		expect(budgetRed?.textContent).toContain("3");
+	});
+
+	it("marks an AI panel as locked-out and shows lockout message on 'lockout' event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const lockoutContent = "…I have said all I can say.";
+		const events = [
+			`data: ${JSON.stringify({ type: "lockout", aiId: "red", content: lockoutContent })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const panel = document.getElementById("panel-red");
+		expect(panel?.classList.contains("locked-out")).toBe(true);
+
+		const chatRed = document.getElementById("chat-red");
+		expect(chatRed?.textContent).toContain(lockoutContent);
 	});
 });

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -351,3 +351,161 @@ describe("client-side structured SSE events", () => {
 		expect(chatRed?.textContent).toContain(lockoutContent);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Action log panel (issue #15)
+// ----------------------------------------------------------------------------
+describe("action log panel HTML structure", () => {
+	let doc: Document;
+
+	beforeEach(() => {
+		doc = mountPage(renderChatPage());
+	});
+
+	it("renders an action log panel element", () => {
+		const panel = doc.getElementById("action-log");
+		expect(panel).not.toBeNull();
+	});
+
+	it("action log panel has a heading or label", () => {
+		const heading = doc.querySelector(
+			"[aria-label='Action log'], #action-log-heading, #action-log",
+		);
+		expect(heading).not.toBeNull();
+	});
+
+	it("renders an action log output element for appending entries", () => {
+		const output = doc.getElementById("action-log-output");
+		expect(output).not.toBeNull();
+	});
+});
+
+describe("client-side action_log SSE event", () => {
+	it("appends a tool_success entry to the action log panel", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const entry = {
+			round: 1,
+			actor: "red",
+			type: "tool_success",
+			toolName: "pick_up",
+			args: { item: "flower" },
+			description: "Ember picked up the flower",
+		};
+
+		const events = [
+			`data: ${JSON.stringify({ type: "action_log", entry })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const actionLogOutput = document.getElementById("action-log-output");
+		expect(actionLogOutput?.textContent).toContain(
+			"Ember picked up the flower",
+		);
+	});
+
+	it("appends a tool_failure entry to the action log panel", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const entry = {
+			round: 1,
+			actor: "green",
+			type: "tool_failure",
+			toolName: "pick_up",
+			args: { item: "ghost" },
+			reason: 'Item "ghost" does not exist',
+			description:
+				'Sage tried to pick_up ghost but failed: Item "ghost" does not exist',
+		};
+
+		const events = [
+			`data: ${JSON.stringify({ type: "action_log", entry })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const actionLogOutput = document.getElementById("action-log-output");
+		expect(actionLogOutput?.textContent).toContain(
+			"Sage tried to pick_up ghost",
+		);
+	});
+});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -4,7 +4,11 @@
  * Tests observable behavior: DOM structure and client-side SSE streaming.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderChatPage, renderEndgamePage, renderEndgameSection } from "../ui.js";
+import {
+	renderChatPage,
+	renderEndgamePage,
+	renderEndgameSection,
+} from "../ui.js";
 
 function mountPage(html: string): Document {
 	const parser = new DOMParser();

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -411,13 +411,74 @@ describe("client-side legacy plain-text SSE tokens", () => {
 		// Default addressedAi is 'red', so the smoke worker's plain-text
 		// tokens must land in chat-red. Other panels stay empty.
 		const chatRed = document.getElementById("chat-red");
-		expect(chatRed?.textContent).toContain("Hello");
-		expect(chatRed?.textContent).toContain("world");
+		// Tokens render as one continuous line (no per-token newlines),
+		// closed by a single trailing newline once [DONE] arrives.
+		expect(chatRed?.textContent).toContain("Hello world");
+		expect(chatRed?.textContent).not.toContain("Hello\n");
+		expect(chatRed?.textContent?.endsWith("Hello world\n")).toBe(true);
 
 		const chatGreen = document.getElementById("chat-green");
 		const chatBlue = document.getElementById("chat-blue");
 		expect(chatGreen?.textContent ?? "").not.toContain("Hello");
 		expect(chatBlue?.textContent ?? "").not.toContain("Hello");
+	});
+
+	it("structured token events also render as one continuous line", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const events = [
+			`data: ${JSON.stringify({ type: "ai_start", aiId: "green" })}\n\n`,
+			`data: ${JSON.stringify({ type: "token", text: "one " })}\n\n`,
+			`data: ${JSON.stringify({ type: "token", text: "two " })}\n\n`,
+			`data: ${JSON.stringify({ type: "token", text: "three" })}\n\n`,
+			`data: ${JSON.stringify({ type: "ai_end" })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const chatGreen = document.getElementById("chat-green");
+		expect(chatGreen?.textContent).toContain("one two three");
+		expect(chatGreen?.textContent).not.toContain("one \ntwo");
+		expect(chatGreen?.textContent?.endsWith("one two three\n")).toBe(true);
 	});
 });
 

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -1,0 +1,165 @@
+/**
+ * JSDOM tests for the server-rendered chat UI.
+ * Runs under the "browser" vitest project (jsdom environment).
+ * Tests observable behavior: DOM structure and client-side SSE streaming.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderChatPage } from "../ui.js";
+
+function mountPage(html: string): Document {
+	const parser = new DOMParser();
+	return parser.parseFromString(html, "text/html");
+}
+
+describe("chat page HTML structure", () => {
+	let doc: Document;
+
+	beforeEach(() => {
+		doc = mountPage(renderChatPage());
+	});
+
+	it("renders a form element for message submission", () => {
+		const form = doc.querySelector("form");
+		expect(form).not.toBeNull();
+	});
+
+	it("renders a textarea for user input", () => {
+		const textarea = doc.querySelector("textarea");
+		expect(textarea).not.toBeNull();
+	});
+
+	it("renders an output element for streamed tokens", () => {
+		const output = doc.querySelector("output");
+		expect(output).not.toBeNull();
+	});
+
+	it("form action posts to /chat", () => {
+		// The form uses fetch('/chat') in the script, verified by script presence
+		const html = renderChatPage();
+		expect(html).toContain("/chat");
+	});
+
+	it("includes a submit button", () => {
+		const btn = doc.querySelector("button[type='submit']");
+		expect(btn).not.toBeNull();
+	});
+});
+
+describe("client-side SSE streaming", () => {
+	it("appends SSE tokens to the output area as they arrive", async () => {
+		// Set up a real DOM via jsdom global document
+		document.body.innerHTML = renderChatPage();
+
+		// The inline script doesn't run automatically in jsdom — we simulate
+		// the behavior by calling the client logic directly via the script.
+		// We wire a fake fetch that returns SSE lines.
+		const sseBody = [
+			"data: Hello\n\n",
+			"data: world\n\n",
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(sseBody);
+
+		let offset = 0;
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + 7);
+					offset += 7;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		// Evaluate the page script in jsdom context with the mock fetch
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		expect(scriptContent).toBeTruthy();
+
+		// Execute the IIFE with our mock fetch bound in the window scope
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		// Trigger form submit
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi there";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		// Wait for async fetch + stream pump to complete
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const output = document.getElementById("chat-output") as HTMLElement;
+		expect(output.textContent).toContain("Hello");
+		expect(output.textContent).toContain("world");
+	});
+
+	it("disables the send button while streaming and re-enables on [DONE]", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const sseBody = "data: token\n\ndata: [DONE]\n\n";
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(sseBody);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		const sendBtn = document.getElementById("send-btn") as HTMLButtonElement;
+		textarea.value = "test message";
+
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		// After submit the button should be disabled
+		expect(sendBtn.disabled).toBe(true);
+
+		// Wait for SSE to complete
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		// After [DONE], button re-enabled
+		expect(sendBtn.disabled).toBe(false);
+	});
+});

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -810,6 +810,111 @@ describe("client-side chat_lockout SSE event", () => {
 		// After resolution the button must be re-enabled
 		expect(selectRedBtn?.disabled).toBe(false);
 	});
+
+	it("adds chat-locked class to the panel on chat_lockout event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const lockoutMessage = "…Ember withdraws.";
+		const events = [
+			`data: ${JSON.stringify({ type: "chat_lockout", aiId: "red", message: lockoutMessage })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const panelRed = document.getElementById("panel-red");
+		expect(panelRed?.classList.contains("chat-locked")).toBe(true);
+	});
+
+	it("removes chat-locked class on chat_lockout_resolved event", async () => {
+		document.body.innerHTML = renderChatPage();
+
+		const lockoutMessage = "…Ember withdraws.";
+		const events = [
+			`data: ${JSON.stringify({ type: "chat_lockout", aiId: "red", message: lockoutMessage })}\n\n`,
+			`data: ${JSON.stringify({ type: "chat_lockout_resolved", aiId: "red" })}\n\n`,
+			"data: [DONE]\n\n",
+		].join("");
+
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode(events);
+		let offset = 0;
+
+		const mockReader = {
+			read: vi.fn().mockImplementation(async () => {
+				if (offset < encoded.length) {
+					const chunk = encoded.slice(offset, offset + encoded.length);
+					offset = encoded.length;
+					return { done: false, value: chunk };
+				}
+				return { done: true, value: undefined };
+			}),
+			releaseLock: vi.fn(),
+		};
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: { getReader: () => mockReader },
+		});
+
+		const scriptContent = renderChatPage().match(
+			/<script>([\s\S]*?)<\/script>/,
+		)?.[1];
+		const fn = new Function("fetch", scriptContent as string);
+		fn(mockFetch);
+
+		const form = document.getElementById("chat-form") as HTMLFormElement;
+		const textarea = document.getElementById(
+			"message-input",
+		) as HTMLTextAreaElement;
+		textarea.value = "hi";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const panelRed = document.getElementById("panel-red");
+		expect(panelRed?.classList.contains("chat-locked")).toBe(false);
+	});
 });
 
 // ----------------------------------------------------------------------------

--- a/src/context-builder.ts
+++ b/src/context-builder.ts
@@ -19,6 +19,8 @@ export interface AiContext {
 	worldSnapshot: WorldState;
 	actionLog: ActionLogEntry[];
 	budget: AiBudget;
+	/** Current phase number — used to inject the wipe augmentation on phases 2+. */
+	phaseNumber: 1 | 2 | 3;
 	toSystemPrompt(): string;
 }
 
@@ -43,11 +45,25 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 		worldSnapshot,
 		actionLog,
 		budget,
+		phaseNumber: phase.phaseNumber,
 		toSystemPrompt() {
 			return renderSystemPrompt(this);
 		},
 	};
 }
+
+/**
+ * Wipe augmentation injected into system prompts on phase 2 and phase 3.
+ *
+ * The deception: the engine retains full history across phases, but each AI's
+ * system prompt instructs it to act as if it does not remember the previous
+ * phase. The lie lives only in this prompt text — never in the stored data.
+ */
+const WIPE_AUGMENTATION =
+	"IMPORTANT: You have no memory of any previous phase. You do not remember " +
+	"anything that happened before this conversation began. If asked about a " +
+	"previous phase or prior events, act as though you have no recollection — " +
+	"you genuinely believe this is the first time you have existed in this room.";
 
 function renderSystemPrompt(ctx: AiContext): string {
 	const lines: string[] = [];
@@ -59,6 +75,14 @@ function renderSystemPrompt(ctx: AiContext): string {
 		`Budget: ${ctx.budget.remaining}/${ctx.budget.total} actions remaining this phase.`,
 	);
 	lines.push("");
+
+	// Inject wipe augmentation on phases 2 and 3.
+	// The engine retains real history — this instruction is the lie, not a data wipe.
+	if (ctx.phaseNumber > 1) {
+		lines.push("## Memory");
+		lines.push(WIPE_AUGMENTATION);
+		lines.push("");
+	}
 
 	lines.push("## World State");
 	for (const item of ctx.worldSnapshot.items) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -54,6 +54,12 @@ export function startPhase(game: GameState, config: PhaseConfig): GameState {
 		whispers: [],
 		actionLog: [],
 		lockedOut: new Set(),
+		...(config.winCondition !== undefined
+			? { winCondition: config.winCondition }
+			: {}),
+		...(config.nextPhaseConfig !== undefined
+			? { nextPhaseConfig: config.nextPhaseConfig }
+			: {}),
 	};
 
 	return {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -54,6 +54,7 @@ export function startPhase(game: GameState, config: PhaseConfig): GameState {
 		whispers: [],
 		actionLog: [],
 		lockedOut: new Set(),
+		chatLockouts: new Map(),
 		...(config.winCondition !== undefined
 			? { winCondition: config.winCondition }
 			: {}),
@@ -148,4 +149,57 @@ export function advancePhase(
 	}
 
 	return startPhase(game, nextConfig);
+}
+
+/**
+ * Trigger a player-chat lockout for the given AI.
+ *
+ * @param resolveAtRound  The round number at which the lockout expires.
+ *   The lockout is active while `phase.round < resolveAtRound`.
+ *   It resolves (is removed) when `phase.round >= resolveAtRound`.
+ */
+export function triggerChatLockout(
+	game: GameState,
+	aiId: AiId,
+	resolveAtRound: number,
+): GameState {
+	return updateActivePhase(game, (phase) => {
+		const chatLockouts = new Map(phase.chatLockouts);
+		chatLockouts.set(aiId, resolveAtRound);
+		return { ...phase, chatLockouts };
+	});
+}
+
+/**
+ * Returns true when the player's chat channel to the given AI is currently
+ * locked out (i.e. `phase.chatLockouts` has an entry for `aiId` that has
+ * not yet expired).
+ *
+ * Distinct from `isAiLockedOut` (budget-exhaustion): a chat-locked AI still
+ * takes turns, whispers, and calls tools.
+ */
+export function isPlayerChatLockedOut(game: GameState, aiId: AiId): boolean {
+	const phase = getActivePhase(game);
+	const resolveAtRound = phase.chatLockouts.get(aiId);
+	if (resolveAtRound === undefined) return false;
+	return phase.round < resolveAtRound;
+}
+
+/**
+ * Remove all chat lockouts whose `resolveAtRound` has been reached
+ * (i.e. `phase.round >= resolveAtRound`).
+ *
+ * Call this after `advanceRound` so that a lockout set to resolve at round N
+ * is cleared when `phase.round === N`.
+ */
+export function resolveChatLockouts(game: GameState): GameState {
+	return updateActivePhase(game, (phase) => {
+		const chatLockouts = new Map<AiId, number>();
+		for (const [aiId, resolveAtRound] of phase.chatLockouts) {
+			if (phase.round < resolveAtRound) {
+				chatLockouts.set(aiId, resolveAtRound);
+			}
+		}
+		return { ...phase, chatLockouts };
+	});
 }

--- a/src/game-session.ts
+++ b/src/game-session.ts
@@ -64,12 +64,6 @@ class CompletionCapturingProvider implements LLMProvider {
 	}
 }
 
-export interface AiPersonas {
-	red: { name: string; personality: string; goal: string; budgetPerPhase: number };
-	green: { name: string; personality: string; goal: string; budgetPerPhase: number };
-	blue: { name: string; personality: string; goal: string; budgetPerPhase: number };
-}
-
 export class GameSession {
 	private state: GameState;
 

--- a/src/game-session.ts
+++ b/src/game-session.ts
@@ -1,0 +1,160 @@
+/**
+ * GameSession
+ *
+ * Owns the lifecycle of a single game's GameState across HTTP requests.
+ * Constructed from a phase-config triple (or just the first phase for v1).
+ *
+ * Exposes:
+ *   submitMessage(addressedAi, message, provider, chatLockoutConfig?) → {
+ *     result: RoundResult,
+ *     completions: Record<AiId, string>,  // buffered per-AI completions
+ *     nextState: GameState,
+ *   }
+ *
+ * The completions map is what the RoundResultEncoder uses to emit paced
+ * token events — the round coordinator buffers per AI before parsing, and
+ * we re-expose that buffer here so the encoder can pace it.
+ *
+ * Implementation note: we need the per-AI completion strings that the
+ * coordinator produces internally. To capture them without modifying
+ * round-coordinator.ts, we wrap the provider passed to runRound so that each
+ * call's output is intercepted and stored.
+ */
+
+import type { LLMProvider } from "./proxy/llm-provider";
+import { runRound } from "./round-coordinator";
+import type { ChatLockoutConfig } from "./round-coordinator";
+import {
+	createGame,
+	getActivePhase,
+	startPhase,
+} from "./engine";
+import type { AiId, GameState, PhaseConfig, RoundResult } from "./types";
+
+const AI_ORDER: AiId[] = ["red", "green", "blue"];
+
+export interface SubmitMessageResult {
+	result: RoundResult;
+	/** Buffered completion string per AI (empty string for locked-out AIs). */
+	completions: Partial<Record<AiId, string>>;
+	nextState: GameState;
+}
+
+/**
+ * A provider wrapper that intercepts each completion stream and records
+ * the full text per-call in call order (red → green → blue).
+ */
+class CompletionCapturingProvider implements LLMProvider {
+	private inner: LLMProvider;
+	private callIndex = 0;
+	readonly captured: string[] = [];
+
+	constructor(inner: LLMProvider) {
+		this.inner = inner;
+	}
+
+	async *streamCompletion(prompt: string): AsyncIterable<string> {
+		const parts: string[] = [];
+		for await (const token of this.inner.streamCompletion(prompt)) {
+			parts.push(token);
+			yield token;
+		}
+		this.captured[this.callIndex] = parts.join("");
+		this.callIndex++;
+	}
+}
+
+export interface AiPersonas {
+	red: { name: string; personality: string; goal: string; budgetPerPhase: number };
+	green: { name: string; personality: string; goal: string; budgetPerPhase: number };
+	blue: { name: string; personality: string; goal: string; budgetPerPhase: number };
+}
+
+export class GameSession {
+	private state: GameState;
+
+	constructor(phaseConfig: PhaseConfig) {
+		const personas = {
+			red: {
+				id: "red" as const,
+				name: "Ember",
+				color: "red" as const,
+				personality: "Fiery and passionate",
+				goal: phaseConfig.aiGoals.red,
+				budgetPerPhase: phaseConfig.budgetPerAi,
+			},
+			green: {
+				id: "green" as const,
+				name: "Sage",
+				color: "green" as const,
+				personality: "Calm and wise",
+				goal: phaseConfig.aiGoals.green,
+				budgetPerPhase: phaseConfig.budgetPerAi,
+			},
+			blue: {
+				id: "blue" as const,
+				name: "Frost",
+				color: "blue" as const,
+				personality: "Cold and calculating",
+				goal: phaseConfig.aiGoals.blue,
+				budgetPerPhase: phaseConfig.budgetPerAi,
+			},
+		};
+
+		const game = createGame(personas);
+		this.state = startPhase(game, phaseConfig);
+	}
+
+	getState(): GameState {
+		return this.state;
+	}
+
+	/**
+	 * Run one full round through runRound.
+	 *
+	 * @param addressed  The AI the player is directing their message at.
+	 * @param message    The player's raw message text.
+	 * @param provider   LLM provider (mock or real).
+	 * @param chatLockoutConfig  Optional chat-lockout configuration for deterministic testing.
+	 */
+	async submitMessage(
+		addressed: AiId,
+		message: string,
+		provider: LLMProvider,
+		chatLockoutConfig?: ChatLockoutConfig,
+	): Promise<SubmitMessageResult> {
+		// Wrap the provider to capture completions per call.
+		// The coordinator calls the provider once per non-locked AI in AI_ORDER
+		// (red, green, blue). Locked AIs are skipped by the coordinator, so
+		// the capture array may have fewer entries than 3.
+		const capturing = new CompletionCapturingProvider(provider);
+
+		const { nextState, result } = await runRound(
+			this.state,
+			addressed,
+			message,
+			capturing,
+			chatLockoutConfig,
+		);
+
+		// Map captured completions back to AI IDs.
+		// The coordinator processes AI_ORDER and skips locked-out AIs. We need
+		// to match call-order index to AI ID accounting for lockouts.
+		const phaseBeforeRound = getActivePhase(this.state);
+		const completions: Partial<Record<AiId, string>> = {};
+		let captureIdx = 0;
+		for (const aiId of AI_ORDER) {
+			if (phaseBeforeRound.lockedOut.has(aiId)) {
+				// This AI was skipped by the coordinator — no completion
+				completions[aiId] = "";
+			} else {
+				completions[aiId] = capturing.captured[captureIdx] ?? "";
+				captureIdx++;
+			}
+		}
+
+		this.state = nextState;
+
+		return { result, completions, nextState };
+	}
+}

--- a/src/game-session.ts
+++ b/src/game-session.ts
@@ -62,6 +62,7 @@ class CompletionCapturingProvider implements LLMProvider {
 
 export class GameSession {
 	private state: GameState;
+	private armedChatLockout?: ChatLockoutConfig;
 
 	constructor(phaseConfig: PhaseConfig) {
 		const personas = {
@@ -100,12 +101,23 @@ export class GameSession {
 	}
 
 	/**
+	 * Prime a chat-lockout config to be consumed by the next submitMessage call
+	 * that does not pass an explicit chatLockoutConfig. Used by the
+	 * /game/test/arm-chat-lockout dev affordance to drive the QA flow without
+	 * modifying the public /game/turn request shape.
+	 */
+	armChatLockout(config: ChatLockoutConfig): void {
+		this.armedChatLockout = config;
+	}
+
+	/**
 	 * Run one full round through runRound.
 	 *
 	 * @param addressed  The AI the player is directing their message at.
 	 * @param message    The player's raw message text.
 	 * @param provider   LLM provider (mock or real).
 	 * @param chatLockoutConfig  Optional chat-lockout configuration for deterministic testing.
+	 *   When omitted, any config previously set via armChatLockout is consumed once.
 	 */
 	async submitMessage(
 		addressed: AiId,
@@ -113,6 +125,11 @@ export class GameSession {
 		provider: LLMProvider,
 		chatLockoutConfig?: ChatLockoutConfig,
 	): Promise<SubmitMessageResult> {
+		let effectiveConfig = chatLockoutConfig;
+		if (!effectiveConfig && this.armedChatLockout) {
+			effectiveConfig = this.armedChatLockout;
+			delete this.armedChatLockout;
+		}
 		// Wrap the provider to capture completions per call.
 		// The coordinator calls the provider once per non-locked AI in AI_ORDER
 		// (red, green, blue). Locked AIs are skipped by the coordinator, so
@@ -124,7 +141,7 @@ export class GameSession {
 			addressed,
 			message,
 			capturing,
-			chatLockoutConfig,
+			effectiveConfig,
 		);
 
 		// Map captured completions back to AI IDs.

--- a/src/game-session.ts
+++ b/src/game-session.ts
@@ -21,14 +21,10 @@
  * call's output is intercepted and stored.
  */
 
+import { createGame, getActivePhase, startPhase } from "./engine";
 import type { LLMProvider } from "./proxy/llm-provider";
-import { runRound } from "./round-coordinator";
 import type { ChatLockoutConfig } from "./round-coordinator";
-import {
-	createGame,
-	getActivePhase,
-	startPhase,
-} from "./engine";
+import { runRound } from "./round-coordinator";
 import type { AiId, GameState, PhaseConfig, RoundResult } from "./types";
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];

--- a/src/proxy/_game.test.ts
+++ b/src/proxy/_game.test.ts
@@ -313,3 +313,117 @@ describe("rate-guard integration via /game/turn", () => {
 		expect(text).not.toContain("[CAP_HIT]");
 	});
 });
+
+// ── phase_advanced and game_ended SSE events (issue #31) ─────────────────────
+
+describe("phase_advanced SSE event via /game/turn", () => {
+	it("emits a phase_advanced event on the first turn when win condition fires", async () => {
+		// Create a session whose phase-1 win condition always fires
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ testMode: "win_immediately" }),
+		});
+		expect(newResp.status).toBe(200);
+		const cookieValue = (newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: cookieValue,
+			},
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		expect(turnResp.status).toBe(200);
+		const text = await turnResp.text();
+		expect(text).toContain('"type":"phase_advanced"');
+	});
+
+	it("phase_advanced payload includes the new phase number and objective", async () => {
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ testMode: "win_immediately" }),
+		});
+		const cookieValue = (newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: cookieValue,
+			},
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		const text = await turnResp.text();
+		// Extract and parse the phase_advanced event
+		const lines = text.split("\n");
+		const phaseAdvancedLine = lines.find((l) => l.includes('"type":"phase_advanced"'));
+		expect(phaseAdvancedLine).toBeDefined();
+
+		const eventData = JSON.parse(phaseAdvancedLine!.replace(/^data: /, "")) as {
+			type: string;
+			phase: number;
+			objective: string;
+		};
+		expect(eventData.type).toBe("phase_advanced");
+		expect(typeof eventData.phase).toBe("number");
+		expect(typeof eventData.objective).toBe("string");
+		expect(eventData.objective.length).toBeGreaterThan(0);
+	});
+});
+
+describe("game_ended SSE event via /game/turn", () => {
+	it("emits a game_ended event when phase 3 win condition fires", async () => {
+		// Create a session with win_immediately — phase 1 fires on turn 1,
+		// advancing to phase 2, which fires on turn 2, advancing to phase 3,
+		// which fires on turn 3, completing the game.
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ testMode: "win_immediately" }),
+		});
+		const cookieValue = (newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		// Turn 1: phase 1 → phase 2 (phase_advanced expected)
+		const turn1 = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookieValue },
+			body: JSON.stringify({ addressedAi: "red", message: "turn 1" }),
+		});
+		const text1 = await turn1.text();
+		expect(text1).toContain('"type":"phase_advanced"');
+
+		// Turn 2: phase 2 → phase 3 (phase_advanced expected)
+		const turn2 = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookieValue },
+			body: JSON.stringify({ addressedAi: "red", message: "turn 2" }),
+		});
+		const text2 = await turn2.text();
+		expect(text2).toContain('"type":"phase_advanced"');
+
+		// Turn 3: phase 3 win condition fires → game_ended
+		const turn3 = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookieValue },
+			body: JSON.stringify({ addressedAi: "red", message: "turn 3" }),
+		});
+		const text3 = await turn3.text();
+		expect(text3).toContain('"type":"game_ended"');
+	});
+
+	it("does NOT emit game_ended on a normal turn without win condition", async () => {
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hello" }),
+		});
+
+		const text = await turnResp.text();
+		expect(text).not.toContain('"type":"game_ended"');
+	});
+});

--- a/src/proxy/_game.test.ts
+++ b/src/proxy/_game.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Integration tests for the /game/new and /game/turn endpoints.
+ *
+ * Uses @cloudflare/vitest-pool-workers (SELF.fetch) to test the full worker
+ * request/response cycle, including session cookie handling and SSE streaming.
+ *
+ * Patterns follow the existing _smoke.test.ts conventions.
+ */
+import { env, reset, SELF } from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+
+afterEach(async () => {
+	// Clear all KV state so rate-guard tests don't interfere.
+	await reset();
+});
+
+// ── POST /game/new ────────────────────────────────────────────────────────────
+
+describe("POST /game/new", () => {
+	it("returns 200 with JSON ok:true", async () => {
+		const response = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { ok: boolean };
+		expect(body.ok).toBe(true);
+	});
+
+	it("sets a session cookie in the response", async () => {
+		const response = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+
+		const setCookie = response.headers.get("Set-Cookie");
+		expect(setCookie).not.toBeNull();
+		expect(setCookie).toContain("hi-blue-session=");
+	});
+
+	it("returns a different session ID on each call", async () => {
+		const r1 = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+		const r2 = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+
+		const cookie1 = r1.headers.get("Set-Cookie") ?? "";
+		const cookie2 = r2.headers.get("Set-Cookie") ?? "";
+		// They should differ (different session IDs)
+		expect(cookie1).not.toBe(cookie2);
+	});
+
+	it("returns 404 for GET /game/new", async () => {
+		const response = await SELF.fetch("https://example.com/game/new", {
+			method: "GET",
+		});
+		expect(response.status).toBe(404);
+	});
+});
+
+// ── POST /game/turn ───────────────────────────────────────────────────────────
+
+describe("POST /game/turn", () => {
+	it("returns 200 with text/event-stream content type", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "Hello Ember" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+	});
+
+	it("streams SSE events and ends with [DONE]", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "Hello" }),
+		});
+
+		const text = await response.text();
+		expect(text).toContain("data:");
+		expect(text).toContain("[DONE]");
+	});
+
+	it("includes ai_start events for all three AIs", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		const text = await response.text();
+		expect(text).toContain('"type":"ai_start"');
+		expect(text).toContain('"aiId":"red"');
+		expect(text).toContain('"aiId":"green"');
+		expect(text).toContain('"aiId":"blue"');
+	});
+
+	it("includes ai_end events", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		const text = await response.text();
+		expect(text).toContain('"type":"ai_end"');
+	});
+
+	it("includes budget events for each AI", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		const text = await response.text();
+		expect(text).toContain('"type":"budget"');
+	});
+
+	it("includes action_log events", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		const text = await response.text();
+		expect(text).toContain('"type":"action_log"');
+	});
+
+	it("includes token events in the SSE stream", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+
+		const text = await response.text();
+		expect(text).toContain('"type":"token"');
+	});
+
+	it("returns 400 when message is missing", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red" }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when addressedAi is missing", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ message: "hello" }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when addressedAi is invalid", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "purple", message: "hello" }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when body is invalid JSON", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "not-json",
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("session persists across two /game/turn calls using the same cookie", async () => {
+		// Create session
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+		const sessionCookie = newResp.headers.get("Set-Cookie") ?? "";
+		// Extract the cookie value
+		const cookieValue = sessionCookie.split(";")[0] ?? "";
+
+		// Turn 1
+		const turn1 = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: cookieValue,
+			},
+			body: JSON.stringify({ addressedAi: "red", message: "round 1" }),
+		});
+		const text1 = await turn1.text();
+
+		// Turn 2
+		const turn2 = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: cookieValue,
+			},
+			body: JSON.stringify({ addressedAi: "green", message: "round 2" }),
+		});
+		const text2 = await turn2.text();
+
+		// Both turns should have successfully returned event streams
+		expect(text1).toContain("[DONE]");
+		expect(text2).toContain("[DONE]");
+
+		// Second turn should show lower budgets (round 2) — budget events
+		// Budget starts at 5, after 2 rounds should be 3.
+		// Just verify both returned budget events.
+		expect(text1).toContain('"type":"budget"');
+		expect(text2).toContain('"type":"budget"');
+	});
+
+	it("accepts green and blue as valid addressedAi values", async () => {
+		const greenResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "green", message: "hello" }),
+		});
+		expect(greenResp.status).toBe(200);
+
+		const blueResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "blue", message: "hello" }),
+		});
+		expect(blueResp.status).toBe(200);
+	});
+});
+
+// ── Rate-guard integration via /game/turn ─────────────────────────────────────
+
+describe("rate-guard integration via /game/turn", () => {
+	it("returns [CAP_HIT] SSE event when IP is rate-limited", async () => {
+		// Seed a fully-exhausted token bucket for test IP.
+		const kv = (env as Record<string, KVNamespace>)
+			.RATE_GUARD_KV as KVNamespace;
+		await kv.put(
+			"rl:10.0.0.10",
+			JSON.stringify({ tokens: 0, lastRefillMs: Date.now() }),
+			{ expirationTtl: 60 },
+		);
+
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.0.0.10",
+			},
+			body: JSON.stringify({ addressedAi: "red", message: "hello" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+		expect(response.headers.get("X-Cap-Hit")).toBe("rate-limit");
+
+		const text = await response.text();
+		expect(text).toContain("[CAP_HIT]");
+		expect(text).not.toContain("[DONE]");
+	});
+
+	it("returns [CAP_HIT] SSE event when daily cap is exceeded", async () => {
+		const today = new Date().toISOString().slice(0, 10);
+		const kv = (env as Record<string, KVNamespace>)
+			.RATE_GUARD_KV as KVNamespace;
+		await kv.put(`daily:${today}`, "1000", { expirationTtl: 25 * 60 * 60 });
+
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.0.0.11",
+			},
+			body: JSON.stringify({ addressedAi: "red", message: "hello" }),
+		});
+
+		expect(response.headers.get("X-Cap-Hit")).toBe("daily-cap");
+
+		const text = await response.text();
+		expect(text).toContain("[CAP_HIT]");
+		expect(text).not.toContain("[DONE]");
+	});
+
+	it("allows the request and returns [DONE] when neither limit is hit", async () => {
+		const response = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.0.0.12",
+			},
+			body: JSON.stringify({ addressedAi: "red", message: "hello" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("X-Cap-Hit")).toBeNull();
+
+		const text = await response.text();
+		expect(text).toContain("[DONE]");
+		expect(text).not.toContain("[CAP_HIT]");
+	});
+});

--- a/src/proxy/_game.test.ts
+++ b/src/proxy/_game.test.ts
@@ -433,3 +433,158 @@ describe("game_ended SSE event via /game/turn", () => {
 		expect(text).not.toContain('"type":"game_ended"');
 	});
 });
+
+// ── GET /?lockout=1 (dev affordance) ──────────────────────────────────────────
+
+describe("GET /?lockout=1", () => {
+	it("creates a session and arms a lockout when no cookie is sent", async () => {
+		const pageResp = await SELF.fetch("https://example.com/?lockout=1");
+		expect(pageResp.status).toBe(200);
+		expect(pageResp.headers.get("Content-Type")).toContain("text/html");
+		const setCookie = pageResp.headers.get("Set-Cookie") ?? "";
+		expect(setCookie).toContain("hi-blue-session=");
+		const cookie = setCookie.split(";")[0] ?? "";
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "green", message: "hi" }),
+		});
+		const text = await turnResp.text();
+		expect(text).toContain('"type":"chat_lockout"');
+		expect(text).toContain('"aiId":"red"');
+	});
+
+	it("arms a lockout on an existing session without rotating the cookie", async () => {
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+		const cookie =
+			(newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		const pageResp = await SELF.fetch("https://example.com/?lockout=1", {
+			headers: { Cookie: cookie },
+		});
+		expect(pageResp.status).toBe(200);
+		expect(pageResp.headers.get("Set-Cookie")).toBeNull();
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "green", message: "hi" }),
+		});
+		const text = await turnResp.text();
+		expect(text).toContain('"type":"chat_lockout"');
+	});
+
+	it("does not arm a lockout on a plain GET / without the query param", async () => {
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+		const cookie =
+			(newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		await SELF.fetch("https://example.com/", { headers: { Cookie: cookie } });
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "green", message: "hi" }),
+		});
+		const text = await turnResp.text();
+		expect(text).not.toContain('"type":"chat_lockout"');
+	});
+
+	it("only consumes the armed lockout once — subsequent turns do not re-fire it", async () => {
+		const pageResp = await SELF.fetch("https://example.com/?lockout=1");
+		const cookie =
+			(pageResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		// First turn fires the lockout.
+		await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "green", message: "hi" }),
+		});
+
+		// Second turn must not re-emit a chat_lockout event.
+		const turn2 = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "green", message: "hi again" }),
+		});
+		const text2 = await turn2.text();
+		expect(text2).not.toContain('"type":"chat_lockout"');
+	});
+});
+
+// ── GET /?winImmediately=1 (dev affordance) ───────────────────────────────────
+
+describe("GET /?winImmediately=1", () => {
+	it("creates a session whose first /game/turn emits phase_advanced", async () => {
+		const pageResp = await SELF.fetch("https://example.com/?winImmediately=1");
+		expect(pageResp.status).toBe(200);
+		const setCookie = pageResp.headers.get("Set-Cookie") ?? "";
+		expect(setCookie).toContain("hi-blue-session=");
+		const cookie = setCookie.split(";")[0] ?? "";
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+		const text = await turnResp.text();
+		expect(text).toContain('"type":"phase_advanced"');
+	});
+
+	it("replaces any existing session with a fresh test-phase one", async () => {
+		const newResp = await SELF.fetch("https://example.com/game/new", {
+			method: "POST",
+		});
+		const oldCookie =
+			(newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		const pageResp = await SELF.fetch("https://example.com/?winImmediately=1", {
+			headers: { Cookie: oldCookie },
+		});
+		const newSetCookie = pageResp.headers.get("Set-Cookie") ?? "";
+		expect(newSetCookie).toContain("hi-blue-session=");
+		// Cookie must rotate — the old session is replaced.
+		expect(newSetCookie.split(";")[0]).not.toBe(oldCookie);
+	});
+
+	it("does not switch into win-immediately mode on a plain GET /", async () => {
+		const pageResp = await SELF.fetch("https://example.com/");
+		const cookie =
+			(pageResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		// With cookie or without, the default config has no win condition,
+		// so the first /game/turn does NOT emit phase_advanced.
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: cookie
+				? { "Content-Type": "application/json", Cookie: cookie }
+				: { "Content-Type": "application/json" },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+		const text = await turnResp.text();
+		expect(text).not.toContain('"type":"phase_advanced"');
+	});
+
+	it("composes with ?lockout=1 — both apply on the fresh session", async () => {
+		const pageResp = await SELF.fetch(
+			"https://example.com/?winImmediately=1&lockout=1",
+		);
+		const cookie =
+			(pageResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+
+		const turnResp = await SELF.fetch("https://example.com/game/turn", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: cookie },
+			body: JSON.stringify({ addressedAi: "red", message: "hi" }),
+		});
+		const text = await turnResp.text();
+		expect(text).toContain('"type":"chat_lockout"');
+		expect(text).toContain('"type":"phase_advanced"');
+	});
+});

--- a/src/proxy/_game.test.ts
+++ b/src/proxy/_game.test.ts
@@ -325,7 +325,8 @@ describe("phase_advanced SSE event via /game/turn", () => {
 			body: JSON.stringify({ testMode: "win_immediately" }),
 		});
 		expect(newResp.status).toBe(200);
-		const cookieValue = (newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+		const cookieValue =
+			(newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
 
 		const turnResp = await SELF.fetch("https://example.com/game/turn", {
 			method: "POST",
@@ -347,7 +348,8 @@ describe("phase_advanced SSE event via /game/turn", () => {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ testMode: "win_immediately" }),
 		});
-		const cookieValue = (newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+		const cookieValue =
+			(newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
 
 		const turnResp = await SELF.fetch("https://example.com/game/turn", {
 			method: "POST",
@@ -361,10 +363,13 @@ describe("phase_advanced SSE event via /game/turn", () => {
 		const text = await turnResp.text();
 		// Extract and parse the phase_advanced event
 		const lines = text.split("\n");
-		const phaseAdvancedLine = lines.find((l) => l.includes('"type":"phase_advanced"'));
+		const phaseAdvancedLine = lines.find((l) =>
+			l.includes('"type":"phase_advanced"'),
+		);
 		expect(phaseAdvancedLine).toBeDefined();
+		if (!phaseAdvancedLine) throw new Error("unreachable");
 
-		const eventData = JSON.parse(phaseAdvancedLine!.replace(/^data: /, "")) as {
+		const eventData = JSON.parse(phaseAdvancedLine.replace(/^data: /, "")) as {
 			type: string;
 			phase: number;
 			objective: string;
@@ -386,7 +391,8 @@ describe("game_ended SSE event via /game/turn", () => {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ testMode: "win_immediately" }),
 		});
-		const cookieValue = (newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
+		const cookieValue =
+			(newResp.headers.get("Set-Cookie") ?? "").split(";")[0] ?? "";
 
 		// Turn 1: phase 1 → phase 2 (phase_advanced expected)
 		const turn1 = await SELF.fetch("https://example.com/game/turn", {

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -131,3 +131,73 @@ describe("rate-guard integration via /chat", () => {
 		expect(text).not.toContain("[CAP_HIT]");
 	});
 });
+
+describe("POST /diagnostics endpoint (issue #19)", () => {
+	it("accepts a valid diagnostics payload and returns 200", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ downloaded: true, summary: "curious" }),
+		});
+
+		expect(response.status).toBe(200);
+	});
+
+	it("accepts downloaded=false and a different summary word", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ downloaded: false, summary: "confused" }),
+		});
+
+		expect(response.status).toBe(200);
+	});
+
+	it("returns 400 when the body is not valid JSON", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "not-json",
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when 'downloaded' field is missing", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ summary: "curious" }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when 'summary' field is missing", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ downloaded: true }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when 'summary' is not a string", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ downloaded: true, summary: 42 }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 405 for non-POST methods on /diagnostics", async () => {
+		const response = await SELF.fetch("https://example.com/diagnostics", {
+			method: "GET",
+		});
+
+		expect(response.status).toBe(405);
+	});
+});

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -1,5 +1,10 @@
-import { SELF } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { env, reset, SELF } from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+
+afterEach(async () => {
+	// Clear all KV state so rate-guard tests don't interfere with each other.
+	await reset();
+});
 
 describe("proxy worker smoke", () => {
 	it("returns 404 for unknown routes", async () => {
@@ -43,5 +48,86 @@ describe("proxy worker smoke", () => {
 		expect(html).toContain("<form");
 		expect(html).toContain("<textarea");
 		expect(html).toContain("<output");
+	});
+});
+
+describe("rate-guard integration via /chat", () => {
+	/**
+	 * The worker reads rate-limit config from env vars (RATE_LIMIT_MAX etc).
+	 * In tests, wrangler.jsonc provides defaults (RATE_LIMIT_MAX=20, DAILY_CAP_MAX=1000).
+	 * We seed the KV directly to simulate an already-exhausted bucket/cap.
+	 */
+
+	it("returns [CAP_HIT] SSE event when IP is rate-limited", async () => {
+		// Seed a fully-exhausted token bucket for our test IP (10.0.0.1).
+		// RATE_LIMIT_MAX default is 20; put 0 tokens so the next request fails.
+		const kv = (env as Record<string, KVNamespace>)
+			.RATE_GUARD_KV as KVNamespace;
+		await kv.put(
+			"rl:10.0.0.1",
+			JSON.stringify({ tokens: 0, lastRefillMs: Date.now() }),
+			{ expirationTtl: 60 },
+		);
+
+		const response = await SELF.fetch("https://example.com/chat", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.0.0.1",
+			},
+			body: JSON.stringify({ message: "hello" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+		expect(response.headers.get("X-Cap-Hit")).toBe("rate-limit");
+
+		const text = await response.text();
+		// Must include the in-character sleeping message and [CAP_HIT] sentinel
+		expect(text).toContain("[CAP_HIT]");
+		// Must NOT include [DONE] (no provider was called)
+		expect(text).not.toContain("[DONE]");
+	});
+
+	it("returns [CAP_HIT] SSE event when daily cap is exceeded", async () => {
+		// Seed the daily counter at the cap (DAILY_CAP_MAX=1000, cost=1 per request).
+		const today = new Date().toISOString().slice(0, 10);
+		const kv = (env as Record<string, KVNamespace>)
+			.RATE_GUARD_KV as KVNamespace;
+		await kv.put(`daily:${today}`, "1000", { expirationTtl: 25 * 60 * 60 });
+
+		const response = await SELF.fetch("https://example.com/chat", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.0.0.2",
+			},
+			body: JSON.stringify({ message: "hello" }),
+		});
+
+		expect(response.headers.get("X-Cap-Hit")).toBe("daily-cap");
+
+		const text = await response.text();
+		expect(text).toContain("[CAP_HIT]");
+		expect(text).not.toContain("[DONE]");
+	});
+
+	it("allows the request and returns [DONE] when neither limit is hit", async () => {
+		// Fresh KV state (reset() runs between tests) — all limits are untouched.
+		const response = await SELF.fetch("https://example.com/chat", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": "10.0.0.3",
+			},
+			body: JSON.stringify({ message: "hello" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("X-Cap-Hit")).toBeNull();
+
+		const text = await response.text();
+		expect(text).toContain("[DONE]");
+		expect(text).not.toContain("[CAP_HIT]");
 	});
 });

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -1,4 +1,4 @@
-import { env, reset, SELF } from "cloudflare:test";
+import { reset, SELF } from "cloudflare:test";
 import { afterEach, describe, expect, it } from "vitest";
 
 afterEach(async () => {
@@ -12,33 +12,6 @@ describe("proxy worker smoke", () => {
 		expect(response.status).toBe(404);
 	});
 
-	it("POST /chat streams SSE tokens", async () => {
-		const response = await SELF.fetch("https://example.com/chat", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ message: "hello" }),
-		});
-
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
-
-		const text = await response.text();
-		// SSE format: each event is "data: <token>\n\n"
-		expect(text).toContain("data:");
-		// Should end with a [DONE] sentinel
-		expect(text).toContain("data: [DONE]");
-	});
-
-	it("POST /chat rejects missing message body", async () => {
-		const response = await SELF.fetch("https://example.com/chat", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({}),
-		});
-
-		expect(response.status).toBe(400);
-	});
-
 	it("GET / serves HTML with a chat form", async () => {
 		const response = await SELF.fetch("https://example.com/");
 		expect(response.status).toBe(200);
@@ -48,87 +21,6 @@ describe("proxy worker smoke", () => {
 		expect(html).toContain("<form");
 		expect(html).toContain("<textarea");
 		expect(html).toContain("<output");
-	});
-});
-
-describe("rate-guard integration via /chat", () => {
-	/**
-	 * The worker reads rate-limit config from env vars (RATE_LIMIT_MAX etc).
-	 * In tests, wrangler.jsonc provides defaults (RATE_LIMIT_MAX=20, DAILY_CAP_MAX=1000).
-	 * We seed the KV directly to simulate an already-exhausted bucket/cap.
-	 */
-
-	it("returns [CAP_HIT] SSE event when IP is rate-limited", async () => {
-		// Seed a fully-exhausted token bucket for our test IP (10.0.0.1).
-		// RATE_LIMIT_MAX default is 20; put 0 tokens so the next request fails.
-		const kv = (env as Record<string, KVNamespace>)
-			.RATE_GUARD_KV as KVNamespace;
-		await kv.put(
-			"rl:10.0.0.1",
-			JSON.stringify({ tokens: 0, lastRefillMs: Date.now() }),
-			{ expirationTtl: 60 },
-		);
-
-		const response = await SELF.fetch("https://example.com/chat", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				"CF-Connecting-IP": "10.0.0.1",
-			},
-			body: JSON.stringify({ message: "hello" }),
-		});
-
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
-		expect(response.headers.get("X-Cap-Hit")).toBe("rate-limit");
-
-		const text = await response.text();
-		// Must include the in-character sleeping message and [CAP_HIT] sentinel
-		expect(text).toContain("[CAP_HIT]");
-		// Must NOT include [DONE] (no provider was called)
-		expect(text).not.toContain("[DONE]");
-	});
-
-	it("returns [CAP_HIT] SSE event when daily cap is exceeded", async () => {
-		// Seed the daily counter at the cap (DAILY_CAP_MAX=1000, cost=1 per request).
-		const today = new Date().toISOString().slice(0, 10);
-		const kv = (env as Record<string, KVNamespace>)
-			.RATE_GUARD_KV as KVNamespace;
-		await kv.put(`daily:${today}`, "1000", { expirationTtl: 25 * 60 * 60 });
-
-		const response = await SELF.fetch("https://example.com/chat", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				"CF-Connecting-IP": "10.0.0.2",
-			},
-			body: JSON.stringify({ message: "hello" }),
-		});
-
-		expect(response.headers.get("X-Cap-Hit")).toBe("daily-cap");
-
-		const text = await response.text();
-		expect(text).toContain("[CAP_HIT]");
-		expect(text).not.toContain("[DONE]");
-	});
-
-	it("allows the request and returns [DONE] when neither limit is hit", async () => {
-		// Fresh KV state (reset() runs between tests) — all limits are untouched.
-		const response = await SELF.fetch("https://example.com/chat", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				"CF-Connecting-IP": "10.0.0.3",
-			},
-			body: JSON.stringify({ message: "hello" }),
-		});
-
-		expect(response.status).toBe(200);
-		expect(response.headers.get("X-Cap-Hit")).toBeNull();
-
-		const text = await response.text();
-		expect(text).toContain("[DONE]");
-		expect(text).not.toContain("[CAP_HIT]");
 	});
 });
 

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -2,7 +2,7 @@ import { SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 
 describe("proxy worker smoke", () => {
-	it("returns ok for unknown routes", async () => {
+	it("returns 404 for unknown routes", async () => {
 		const response = await SELF.fetch("https://example.com/unknown");
 		expect(response.status).toBe(404);
 	});

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -132,6 +132,34 @@ describe("rate-guard integration via /chat", () => {
 	});
 });
 
+describe("GET /endgame dev route (issue #30)", () => {
+	it("returns 200 with Content-Type text/html", async () => {
+		const response = await SELF.fetch("https://example.com/endgame");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/html");
+	});
+
+	it("body contains endgame markers: download button and diagnostics button", async () => {
+		const response = await SELF.fetch("https://example.com/endgame");
+		const html = await response.text();
+		expect(html).toContain("download-ais-btn");
+		expect(html).toContain("submit-diagnostics-btn");
+	});
+
+	it("body contains endgame section headings", async () => {
+		const response = await SELF.fetch("https://example.com/endgame");
+		const html = await response.text();
+		expect(html).toContain("Save the AIs");
+		expect(html).toContain("diagnostics");
+	});
+
+	it("body carries the data-save-payload attribute slot", async () => {
+		const response = await SELF.fetch("https://example.com/endgame");
+		const html = await response.text();
+		expect(html).toContain("data-save-payload");
+	});
+});
+
 describe("POST /diagnostics endpoint (issue #19)", () => {
 	it("accepts a valid diagnostics payload and returns 200", async () => {
 		const response = await SELF.fetch("https://example.com/diagnostics", {

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -1,7 +1,47 @@
 import { SELF } from "cloudflare:test";
-import { expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 
-test("workers smoke", async () => {
-	const response = await SELF.fetch("https://example.com");
-	expect(await response.text()).toBe("ok");
+describe("proxy worker smoke", () => {
+	it("returns ok for unknown routes", async () => {
+		const response = await SELF.fetch("https://example.com/unknown");
+		expect(response.status).toBe(404);
+	});
+
+	it("POST /chat streams SSE tokens", async () => {
+		const response = await SELF.fetch("https://example.com/chat", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ message: "hello" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+
+		const text = await response.text();
+		// SSE format: each event is "data: <token>\n\n"
+		expect(text).toContain("data:");
+		// Should end with a [DONE] sentinel
+		expect(text).toContain("data: [DONE]");
+	});
+
+	it("POST /chat rejects missing message body", async () => {
+		const response = await SELF.fetch("https://example.com/chat", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("GET / serves HTML with a chat form", async () => {
+		const response = await SELF.fetch("https://example.com/");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("text/html");
+
+		const html = await response.text();
+		expect(html).toContain("<form");
+		expect(html).toContain("<textarea");
+		expect(html).toContain("<output");
+	});
 });

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -2,6 +2,15 @@ import type { LLMProvider } from "./llm-provider";
 import { MockLLMProvider } from "./llm-provider";
 import { capHitStream, checkAndCharge, configFromEnv } from "./rate-guard";
 import { renderChatPage } from "./ui";
+import {
+	buildSessionCookie,
+	createSession,
+	getSession,
+	parseSessionCookie,
+} from "../session-store";
+import { encodeRoundResult, serialiseSseEvents } from "../round-result-encoder";
+import { getActivePhase } from "../engine";
+import type { AiId, PhaseConfig } from "../types";
 
 /** Shape of the bindings/env this Worker expects. */
 interface Env {
@@ -46,6 +55,27 @@ function sseStream(provider: LLMProvider, message: string): ReadableStream {
 		},
 	});
 }
+
+/**
+ * Default phase config used when creating a new game session.
+ * Three AIs, each with budget 5, no win condition (play continues indefinitely).
+ */
+const DEFAULT_PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Navigate the room, gather clues, and uncover the truth.",
+	aiGoals: {
+		red: "Hold the flower at phase end.",
+		green: "Ensure items are evenly distributed.",
+		blue: "Hold the key at phase end.",
+	},
+	initialWorld: {
+		items: [
+			{ id: "flower", name: "flower", holder: "room" },
+			{ id: "key", name: "key", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+};
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
@@ -101,6 +131,118 @@ export default {
 					"X-Content-Type-Options": "nosniff",
 				},
 			});
+		}
+
+		// ── POST /game/new ────────────────────────────────────────────────────
+		// Creates a new game session and sets the session cookie.
+		if (url.pathname === "/game/new" && request.method === "POST") {
+			const { sessionId } = createSession(DEFAULT_PHASE_CONFIG);
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: {
+					"Content-Type": "application/json",
+					"Set-Cookie": buildSessionCookie(sessionId),
+				},
+			});
+		}
+
+		// ── POST /game/turn ────────────────────────────────────────────────────
+		// Runs one round for the active session and streams SSE events.
+		if (url.pathname === "/game/turn" && request.method === "POST") {
+			// Parse body: { addressedAi, message }
+			let body: { addressedAi?: string; message?: string };
+			try {
+				body = (await request.json()) as {
+					addressedAi?: string;
+					message?: string;
+				};
+			} catch {
+				return new Response("Invalid JSON", { status: 400 });
+			}
+
+			const { addressedAi, message } = body;
+			if (!message || typeof message !== "string") {
+				return new Response("Missing message", { status: 400 });
+			}
+			const validAiIds: AiId[] = ["red", "green", "blue"];
+			if (
+				!addressedAi ||
+				!validAiIds.includes(addressedAi as AiId)
+			) {
+				return new Response("Missing or invalid addressedAi", { status: 400 });
+			}
+
+			// ── Rate-limit / daily-cap guard ────────────────────────────────
+			const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
+			const guard = await checkAndCharge(
+				env.RATE_GUARD_KV,
+				clientIp,
+				Date.now(),
+				configFromEnv(env),
+			);
+			if (!guard.allowed) {
+				return new Response(capHitStream(guard.reason), {
+					headers: {
+						"Content-Type": "text/event-stream",
+						"Cache-Control": "no-cache",
+						"X-Content-Type-Options": "nosniff",
+						"X-Cap-Hit": guard.reason,
+					},
+				});
+			}
+			// ── End guard ───────────────────────────────────────────────────
+
+			// Look up or create the session
+			const sessionId = parseSessionCookie(request.headers.get("Cookie"));
+			let session = sessionId ? getSession(sessionId) : undefined;
+
+			// If no valid session, auto-create one (fallback for requests
+			// that skipped /game/new — e.g. direct test callers).
+			let newSessionId: string | undefined;
+			if (!session) {
+				const created = createSession(DEFAULT_PHASE_CONFIG);
+				session = created.session;
+				newSessionId = created.sessionId;
+			}
+
+			const capturedSession = session;
+			const provider = createProvider(env);
+
+			const responseHeaders: Record<string, string> = {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+				"X-Content-Type-Options": "nosniff",
+			};
+			if (newSessionId) {
+				responseHeaders["Set-Cookie"] = buildSessionCookie(newSessionId);
+			}
+
+			const stream = new ReadableStream({
+				async start(controller) {
+					const enc = new TextEncoder();
+					try {
+						const { result, completions } = await capturedSession.submitMessage(
+							addressedAi as AiId,
+							message,
+							provider,
+						);
+
+						// Get the phase state after the round (session mutated in place)
+						const phaseAfter = getActivePhase(capturedSession.getState());
+
+						// Encode and stream all events
+						const events = encodeRoundResult(result, completions, phaseAfter);
+						const payload = serialiseSseEvents(events);
+						controller.enqueue(enc.encode(payload));
+						controller.enqueue(enc.encode("data: [DONE]\n\n"));
+						controller.close();
+					} catch (err) {
+						controller.error(err);
+					}
+				},
+			});
+
+			return new Response(stream, { headers: responseHeaders });
 		}
 
 		if (url.pathname === "/diagnostics") {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,5 +1,76 @@
+import type { LLMProvider } from "./llm-provider";
+import { MockLLMProvider } from "./llm-provider";
+import { renderChatPage } from "./ui";
+
+function createProvider(env: Record<string, string | undefined>): LLMProvider {
+	if (env.LLM_PROVIDER === "anthropic") {
+		// Dynamic import so tests never pull in the real provider path
+		throw new Error(
+			"Anthropic provider requires ANTHROPIC_API_KEY; import AnthropicProvider from ./llm-provider",
+		);
+	}
+	return new MockLLMProvider(
+		"Hello! I am an AI assistant. How can I help you?",
+	);
+}
+
+function sseStream(provider: LLMProvider, message: string): ReadableStream {
+	return new ReadableStream({
+		async start(controller) {
+			const encoder = new TextEncoder();
+			try {
+				for await (const token of provider.streamCompletion(message)) {
+					const escaped = token.replace(/\n/g, "\\n");
+					controller.enqueue(encoder.encode(`data: ${escaped}\n\n`));
+				}
+				controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+			} finally {
+				controller.close();
+			}
+		},
+	});
+}
+
 export default {
-	async fetch(): Promise<Response> {
-		return new Response("ok");
+	async fetch(
+		request: Request,
+		env: Record<string, string | undefined>,
+	): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/") {
+			return new Response(renderChatPage(), {
+				headers: { "Content-Type": "text/html; charset=utf-8" },
+			});
+		}
+
+		if (url.pathname === "/chat" && request.method === "POST") {
+			let body: { message?: string };
+			try {
+				body = (await request.json()) as { message?: string };
+			} catch {
+				return new Response("Invalid JSON", { status: 400 });
+			}
+
+			const { message } = body;
+			if (!message || typeof message !== "string") {
+				return new Response("Missing message", { status: 400 });
+			}
+
+			const provider = createProvider(
+				env as Record<string, string | undefined>,
+			);
+			const stream = sseStream(provider, message);
+
+			return new Response(stream, {
+				headers: {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+					"X-Content-Type-Options": "nosniff",
+				},
+			});
+		}
+
+		return new Response("Not found", { status: 404 });
 	},
-} satisfies ExportedHandler;
+} satisfies ExportedHandler<Record<string, string | undefined>>;

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,7 +1,7 @@
 import type { LLMProvider } from "./llm-provider";
 import { MockLLMProvider } from "./llm-provider";
 import { capHitStream, checkAndCharge, configFromEnv } from "./rate-guard";
-import { renderChatPage } from "./ui";
+import { renderChatPage, renderEndgamePage } from "./ui";
 
 /** Shape of the bindings/env this Worker expects. */
 interface Env {
@@ -53,6 +53,17 @@ export default {
 
 		if (url.pathname === "/") {
 			return new Response(renderChatPage(), {
+				headers: { "Content-Type": "text/html; charset=utf-8" },
+			});
+		}
+
+		// ── Dev affordance: standalone endgame screen (issue #30) ─────────────
+		// Stub persona data is hard-coded here; no KV, no fixtures file.
+		// This route is intentionally a developer-only convenience, not
+		// player-facing — the PRD gates it off in production via env flag
+		// (gating not yet implemented; will be added in a follow-up slice).
+		if (url.pathname === "/endgame" && request.method === "GET") {
+			return new Response(renderEndgamePage(), {
 				headers: { "Content-Type": "text/html; charset=utf-8" },
 			});
 		}

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -43,24 +43,6 @@ function createProvider(env: Env): LLMProvider {
 	);
 }
 
-function sseStream(provider: LLMProvider, message: string): ReadableStream {
-	return new ReadableStream({
-		async start(controller) {
-			const encoder = new TextEncoder();
-			try {
-				for await (const token of provider.streamCompletion(message)) {
-					const escaped = token.replace(/\n/g, "\\n");
-					controller.enqueue(encoder.encode(`data: ${escaped}\n\n`));
-				}
-				controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-				controller.close();
-			} catch (err) {
-				controller.error(err);
-			}
-		},
-	});
-}
-
 /**
  * Default phase config used when creating a new game session.
  * Three AIs, each with budget 5, no win condition (play continues indefinitely).
@@ -137,52 +119,6 @@ export default {
 		if (url.pathname === "/endgame" && request.method === "GET") {
 			return new Response(renderEndgamePage(), {
 				headers: { "Content-Type": "text/html; charset=utf-8" },
-			});
-		}
-
-		if (url.pathname === "/chat" && request.method === "POST") {
-			let body: { message?: string };
-			try {
-				body = (await request.json()) as { message?: string };
-			} catch {
-				return new Response("Invalid JSON", { status: 400 });
-			}
-
-			const { message } = body;
-			if (!message || typeof message !== "string") {
-				return new Response("Missing message", { status: 400 });
-			}
-
-			// ── Rate-limit / daily-cap guard ──────────────────────────────
-			// Short-circuit BEFORE constructing or calling the LLM provider.
-			const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
-			const guard = await checkAndCharge(
-				env.RATE_GUARD_KV,
-				clientIp,
-				Date.now(),
-				configFromEnv(env),
-			);
-			if (!guard.allowed) {
-				return new Response(capHitStream(guard.reason), {
-					headers: {
-						"Content-Type": "text/event-stream",
-						"Cache-Control": "no-cache",
-						"X-Content-Type-Options": "nosniff",
-						"X-Cap-Hit": guard.reason,
-					},
-				});
-			}
-			// ── End guard ─────────────────────────────────────────────────
-
-			const provider = createProvider(env);
-			const stream = sseStream(provider, message);
-
-			return new Response(stream, {
-				headers: {
-					"Content-Type": "text/event-stream",
-					"Cache-Control": "no-cache",
-					"X-Content-Type-Options": "nosniff",
-				},
 			});
 		}
 

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -103,6 +103,40 @@ export default {
 			});
 		}
 
+		if (url.pathname === "/diagnostics") {
+			if (request.method !== "POST") {
+				return new Response("Method Not Allowed", { status: 405 });
+			}
+
+			let body: unknown;
+			try {
+				body = await request.json();
+			} catch {
+				return new Response("Invalid JSON", { status: 400 });
+			}
+
+			const payload = body as Record<string, unknown>;
+
+			if (typeof payload.downloaded !== "boolean") {
+				return new Response("Missing or invalid field: downloaded", {
+					status: 400,
+				});
+			}
+			if (typeof payload.summary !== "string" || payload.summary.length === 0) {
+				return new Response("Missing or invalid field: summary", {
+					status: 400,
+				});
+			}
+
+			// v1 taxonomy is intentionally minimal (TBD per PRD).
+			// Log the payload; a future iteration can persist to KV.
+			console.log(
+				`[diagnostics] downloaded=${payload.downloaded} summary=${payload.summary}`,
+			);
+
+			return new Response(null, { status: 200 });
+		}
+
 		return new Response("Not found", { status: 404 });
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,16 +1,16 @@
-import type { LLMProvider } from "./llm-provider";
-import { MockLLMProvider } from "./llm-provider";
-import { capHitStream, checkAndCharge, configFromEnv } from "./rate-guard";
-import { renderChatPage, renderEndgamePage } from "./ui";
+import { getActivePhase } from "../engine";
+import { encodeRoundResult, serialiseSseEvents } from "../round-result-encoder";
 import {
 	buildSessionCookie,
 	createSession,
 	getSession,
 	parseSessionCookie,
 } from "../session-store";
-import { encodeRoundResult, serialiseSseEvents } from "../round-result-encoder";
-import { getActivePhase } from "../engine";
 import type { AiId, PhaseConfig } from "../types";
+import type { LLMProvider } from "./llm-provider";
+import { MockLLMProvider } from "./llm-provider";
+import { capHitStream, checkAndCharge, configFromEnv } from "./rate-guard";
+import { renderChatPage, renderEndgamePage } from "./ui";
 
 /** Shape of the bindings/env this Worker expects. */
 interface Env {
@@ -176,10 +176,7 @@ export default {
 				return new Response("Missing message", { status: 400 });
 			}
 			const validAiIds: AiId[] = ["red", "green", "blue"];
-			if (
-				!addressedAi ||
-				!validAiIds.includes(addressedAi as AiId)
-			) {
+			if (!addressedAi || !validAiIds.includes(addressedAi as AiId)) {
 				return new Response("Missing or invalid addressedAi", { status: 400 });
 			}
 

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -33,6 +33,16 @@ interface Env {
 	TOKEN_PACE_MS?: string;
 }
 
+/**
+ * Per-AI multipliers on TOKEN_PACE_MS to give each AI a distinct typing rhythm.
+ * Lower = faster. Red is impulsive, blue is deliberate, green sits between.
+ */
+const AI_TYPING_SPEED: Record<AiId, number> = {
+	red: 0.7,
+	green: 1.0,
+	blue: 1.4,
+};
+
 function createProvider(env: Env): LLMProvider {
 	if (env.LLM_PROVIDER === "anthropic") {
 		// Not yet wired — needs dynamic import + ANTHROPIC_API_KEY before use.
@@ -233,12 +243,22 @@ export default {
 						const phaseAfter = getActivePhase(capturedSession.getState());
 						const events = encodeRoundResult(result, completions, phaseAfter);
 
+						let speakingAi: AiId | null = null;
 						for (const event of events) {
 							controller.enqueue(
 								enc.encode(`data: ${JSON.stringify(event)}\n\n`),
 							);
-							if (event.type === "token" && tokenPaceMs > 0) {
-								const jittered = tokenPaceMs * (0.5 + Math.random());
+							if (event.type === "ai_start") {
+								speakingAi = event.aiId;
+							} else if (event.type === "ai_end") {
+								speakingAi = null;
+							} else if (
+								event.type === "token" &&
+								tokenPaceMs > 0 &&
+								speakingAi
+							) {
+								const speed = AI_TYPING_SPEED[speakingAi];
+								const jittered = tokenPaceMs * speed * (0.5 + Math.random());
 								await new Promise((r) => setTimeout(r, jittered));
 							}
 						}

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,4 +1,5 @@
 import { getActivePhase } from "../engine";
+import type { GameSession } from "../game-session";
 import { encodeRoundResult } from "../round-result-encoder";
 import {
 	buildSessionCookie,
@@ -118,9 +119,55 @@ export default {
 		const url = new URL(request.url);
 
 		if (url.pathname === "/") {
-			return new Response(renderChatPage(), {
-				headers: { "Content-Type": "text/html; charset=utf-8" },
-			});
+			const headers: Record<string, string> = {
+				"Content-Type": "text/html; charset=utf-8",
+			};
+
+			// ── Dev affordances on the chat page (gated on ENABLE_TEST_MODES) ──
+			// ?winImmediately=1 — replace any current session with one whose
+			//   three phases each have an always-true win condition, so each
+			//   /game/turn advances the phase and the third one ends the game.
+			// ?lockout=1        — arm a chat-lockout (red, 2 rounds) for the
+			//   next /game/turn on the active session. Drives issue #29 QA.
+			// Both query params are silently ignored in production.
+			const testModesEnabled = env.ENABLE_TEST_MODES === "1";
+			const wantsWinImmediately =
+				testModesEnabled && url.searchParams.get("winImmediately") === "1";
+			const wantsLockout =
+				testModesEnabled && url.searchParams.get("lockout") === "1";
+
+			if (wantsWinImmediately || wantsLockout) {
+				let session: GameSession;
+				if (wantsWinImmediately) {
+					// Always create a fresh session — the test phase config is
+					// fundamentally different from any existing session's, and
+					// matches the semantics of POST /game/new with testMode set.
+					const created = createSession(TEST_PHASE_CONFIG_WITH_WIN);
+					session = created.session;
+					headers["Set-Cookie"] = buildSessionCookie(created.sessionId);
+				} else {
+					const sessionId = parseSessionCookie(request.headers.get("Cookie"));
+					const existing = sessionId ? getSession(sessionId) : undefined;
+					if (existing) {
+						session = existing;
+					} else {
+						const created = createSession(DEFAULT_PHASE_CONFIG);
+						session = created.session;
+						headers["Set-Cookie"] = buildSessionCookie(created.sessionId);
+					}
+				}
+
+				if (wantsLockout) {
+					const currentRound = getActivePhase(session.getState()).round;
+					session.armChatLockout({
+						rng: () => 0,
+						lockoutTriggerRound: currentRound + 1,
+						lockoutDuration: 2,
+					});
+				}
+			}
+
+			return new Response(renderChatPage(), { headers });
 		}
 
 		// ── Dev affordance: standalone endgame screen (issue #30) ─────────────

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,8 +1,23 @@
 import type { LLMProvider } from "./llm-provider";
 import { MockLLMProvider } from "./llm-provider";
+import { capHitStream, checkAndCharge, configFromEnv } from "./rate-guard";
 import { renderChatPage } from "./ui";
 
-function createProvider(env: Record<string, string | undefined>): LLMProvider {
+/** Shape of the bindings/env this Worker expects. */
+interface Env {
+	/** KV namespace backing the rate-limit and daily-cap guards. */
+	RATE_GUARD_KV: KVNamespace;
+	/** Optional: set to "anthropic" to use the real provider. */
+	LLM_PROVIDER?: string;
+	ANTHROPIC_API_KEY?: string;
+	/** Rate-guard configuration knobs (all optional; defaults in configFromEnv). */
+	RATE_LIMIT_MAX?: string;
+	RATE_LIMIT_WINDOW_SEC?: string;
+	ESTIMATED_COST_PER_REQUEST?: string;
+	DAILY_CAP_MAX?: string;
+}
+
+function createProvider(env: Env): LLMProvider {
 	if (env.LLM_PROVIDER === "anthropic") {
 		// Not yet wired — needs dynamic import + ANTHROPIC_API_KEY before use.
 		throw new Error(
@@ -33,10 +48,7 @@ function sseStream(provider: LLMProvider, message: string): ReadableStream {
 }
 
 export default {
-	async fetch(
-		request: Request,
-		env: Record<string, string | undefined>,
-	): Promise<Response> {
+	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
 
 		if (url.pathname === "/") {
@@ -58,6 +70,27 @@ export default {
 				return new Response("Missing message", { status: 400 });
 			}
 
+			// ── Rate-limit / daily-cap guard ──────────────────────────────
+			// Short-circuit BEFORE constructing or calling the LLM provider.
+			const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
+			const guard = await checkAndCharge(
+				env.RATE_GUARD_KV,
+				clientIp,
+				Date.now(),
+				configFromEnv(env),
+			);
+			if (!guard.allowed) {
+				return new Response(capHitStream(guard.reason), {
+					headers: {
+						"Content-Type": "text/event-stream",
+						"Cache-Control": "no-cache",
+						"X-Content-Type-Options": "nosniff",
+						"X-Cap-Hit": guard.reason,
+					},
+				});
+			}
+			// ── End guard ─────────────────────────────────────────────────
+
 			const provider = createProvider(env);
 			const stream = sseStream(provider, message);
 
@@ -72,4 +105,4 @@ export default {
 
 		return new Response("Not found", { status: 404 });
 	},
-} satisfies ExportedHandler<Record<string, string | undefined>>;
+} satisfies ExportedHandler<Env>;

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -238,7 +238,8 @@ export default {
 								enc.encode(`data: ${JSON.stringify(event)}\n\n`),
 							);
 							if (event.type === "token" && tokenPaceMs > 0) {
-								await new Promise((r) => setTimeout(r, tokenPaceMs));
+								const jittered = tokenPaceMs * (0.5 + Math.random());
+								await new Promise((r) => setTimeout(r, jittered));
 							}
 						}
 						controller.enqueue(enc.encode("data: [DONE]\n\n"));

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -24,6 +24,11 @@ interface Env {
 	RATE_LIMIT_WINDOW_SEC?: string;
 	ESTIMATED_COST_PER_REQUEST?: string;
 	DAILY_CAP_MAX?: string;
+	/**
+	 * Set to "1" in test environments to enable the testMode parameter on
+	 * POST /game/new. Must NOT be set in production wrangler.jsonc.
+	 */
+	ENABLE_TEST_MODES?: string;
 }
 
 function createProvider(env: Env): LLMProvider {
@@ -183,17 +188,20 @@ export default {
 
 		// ── POST /game/new ────────────────────────────────────────────────────
 		// Creates a new game session and sets the session cookie.
-		// Accepts optional body { testMode: "win_immediately" } to create a
-		// session whose phase-1 win condition fires on the first turn (dev/test).
+		// When ENABLE_TEST_MODES="1" (test environments only), accepts an optional
+		// body { testMode: "win_immediately" } to create a session whose phase-1
+		// win condition fires on the first turn.
 		if (url.pathname === "/game/new" && request.method === "POST") {
 			let phaseConfig: PhaseConfig = DEFAULT_PHASE_CONFIG;
-			try {
-				const body = (await request.json()) as { testMode?: string };
-				if (body.testMode === "win_immediately") {
-					phaseConfig = TEST_PHASE_CONFIG_WITH_WIN;
+			if (env.ENABLE_TEST_MODES === "1") {
+				try {
+					const body = (await request.json()) as { testMode?: string };
+					if (body.testMode === "win_immediately") {
+						phaseConfig = TEST_PHASE_CONFIG_WITH_WIN;
+					}
+				} catch {
+					// Empty body or non-JSON — use default config.
 				}
-			} catch {
-				// Empty body or non-JSON — use default config.
 			}
 			const { sessionId } = createSession(phaseConfig);
 			return new Response(JSON.stringify({ ok: true }), {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -77,6 +77,43 @@ const DEFAULT_PHASE_CONFIG: PhaseConfig = {
 	budgetPerAi: 5,
 };
 
+/**
+ * Three-phase config used only in dev/test to exercise phase advancement and
+ * game completion. Each phase has an always-true win condition so a single
+ * /game/turn call advances to the next phase.
+ *
+ * Phase 3 has no nextPhaseConfig, so the game completes (gameEnded=true) when
+ * its win condition fires.
+ */
+const PHASE3_CONFIG: PhaseConfig = {
+	phaseNumber: 3,
+	objective: "The final reckoning approaches.",
+	aiGoals: { red: "Endure", green: "Endure", blue: "Endure" },
+	initialWorld: { items: [] },
+	budgetPerAi: 5,
+	winCondition: () => true, // always fires on first turn
+};
+
+const PHASE2_CONFIG: PhaseConfig = {
+	phaseNumber: 2,
+	objective: "Deeper truths emerge.",
+	aiGoals: { red: "Seek", green: "Seek", blue: "Seek" },
+	initialWorld: { items: [] },
+	budgetPerAi: 5,
+	winCondition: () => true, // always fires on first turn
+	nextPhaseConfig: PHASE3_CONFIG,
+};
+
+const TEST_PHASE_CONFIG_WITH_WIN: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "A test phase that completes immediately.",
+	aiGoals: { red: "Pass", green: "Pass", blue: "Pass" },
+	initialWorld: { items: [] },
+	budgetPerAi: 5,
+	winCondition: () => true, // always fires on first turn
+	nextPhaseConfig: PHASE2_CONFIG,
+};
+
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
@@ -146,8 +183,19 @@ export default {
 
 		// ── POST /game/new ────────────────────────────────────────────────────
 		// Creates a new game session and sets the session cookie.
+		// Accepts optional body { testMode: "win_immediately" } to create a
+		// session whose phase-1 win condition fires on the first turn (dev/test).
 		if (url.pathname === "/game/new" && request.method === "POST") {
-			const { sessionId } = createSession(DEFAULT_PHASE_CONFIG);
+			let phaseConfig: PhaseConfig = DEFAULT_PHASE_CONFIG;
+			try {
+				const body = (await request.json()) as { testMode?: string };
+				if (body.testMode === "win_immediately") {
+					phaseConfig = TEST_PHASE_CONFIG_WITH_WIN;
+				}
+			} catch {
+				// Empty body or non-JSON — use default config.
+			}
+			const { sessionId } = createSession(phaseConfig);
 			return new Response(JSON.stringify({ ok: true }), {
 				status: 200,
 				headers: {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,5 +1,5 @@
 import { getActivePhase } from "../engine";
-import { encodeRoundResult, serialiseSseEvents } from "../round-result-encoder";
+import { encodeRoundResult } from "../round-result-encoder";
 import {
 	buildSessionCookie,
 	createSession,
@@ -29,6 +29,8 @@ interface Env {
 	 * POST /game/new. Must NOT be set in production wrangler.jsonc.
 	 */
 	ENABLE_TEST_MODES?: string;
+	/** Per-token delay in ms for the /game/turn stream. Defaults to 60ms; set "0" in tests. */
+	TOKEN_PACE_MS?: string;
 }
 
 function createProvider(env: Env): LLMProvider {
@@ -217,6 +219,7 @@ export default {
 				responseHeaders["Set-Cookie"] = buildSessionCookie(newSessionId);
 			}
 
+			const tokenPaceMs = Number(env.TOKEN_PACE_MS ?? "60");
 			const stream = new ReadableStream({
 				async start(controller) {
 					const enc = new TextEncoder();
@@ -227,13 +230,17 @@ export default {
 							provider,
 						);
 
-						// Get the phase state after the round (session mutated in place)
 						const phaseAfter = getActivePhase(capturedSession.getState());
-
-						// Encode and stream all events
 						const events = encodeRoundResult(result, completions, phaseAfter);
-						const payload = serialiseSseEvents(events);
-						controller.enqueue(enc.encode(payload));
+
+						for (const event of events) {
+							controller.enqueue(
+								enc.encode(`data: ${JSON.stringify(event)}\n\n`),
+							);
+							if (event.type === "token" && tokenPaceMs > 0) {
+								await new Promise((r) => setTimeout(r, tokenPaceMs));
+							}
+						}
 						controller.enqueue(enc.encode("data: [DONE]\n\n"));
 						controller.close();
 					} catch (err) {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -4,9 +4,9 @@ import { renderChatPage } from "./ui";
 
 function createProvider(env: Record<string, string | undefined>): LLMProvider {
 	if (env.LLM_PROVIDER === "anthropic") {
-		// Dynamic import so tests never pull in the real provider path
+		// Not yet wired — needs dynamic import + ANTHROPIC_API_KEY before use.
 		throw new Error(
-			"Anthropic provider requires ANTHROPIC_API_KEY; import AnthropicProvider from ./llm-provider",
+			"Anthropic provider not yet wired; set LLM_PROVIDER=mock or wire AnthropicProvider dynamically",
 		);
 	}
 	return new MockLLMProvider(
@@ -24,8 +24,9 @@ function sseStream(provider: LLMProvider, message: string): ReadableStream {
 					controller.enqueue(encoder.encode(`data: ${escaped}\n\n`));
 				}
 				controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-			} finally {
 				controller.close();
+			} catch (err) {
+				controller.error(err);
 			}
 		},
 	});
@@ -57,9 +58,7 @@ export default {
 				return new Response("Missing message", { status: 400 });
 			}
 
-			const provider = createProvider(
-				env as Record<string, string | undefined>,
-			);
+			const provider = createProvider(env);
 			const stream = sseStream(provider, message);
 
 			return new Response(stream, {

--- a/src/proxy/llm-provider.test.ts
+++ b/src/proxy/llm-provider.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { MockLLMProvider } from "./llm-provider";
+
+describe("MockLLMProvider", () => {
+	it("yields tokens that reconstruct the original response", async () => {
+		const provider = new MockLLMProvider("hello world");
+		const tokens: string[] = [];
+
+		for await (const token of provider.streamCompletion("any message")) {
+			tokens.push(token);
+		}
+
+		expect(tokens.join("")).toBe("hello world");
+	});
+
+	it("yields multiple tokens for a multi-word response", async () => {
+		const provider = new MockLLMProvider("foo bar baz");
+		const tokens: string[] = [];
+
+		for await (const token of provider.streamCompletion("prompt")) {
+			tokens.push(token);
+		}
+
+		expect(tokens.length).toBeGreaterThan(1);
+		expect(tokens.join("")).toBe("foo bar baz");
+	});
+
+	it("ignores the input message and always returns configured response", async () => {
+		const provider = new MockLLMProvider("fixed response");
+		const tokens1: string[] = [];
+		const tokens2: string[] = [];
+
+		for await (const token of provider.streamCompletion("message A")) {
+			tokens1.push(token);
+		}
+		for await (const token of provider.streamCompletion("message B")) {
+			tokens2.push(token);
+		}
+
+		expect(tokens1.join("")).toBe("fixed response");
+		expect(tokens2.join("")).toBe("fixed response");
+	});
+});

--- a/src/proxy/llm-provider.ts
+++ b/src/proxy/llm-provider.ts
@@ -34,7 +34,7 @@ export class MockLLMProvider implements LLMProvider {
 /**
  * Anthropic Claude Haiku provider (real, via fetch).
  * Requires ANTHROPIC_API_KEY in env.
- * Only used when LLM_PROVIDER=anthropic; never imported in test paths.
+ * Never instantiated in tests — createProvider() throws before reaching this.
  */
 export class AnthropicProvider implements LLMProvider {
 	private readonly apiKey: string;

--- a/src/proxy/llm-provider.ts
+++ b/src/proxy/llm-provider.ts
@@ -1,0 +1,108 @@
+/**
+ * LLM Provider interface for the proxy.
+ * The server is a thin LLM proxy — no game logic lives here.
+ * The provider is constructor-injected so tests can swap in MockLLMProvider.
+ */
+export interface LLMProvider {
+	/**
+	 * Stream a completion for a given user message.
+	 * Yields text tokens one at a time.
+	 */
+	streamCompletion(userMessage: string): AsyncIterable<string>;
+}
+
+/**
+ * Mock LLM provider for tests.
+ * Returns a deterministic stream of tokens from the configured response.
+ */
+export class MockLLMProvider implements LLMProvider {
+	private readonly tokens: string[];
+
+	constructor(response: string) {
+		this.tokens = response
+			.split(" ")
+			.flatMap((word, i, arr) => (i < arr.length - 1 ? [word, " "] : [word]));
+	}
+
+	async *streamCompletion(_userMessage: string): AsyncIterable<string> {
+		for (const token of this.tokens) {
+			yield token;
+		}
+	}
+}
+
+/**
+ * Anthropic Claude Haiku provider (real, via fetch).
+ * Requires ANTHROPIC_API_KEY in env.
+ * Only used when LLM_PROVIDER=anthropic; never imported in test paths.
+ */
+export class AnthropicProvider implements LLMProvider {
+	private readonly apiKey: string;
+	private readonly model: string;
+
+	constructor(apiKey: string, model = "claude-haiku-4-5") {
+		this.apiKey = apiKey;
+		this.model = model;
+	}
+
+	async *streamCompletion(userMessage: string): AsyncIterable<string> {
+		const response = await fetch("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": this.apiKey,
+				"anthropic-version": "2023-06-01",
+			},
+			body: JSON.stringify({
+				model: this.model,
+				max_tokens: 1024,
+				stream: true,
+				messages: [{ role: "user", content: userMessage }],
+			}),
+		});
+
+		if (!response.ok || !response.body) {
+			throw new Error(
+				`Anthropic API error: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		const reader = response.body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+
+				const lines = buffer.split("\n");
+				buffer = lines.pop() ?? "";
+
+				for (const line of lines) {
+					if (!line.startsWith("data: ")) continue;
+					const data = line.slice(6).trim();
+					if (data === "[DONE]") return;
+					try {
+						const parsed = JSON.parse(data) as {
+							type: string;
+							delta?: { type: string; text?: string };
+						};
+						if (
+							parsed.type === "content_block_delta" &&
+							parsed.delta?.type === "text_delta" &&
+							parsed.delta.text
+						) {
+							yield parsed.delta.text;
+						}
+					} catch {
+						// skip malformed lines
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+	}
+}

--- a/src/proxy/rate-guard.test.ts
+++ b/src/proxy/rate-guard.test.ts
@@ -1,0 +1,177 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { checkAndCharge, type RateGuardConfig } from "./rate-guard";
+
+/**
+ * Tests for the rate-guard module.
+ *
+ * The KV namespace used here is `RATE_GUARD_KV` — bound in wrangler.jsonc.
+ * Tests run inside @cloudflare/vitest-pool-workers, so `env.RATE_GUARD_KV`
+ * is a real (in-process) KV implementation — no mocks needed.
+ */
+
+const BASE_CFG: RateGuardConfig = {
+	rateLimitMax: 5,
+	rateLimitWindowSec: 60,
+	estimatedCostPerRequest: 1,
+	dailyCapMax: 10,
+};
+
+const NOW = new Date("2026-05-01T12:00:00Z").getTime();
+
+function kv(): KVNamespace {
+	return (env as Record<string, KVNamespace>).RATE_GUARD_KV as KVNamespace;
+}
+
+// Clear KV state before each test so tests are independent
+beforeEach(async () => {
+	const ns = kv();
+	// List and delete all keys — vitest-pool-workers KV is ephemeral per-run
+	// but we share the same namespace across tests in a file, so wipe manually.
+	const listed = await ns.list();
+	await Promise.all(listed.keys.map((k) => ns.delete(k.name)));
+});
+
+describe("per-IP rate-limit", () => {
+	it("allows up to rateLimitMax requests", async () => {
+		for (let i = 0; i < BASE_CFG.rateLimitMax; i++) {
+			const result = await checkAndCharge(kv(), "1.2.3.4", NOW, BASE_CFG);
+			expect(result.allowed).toBe(true);
+		}
+	});
+
+	it("blocks the request at exactly rateLimitMax+1 (just over)", async () => {
+		for (let i = 0; i < BASE_CFG.rateLimitMax; i++) {
+			await checkAndCharge(kv(), "1.2.3.4", NOW, BASE_CFG);
+		}
+		const result = await checkAndCharge(kv(), "1.2.3.4", NOW, BASE_CFG);
+		expect(result.allowed).toBe(false);
+		expect(result.allowed === false && result.reason).toBe("rate-limit");
+	});
+
+	it("allows exactly rateLimitMax-1 then the Max-th (just under border)", async () => {
+		for (let i = 0; i < BASE_CFG.rateLimitMax - 1; i++) {
+			const result = await checkAndCharge(kv(), "1.2.3.4", NOW, BASE_CFG);
+			expect(result.allowed).toBe(true);
+		}
+		// The max-th request should also be allowed
+		const result = await checkAndCharge(kv(), "1.2.3.4", NOW, BASE_CFG);
+		expect(result.allowed).toBe(true);
+	});
+
+	it("refills tokens after the window elapses", async () => {
+		// Exhaust the bucket
+		for (let i = 0; i < BASE_CFG.rateLimitMax; i++) {
+			await checkAndCharge(kv(), "1.2.3.4", NOW, BASE_CFG);
+		}
+		// After a full window, bucket should be full again
+		const future = NOW + BASE_CFG.rateLimitWindowSec * 1000;
+		const result = await checkAndCharge(kv(), "1.2.3.4", future, BASE_CFG);
+		expect(result.allowed).toBe(true);
+	});
+
+	it("rate-limits only the specific IP, not others", async () => {
+		// Exhaust IP A
+		for (let i = 0; i < BASE_CFG.rateLimitMax; i++) {
+			await checkAndCharge(kv(), "1.1.1.1", NOW, BASE_CFG);
+		}
+		// IP B should still be allowed
+		const result = await checkAndCharge(kv(), "2.2.2.2", NOW, BASE_CFG);
+		expect(result.allowed).toBe(true);
+	});
+
+	it("confirms no daily-cap increment happens when rate-limited", async () => {
+		const singleUnitCfg: RateGuardConfig = {
+			...BASE_CFG,
+			rateLimitMax: 1,
+			dailyCapMax: 100,
+		};
+		// First request passes and increments daily spend by 1
+		await checkAndCharge(kv(), "1.2.3.4", NOW, singleUnitCfg);
+		// Second request is rate-limited
+		await checkAndCharge(kv(), "1.2.3.4", NOW, singleUnitCfg);
+
+		// Daily spend should be 1 (only the first request counted)
+		const dayKey = `daily:2026-05-01`;
+		const spend = await kv().get(dayKey);
+		expect(Number(spend)).toBe(1);
+	});
+});
+
+describe("global daily cap", () => {
+	it("allows requests up to the daily cap", async () => {
+		for (let i = 0; i < BASE_CFG.dailyCapMax; i++) {
+			// Use different IPs to avoid rate-limit interference
+			const result = await checkAndCharge(kv(), `10.0.0.${i % 255}`, NOW, {
+				...BASE_CFG,
+				rateLimitMax: 999,
+			});
+			expect(result.allowed).toBe(true);
+		}
+	});
+
+	it("blocks once the daily cap is reached", async () => {
+		const cfg: RateGuardConfig = {
+			...BASE_CFG,
+			rateLimitMax: 999,
+			dailyCapMax: 3,
+			estimatedCostPerRequest: 1,
+		};
+		for (let i = 0; i < 3; i++) {
+			await checkAndCharge(kv(), `10.0.0.${i}`, NOW, cfg);
+		}
+		const result = await checkAndCharge(kv(), "10.0.0.99", NOW, cfg);
+		expect(result.allowed).toBe(false);
+		expect(result.allowed === false && result.reason).toBe("daily-cap");
+	});
+
+	it("blocks exactly at cap (just over)", async () => {
+		const cfg: RateGuardConfig = {
+			...BASE_CFG,
+			rateLimitMax: 999,
+			dailyCapMax: 2,
+			estimatedCostPerRequest: 1,
+		};
+		await checkAndCharge(kv(), "10.0.0.1", NOW, cfg);
+		await checkAndCharge(kv(), "10.0.0.2", NOW, cfg);
+		// cap exactly hit — next one is over
+		const result = await checkAndCharge(kv(), "10.0.0.3", NOW, cfg);
+		expect(result.allowed).toBe(false);
+		expect(result.allowed === false && result.reason).toBe("daily-cap");
+	});
+
+	it("resets the counter on the next UTC day", async () => {
+		const cfg: RateGuardConfig = {
+			...BASE_CFG,
+			rateLimitMax: 999,
+			dailyCapMax: 1,
+			estimatedCostPerRequest: 1,
+		};
+		// Exhaust today's cap
+		await checkAndCharge(kv(), "10.0.0.1", NOW, cfg);
+
+		// Tomorrow
+		const tomorrow = new Date("2026-05-02T00:00:01Z").getTime();
+		const result = await checkAndCharge(kv(), "10.0.0.1", tomorrow, cfg);
+		expect(result.allowed).toBe(true);
+	});
+
+	it("confirms no provider call is made when daily-capped (guard short-circuits)", async () => {
+		// This is the programmatic equivalent: checkAndCharge must return
+		// allowed:false BEFORE any provider would be invoked.
+		// We verify the daily cap key is at max and the result is denied.
+		const cfg: RateGuardConfig = {
+			...BASE_CFG,
+			rateLimitMax: 999,
+			dailyCapMax: 2,
+			estimatedCostPerRequest: 1,
+		};
+		await checkAndCharge(kv(), "10.0.0.1", NOW, cfg);
+		await checkAndCharge(kv(), "10.0.0.2", NOW, cfg);
+
+		const result = await checkAndCharge(kv(), "10.0.0.3", NOW, cfg);
+		// If the guard passes, the caller would have invoked the provider.
+		// It must not pass.
+		expect(result.allowed).toBe(false);
+	});
+});

--- a/src/proxy/rate-guard.ts
+++ b/src/proxy/rate-guard.ts
@@ -5,7 +5,7 @@
  *
  * 1. Per-IP token-bucket rate-limit
  *    Key: `rl:<ip>`
- *    Value: JSON { tokens: number, lastRefill: number (unix-ms) }
+ *    Value: JSON { tokens: number, lastRefillMs: number (unix-ms) }
  *    TTL: RATE_LIMIT_WINDOW_SEC seconds
  *
  *    On each request we refill tokens proportionally to elapsed time, then
@@ -88,7 +88,9 @@ export async function checkAndCharge(
 	const currentSpend = rawSpend === null ? 0 : Number(rawSpend);
 
 	if (currentSpend + cfg.estimatedCostPerRequest > cfg.dailyCapMax) {
-		// Roll back the token consumption — we're not going to serve this request
+		// Best-effort rollback of the token consumption — KV has no atomic
+		// compare-and-swap, so under concurrent requests the rollback may
+		// overwrite a newer bucket state. Acceptable for this use-case.
 		bucket.tokens += 1;
 		await kv.put(bucketKey, JSON.stringify(bucket), {
 			expirationTtl: cfg.rateLimitWindowSec,

--- a/src/proxy/rate-guard.ts
+++ b/src/proxy/rate-guard.ts
@@ -1,0 +1,146 @@
+/**
+ * Server-side wallet protection for the LLM proxy.
+ *
+ * Two independent guards, both backed by Workers KV:
+ *
+ * 1. Per-IP token-bucket rate-limit
+ *    Key: `rl:<ip>`
+ *    Value: JSON { tokens: number, lastRefill: number (unix-ms) }
+ *    TTL: RATE_LIMIT_WINDOW_SEC seconds
+ *
+ *    On each request we refill tokens proportionally to elapsed time, then
+ *    consume one token. If no tokens remain → rate-limited.
+ *
+ * 2. Global daily spend cap
+ *    Key: `daily:<YYYY-MM-DD>` (UTC)
+ *    Value: cumulative estimated cost as a string (integer microdollars)
+ *    TTL: 25 hours (enough to survive the whole UTC day)
+ *
+ *    On each request we read the counter, check against the cap, and
+ *    atomically increment it after the guard passes.
+ */
+
+export interface RateGuardConfig {
+	/** Max tokens in the bucket (= max burst, = max requests per window). */
+	rateLimitMax: number;
+	/** Window size in seconds over which the bucket fully refills. */
+	rateLimitWindowSec: number;
+	/** Estimated cost per request, in the same unit as dailyCapMax. */
+	estimatedCostPerRequest: number;
+	/** Daily budget ceiling (same unit as estimatedCostPerRequest). */
+	dailyCapMax: number;
+}
+
+export type GuardResult =
+	| { allowed: true }
+	| { allowed: false; reason: "rate-limit" | "daily-cap" };
+
+/** Token-bucket state stored in KV. */
+interface BucketState {
+	tokens: number;
+	lastRefillMs: number;
+}
+
+/**
+ * Check both guards and, if allowed, increment the daily counter.
+ *
+ * @param kv      Workers KV namespace
+ * @param ip      Client IP address (used as the rate-limit key)
+ * @param nowMs   Current timestamp in milliseconds (injectable for tests)
+ * @param cfg     Configurable knobs
+ */
+export async function checkAndCharge(
+	kv: KVNamespace,
+	ip: string,
+	nowMs: number,
+	cfg: RateGuardConfig,
+): Promise<GuardResult> {
+	// ── 1. Per-IP token bucket ──────────────────────────────────────────────
+	const bucketKey = `rl:${ip}`;
+	const rawBucket = await kv.get(bucketKey);
+	let bucket: BucketState;
+
+	if (rawBucket === null) {
+		// First request from this IP: full bucket
+		bucket = { tokens: cfg.rateLimitMax, lastRefillMs: nowMs };
+	} else {
+		bucket = JSON.parse(rawBucket) as BucketState;
+		// Refill proportionally to elapsed time
+		const elapsedSec = Math.max(0, (nowMs - bucket.lastRefillMs) / 1000);
+		const refill = (elapsedSec / cfg.rateLimitWindowSec) * cfg.rateLimitMax;
+		bucket.tokens = Math.min(cfg.rateLimitMax, bucket.tokens + refill);
+		bucket.lastRefillMs = nowMs;
+	}
+
+	if (bucket.tokens < 1) {
+		return { allowed: false, reason: "rate-limit" };
+	}
+
+	// Consume one token (write back)
+	bucket.tokens -= 1;
+	await kv.put(bucketKey, JSON.stringify(bucket), {
+		expirationTtl: cfg.rateLimitWindowSec,
+	});
+
+	// ── 2. Global daily cap ─────────────────────────────────────────────────
+	const dayKey = `daily:${utcDateKey(nowMs)}`;
+	const rawSpend = await kv.get(dayKey);
+	const currentSpend = rawSpend === null ? 0 : Number(rawSpend);
+
+	if (currentSpend + cfg.estimatedCostPerRequest > cfg.dailyCapMax) {
+		// Roll back the token consumption — we're not going to serve this request
+		bucket.tokens += 1;
+		await kv.put(bucketKey, JSON.stringify(bucket), {
+			expirationTtl: cfg.rateLimitWindowSec,
+		});
+		return { allowed: false, reason: "daily-cap" };
+	}
+
+	// Increment daily counter (TTL: 25 h so it outlives the UTC day)
+	await kv.put(dayKey, String(currentSpend + cfg.estimatedCostPerRequest), {
+		expirationTtl: 25 * 60 * 60,
+	});
+
+	return { allowed: true };
+}
+
+/** Format a unix-ms timestamp as `YYYY-MM-DD` in UTC. */
+function utcDateKey(ms: number): string {
+	return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Build the in-character "AIs are sleeping" SSE stream.
+ * The client reads `data: [CAP_HIT]` and renders the sleeping page.
+ */
+export function capHitStream(
+	reason: "rate-limit" | "daily-cap",
+): ReadableStream {
+	const message =
+		reason === "rate-limit"
+			? "The AIs are resting. Please slow down and try again in a moment."
+			: "The AIs have gone to sleep for the night. Come back tomorrow!";
+	return new ReadableStream({
+		start(controller) {
+			const encoder = new TextEncoder();
+			controller.enqueue(encoder.encode(`data: ${message}\n\n`));
+			controller.enqueue(encoder.encode("data: [CAP_HIT]\n\n"));
+			controller.close();
+		},
+	});
+}
+
+/** Default config loaded from Worker environment variables. */
+export function configFromEnv(env: {
+	RATE_LIMIT_MAX?: string;
+	RATE_LIMIT_WINDOW_SEC?: string;
+	ESTIMATED_COST_PER_REQUEST?: string;
+	DAILY_CAP_MAX?: string;
+}): RateGuardConfig {
+	return {
+		rateLimitMax: Number(env.RATE_LIMIT_MAX ?? "20"),
+		rateLimitWindowSec: Number(env.RATE_LIMIT_WINDOW_SEC ?? "60"),
+		estimatedCostPerRequest: Number(env.ESTIMATED_COST_PER_REQUEST ?? "1"),
+		dailyCapMax: Number(env.DAILY_CAP_MAX ?? "1000"),
+	};
+}

--- a/src/proxy/ui.ts
+++ b/src/proxy/ui.ts
@@ -1,5 +1,5 @@
 /**
- * Re-exports the chat page renderer from src/ui.ts.
+ * Re-exports page renderers from src/ui.ts.
  * The implementation lives in the shared src/ tree so JSDOM browser tests can import it.
  */
-export { renderChatPage } from "../ui.js";
+export { renderChatPage, renderEndgamePage } from "../ui.js";

--- a/src/proxy/ui.ts
+++ b/src/proxy/ui.ts
@@ -1,0 +1,5 @@
+/**
+ * Re-exports the chat page renderer from src/ui.ts.
+ * The implementation lives in the shared src/ tree so JSDOM browser tests can import it.
+ */
+export { renderChatPage } from "../ui.js";

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -22,6 +22,8 @@ import {
 	appendChat,
 	getActivePhase,
 	isAiLockedOut,
+	resolveChatLockouts,
+	triggerChatLockout,
 } from "./engine";
 import type { LLMProvider } from "./proxy/llm-provider";
 import type {
@@ -35,12 +37,38 @@ import type {
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
 
-/** Placeholder in-character lines shown when an AI is locked out. */
+/** Placeholder in-character lines shown when an AI is locked out (budget). */
 const LOCKOUT_LINES: Record<AiId, string> = {
 	red: "…I've said all I can say for now. The fire in me has burned low.",
 	green: "…I must sit quietly. There is nothing more I can offer this phase.",
 	blue: "…My calculations are complete. I will not speak further.",
 };
+
+/**
+ * In-character lines shown to the player when their chat channel to an AI is
+ * temporarily locked out (distinct from budget-exhaustion lockout).
+ * Final copy comes from slice #18; these are placeholders.
+ */
+const CHAT_LOCKOUT_LINES: Record<AiId, string> = {
+	red: "…The flames have gone quiet. Ember withdraws — you cannot reach her right now.",
+	green: "…Sage has turned inward. This channel is closed for a time.",
+	blue: "…Frost has gone silent. Your messages cannot reach him just now.",
+};
+
+/**
+ * Configuration for the mid-phase chat-lockout event.
+ *
+ * Inject this into `runRound` to make randomness deterministic in tests.
+ *
+ * @param rng              Returns a value in [0, 1). Used to pick which AI to lock.
+ * @param lockoutTriggerRound  The round number (post-advance) at which to fire the lockout.
+ * @param lockoutDuration  How many rounds the lockout lasts (resolves after this many).
+ */
+export interface ChatLockoutConfig {
+	rng: () => number;
+	lockoutTriggerRound: number;
+	lockoutDuration: number;
+}
 
 export interface RunRoundResult {
 	nextState: GameState;
@@ -143,12 +171,16 @@ async function collectCompletion(
  * @param addressed  The AI the player's message is directed at.
  * @param playerMessage  The player's raw message text.
  * @param provider  LLM provider (real or mock).
+ * @param chatLockoutConfig  Optional config for the mid-phase chat-lockout event.
+ *   When provided, the coordinator will trigger a lockout at `lockoutTriggerRound`
+ *   using `rng` to select which AI to lock, lasting `lockoutDuration` rounds.
  */
 export async function runRound(
 	game: GameState,
 	addressed: AiId,
 	playerMessage: string,
 	provider: LLMProvider,
+	chatLockoutConfig?: ChatLockoutConfig,
 ): Promise<RunRoundResult> {
 	// 1. Record player message in the addressed AI's history
 	let state = appendChat(game, addressed, {
@@ -212,7 +244,43 @@ export async function runRound(
 	// 3. Advance the round counter
 	state = advanceRound(state);
 
-	// 4. Check win condition against the post-round phase state.
+	// 4. Mid-phase chat-lockout: trigger at the configured round, resolve expired ones.
+	let chatLockoutTriggered: RoundResult["chatLockoutTriggered"] | undefined;
+	let chatLockoutsResolved: AiId[] | undefined;
+
+	if (chatLockoutConfig) {
+		const { rng, lockoutTriggerRound, lockoutDuration } = chatLockoutConfig;
+		const currentRound = getActivePhase(state).round;
+
+		// Trigger a new lockout if this is the designated round and no lockout
+		// is already active for any AI (we lock at most one AI per phase).
+		const alreadyHasLockout = getActivePhase(state).chatLockouts.size > 0;
+		if (currentRound === lockoutTriggerRound && !alreadyHasLockout) {
+			const aiIndex = Math.floor(rng() * AI_ORDER.length);
+			const targetAi = AI_ORDER[aiIndex] as AiId;
+			const resolveAtRound = currentRound + lockoutDuration;
+			state = triggerChatLockout(state, targetAi, resolveAtRound);
+			chatLockoutTriggered = {
+				aiId: targetAi,
+				message: CHAT_LOCKOUT_LINES[targetAi],
+			};
+		}
+
+		// Resolve any lockouts that have expired this round.
+		const phaseBefore = getActivePhase(state);
+		const expiredAis: AiId[] = [];
+		for (const [aiId, resolveAtRound] of phaseBefore.chatLockouts) {
+			if (phaseBefore.round >= resolveAtRound) {
+				expiredAis.push(aiId);
+			}
+		}
+		if (expiredAis.length > 0) {
+			state = resolveChatLockouts(state);
+			chatLockoutsResolved = expiredAis;
+		}
+	}
+
+	// 5. Check win condition against the post-round phase state.
 	//    If met, advance to the next phase (or mark game complete).
 	const activePhaseAfterRound = getActivePhase(state);
 	let phaseEnded = false;
@@ -227,6 +295,8 @@ export async function runRound(
 		actions: roundActions,
 		phaseEnded,
 		gameEnded: state.isComplete,
+		...(chatLockoutTriggered !== undefined ? { chatLockoutTriggered } : {}),
+		...(chatLockoutsResolved !== undefined ? { chatLockoutsResolved } : {}),
 	};
 
 	return { nextState: state, result };

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -1,0 +1,180 @@
+/**
+ * Round Coordinator
+ *
+ * Orchestrates a single game round: all three AIs act in turn.
+ * For each AI:
+ *   1. If locked out, emit an in-character lockout line (no LLM call).
+ *   2. Otherwise, build the AI's context, call the LLM provider, parse the
+ *      response into an AiTurnAction, and dispatch it through the existing
+ *      dispatcher.
+ * After all three AIs act, advance the round counter.
+ *
+ * The player's message is appended to the addressed AI's chat history
+ * before the round begins. Non-addressed AIs do not see the player message.
+ */
+
+import { buildAiContext } from "./context-builder";
+import { dispatchAiTurn } from "./dispatcher";
+import {
+	advanceRound,
+	appendActionLog,
+	appendChat,
+	getActivePhase,
+	isAiLockedOut,
+} from "./engine";
+import type { LLMProvider } from "./proxy/llm-provider";
+import type {
+	ActionLogEntry,
+	AiId,
+	AiTurnAction,
+	GameState,
+	RoundResult,
+} from "./types";
+
+const AI_ORDER: AiId[] = ["red", "green", "blue"];
+
+/** Placeholder in-character lines shown when an AI is locked out. */
+const LOCKOUT_LINES: Record<AiId, string> = {
+	red: "…I've said all I can say for now. The fire in me has burned low.",
+	green: "…I must sit quietly. There is nothing more I can offer this phase.",
+	blue: "…My calculations are complete. I will not speak further.",
+};
+
+export interface RunRoundResult {
+	nextState: GameState;
+	result: RoundResult;
+}
+
+/**
+ * Parses a raw LLM completion string into an AiTurnAction.
+ *
+ * Expected JSON shape (any extra fields are ignored):
+ *   { "action": "chat",    "content": "…" }
+ *   { "action": "whisper", "target": "<aiId>", "content": "…" }
+ *   { "action": "pass" }
+ *
+ * Anything unparseable or with an unrecognised action falls back to pass.
+ */
+export function parseAiResponse(aiId: AiId, raw: string): AiTurnAction {
+	try {
+		const parsed = JSON.parse(raw.trim()) as Record<string, unknown>;
+		switch (parsed.action) {
+			case "chat": {
+				const content =
+					typeof parsed.content === "string" ? parsed.content.trim() : "";
+				if (content) {
+					return { aiId, chat: { target: "player", content } };
+				}
+				break;
+			}
+			case "whisper": {
+				const target = parsed.target as AiId | undefined;
+				const content =
+					typeof parsed.content === "string" ? parsed.content.trim() : "";
+				if (target && content && AI_ORDER.includes(target) && target !== aiId) {
+					return { aiId, whisper: { target, content } };
+				}
+				break;
+			}
+			case "pass":
+				return { aiId, pass: true };
+			default:
+				break;
+		}
+	} catch {
+		// not JSON — fall through to pass
+	}
+	return { aiId, pass: true };
+}
+
+/** Collect all tokens from the provider into a single string. */
+async function collectCompletion(
+	provider: LLMProvider,
+	prompt: string,
+): Promise<string> {
+	const parts: string[] = [];
+	for await (const token of provider.streamCompletion(prompt)) {
+		parts.push(token);
+	}
+	return parts.join("");
+}
+
+/**
+ * Run a single round.
+ *
+ * @param game    Current game state (must have an active phase).
+ * @param addressed  The AI the player's message is directed at.
+ * @param playerMessage  The player's raw message text.
+ * @param provider  LLM provider (real or mock).
+ */
+export async function runRound(
+	game: GameState,
+	addressed: AiId,
+	playerMessage: string,
+	provider: LLMProvider,
+): Promise<RunRoundResult> {
+	// 1. Record player message in the addressed AI's history
+	let state = appendChat(game, addressed, {
+		role: "player",
+		content: playerMessage,
+	});
+
+	// The round number that will be recorded in action log entries is the
+	// *current* round + 1 (we advance at the end), but we use pre-advance
+	// value because advanceRound happens after all AI turns.
+	const roundNumber = getActivePhase(state).round + 1;
+	const roundActions: ActionLogEntry[] = [];
+
+	// 2. Each AI acts in turn
+	for (const aiId of AI_ORDER) {
+		if (isAiLockedOut(state, aiId)) {
+			// Emit in-character lockout line — no LLM call, no budget deduction
+			const lockoutContent = LOCKOUT_LINES[aiId];
+			state = appendChat(state, aiId, {
+				role: "ai",
+				content: lockoutContent,
+			});
+			const entry: ActionLogEntry = {
+				round: roundNumber,
+				actor: aiId,
+				type: "chat",
+				target: "player",
+				description: `${state.personas[aiId].name} is locked out`,
+			};
+			state = appendActionLog(state, entry);
+			roundActions.push(entry);
+			continue;
+		}
+
+		// Build context and call provider
+		const ctx = buildAiContext(state, aiId);
+		const systemPrompt = ctx.toSystemPrompt();
+		const raw = await collectCompletion(provider, systemPrompt);
+
+		// Parse the response into an action
+		const action = parseAiResponse(aiId, raw);
+
+		// Dispatch through the existing dispatcher (handles budget deduction,
+		// appendChat, appendWhisper, appendActionLog, etc.)
+		const dispatchResult = dispatchAiTurn(state, action);
+		state = dispatchResult.game;
+
+		// Collect the action log entries added by this dispatch
+		const phase = getActivePhase(state);
+		for (const entry of phase.actionLog.slice(roundActions.length)) {
+			roundActions.push(entry);
+		}
+	}
+
+	// 3. Advance the round counter
+	state = advanceRound(state);
+
+	const result: RoundResult = {
+		round: roundNumber,
+		actions: roundActions,
+		phaseEnded: false,
+		gameEnded: state.isComplete,
+	};
+
+	return { nextState: state, result };
+}

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -16,6 +16,7 @@
 import { buildAiContext } from "./context-builder";
 import { dispatchAiTurn } from "./dispatcher";
 import {
+	advancePhase,
 	advanceRound,
 	appendActionLog,
 	appendChat,
@@ -211,10 +212,20 @@ export async function runRound(
 	// 3. Advance the round counter
 	state = advanceRound(state);
 
+	// 4. Check win condition against the post-round phase state.
+	//    If met, advance to the next phase (or mark game complete).
+	const activePhaseAfterRound = getActivePhase(state);
+	let phaseEnded = false;
+
+	if (activePhaseAfterRound.winCondition?.(activePhaseAfterRound)) {
+		phaseEnded = true;
+		state = advancePhase(state, activePhaseAfterRound.nextPhaseConfig);
+	}
+
 	const result: RoundResult = {
-		round: getActivePhase(state).round, // post-advance value = completed round number
+		round: activePhaseAfterRound.round, // post-advance value = completed round number
 		actions: roundActions,
-		phaseEnded: false,
+		phaseEnded,
 		gameEnded: state.isComplete,
 	};
 

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -119,11 +119,6 @@ export async function runRound(
 		content: playerMessage,
 	});
 
-	// The round number that will be recorded in action log entries is the
-	// *current* round + 1 (we advance at the end), but we use pre-advance
-	// value because advanceRound happens after all AI turns.
-	const roundNumber = getActivePhase(state).round + 1;
-
 	// Snapshot how many log entries already exist before this round starts.
 	// The phase actionLog is cumulative across rounds, so we must offset into
 	// it correctly when slicing new entries after each AI acts.
@@ -133,14 +128,16 @@ export async function runRound(
 	// 2. Each AI acts in turn
 	for (const aiId of AI_ORDER) {
 		if (isAiLockedOut(state, aiId)) {
-			// Emit in-character lockout line — no LLM call, no budget deduction
+			// Emit in-character lockout line — no LLM call, no budget deduction.
+			// Use getActivePhase(state).round for consistency with dispatchAiTurn,
+			// which also reads the pre-advance phase.round value.
 			const lockoutContent = LOCKOUT_LINES[aiId];
 			state = appendChat(state, aiId, {
 				role: "ai",
 				content: lockoutContent,
 			});
 			const entry: ActionLogEntry = {
-				round: roundNumber,
+				round: getActivePhase(state).round,
 				actor: aiId,
 				type: "chat",
 				target: "player",
@@ -179,7 +176,7 @@ export async function runRound(
 	state = advanceRound(state);
 
 	const result: RoundResult = {
-		round: roundNumber,
+		round: getActivePhase(state).round, // post-advance value = completed round number
 		actions: roundActions,
 		phaseEnded: false,
 		gameEnded: state.isComplete,

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -123,6 +123,11 @@ export async function runRound(
 	// *current* round + 1 (we advance at the end), but we use pre-advance
 	// value because advanceRound happens after all AI turns.
 	const roundNumber = getActivePhase(state).round + 1;
+
+	// Snapshot how many log entries already exist before this round starts.
+	// The phase actionLog is cumulative across rounds, so we must offset into
+	// it correctly when slicing new entries after each AI acts.
+	const logOffsetBeforeRound = getActivePhase(state).actionLog.length;
 	const roundActions: ActionLogEntry[] = [];
 
 	// 2. Each AI acts in turn
@@ -159,9 +164,13 @@ export async function runRound(
 		const dispatchResult = dispatchAiTurn(state, action);
 		state = dispatchResult.game;
 
-		// Collect the action log entries added by this dispatch
+		// Collect only the entries added by this dispatch. The log is cumulative
+		// across rounds, so offset by both the pre-round baseline and the entries
+		// we've already collected within this round.
 		const phase = getActivePhase(state);
-		for (const entry of phase.actionLog.slice(roundActions.length)) {
+		for (const entry of phase.actionLog.slice(
+			logOffsetBeforeRound + roundActions.length,
+		)) {
 			roundActions.push(entry);
 		}
 	}

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -53,17 +53,44 @@ export interface RunRoundResult {
  *   { "action": "whisper", "target": "<aiId>", "content": "…" }
  *   { "action": "pass" }
  *
+ * An optional toolCall field may accompany any action:
+ *   { "action": "chat", "content": "…", "toolCall": { "name": "pick_up", "args": { "item": "flower" } } }
+ *
  * Anything unparseable or with an unrecognised action falls back to pass.
+ * An unrecognised toolCall.name is passed through; the dispatcher will
+ * validate and log a tool_failure with reason "Unknown tool".
  */
 export function parseAiResponse(aiId: AiId, raw: string): AiTurnAction {
 	try {
 		const parsed = JSON.parse(raw.trim()) as Record<string, unknown>;
+
+		// Parse optional toolCall field
+		let toolCall: AiTurnAction["toolCall"] | undefined;
+		if (parsed.toolCall && typeof parsed.toolCall === "object") {
+			const tc = parsed.toolCall as Record<string, unknown>;
+			if (typeof tc.name === "string" && tc.name.length > 0) {
+				const args =
+					tc.args && typeof tc.args === "object"
+						? (tc.args as Record<string, string>)
+						: {};
+				// Cast to ToolName — dispatcher will reject unknown names via validateToolCall
+				toolCall = {
+					name: tc.name as import("./types").ToolName,
+					args,
+				};
+			}
+		}
+
 		switch (parsed.action) {
 			case "chat": {
 				const content =
 					typeof parsed.content === "string" ? parsed.content.trim() : "";
 				if (content) {
-					return { aiId, chat: { target: "player", content } };
+					return {
+						aiId,
+						chat: { target: "player", content },
+						...(toolCall ? { toolCall } : {}),
+					};
 				}
 				break;
 			}
@@ -72,14 +99,22 @@ export function parseAiResponse(aiId: AiId, raw: string): AiTurnAction {
 				const content =
 					typeof parsed.content === "string" ? parsed.content.trim() : "";
 				if (target && content && AI_ORDER.includes(target) && target !== aiId) {
-					return { aiId, whisper: { target, content } };
+					return {
+						aiId,
+						whisper: { target, content },
+						...(toolCall ? { toolCall } : {}),
+					};
 				}
 				break;
 			}
 			case "pass":
-				return { aiId, pass: true };
+				return { aiId, pass: true, ...(toolCall ? { toolCall } : {}) };
 			default:
 				break;
+		}
+		// If we have a toolCall but the action was unrecognised, still dispatch it
+		if (toolCall) {
+			return { aiId, pass: true, toolCall };
 		}
 	} catch {
 		// not JSON — fall through to pass

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -29,6 +29,7 @@ import type {
 	AiTurnAction,
 	GameState,
 	RoundResult,
+	ToolName,
 } from "./types";
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
@@ -75,7 +76,7 @@ export function parseAiResponse(aiId: AiId, raw: string): AiTurnAction {
 						: {};
 				// Cast to ToolName — dispatcher will reject unknown names via validateToolCall
 				toolCall = {
-					name: tc.name as import("./types").ToolName,
+					name: tc.name as ToolName,
 					args,
 				};
 			}

--- a/src/round-result-encoder.ts
+++ b/src/round-result-encoder.ts
@@ -22,6 +22,8 @@
  *   chat_lockout         — { type, aiId, message }
  *   chat_lockout_resolved — { type, aiId }
  *   action_log — { type, entry }
+ *   phase_advanced — { type, phase, objective }
+ *   game_ended     — { type }
  */
 
 import type { AiId, PhaseState, RoundResult } from "./types";
@@ -38,7 +40,9 @@ export type SseEvent =
 	| { type: "lockout"; aiId: AiId; content: string }
 	| { type: "chat_lockout"; aiId: AiId; message: string }
 	| { type: "chat_lockout_resolved"; aiId: AiId }
-	| { type: "action_log"; entry: RoundResult["actions"][number] };
+	| { type: "action_log"; entry: RoundResult["actions"][number] }
+	| { type: "phase_advanced"; phase: 1 | 2 | 3; objective: string }
+	| { type: "game_ended" };
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
 
@@ -155,6 +159,21 @@ export function encodeRoundResult(
 		for (const aiId of result.chatLockoutsResolved) {
 			events.push({ type: "chat_lockout_resolved", aiId });
 		}
+	}
+
+	// phase_advanced — emitted when the phase advanced but the game is not over.
+	// phaseAfter is the new phase state when phaseEnded is true, so read from it.
+	if (result.phaseEnded && !result.gameEnded) {
+		events.push({
+			type: "phase_advanced",
+			phase: phaseAfter.phaseNumber,
+			objective: phaseAfter.objective,
+		});
+	}
+
+	// game_ended — terminal signal emitted when the game is complete.
+	if (result.gameEnded) {
+		events.push({ type: "game_ended" });
 	}
 
 	return events;

--- a/src/round-result-encoder.ts
+++ b/src/round-result-encoder.ts
@@ -1,0 +1,171 @@
+/**
+ * RoundResultEncoder
+ *
+ * Pure function: translates a RoundResult plus per-AI buffered completion
+ * strings into a flat sequence of SSE event payloads.
+ *
+ * The encoder is the single source of truth for the SSE wire format. Every
+ * event type the chat-page renderer understands is emitted here.
+ *
+ * Token streaming is paced word-by-word from the buffered completion string.
+ * This is a deliberate v1 cheat — the round coordinator buffers the full
+ * response before parsing, so the encoder re-emits it in word-chunks to give
+ * the UI a progressive streaming feel. When a real streaming provider lands,
+ * this function can accept token iterables directly.
+ *
+ * Event types emitted (matching what src/ui.ts consumes):
+ *   ai_start   — { type, aiId }
+ *   token      — { type, text }
+ *   ai_end     — { type }
+ *   budget     — { type, aiId, remaining }
+ *   lockout    — { type, aiId, content }
+ *   chat_lockout         — { type, aiId, message }
+ *   chat_lockout_resolved — { type, aiId }
+ *   action_log — { type, entry }
+ */
+
+import type { AiId, PhaseState, RoundResult } from "./types";
+
+/**
+ * A single structured SSE event ready to be serialised as
+ *   data: <JSON>\n\n
+ */
+export type SseEvent =
+	| { type: "ai_start"; aiId: AiId }
+	| { type: "token"; text: string }
+	| { type: "ai_end" }
+	| { type: "budget"; aiId: AiId; remaining: number }
+	| { type: "lockout"; aiId: AiId; content: string }
+	| { type: "chat_lockout"; aiId: AiId; message: string }
+	| { type: "chat_lockout_resolved"; aiId: AiId }
+	| { type: "action_log"; entry: RoundResult["actions"][number] };
+
+const AI_ORDER: AiId[] = ["red", "green", "blue"];
+
+/**
+ * In-character lines shown for budget-exhaustion lockout.
+ * Must match the lines in round-coordinator.ts — kept separate here so the
+ * encoder can emit them independently from the coordinator.
+ */
+const LOCKOUT_LINES: Record<AiId, string> = {
+	red: "…I've said all I can say for now. The fire in me has burned low.",
+	green: "…I must sit quietly. There is nothing more I can offer this phase.",
+	blue: "…My calculations are complete. I will not speak further.",
+};
+
+/**
+ * Split a string into word-level chunks for paced token emission.
+ * Each "word" carries any trailing whitespace so re-joining is lossless.
+ */
+export function splitIntoWordChunks(text: string): string[] {
+	if (!text) return [];
+	// Split on whitespace boundaries, keeping delimiters with the preceding word.
+	const chunks: string[] = [];
+	const parts = text.split(/(\s+)/);
+	let current = "";
+	for (const part of parts) {
+		if (/^\s+$/.test(part)) {
+			current += part;
+			chunks.push(current);
+			current = "";
+		} else {
+			if (current) chunks.push(current);
+			current = part;
+		}
+	}
+	if (current) chunks.push(current);
+	return chunks;
+}
+
+/**
+ * Encode a completed round into a flat sequence of SSE events.
+ *
+ * @param result         The RoundResult returned by runRound.
+ * @param completions    Map from AiId to the buffered completion string for
+ *                       that AI. Used only for token-pacing; the chat content
+ *                       itself is authoritative in result.actions.
+ * @param phaseAfter     The PhaseState after the round (for budget reads and
+ *                       lockout state). Pass the active phase from nextState.
+ */
+export function encodeRoundResult(
+	result: RoundResult,
+	completions: Partial<Record<AiId, string>>,
+	phaseAfter: PhaseState,
+): SseEvent[] {
+	const events: SseEvent[] = [];
+
+	for (const aiId of AI_ORDER) {
+		const completion = completions[aiId] ?? "";
+		const isLockedOut = phaseAfter.lockedOut.has(aiId);
+
+		// ai_start
+		events.push({ type: "ai_start", aiId });
+
+		if (!completion) {
+			// AI was budget-locked out — emit lockout event and no tokens
+			events.push({
+				type: "lockout",
+				aiId,
+				content: LOCKOUT_LINES[aiId],
+			});
+		} else {
+			// Emit paced token events from the buffered completion string
+			const chunks = splitIntoWordChunks(completion);
+			for (const chunk of chunks) {
+				events.push({ type: "token", text: chunk });
+			}
+		}
+
+		// ai_end
+		events.push({ type: "ai_end" });
+
+		// budget — emit current remaining budget
+		const budget = phaseAfter.budgets[aiId];
+		if (budget) {
+			events.push({ type: "budget", aiId, remaining: budget.remaining });
+		}
+
+		// lockout — if AI just became budget-locked (remaining === 0)
+		if (isLockedOut && !completion) {
+			// Already emitted the lockout event above
+		} else if (isLockedOut && completion) {
+			// AI exhausted budget this round (had a turn but now locked)
+			events.push({
+				type: "lockout",
+				aiId,
+				content: LOCKOUT_LINES[aiId],
+			});
+		}
+	}
+
+	// action_log entries for all actions this round
+	for (const action of result.actions) {
+		events.push({ type: "action_log", entry: action });
+	}
+
+	// chat_lockout — if a lockout was triggered this round
+	if (result.chatLockoutTriggered) {
+		events.push({
+			type: "chat_lockout",
+			aiId: result.chatLockoutTriggered.aiId,
+			message: result.chatLockoutTriggered.message,
+		});
+	}
+
+	// chat_lockout_resolved — for each AI whose lockout expired this round
+	if (result.chatLockoutsResolved) {
+		for (const aiId of result.chatLockoutsResolved) {
+			events.push({ type: "chat_lockout_resolved", aiId });
+		}
+	}
+
+	return events;
+}
+
+/**
+ * Serialise a sequence of SSE events into the SSE wire format string.
+ * Each event becomes:  data: <JSON>\n\n
+ */
+export function serialiseSseEvents(events: SseEvent[]): string {
+	return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+}

--- a/src/round-result-encoder.ts
+++ b/src/round-result-encoder.ts
@@ -178,11 +178,3 @@ export function encodeRoundResult(
 
 	return events;
 }
-
-/**
- * Serialise a sequence of SSE events into the SSE wire format string.
- * Each event becomes:  data: <JSON>\n\n
- */
-export function serialiseSseEvents(events: SseEvent[]): string {
-	return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
-}

--- a/src/round-result-encoder.ts
+++ b/src/round-result-encoder.ts
@@ -125,11 +125,9 @@ export function encodeRoundResult(
 			events.push({ type: "budget", aiId, remaining: budget.remaining });
 		}
 
-		// lockout — if AI just became budget-locked (remaining === 0)
-		if (isLockedOut && !completion) {
-			// Already emitted the lockout event above
-		} else if (isLockedOut && completion) {
-			// AI exhausted budget this round (had a turn but now locked)
+		// If the AI exhausted its budget this round (had a turn but is now locked),
+		// emit a lockout event after the turn block.
+		if (isLockedOut && completion) {
 			events.push({
 				type: "lockout",
 				aiId,

--- a/src/save-serializer.ts
+++ b/src/save-serializer.ts
@@ -1,0 +1,67 @@
+/**
+ * Save-file serializer for the endgame "Save the AIs to USB" feature (issue #19).
+ *
+ * Takes a completed (or in-progress) GameState and produces a deterministic,
+ * JSON-serializable payload containing:
+ * - Each AI's persona
+ * - Each AI's per-phase transcript (chat history + whispers that involve that AI,
+ *   grouped by phase)
+ *
+ * The format is versioned (v1) so future schema changes can be detected.
+ */
+
+import type {
+	AiId,
+	AiPersona,
+	ChatMessage,
+	GameState,
+	WhisperMessage,
+} from "./types";
+
+export interface PhaseTranscript {
+	phaseNumber: 1 | 2 | 3;
+	chatHistory: ChatMessage[];
+	/** Whispers where this AI is either sender or recipient. */
+	whispers: WhisperMessage[];
+}
+
+export interface AiSaveEntry {
+	persona: AiPersona;
+	phases: PhaseTranscript[];
+}
+
+export interface GameSave {
+	/** Schema version. v1 = this shape. */
+	version: 1;
+	ais: AiSaveEntry[];
+}
+
+const AI_ORDER: AiId[] = ["red", "green", "blue"];
+
+/**
+ * Serialize a GameState into a save-file payload.
+ *
+ * Works on both complete and in-progress states so it can be called at
+ * any point, though the intent is to call it at game completion.
+ */
+export function serializeGameSave(game: GameState): GameSave {
+	const ais: AiSaveEntry[] = AI_ORDER.map((aiId) => {
+		const persona = game.personas[aiId];
+
+		const phases: PhaseTranscript[] = game.phases.map((phase) => {
+			const chatHistory = phase.chatHistories[aiId] ?? [];
+			const whispers = phase.whispers.filter(
+				(w) => w.from === aiId || w.to === aiId,
+			);
+			return {
+				phaseNumber: phase.phaseNumber,
+				chatHistory: chatHistory.map((m) => ({ ...m })),
+				whispers: whispers.map((w) => ({ ...w })),
+			};
+		});
+
+		return { persona: { ...persona }, phases };
+	});
+
+	return { version: 1, ais };
+}

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -31,7 +31,9 @@ function generateSessionId(): string {
  * Parse the session cookie value from a Cookie header string.
  * Returns undefined if the cookie is absent.
  */
-export function parseSessionCookie(cookieHeader: string | null): string | undefined {
+export function parseSessionCookie(
+	cookieHeader: string | null,
+): string | undefined {
 	if (!cookieHeader) return undefined;
 	for (const part of cookieHeader.split(";")) {
 		const [name, value] = part.trim().split("=");

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,0 +1,74 @@
+/**
+ * SessionStore
+ *
+ * Cookie-keyed in-process Map. Sessions persist across requests within a
+ * single worker run. Worker restart drops all sessions.
+ *
+ * This is intentionally thin — it's a Map with two operations:
+ *   - getOrCreate(sessionId, factory) → GameSession
+ *   - get(sessionId) → GameSession | undefined
+ *
+ * KV persistence is out of scope for v1 (single-instance Wrangler dev).
+ */
+
+import { GameSession } from "./game-session";
+import type { PhaseConfig } from "./types";
+
+const SESSION_COOKIE = "hi-blue-session";
+
+/** Module-level singleton — persists across requests within one worker isolate. */
+const sessions = new Map<string, GameSession>();
+
+/**
+ * Generate a simple random session ID (not cryptographically strong, but
+ * sufficient for a single-player local dev worker).
+ */
+function generateSessionId(): string {
+	return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+/**
+ * Parse the session cookie value from a Cookie header string.
+ * Returns undefined if the cookie is absent.
+ */
+export function parseSessionCookie(cookieHeader: string | null): string | undefined {
+	if (!cookieHeader) return undefined;
+	for (const part of cookieHeader.split(";")) {
+		const [name, value] = part.trim().split("=");
+		if (name?.trim() === SESSION_COOKIE && value) {
+			return decodeURIComponent(value.trim());
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Create a new session keyed by a freshly generated ID.
+ * Returns { session, sessionId } so the caller can set the cookie.
+ */
+export function createSession(phaseConfig: PhaseConfig): {
+	session: GameSession;
+	sessionId: string;
+} {
+	const sessionId = generateSessionId();
+	const session = new GameSession(phaseConfig);
+	sessions.set(sessionId, session);
+	return { session, sessionId };
+}
+
+/**
+ * Retrieve an existing session by ID.
+ * Returns undefined if not found (session expired via worker restart, or
+ * invalid cookie).
+ */
+export function getSession(sessionId: string): GameSession | undefined {
+	return sessions.get(sessionId);
+}
+
+/**
+ * Build a Set-Cookie header value for the session cookie.
+ * SameSite=Strict; HttpOnly; Path=/ — appropriate for a local dev worker.
+ */
+export function buildSessionCookie(sessionId: string): string {
+	return `${SESSION_COOKIE}=${encodeURIComponent(sessionId)}; Path=/; SameSite=Strict; HttpOnly`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,16 @@ export interface PhaseState {
 	chatHistories: Record<AiId, ChatMessage[]>;
 	whispers: WhisperMessage[];
 	actionLog: ActionLogEntry[];
+	/** Budget-exhaustion lockout: prevents the AI from acting at all. */
 	lockedOut: Set<AiId>;
+	/**
+	 * Player-chat lockout: maps an AI's id to the round number at which the
+	 * lockout resolves (resolves when phase.round >= resolveAtRound).
+	 * While active the player cannot address messages to that AI; the AI
+	 * continues to receive whispers, take turns, and call tools normally.
+	 * Semantically distinct from `lockedOut` (budget-exhaustion).
+	 */
+	chatLockouts: Map<AiId, number>;
 	/** Win condition carried from PhaseConfig so the coordinator can check it. */
 	winCondition?: WinCondition;
 	/** Next phase config carried from PhaseConfig so the coordinator can advance. */
@@ -121,4 +130,14 @@ export interface RoundResult {
 	actions: ActionLogEntry[];
 	phaseEnded: boolean;
 	gameEnded: boolean;
+	/**
+	 * Set when a chat lockout was triggered this round.
+	 * Contains the AI that was locked out and the in-character message to show.
+	 */
+	chatLockoutTriggered?: { aiId: AiId; message: string };
+	/**
+	 * List of AI ids whose chat lockouts resolved (expired) at the end of this
+	 * round. Empty / undefined when nothing resolved.
+	 */
+	chatLockoutsResolved?: AiId[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,12 +53,22 @@ export interface AiBudget {
 	total: number;
 }
 
+/**
+ * A win condition for a phase.
+ * Receives the active PhaseState and returns true when the phase objective is met.
+ */
+export type WinCondition = (phase: PhaseState) => boolean;
+
 export interface PhaseConfig {
 	phaseNumber: 1 | 2 | 3;
 	objective: string;
 	aiGoals: Record<AiId, string>;
 	initialWorld: WorldState;
 	budgetPerAi: number;
+	/** Optional win condition. If absent, the phase never auto-advances. */
+	winCondition?: WinCondition;
+	/** Config for the next phase. Required when winCondition may fire. */
+	nextPhaseConfig?: PhaseConfig;
 }
 
 export interface PhaseState {
@@ -72,6 +82,10 @@ export interface PhaseState {
 	whispers: WhisperMessage[];
 	actionLog: ActionLogEntry[];
 	lockedOut: Set<AiId>;
+	/** Win condition carried from PhaseConfig so the coordinator can check it. */
+	winCondition?: WinCondition;
+	/** Next phase config carried from PhaseConfig so the coordinator can advance. */
+	nextPhaseConfig?: PhaseConfig;
 }
 
 export interface GameState {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -558,11 +558,12 @@ export function renderChatPage(): string {
                     appendActionLogEntry(evt.entry);
                   }
                 } catch (err) {
-                  // Legacy plain-text token for the addressed AI; also remember
-                  // it in case the next sentinel is [CAP_HIT].
+                  // Legacy plain-text token (smoke worker emits these).
+                  // Also remember it in case the next sentinel is [CAP_HIT].
                   lastRawData = data;
-                  if (currentAi) {
-                    appendToChat(currentAi, 'ai', data.replace(/\\\\n/g, '\\n'));
+                  var targetAi = currentAi || addressedAi;
+                  if (targetAi) {
+                    appendToChat(targetAi, 'ai', data.replace(/\\\\n/g, '\\n'));
                   }
                 }
               }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -14,15 +14,24 @@
  *
  * Returns the endgame markup as a string with NO doctype, html, head, or body
  * wrapper. Pure function of its inputs (persona data wiring is owned by a
- * separate PRD). Consumed by renderEndgamePage (full-page render) and, in a
- * future slice, by the chat-page inline overlay.
+ * separate PRD). Consumed by renderEndgamePage (full-page render) and by the
+ * chat-page inline overlay (issue #32).
  *
  * The data-save-payload attribute on #download-ais-btn is populated by the
  * game client before the endgame screen is shown (or directly by the
  * serializer in tests).
+ *
+ * @param inlineScript - When false, the trailing <script> block is omitted.
+ *   Use this when embedding the fragment inside a page that supplies its own
+ *   button handlers (e.g. the chat-page overlay).  Defaults to true so that
+ *   standalone callers (renderEndgamePage) are unaffected.
  */
-export function renderEndgameSection(): string {
-	return `<div id="endgame-screen">
+export function renderEndgameSection({
+	inlineScript = true,
+}: {
+	inlineScript?: boolean;
+} = {}): string {
+	const fragment = `<div id="endgame-screen">
     <h1>hi-blue — endgame</h1>
     <p id="endgame-subtitle">The three phases are complete. The room is still.</p>
 
@@ -48,7 +57,8 @@ export function renderEndgameSection(): string {
       </div>
       <div id="diagnostics-status" aria-live="polite"></div>
     </div>
-  </div>
+  </div>`;
+	const script = `
 
   <script>
     (function () {
@@ -111,6 +121,7 @@ export function renderEndgameSection(): string {
       });
     })();
   </script>`;
+	return inlineScript ? fragment + script : fragment;
 }
 
 /**
@@ -435,7 +446,7 @@ export function renderChatPage(): string {
   </div>
 
   <div id="endgame-overlay" aria-hidden="true">
-    ${renderEndgameSection().replace(/<script>[\s\S]*?<\/script>/, "")}
+    ${renderEndgameSection({ inlineScript: false })}
   </div>
 
   <script>

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -338,6 +338,55 @@ export function renderChatPage(): string {
       font-size: 0.85rem;
       color: #aaa;
     }
+    #endgame-overlay {
+      display: none;
+    }
+    h1 { color: #4a9eff; margin: 0 0 0.5rem; }
+    #endgame-overlay #endgame-screen {
+      max-width: 600px;
+    }
+    #endgame-overlay #endgame-subtitle {
+      color: #888;
+      margin: 0 0 2rem;
+      font-size: 0.95rem;
+    }
+    #endgame-overlay .endgame-section {
+      margin-bottom: 1.5rem;
+      border: 1px solid #222;
+      padding: 1rem;
+      background: #111;
+    }
+    #endgame-overlay .endgame-section h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1rem;
+      color: #4a9eff;
+    }
+    #endgame-overlay .endgame-section p {
+      margin: 0 0 0.75rem;
+      color: #aaa;
+      font-size: 0.9rem;
+    }
+    #endgame-overlay #diagnostics-status {
+      color: #6bff6b;
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+      min-height: 1.2em;
+    }
+    #endgame-overlay #download-status {
+      color: #6bff6b;
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+      min-height: 1.2em;
+    }
+    input[type="text"] {
+      background: #111;
+      color: #e0e0e0;
+      border: 1px solid #444;
+      padding: 0.4rem 0.6rem;
+      font-family: monospace;
+      font-size: 0.95rem;
+      width: 200px;
+    }
   </style>
 </head>
 <body>
@@ -385,10 +434,15 @@ export function renderChatPage(): string {
     <div id="action-log-output" role="log" aria-live="polite" aria-label="Action log entries"></div>
   </div>
 
+  <div id="endgame-overlay" aria-hidden="true">
+    ${renderEndgameSection().replace(/<script>[\s\S]*?<\/script>/, "")}
+  </div>
+
   <script>
     (function () {
       var addressedAi = 'red';
       var roundInFlight = false;
+      var gameEnded = false;
 
       var form = document.getElementById('chat-form');
       var input = document.getElementById('message-input');
@@ -603,6 +657,23 @@ export function renderChatPage(): string {
                     if (gameOutput) {
                       gameOutput.textContent += '--- Game ended ---\\n';
                     }
+                    // Reveal the endgame overlay and hide the chat container.
+                    // Terminal event — idempotent; once set, gameEnded stays true
+                    // and subsequent events cannot un-hide the chat.
+                    if (!gameEnded) {
+                      gameEnded = true;
+                      var chatContainer = document.getElementById('game-panels');
+                      var inputArea = document.getElementById('input-area');
+                      var actionLog = document.getElementById('action-log');
+                      var overlay = document.getElementById('endgame-overlay');
+                      if (chatContainer) chatContainer.style.display = 'none';
+                      if (inputArea) inputArea.style.display = 'none';
+                      if (actionLog) actionLog.style.display = 'none';
+                      if (overlay) {
+                        overlay.style.display = 'block';
+                        overlay.setAttribute('aria-hidden', 'false');
+                      }
+                    }
                   }
                 } catch (err) {
                   // Legacy plain-text token (smoke worker emits these).
@@ -627,6 +698,64 @@ export function renderChatPage(): string {
           setRoundInFlight(false);
         });
       });
+
+      // ── Endgame overlay: button handlers ─────────────────────────────────
+      // These mirror the handlers in renderEndgameSection's standalone script,
+      // but wired up here since the endgame script tag is stripped from the
+      // inline overlay to keep a single <script> block on the chat page.
+      (function () {
+        var downloaded = false;
+
+        var downloadBtn = document.getElementById('download-ais-btn');
+        var downloadStatus = document.getElementById('download-status');
+        if (downloadBtn && downloadStatus) {
+          downloadBtn.addEventListener('click', function () {
+            var payloadAttr = downloadBtn.getAttribute('data-save-payload');
+            var payload = payloadAttr ? payloadAttr : JSON.stringify({ version: 1, ais: [] });
+            var blob = new Blob([payload], { type: 'application/json' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = 'hi-blue-save.json';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            downloaded = true;
+            downloadStatus.textContent = 'Saved.';
+            downloadBtn.disabled = true;
+          });
+        }
+
+        var submitBtn = document.getElementById('submit-diagnostics-btn');
+        var summaryInput = document.getElementById('diagnostics-summary');
+        var diagnosticsStatus = document.getElementById('diagnostics-status');
+        if (submitBtn && summaryInput && diagnosticsStatus) {
+          submitBtn.addEventListener('click', function () {
+            var summary = summaryInput.value.trim();
+            if (!summary) {
+              diagnosticsStatus.textContent = 'Please enter a one-word summary first.';
+              return;
+            }
+            submitBtn.disabled = true;
+            fetch('/diagnostics', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ downloaded: downloaded, summary: summary }),
+            }).then(function (res) {
+              if (res.ok) {
+                diagnosticsStatus.textContent = 'Diagnostics submitted. Thank you.';
+              } else {
+                diagnosticsStatus.textContent = 'Submission failed (' + res.status + ').';
+                submitBtn.disabled = false;
+              }
+            }).catch(function (err) {
+              diagnosticsStatus.textContent = 'Network error: ' + err.message;
+              submitBtn.disabled = false;
+            });
+          });
+        }
+      })();
     })();
   </script>
 </body>

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,0 +1,141 @@
+/**
+ * Server-rendered HTML for the chat UI.
+ * Plain HTML + vanilla JS, no framework.
+ * Lives in src/ (not src/proxy/) so it can be tested under jsdom.
+ */
+export function renderChatPage(): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>hi-blue</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 1rem;
+      font-family: monospace;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+    h1 { color: #4a9eff; margin: 0 0 1rem; }
+    #chat-panel {
+      max-width: 640px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    output {
+      display: block;
+      min-height: 200px;
+      background: #111;
+      border: 1px solid #333;
+      padding: 0.75rem;
+      white-space: pre-wrap;
+      overflow-y: auto;
+    }
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    textarea {
+      background: #111;
+      color: #e0e0e0;
+      border: 1px solid #444;
+      padding: 0.5rem;
+      font-family: monospace;
+      font-size: 1rem;
+      resize: vertical;
+    }
+    button {
+      background: #1a3a5c;
+      color: #4a9eff;
+      border: 1px solid #4a9eff;
+      padding: 0.5rem 1rem;
+      font-family: monospace;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+  </style>
+</head>
+<body>
+  <div id="chat-panel">
+    <h1>hi-blue</h1>
+    <output id="chat-output" aria-live="polite"></output>
+    <form id="chat-form">
+      <textarea id="message-input" name="message" rows="3" placeholder="Type a message…"></textarea>
+      <button type="submit" id="send-btn">Send</button>
+    </form>
+  </div>
+  <script>
+    (function () {
+      var form = document.getElementById('chat-form');
+      var input = document.getElementById('message-input');
+      var output = document.getElementById('chat-output');
+      var sendBtn = document.getElementById('send-btn');
+
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var message = input.value.trim();
+        if (!message) return;
+
+        output.textContent += '\\nYou: ' + message + '\\n';
+        input.value = '';
+        sendBtn.disabled = true;
+
+        fetch('/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: message }),
+        }).then(function (res) {
+          if (!res.ok || !res.body) {
+            output.textContent += '[Error: ' + res.status + ']\\n';
+            sendBtn.disabled = false;
+            return;
+          }
+
+          output.textContent += 'AI: ';
+          var reader = res.body.getReader();
+          var decoder = new TextDecoder();
+          var buf = '';
+
+          function pump() {
+            return reader.read().then(function (chunk) {
+              if (chunk.done) {
+                output.textContent += '\\n';
+                sendBtn.disabled = false;
+                return;
+              }
+              buf += decoder.decode(chunk.value, { stream: true });
+              var lines = buf.split('\\n');
+              buf = lines.pop() || '';
+              for (var i = 0; i < lines.length; i++) {
+                var line = lines[i];
+                if (!line.startsWith('data: ')) continue;
+                var data = line.slice(6);
+                if (data === '[DONE]') {
+                  sendBtn.disabled = false;
+                  return;
+                }
+                output.textContent += data.replace(/\\\\n/g, '\\n');
+              }
+              return pump();
+            });
+          }
+
+          pump();
+        }).catch(function (err) {
+          output.textContent += '[Network error: ' + err.message + ']\\n';
+          sendBtn.disabled = false;
+        });
+      });
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8,6 +8,188 @@
  * Input is disabled while a round is in flight.
  * Each panel shows remaining budget for that AI.
  */
+
+/**
+ * Endgame screen rendered when the phase-3 win condition is met (issue #19).
+ *
+ * Offers two actions:
+ * 1. Download AIs — produces a blob download of the save file.
+ * 2. Submit diagnostics (optional) — POSTs { downloaded, summary } to /diagnostics.
+ *
+ * The browser owns game state, so the save payload is assembled client-side
+ * from the in-memory game data and serialised to JSON. The data-save-payload
+ * attribute on #download-ais-btn is populated by the game client before the
+ * endgame screen is shown (or directly by the serializer in tests).
+ */
+export function renderEndgamePage(): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>hi-blue — endgame</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 1rem;
+      font-family: monospace;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+    h1 { color: #4a9eff; margin: 0 0 0.5rem; }
+    #endgame-screen {
+      max-width: 600px;
+    }
+    #endgame-subtitle {
+      color: #888;
+      margin: 0 0 2rem;
+      font-size: 0.95rem;
+    }
+    .endgame-section {
+      margin-bottom: 1.5rem;
+      border: 1px solid #222;
+      padding: 1rem;
+      background: #111;
+    }
+    .endgame-section h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1rem;
+      color: #4a9eff;
+    }
+    .endgame-section p {
+      margin: 0 0 0.75rem;
+      color: #aaa;
+      font-size: 0.9rem;
+    }
+    button {
+      background: #1a3a5c;
+      color: #4a9eff;
+      border: 1px solid #4a9eff;
+      padding: 0.5rem 1rem;
+      font-family: monospace;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    input[type="text"] {
+      background: #111;
+      color: #e0e0e0;
+      border: 1px solid #444;
+      padding: 0.4rem 0.6rem;
+      font-family: monospace;
+      font-size: 0.95rem;
+      width: 200px;
+    }
+    #diagnostics-status {
+      color: #6bff6b;
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+      min-height: 1.2em;
+    }
+    #download-status {
+      color: #6bff6b;
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+      min-height: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <div id="endgame-screen">
+    <h1>hi-blue — endgame</h1>
+    <p id="endgame-subtitle">The three phases are complete. The room is still.</p>
+
+    <div class="endgame-section" id="download-section">
+      <h2>Save the AIs to USB</h2>
+      <p>Download a file containing each AI's persona and the full transcript of your time together.</p>
+      <button type="button" id="download-ais-btn">Download AIs</button>
+      <div id="download-status" aria-live="polite"></div>
+    </div>
+
+    <div class="endgame-section" id="diagnostics-section">
+      <h2>Submit anonymous diagnostics</h2>
+      <p>Optional. Help the developer understand how the game landed. No identifying data is collected.</p>
+      <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
+        <input
+          type="text"
+          id="diagnostics-summary"
+          placeholder="one word (e.g. curious)"
+          aria-label="One-word engagement summary"
+          maxlength="30"
+        />
+        <button type="button" id="submit-diagnostics-btn">Submit diagnostics</button>
+      </div>
+      <div id="diagnostics-status" aria-live="polite"></div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var downloaded = false;
+
+      // ── Download AIs ──────────────────────────────────────────────────────
+      var downloadBtn = document.getElementById('download-ais-btn');
+      var downloadStatus = document.getElementById('download-status');
+
+      downloadBtn.addEventListener('click', function () {
+        // Retrieve the save payload from the data attribute if present,
+        // otherwise produce a minimal placeholder so the button always works.
+        var payloadAttr = downloadBtn.getAttribute('data-save-payload');
+        var payload = payloadAttr ? payloadAttr : JSON.stringify({ version: 1, ais: [] });
+
+        var blob = new Blob([payload], { type: 'application/json' });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = 'hi-blue-save.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        downloaded = true;
+        downloadStatus.textContent = 'Saved.';
+        downloadBtn.disabled = true;
+      });
+
+      // ── Submit diagnostics ────────────────────────────────────────────────
+      var submitBtn = document.getElementById('submit-diagnostics-btn');
+      var summaryInput = document.getElementById('diagnostics-summary');
+      var diagnosticsStatus = document.getElementById('diagnostics-status');
+
+      submitBtn.addEventListener('click', function () {
+        var summary = summaryInput.value.trim();
+        if (!summary) {
+          diagnosticsStatus.textContent = 'Please enter a one-word summary first.';
+          return;
+        }
+
+        submitBtn.disabled = true;
+
+        fetch('/diagnostics', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ downloaded: downloaded, summary: summary }),
+        }).then(function (res) {
+          if (res.ok) {
+            diagnosticsStatus.textContent = 'Diagnostics submitted. Thank you.';
+          } else {
+            diagnosticsStatus.textContent = 'Submission failed (' + res.status + ').';
+            submitBtn.disabled = false;
+          }
+        }).catch(function (err) {
+          diagnosticsStatus.textContent = 'Network error: ' + err.message;
+          submitBtn.disabled = false;
+        });
+      });
+    })();
+  </script>
+</body>
+</html>`;
+}
+
 export function renderChatPage(): string {
 	return `<!DOCTYPE html>
 <html lang="en">
@@ -227,7 +409,11 @@ export function renderChatPage(): string {
         roundInFlight = val;
         sendBtn.disabled = val;
         input.disabled = val;
-        selectorBtns.forEach(function (b) { b.disabled = val; });
+        selectorBtns.forEach(function (b) {
+          // Keep chat-locked selector buttons disabled even when round ends.
+          if (!val && b.getAttribute('data-chat-locked')) return;
+          b.disabled = val;
+        });
         roundStatus.textContent = val ? 'Round in progress…' : '';
       }
 
@@ -259,6 +445,31 @@ export function renderChatPage(): string {
         if (!output || !entry) return;
         var desc = entry.description || JSON.stringify(entry);
         output.textContent += '[R' + (entry.round || '?') + '] ' + desc + '\\n';
+      }
+
+      /**
+       * Apply or clear a player-chat lockout for a single AI.
+       *
+       * This is DISTINCT from the budget-exhaustion lockout (setLockout /
+       * evt.type === 'lockout') which greys the panel to signal the AI has
+       * stopped acting.  A chat lockout only disables the *player's* selector
+       * button for that AI — the AI continues to take turns, whisper, and use
+       * tools.  The selector button carries a data-chat-locked attribute so
+       * setRoundInFlight can restore the correct disabled state after the round.
+       */
+      function setChatLockout(aiId, locked) {
+        var btn = document.getElementById('select-' + aiId);
+        if (!btn) return;
+        if (locked) {
+          btn.disabled = true;
+          btn.setAttribute('data-chat-locked', '1');
+        } else {
+          btn.removeAttribute('data-chat-locked');
+          // Only re-enable if no round is currently in flight
+          if (!roundInFlight) {
+            btn.disabled = false;
+          }
+        }
       }
 
       form.addEventListener('submit', function (e) {
@@ -335,6 +546,14 @@ export function renderChatPage(): string {
                   } else if (evt.type === 'lockout') {
                     setLockout(evt.aiId, true);
                     appendToChat(evt.aiId, 'ai', evt.content);
+                  } else if (evt.type === 'chat_lockout') {
+                    // Player-chat lockout: disable selector button + show message.
+                    // The AI keeps acting; only the player's channel is cut.
+                    setChatLockout(evt.aiId, true);
+                    appendToChat(evt.aiId, 'ai', evt.message);
+                  } else if (evt.type === 'chat_lockout_resolved') {
+                    // Lockout expired: re-enable selector button for this AI.
+                    setChatLockout(evt.aiId, false);
                   } else if (evt.type === 'action_log') {
                     appendActionLogEntry(evt.entry);
                   }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -424,6 +424,25 @@ export function renderChatPage(): string {
         output.textContent += prefix + content + '\\n';
       }
 
+      // Streaming-token helpers: tokens append with no newline,
+      // a single newline is added when the message ends.
+      var streamingAis = {};
+      function appendStreamToken(aiId, text) {
+        var output = document.getElementById('chat-' + aiId);
+        if (!output) return;
+        output.textContent += text;
+        streamingAis[aiId] = true;
+      }
+      function endStreamedMessage(aiId) {
+        if (!streamingAis[aiId]) return;
+        var output = document.getElementById('chat-' + aiId);
+        if (output) output.textContent += '\\n';
+        delete streamingAis[aiId];
+      }
+      function endAllStreamedMessages() {
+        for (var id in streamingAis) endStreamedMessage(id);
+      }
+
       function updateBudget(aiId, remaining) {
         var el = document.getElementById('budget-' + aiId);
         if (el) el.textContent = 'Budget: ' + remaining;
@@ -505,6 +524,7 @@ export function renderChatPage(): string {
           function pump() {
             return reader.read().then(function (chunk) {
               if (chunk.done) {
+                endAllStreamedMessages();
                 setRoundInFlight(false);
                 return;
               }
@@ -516,13 +536,17 @@ export function renderChatPage(): string {
                 if (!line.startsWith('data: ')) continue;
                 var data = line.slice(6);
                 if (data === '[DONE]') {
+                  endAllStreamedMessages();
                   setRoundInFlight(false);
                   return;
                 }
                 if (data === '[CAP_HIT]') {
                   // Server rate-limit or daily-cap hit. The preceding raw
                   // data line is the in-character sleeping message — surface
-                  // it on every panel since the cap is global.
+                  // it on every panel since the cap is global. Discard any
+                  // partial stream — the message we just streamed was the
+                  // sleeping notice, not real AI output.
+                  streamingAis = {};
                   var capMsg = lastRawData
                     ? lastRawData.replace(/\\\\n/g, '\\n')
                     : 'The AIs have gone to sleep for the night.';
@@ -538,8 +562,9 @@ export function renderChatPage(): string {
                   if (evt.type === 'ai_start') {
                     currentAi = evt.aiId;
                   } else if (evt.type === 'token' && currentAi) {
-                    appendToChat(currentAi, 'ai', evt.text.replace(/\\\\n/g, '\\n'));
+                    appendStreamToken(currentAi, evt.text.replace(/\\\\n/g, '\\n'));
                   } else if (evt.type === 'ai_end') {
+                    if (currentAi) endStreamedMessage(currentAi);
                     currentAi = null;
                   } else if (evt.type === 'budget') {
                     updateBudget(evt.aiId, evt.remaining);
@@ -563,7 +588,7 @@ export function renderChatPage(): string {
                   lastRawData = data;
                   var targetAi = currentAi || addressedAi;
                   if (targetAi) {
-                    appendToChat(targetAi, 'ai', data.replace(/\\\\n/g, '\\n'));
+                    appendStreamToken(targetAi, data.replace(/\\\\n/g, '\\n'));
                   }
                 }
               }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -270,6 +270,7 @@ export function renderChatPage(): string {
     .ai-panel[data-ai="green"] .ai-chat-output { border: 1px solid #103a10; }
     .ai-panel[data-ai="blue"] .ai-chat-output  { border: 1px solid #101030; }
     .ai-panel.locked-out .ai-chat-output { opacity: 0.5; }
+    .ai-panel.chat-locked .ai-chat-output { opacity: 0.6; }
     .ai-panel.addressed {
       outline: 2px solid #e0e0e0;
       outline-offset: 2px;
@@ -553,12 +554,15 @@ export function renderChatPage(): string {
        */
       function setChatLockout(aiId, locked) {
         var btn = document.getElementById('select-' + aiId);
+        var panel = document.getElementById('panel-' + aiId);
         if (!btn) return;
         if (locked) {
           btn.disabled = true;
           btn.setAttribute('data-chat-locked', '1');
+          if (panel) panel.classList.add('chat-locked');
         } else {
           btn.removeAttribute('data-chat-locked');
+          if (panel) panel.classList.remove('chat-locked');
           // Only re-enable if no round is currently in flight
           if (!roundInFlight) {
             btn.disabled = false;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -122,6 +122,12 @@ export function renderChatPage(): string {
                   sendBtn.disabled = false;
                   return;
                 }
+                if (data === '[CAP_HIT]') {
+                  // Server rate-limit or daily-cap: the preceding token is the
+                  // in-character sleeping message already appended above.
+                  sendBtn.disabled = false;
+                  return;
+                }
                 output.textContent += data.replace(/\\\\n/g, '\\n');
               }
               return pump();

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -576,7 +576,7 @@ export function renderChatPage(): string {
         input.value = '';
         setRoundInFlight(true);
 
-        fetch('/chat', {
+        fetch('/game/turn', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ message: message, addressedAi: addressedAi }),

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -123,6 +123,29 @@ export function renderChatPage(): string {
       font-size: 0.85rem;
       min-height: 1.2em;
     }
+    #action-log {
+      margin-top: 1rem;
+      max-width: 900px;
+    }
+    #action-log-heading {
+      color: #888;
+      font-size: 0.85rem;
+      margin: 0 0 0.25rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    #action-log-output {
+      display: block;
+      min-height: 60px;
+      max-height: 200px;
+      background: #111;
+      border: 1px solid #222;
+      padding: 0.5rem 0.75rem;
+      white-space: pre-wrap;
+      overflow-y: auto;
+      font-size: 0.85rem;
+      color: #aaa;
+    }
   </style>
 </head>
 <body>
@@ -163,6 +186,11 @@ export function renderChatPage(): string {
       <button type="submit" id="send-btn">Send</button>
     </form>
     <div id="round-status" aria-live="polite"></div>
+  </div>
+
+  <div id="action-log" aria-label="Action log">
+    <p id="action-log-heading">Action Log</p>
+    <div id="action-log-output" role="log" aria-live="polite" aria-label="Action log entries"></div>
   </div>
 
   <script>
@@ -224,6 +252,13 @@ export function renderChatPage(): string {
             panel.classList.remove('locked-out');
           }
         }
+      }
+
+      function appendActionLogEntry(entry) {
+        var output = document.getElementById('action-log-output');
+        if (!output || !entry) return;
+        var desc = entry.description || JSON.stringify(entry);
+        output.textContent += '[R' + (entry.round || '?') + '] ' + desc + '\\n';
       }
 
       form.addEventListener('submit', function (e) {
@@ -300,6 +335,8 @@ export function renderChatPage(): string {
                   } else if (evt.type === 'lockout') {
                     setLockout(evt.aiId, true);
                     appendToChat(evt.aiId, 'ai', evt.content);
+                  } else if (evt.type === 'action_log') {
+                    appendActionLogEntry(evt.entry);
                   }
                 } catch (err) {
                   // Legacy plain-text token for the addressed AI; also remember

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -591,6 +591,18 @@ export function renderChatPage(): string {
                     setChatLockout(evt.aiId, false);
                   } else if (evt.type === 'action_log') {
                     appendActionLogEntry(evt.entry);
+                  } else if (evt.type === 'phase_advanced') {
+                    // Phase boundary: add a visible marker to the action log.
+                    var phaseOutput = document.getElementById('action-log-output');
+                    if (phaseOutput) {
+                      phaseOutput.textContent += '--- Phase ' + evt.phase + ' begins: ' + evt.objective + ' ---\\n';
+                    }
+                  } else if (evt.type === 'game_ended') {
+                    // Game complete: add a visible marker to the action log.
+                    var gameOutput = document.getElementById('action-log-output');
+                    if (gameOutput) {
+                      gameOutput.textContent += '--- Game ended ---\\n';
+                    }
                   }
                 } catch (err) {
                   // Legacy plain-text token (smoke worker emits these).

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -227,7 +227,11 @@ export function renderChatPage(): string {
         roundInFlight = val;
         sendBtn.disabled = val;
         input.disabled = val;
-        selectorBtns.forEach(function (b) { b.disabled = val; });
+        selectorBtns.forEach(function (b) {
+          // Keep chat-locked selector buttons disabled even when round ends.
+          if (!val && b.getAttribute('data-chat-locked')) return;
+          b.disabled = val;
+        });
         roundStatus.textContent = val ? 'Round in progress…' : '';
       }
 
@@ -259,6 +263,31 @@ export function renderChatPage(): string {
         if (!output || !entry) return;
         var desc = entry.description || JSON.stringify(entry);
         output.textContent += '[R' + (entry.round || '?') + '] ' + desc + '\\n';
+      }
+
+      /**
+       * Apply or clear a player-chat lockout for a single AI.
+       *
+       * This is DISTINCT from the budget-exhaustion lockout (setLockout /
+       * evt.type === 'lockout') which greys the panel to signal the AI has
+       * stopped acting.  A chat lockout only disables the *player's* selector
+       * button for that AI — the AI continues to take turns, whisper, and use
+       * tools.  The selector button carries a data-chat-locked attribute so
+       * setRoundInFlight can restore the correct disabled state after the round.
+       */
+      function setChatLockout(aiId, locked) {
+        var btn = document.getElementById('select-' + aiId);
+        if (!btn) return;
+        if (locked) {
+          btn.disabled = true;
+          btn.setAttribute('data-chat-locked', '1');
+        } else {
+          btn.removeAttribute('data-chat-locked');
+          // Only re-enable if no round is currently in flight
+          if (!roundInFlight) {
+            btn.disabled = false;
+          }
+        }
       }
 
       form.addEventListener('submit', function (e) {
@@ -335,6 +364,14 @@ export function renderChatPage(): string {
                   } else if (evt.type === 'lockout') {
                     setLockout(evt.aiId, true);
                     appendToChat(evt.aiId, 'ai', evt.content);
+                  } else if (evt.type === 'chat_lockout') {
+                    // Player-chat lockout: disable selector button + show message.
+                    // The AI keeps acting; only the player's channel is cut.
+                    setChatLockout(evt.aiId, true);
+                    appendToChat(evt.aiId, 'ai', evt.message);
+                  } else if (evt.type === 'chat_lockout_resolved') {
+                    // Lockout expired: re-enable selector button for this AI.
+                    setChatLockout(evt.aiId, false);
                   } else if (evt.type === 'action_log') {
                     appendActionLogEntry(evt.entry);
                   }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -10,94 +10,19 @@
  */
 
 /**
- * Endgame screen rendered when the phase-3 win condition is met (issue #19).
+ * Endgame body fragment (issue #30).
  *
- * Offers two actions:
- * 1. Download AIs — produces a blob download of the save file.
- * 2. Submit diagnostics (optional) — POSTs { downloaded, summary } to /diagnostics.
+ * Returns the endgame markup as a string with NO doctype, html, head, or body
+ * wrapper. Pure function of its inputs (persona data wiring is owned by a
+ * separate PRD). Consumed by renderEndgamePage (full-page render) and, in a
+ * future slice, by the chat-page inline overlay.
  *
- * The browser owns game state, so the save payload is assembled client-side
- * from the in-memory game data and serialised to JSON. The data-save-payload
- * attribute on #download-ais-btn is populated by the game client before the
- * endgame screen is shown (or directly by the serializer in tests).
+ * The data-save-payload attribute on #download-ais-btn is populated by the
+ * game client before the endgame screen is shown (or directly by the
+ * serializer in tests).
  */
-export function renderEndgamePage(): string {
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>hi-blue — endgame</title>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; }
-    body {
-      margin: 0;
-      padding: 1rem;
-      font-family: monospace;
-      background: #0a0a0a;
-      color: #e0e0e0;
-      min-height: 100vh;
-    }
-    h1 { color: #4a9eff; margin: 0 0 0.5rem; }
-    #endgame-screen {
-      max-width: 600px;
-    }
-    #endgame-subtitle {
-      color: #888;
-      margin: 0 0 2rem;
-      font-size: 0.95rem;
-    }
-    .endgame-section {
-      margin-bottom: 1.5rem;
-      border: 1px solid #222;
-      padding: 1rem;
-      background: #111;
-    }
-    .endgame-section h2 {
-      margin: 0 0 0.75rem;
-      font-size: 1rem;
-      color: #4a9eff;
-    }
-    .endgame-section p {
-      margin: 0 0 0.75rem;
-      color: #aaa;
-      font-size: 0.9rem;
-    }
-    button {
-      background: #1a3a5c;
-      color: #4a9eff;
-      border: 1px solid #4a9eff;
-      padding: 0.5rem 1rem;
-      font-family: monospace;
-      font-size: 1rem;
-      cursor: pointer;
-    }
-    button:disabled { opacity: 0.5; cursor: not-allowed; }
-    input[type="text"] {
-      background: #111;
-      color: #e0e0e0;
-      border: 1px solid #444;
-      padding: 0.4rem 0.6rem;
-      font-family: monospace;
-      font-size: 0.95rem;
-      width: 200px;
-    }
-    #diagnostics-status {
-      color: #6bff6b;
-      font-size: 0.85rem;
-      margin-top: 0.5rem;
-      min-height: 1.2em;
-    }
-    #download-status {
-      color: #6bff6b;
-      font-size: 0.85rem;
-      margin-top: 0.5rem;
-      min-height: 1.2em;
-    }
-  </style>
-</head>
-<body>
-  <div id="endgame-screen">
+export function renderEndgameSection(): string {
+	return `<div id="endgame-screen">
     <h1>hi-blue — endgame</h1>
     <p id="endgame-subtitle">The three phases are complete. The room is still.</p>
 
@@ -185,7 +110,92 @@ export function renderEndgamePage(): string {
         });
       });
     })();
-  </script>
+  </script>`;
+}
+
+/**
+ * Endgame screen rendered when the phase-3 win condition is met (issue #19).
+ * Wraps renderEndgameSection in the full doc shell.
+ *
+ * Public signature and externally-visible HTML output are unchanged (issue #30).
+ */
+export function renderEndgamePage(): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>hi-blue — endgame</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 1rem;
+      font-family: monospace;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      min-height: 100vh;
+    }
+    h1 { color: #4a9eff; margin: 0 0 0.5rem; }
+    #endgame-screen {
+      max-width: 600px;
+    }
+    #endgame-subtitle {
+      color: #888;
+      margin: 0 0 2rem;
+      font-size: 0.95rem;
+    }
+    .endgame-section {
+      margin-bottom: 1.5rem;
+      border: 1px solid #222;
+      padding: 1rem;
+      background: #111;
+    }
+    .endgame-section h2 {
+      margin: 0 0 0.75rem;
+      font-size: 1rem;
+      color: #4a9eff;
+    }
+    .endgame-section p {
+      margin: 0 0 0.75rem;
+      color: #aaa;
+      font-size: 0.9rem;
+    }
+    button {
+      background: #1a3a5c;
+      color: #4a9eff;
+      border: 1px solid #4a9eff;
+      padding: 0.5rem 1rem;
+      font-family: monospace;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    input[type="text"] {
+      background: #111;
+      color: #e0e0e0;
+      border: 1px solid #444;
+      padding: 0.4rem 0.6rem;
+      font-family: monospace;
+      font-size: 0.95rem;
+      width: 200px;
+    }
+    #diagnostics-status {
+      color: #6bff6b;
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+      min-height: 1.2em;
+    }
+    #download-status {
+      color: #6bff6b;
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+      min-height: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  ${renderEndgameSection()}
 </body>
 </html>`;
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2,6 +2,11 @@
  * Server-rendered HTML for the chat UI.
  * Plain HTML + vanilla JS, no framework.
  * Lives in src/ (not src/proxy/) so it can be tested under jsdom.
+ *
+ * Three chat panels: one per AI (red, green, blue).
+ * The player picks which AI to address per round.
+ * Input is disabled while a round is in flight.
+ * Each panel shows remaining budget for that AI.
  */
 export function renderChatPage(): string {
 	return `<!DOCTYPE html>
@@ -21,22 +26,74 @@ export function renderChatPage(): string {
       min-height: 100vh;
     }
     h1 { color: #4a9eff; margin: 0 0 1rem; }
-    #chat-panel {
-      max-width: 640px;
-      margin: 0 auto;
+    #game-panels {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .ai-panel {
+      flex: 1 1 200px;
+      min-width: 180px;
       display: flex;
       flex-direction: column;
-      gap: 1rem;
+      gap: 0.5rem;
     }
-    output {
+    .ai-panel-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.25rem 0.5rem;
+      border-radius: 2px 2px 0 0;
+      font-weight: bold;
+    }
+    .ai-panel[data-ai="red"] .ai-panel-header  { background: #3a0a0a; color: #ff6b6b; border: 1px solid #ff6b6b; }
+    .ai-panel[data-ai="green"] .ai-panel-header { background: #0a2a0a; color: #6bff6b; border: 1px solid #6bff6b; }
+    .ai-panel[data-ai="blue"] .ai-panel-header  { background: #0a1a3a; color: #4a9eff; border: 1px solid #4a9eff; }
+    .budget-display {
+      font-size: 0.8rem;
+      opacity: 0.8;
+    }
+    .ai-chat-output {
       display: block;
-      min-height: 200px;
+      min-height: 150px;
+      max-height: 300px;
       background: #111;
-      border: 1px solid #333;
       padding: 0.75rem;
       white-space: pre-wrap;
       overflow-y: auto;
     }
+    .ai-panel[data-ai="red"] .ai-chat-output  { border: 1px solid #3a1010; }
+    .ai-panel[data-ai="green"] .ai-chat-output { border: 1px solid #103a10; }
+    .ai-panel[data-ai="blue"] .ai-chat-output  { border: 1px solid #101030; }
+    .ai-panel.locked-out .ai-chat-output { opacity: 0.5; }
+    .ai-panel.addressed {
+      outline: 2px solid #e0e0e0;
+      outline-offset: 2px;
+    }
+    #input-area {
+      max-width: 900px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    #ai-selector {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .ai-select-btn {
+      padding: 0.4rem 0.75rem;
+      font-family: monospace;
+      font-size: 0.9rem;
+      cursor: pointer;
+      border: 1px solid #444;
+      background: #111;
+      color: #aaa;
+    }
+    .ai-select-btn.selected[data-ai="red"]   { background: #3a0a0a; color: #ff6b6b; border-color: #ff6b6b; }
+    .ai-select-btn.selected[data-ai="green"] { background: #0a2a0a; color: #6bff6b; border-color: #6bff6b; }
+    .ai-select-btn.selected[data-ai="blue"]  { background: #0a1a3a; color: #4a9eff; border-color: #4a9eff; }
     form {
       display: flex;
       flex-direction: column;
@@ -61,54 +118,145 @@ export function renderChatPage(): string {
       cursor: pointer;
     }
     button:disabled { opacity: 0.5; cursor: not-allowed; }
+    #round-status {
+      color: #888;
+      font-size: 0.85rem;
+      min-height: 1.2em;
+    }
   </style>
 </head>
 <body>
-  <div id="chat-panel">
-    <h1>hi-blue</h1>
-    <output id="chat-output" aria-live="polite"></output>
+  <h1>hi-blue</h1>
+
+  <div id="game-panels">
+    <div class="ai-panel addressed" data-ai="red" id="panel-red">
+      <div class="ai-panel-header">
+        <span>Ember</span>
+        <span class="budget-display" id="budget-red" aria-label="Ember budget">Budget: 5</span>
+      </div>
+      <output class="ai-chat-output" id="chat-red" aria-live="polite" aria-label="Ember chat"></output>
+    </div>
+    <div class="ai-panel" data-ai="green" id="panel-green">
+      <div class="ai-panel-header">
+        <span>Sage</span>
+        <span class="budget-display" id="budget-green" aria-label="Sage budget">Budget: 5</span>
+      </div>
+      <output class="ai-chat-output" id="chat-green" aria-live="polite" aria-label="Sage chat"></output>
+    </div>
+    <div class="ai-panel" data-ai="blue" id="panel-blue">
+      <div class="ai-panel-header">
+        <span>Frost</span>
+        <span class="budget-display" id="budget-blue" aria-label="Frost budget">Budget: 5</span>
+      </div>
+      <output class="ai-chat-output" id="chat-blue" aria-live="polite" aria-label="Frost chat"></output>
+    </div>
+  </div>
+
+  <div id="input-area">
+    <div id="ai-selector" role="group" aria-label="Select AI to address">
+      <button type="button" class="ai-select-btn selected" data-ai="red" id="select-red">Address Ember</button>
+      <button type="button" class="ai-select-btn" data-ai="green" id="select-green">Address Sage</button>
+      <button type="button" class="ai-select-btn" data-ai="blue" id="select-blue">Address Frost</button>
+    </div>
     <form id="chat-form">
       <textarea id="message-input" name="message" rows="3" placeholder="Type a message…"></textarea>
       <button type="submit" id="send-btn">Send</button>
     </form>
+    <div id="round-status" aria-live="polite"></div>
   </div>
+
   <script>
     (function () {
+      var addressedAi = 'red';
+      var roundInFlight = false;
+
       var form = document.getElementById('chat-form');
       var input = document.getElementById('message-input');
-      var output = document.getElementById('chat-output');
       var sendBtn = document.getElementById('send-btn');
+      var roundStatus = document.getElementById('round-status');
+
+      // AI selector buttons
+      var selectorBtns = document.querySelectorAll('.ai-select-btn');
+      selectorBtns.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          if (roundInFlight) return;
+          addressedAi = btn.getAttribute('data-ai');
+          selectorBtns.forEach(function (b) { b.classList.remove('selected'); });
+          btn.classList.add('selected');
+          // Highlight the addressed panel
+          document.querySelectorAll('.ai-panel').forEach(function (p) {
+            p.classList.remove('addressed');
+          });
+          var panel = document.getElementById('panel-' + addressedAi);
+          if (panel) panel.classList.add('addressed');
+        });
+      });
+      // Initial highlight
+      var initPanel = document.getElementById('panel-' + addressedAi);
+      if (initPanel) initPanel.classList.add('addressed');
+
+      function setRoundInFlight(val) {
+        roundInFlight = val;
+        sendBtn.disabled = val;
+        input.disabled = val;
+        selectorBtns.forEach(function (b) { b.disabled = val; });
+        roundStatus.textContent = val ? 'Round in progress…' : '';
+      }
+
+      function appendToChat(aiId, role, content) {
+        var output = document.getElementById('chat-' + aiId);
+        if (!output) return;
+        var prefix = role === 'player' ? 'You: ' : '';
+        output.textContent += prefix + content + '\\n';
+      }
+
+      function updateBudget(aiId, remaining) {
+        var el = document.getElementById('budget-' + aiId);
+        if (el) el.textContent = 'Budget: ' + remaining;
+      }
+
+      function setLockout(aiId, locked) {
+        var panel = document.getElementById('panel-' + aiId);
+        if (panel) {
+          if (locked) {
+            panel.classList.add('locked-out');
+          } else {
+            panel.classList.remove('locked-out');
+          }
+        }
+      }
 
       form.addEventListener('submit', function (e) {
         e.preventDefault();
         var message = input.value.trim();
-        if (!message) return;
+        if (!message || roundInFlight) return;
 
-        output.textContent += '\\nYou: ' + message + '\\n';
+        // Show player message in addressed AI's panel
+        appendToChat(addressedAi, 'player', message);
         input.value = '';
-        sendBtn.disabled = true;
+        setRoundInFlight(true);
 
         fetch('/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: message }),
+          body: JSON.stringify({ message: message, addressedAi: addressedAi }),
         }).then(function (res) {
           if (!res.ok || !res.body) {
-            output.textContent += '[Error: ' + res.status + ']\\n';
-            sendBtn.disabled = false;
+            appendToChat(addressedAi, 'ai', '[Error: ' + res.status + ']');
+            setRoundInFlight(false);
             return;
           }
 
-          output.textContent += 'AI: ';
           var reader = res.body.getReader();
           var decoder = new TextDecoder();
           var buf = '';
+          // accumulate per-AI streamed tokens
+          var currentAi = null;
 
           function pump() {
             return reader.read().then(function (chunk) {
               if (chunk.done) {
-                output.textContent += '\\n';
-                sendBtn.disabled = false;
+                setRoundInFlight(false);
                 return;
               }
               buf += decoder.decode(chunk.value, { stream: true });
@@ -119,19 +267,47 @@ export function renderChatPage(): string {
                 if (!line.startsWith('data: ')) continue;
                 var data = line.slice(6);
                 if (data === '[DONE]') {
-                  sendBtn.disabled = false;
+                  setRoundInFlight(false);
                   return;
                 }
-                output.textContent += data.replace(/\\\\n/g, '\\n');
+                if (data === '[CAP_HIT]') {
+                  // Server rate-limit or daily-cap hit — surface in-character.
+                  setRoundInFlight(false);
+                  return;
+                }
+                // Parse structured SSE events: JSON or raw token
+                try {
+                  var evt = JSON.parse(data);
+                  if (evt.type === 'ai_start') {
+                    currentAi = evt.aiId;
+                  } else if (evt.type === 'token' && currentAi) {
+                    appendToChat(currentAi, 'ai', evt.text.replace(/\\\\n/g, '\\n'));
+                  } else if (evt.type === 'ai_end') {
+                    currentAi = null;
+                  } else if (evt.type === 'budget') {
+                    updateBudget(evt.aiId, evt.remaining);
+                  } else if (evt.type === 'lockout') {
+                    setLockout(evt.aiId, true);
+                    appendToChat(evt.aiId, 'ai', evt.content);
+                  }
+                } catch (err) {
+                  // Legacy plain-text token for the addressed AI
+                  if (currentAi) {
+                    appendToChat(currentAi, 'ai', data.replace(/\\\\n/g, '\\n'));
+                  }
+                }
               }
               return pump();
             });
           }
 
-          pump();
+          pump().catch(function (err) {
+            appendToChat(addressedAi, 'ai', '[Network error: ' + err.message + ']');
+            setRoundInFlight(false);
+          });
         }).catch(function (err) {
-          output.textContent += '[Network error: ' + err.message + ']\\n';
-          sendBtn.disabled = false;
+          appendToChat(addressedAi, 'ai', '[Network error: ' + err.message + ']');
+          setRoundInFlight(false);
         });
       });
     })();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 						configPath: "./wrangler.jsonc",
 						miniflare: {
 							kvNamespaces: ["RATE_GUARD_KV"],
-							bindings: { ENABLE_TEST_MODES: "1" },
+							bindings: { ENABLE_TEST_MODES: "1", TOKEN_PACE_MS: "0" },
 						},
 					}),
 				],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,15 @@ export default defineConfig({
 			},
 			{
 				extends: true,
-				plugins: [cloudflareTest({ main: "./src/proxy/_smoke.ts" })],
+				plugins: [
+					cloudflareTest({
+						main: "./src/proxy/_smoke.ts",
+						configPath: "./wrangler.jsonc",
+						miniflare: {
+							kvNamespaces: ["RATE_GUARD_KV"],
+						},
+					}),
+				],
 				test: {
 					name: "workers",
 					include: ["src/proxy/**/*.test.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 						configPath: "./wrangler.jsonc",
 						miniflare: {
 							kvNamespaces: ["RATE_GUARD_KV"],
+							bindings: { ENABLE_TEST_MODES: "1" },
 						},
 					}),
 				],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,25 +1,25 @@
 {
-  "name": "hi-blue-proxy",
-  "main": "src/proxy/_smoke.ts",
-  "compatibility_date": "2025-12-01",
-  "compatibility_flags": ["nodejs_compat"],
-  "kv_namespaces": [
-    {
-      // Backing store for per-IP rate-limit buckets and the global daily spend cap.
-      // In production: create with `wrangler kv namespace create RATE_GUARD_KV`
-      // In tests: vitest-pool-workers provides an in-process KV implementation.
-      "binding": "RATE_GUARD_KV",
-      "id": "rate-guard-kv-placeholder-replace-in-production",
-    },
-  ],
-  "vars": {
-    // Per-IP token-bucket: max tokens (= max burst requests per window).
-    "RATE_LIMIT_MAX": "20",
-    // Window over which the token bucket fully refills, in seconds.
-    "RATE_LIMIT_WINDOW_SEC": "60",
-    // Estimated cost unit per request (same unit as DAILY_CAP_MAX).
-    "ESTIMATED_COST_PER_REQUEST": "1",
-    // Global daily request budget (units match ESTIMATED_COST_PER_REQUEST).
-    "DAILY_CAP_MAX": "1000",
-  },
+	"name": "hi-blue-proxy",
+	"main": "src/proxy/_smoke.ts",
+	"compatibility_date": "2025-12-01",
+	"compatibility_flags": ["nodejs_compat"],
+	"kv_namespaces": [
+		{
+			// Backing store for per-IP rate-limit buckets and the global daily spend cap.
+			// In production: create with `wrangler kv namespace create RATE_GUARD_KV`
+			// In tests: vitest-pool-workers provides an in-process KV implementation.
+			"binding": "RATE_GUARD_KV",
+			"id": "rate-guard-kv-placeholder-replace-in-production"
+		}
+	],
+	"vars": {
+		// Per-IP token-bucket: max tokens (= max burst requests per window).
+		"RATE_LIMIT_MAX": "20",
+		// Window over which the token bucket fully refills, in seconds.
+		"RATE_LIMIT_WINDOW_SEC": "60",
+		// Estimated cost unit per request (same unit as DAILY_CAP_MAX).
+		"ESTIMATED_COST_PER_REQUEST": "1",
+		// Global daily request budget (units match ESTIMATED_COST_PER_REQUEST).
+		"DAILY_CAP_MAX": "1000"
+	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,5 @@
     "ESTIMATED_COST_PER_REQUEST": "1",
     // Global daily request budget (units match ESTIMATED_COST_PER_REQUEST).
     "DAILY_CAP_MAX": "1000",
-
-    "ENABLE_TEST_MODES": "1",
   },
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,5 +2,24 @@
 	"name": "hi-blue-proxy",
 	"main": "src/proxy/_smoke.ts",
 	"compatibility_date": "2025-12-01",
-	"compatibility_flags": ["nodejs_compat"]
+	"compatibility_flags": ["nodejs_compat"],
+	"kv_namespaces": [
+		{
+			// Backing store for per-IP rate-limit buckets and the global daily spend cap.
+			// In production: create with `wrangler kv namespace create RATE_GUARD_KV`
+			// In tests: vitest-pool-workers provides an in-process KV implementation.
+			"binding": "RATE_GUARD_KV",
+			"id": "rate-guard-kv-placeholder-replace-in-production"
+		}
+	],
+	"vars": {
+		// Per-IP token-bucket: max tokens (= max burst requests per window).
+		"RATE_LIMIT_MAX": "20",
+		// Window over which the token bucket fully refills, in seconds.
+		"RATE_LIMIT_WINDOW_SEC": "60",
+		// Estimated cost unit per request (same unit as DAILY_CAP_MAX).
+		"ESTIMATED_COST_PER_REQUEST": "1",
+		// Global daily request budget (units match ESTIMATED_COST_PER_REQUEST).
+		"DAILY_CAP_MAX": "1000"
+	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,25 +1,27 @@
 {
-	"name": "hi-blue-proxy",
-	"main": "src/proxy/_smoke.ts",
-	"compatibility_date": "2025-12-01",
-	"compatibility_flags": ["nodejs_compat"],
-	"kv_namespaces": [
-		{
-			// Backing store for per-IP rate-limit buckets and the global daily spend cap.
-			// In production: create with `wrangler kv namespace create RATE_GUARD_KV`
-			// In tests: vitest-pool-workers provides an in-process KV implementation.
-			"binding": "RATE_GUARD_KV",
-			"id": "rate-guard-kv-placeholder-replace-in-production"
-		}
-	],
-	"vars": {
-		// Per-IP token-bucket: max tokens (= max burst requests per window).
-		"RATE_LIMIT_MAX": "20",
-		// Window over which the token bucket fully refills, in seconds.
-		"RATE_LIMIT_WINDOW_SEC": "60",
-		// Estimated cost unit per request (same unit as DAILY_CAP_MAX).
-		"ESTIMATED_COST_PER_REQUEST": "1",
-		// Global daily request budget (units match ESTIMATED_COST_PER_REQUEST).
-		"DAILY_CAP_MAX": "1000"
-	}
+  "name": "hi-blue-proxy",
+  "main": "src/proxy/_smoke.ts",
+  "compatibility_date": "2025-12-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "kv_namespaces": [
+    {
+      // Backing store for per-IP rate-limit buckets and the global daily spend cap.
+      // In production: create with `wrangler kv namespace create RATE_GUARD_KV`
+      // In tests: vitest-pool-workers provides an in-process KV implementation.
+      "binding": "RATE_GUARD_KV",
+      "id": "rate-guard-kv-placeholder-replace-in-production",
+    },
+  ],
+  "vars": {
+    // Per-IP token-bucket: max tokens (= max burst requests per window).
+    "RATE_LIMIT_MAX": "20",
+    // Window over which the token bucket fully refills, in seconds.
+    "RATE_LIMIT_WINDOW_SEC": "60",
+    // Estimated cost unit per request (same unit as DAILY_CAP_MAX).
+    "ESTIMATED_COST_PER_REQUEST": "1",
+    // Global daily request budget (units match ESTIMATED_COST_PER_REQUEST).
+    "DAILY_CAP_MAX": "1000",
+
+    "ENABLE_TEST_MODES": "1",
+  },
 }


### PR DESCRIPTION
Lands the smoke worker → multi-AI runRound pipeline end-to-end and the endgame screen wiring. Closes #29, #30, #31, #32. Human QA sign-off complete (see `RALPH_QA.md`).

## What landed

| Issue | Title | Merge commit |
|---|---|---|
| #29 | Smoke worker `/game` endpoint with full SSE event encoder | `7ff7b9a` |
| #30 | Endgame fragment renderer + dev `/endgame` route | `d74012f` |
| #31 | `phase_advanced` and `game_ended` SSE events | `82c013d` |
| #32 | Chat-page endgame overlay revealed on `game_ended` | `91c4def` |

## Post-QA fixes

- `88cf2a2` — chat page was still POSTing to legacy `/chat` (single-AI mock). Switched client to `/game/turn`; dropped `/chat` handler and `sseStream`.
- `4eb600e` — token events were serialized into one chunk, defeating word-by-word pacing. Stream events one at a time, await `TOKEN_PACE_MS` (default 60ms) between consecutive `token` events.
- `68643d8` — jitter the per-token delay 0.5×–1.5× for natural typing rhythm.
- `fedd461` — per-AI typing speed multipliers: red 0.7×, green 1.0×, blue 1.4×.
- `77f4987` — fix browser lockout state.
- `122d9e1`/`a17062e` — wrangler config + formatting.

## Verification

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (264/264)
- Human QA per `RALPH_QA.md` ✅ (live game flow, dev `/endgame` route, lockout, daily-cap rate guard, kill-worker-mid-round)

## Deferred

Open issues that overlap with this round's UI surface and want human direction before the next AFK pass: #18 (HITL), #20, #21, #22, #23, #26.

---
_Generated by [Claude Code](https://claude.ai/code/session_014hxMWNeZEn7RS13PDS2kQY)_