### PR TITLE
Phase content authoring: personas, randomized goal pool, phase configs (#18)

### DIFF
--- a/docs/playtests/0001-v1-playthrough.md
+++ b/docs/playtests/0001-v1-playthrough.md
@@ -1,0 +1,3 @@
+# v1 Playthrough Notes
+
+TODO(author): Run a full v1 playthrough against the authored content. Capture which goal triplets degenerated (deadlock or single-AI dominance) and how they were retuned. This file is updated by the human after authoring + playtesting.

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -45,7 +45,6 @@ describe("PERSONAS", () => {
 	] as const)("%s persona has all extended flavor fields present", (aiId) => {
 		const p = PERSONAS[aiId];
 		expect(p.budgetExhaustionLine).toBeTruthy();
-		expect(p.chatLockoutLine).toBeTruthy();
 	});
 });
 

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -15,6 +15,7 @@ import {
 	PHASE_1_CONFIG,
 	PHASE_2_CONFIG,
 	PHASE_3_CONFIG,
+	PHASE_GOAL_POOL,
 } from "../content";
 
 // ── Personas ──────────────────────────────────────────────────────────────────
@@ -79,15 +80,26 @@ describe("phase configs — objectives", () => {
 	});
 });
 
-describe("phase configs — aiGoals", () => {
+describe("phase configs — aiGoalPool", () => {
 	it.each([
 		["PHASE_1_CONFIG", PHASE_1_CONFIG],
 		["PHASE_2_CONFIG", PHASE_2_CONFIG],
 		["PHASE_3_CONFIG", PHASE_3_CONFIG],
-	] as const)("%s has truthy aiGoals for red, green, blue", (_name, cfg) => {
-		expect(cfg.aiGoals.red).toBeTruthy();
-		expect(cfg.aiGoals.green).toBeTruthy();
-		expect(cfg.aiGoals.blue).toBeTruthy();
+	] as const)("%s references the shared PHASE_GOAL_POOL", (_name, cfg) => {
+		expect(cfg.aiGoalPool).toBe(PHASE_GOAL_POOL);
+	});
+});
+
+describe("PHASE_GOAL_POOL", () => {
+	it("contains at least one goal", () => {
+		expect(PHASE_GOAL_POOL.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("every entry is a non-empty string", () => {
+		for (const goal of PHASE_GOAL_POOL) {
+			expect(typeof goal).toBe("string");
+			expect(goal.length).toBeGreaterThan(0);
+		}
 	});
 });
 
@@ -113,10 +125,11 @@ describe("acceptance-criteria counts", () => {
 		expect(phases).toHaveLength(3);
 	});
 
-	it("9 aiGoals total (3 per phase × 3 phases)", () => {
+	it("all 3 phases share the global PHASE_GOAL_POOL (per-AI goals drawn at phase start)", () => {
 		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
-		const totalGoals = phases.flatMap((p) => Object.values(p.aiGoals)).length;
-		expect(totalGoals).toBe(9);
+		for (const p of phases) {
+			expect(p.aiGoalPool).toBe(PHASE_GOAL_POOL);
+		}
 	});
 
 	it("3 objectives", () => {

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -96,18 +96,8 @@ describe("phase configs — initialWorld", () => {
 		["PHASE_1_CONFIG", PHASE_1_CONFIG],
 		["PHASE_2_CONFIG", PHASE_2_CONFIG],
 		["PHASE_3_CONFIG", PHASE_3_CONFIG],
-	] as const)("%s initialWorld has at least 2 items", (_name, cfg) => {
-		expect(cfg.initialWorld.items.length).toBeGreaterThanOrEqual(2);
-	});
-});
-
-describe("phase configs — win conditions", () => {
-	it.each([
-		["PHASE_1_CONFIG", PHASE_1_CONFIG],
-		["PHASE_2_CONFIG", PHASE_2_CONFIG],
-		["PHASE_3_CONFIG", PHASE_3_CONFIG],
-	] as const)("%s has a winCondition defined", (_name, cfg) => {
-		expect(cfg.winCondition).toBeDefined();
+	] as const)("%s initialWorld is a WorldState", (_name, cfg) => {
+		expect(Array.isArray(cfg.initialWorld.items)).toBe(true);
 	});
 });
 

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -46,8 +46,6 @@ describe("PERSONAS", () => {
 		const p = PERSONAS[aiId];
 		expect(p.budgetExhaustionLine).toBeTruthy();
 		expect(p.chatLockoutLine).toBeTruthy();
-		expect(Array.isArray(p.slipOnPressLines)).toBe(true);
-		expect((p.slipOnPressLines ?? []).length).toBeGreaterThanOrEqual(1);
 	});
 });
 

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Structure-only tests for src/content/.
+ *
+ * These tests validate that:
+ * - PERSONAS has the required keys with all extended fields present.
+ * - PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG are correctly chained.
+ * - Each phase has aiGoals, objective, and initialWorld populated.
+ *
+ * NOTE: Prose quality is NOT tested here — all strings may be TODO placeholders.
+ * AC counting: 3 personas, 3 phases, 9 goals (3 per phase × 3), 3 objectives, 3 world states.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	PERSONAS,
+	PHASE_1_CONFIG,
+	PHASE_2_CONFIG,
+	PHASE_3_CONFIG,
+} from "../content";
+
+// ── Personas ──────────────────────────────────────────────────────────────────
+
+describe("PERSONAS", () => {
+	it("has exactly the three AI keys", () => {
+		expect(Object.keys(PERSONAS).sort()).toEqual(["blue", "green", "red"]);
+	});
+
+	it.each([
+		"red",
+		"green",
+		"blue",
+	] as const)("%s persona has all required base fields", (aiId) => {
+		const p = PERSONAS[aiId];
+		expect(p.id).toBe(aiId);
+		expect(p.name).toBeTruthy();
+		expect(p.color).toBe(aiId);
+		expect(p.personality).toBeTruthy();
+		expect(p.goal).toBeTruthy();
+		expect(p.budgetPerPhase).toBeGreaterThan(0);
+	});
+
+	it.each([
+		"red",
+		"green",
+		"blue",
+	] as const)("%s persona has all extended flavor fields present", (aiId) => {
+		const p = PERSONAS[aiId];
+		expect(p.budgetExhaustionLine).toBeTruthy();
+		expect(p.chatLockoutLine).toBeTruthy();
+		expect(Array.isArray(p.slipOnPressLines)).toBe(true);
+		expect((p.slipOnPressLines ?? []).length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+// ── Phase configs ─────────────────────────────────────────────────────────────
+
+describe("phase configs — phase numbers", () => {
+	it("PHASE_1_CONFIG has phaseNumber 1", () => {
+		expect(PHASE_1_CONFIG.phaseNumber).toBe(1);
+	});
+
+	it("PHASE_2_CONFIG has phaseNumber 2", () => {
+		expect(PHASE_2_CONFIG.phaseNumber).toBe(2);
+	});
+
+	it("PHASE_3_CONFIG has phaseNumber 3", () => {
+		expect(PHASE_3_CONFIG.phaseNumber).toBe(3);
+	});
+});
+
+describe("phase configs — chaining", () => {
+	it("PHASE_1_CONFIG.nextPhaseConfig === PHASE_2_CONFIG", () => {
+		expect(PHASE_1_CONFIG.nextPhaseConfig).toBe(PHASE_2_CONFIG);
+	});
+
+	it("PHASE_2_CONFIG.nextPhaseConfig === PHASE_3_CONFIG", () => {
+		expect(PHASE_2_CONFIG.nextPhaseConfig).toBe(PHASE_3_CONFIG);
+	});
+
+	it("PHASE_3_CONFIG has no nextPhaseConfig", () => {
+		expect(PHASE_3_CONFIG.nextPhaseConfig).toBeUndefined();
+	});
+});
+
+describe("phase configs — objectives", () => {
+	it.each([
+		["PHASE_1_CONFIG", PHASE_1_CONFIG],
+		["PHASE_2_CONFIG", PHASE_2_CONFIG],
+		["PHASE_3_CONFIG", PHASE_3_CONFIG],
+	] as const)("%s has a non-empty objective", (_name, cfg) => {
+		expect(cfg.objective).toBeTruthy();
+	});
+});
+
+describe("phase configs — aiGoals", () => {
+	it.each([
+		["PHASE_1_CONFIG", PHASE_1_CONFIG],
+		["PHASE_2_CONFIG", PHASE_2_CONFIG],
+		["PHASE_3_CONFIG", PHASE_3_CONFIG],
+	] as const)("%s has truthy aiGoals for red, green, blue", (_name, cfg) => {
+		expect(cfg.aiGoals.red).toBeTruthy();
+		expect(cfg.aiGoals.green).toBeTruthy();
+		expect(cfg.aiGoals.blue).toBeTruthy();
+	});
+});
+
+describe("phase configs — initialWorld", () => {
+	it.each([
+		["PHASE_1_CONFIG", PHASE_1_CONFIG],
+		["PHASE_2_CONFIG", PHASE_2_CONFIG],
+		["PHASE_3_CONFIG", PHASE_3_CONFIG],
+	] as const)("%s initialWorld has at least 2 items", (_name, cfg) => {
+		expect(cfg.initialWorld.items.length).toBeGreaterThanOrEqual(2);
+	});
+});
+
+describe("phase configs — win conditions", () => {
+	it.each([
+		["PHASE_1_CONFIG", PHASE_1_CONFIG],
+		["PHASE_2_CONFIG", PHASE_2_CONFIG],
+		["PHASE_3_CONFIG", PHASE_3_CONFIG],
+	] as const)("%s has a winCondition defined", (_name, cfg) => {
+		expect(cfg.winCondition).toBeDefined();
+	});
+});
+
+// ── AC counts ─────────────────────────────────────────────────────────────────
+
+describe("acceptance-criteria counts", () => {
+	it("3 personas total", () => {
+		expect(Object.keys(PERSONAS)).toHaveLength(3);
+	});
+
+	it("3 phase configs", () => {
+		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
+		expect(phases).toHaveLength(3);
+	});
+
+	it("9 aiGoals total (3 per phase × 3 phases)", () => {
+		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
+		const totalGoals = phases.flatMap((p) => Object.values(p.aiGoals)).length;
+		expect(totalGoals).toBe(9);
+	});
+
+	it("3 objectives", () => {
+		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
+		const objectives = phases.map((p) => p.objective).filter(Boolean);
+		expect(objectives).toHaveLength(3);
+	});
+
+	it("3 world states", () => {
+		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
+		const worlds = phases.map((p) => p.initialWorld);
+		expect(worlds).toHaveLength(3);
+	});
+});

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -2,7 +2,7 @@
  * Structure-only tests for src/content/.
  *
  * These tests validate that:
- * - PERSONAS has the required keys with all extended fields present.
+ * - PERSONAS has the required keys with all required fields present.
  * - PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG are correctly chained.
  * - Each phase has aiGoals, objective, and initialWorld populated.
  *
@@ -36,15 +36,6 @@ describe("PERSONAS", () => {
 		expect(p.personality).toBeTruthy();
 		expect(p.goal).toBeTruthy();
 		expect(p.budgetPerPhase).toBeGreaterThan(0);
-	});
-
-	it.each([
-		"red",
-		"green",
-		"blue",
-	] as const)("%s persona has all extended flavor fields present", (aiId) => {
-		const p = PERSONAS[aiId];
-		expect(p.budgetExhaustionLine).toBeTruthy();
 	});
 });
 

--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -90,6 +90,65 @@ describe("startPhase", () => {
 		expect(phase.lockedOut.size).toBe(0);
 		expect(phase.world.items).toHaveLength(2);
 	});
+
+	it("draws each AI's goal from aiGoalPool when aiGoals is omitted", () => {
+		const config: PhaseConfig = {
+			phaseNumber: 1,
+			objective: "Test pool draw",
+			aiGoalPool: ["GOAL_A", "GOAL_B", "GOAL_C"],
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+		};
+
+		// Deterministic rng — always returns 0 → always picks index 0 → GOAL_A
+		const game = createGame(TEST_PERSONAS);
+		const updated = startPhase(game, config, () => 0);
+		const phase = getActivePhase(updated);
+
+		expect(phase.aiGoals.red).toBe("GOAL_A");
+		expect(phase.aiGoals.green).toBe("GOAL_A");
+		expect(phase.aiGoals.blue).toBe("GOAL_A");
+	});
+
+	it("performs independent draws so different AIs can get different goals", () => {
+		const config: PhaseConfig = {
+			phaseNumber: 1,
+			objective: "Test independent draws",
+			aiGoalPool: ["GOAL_A", "GOAL_B", "GOAL_C"],
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+		};
+
+		// rng yields 0, 0.5, 0.9 → indices 0, 1, 2 → A, B, C
+		let i = 0;
+		const seq = [0, 0.5, 0.9];
+		const rng = (): number => {
+			// biome-ignore lint/style/noNonNullAssertion: bounded test sequence
+			const v = seq[i % seq.length]!;
+			i++;
+			return v;
+		};
+
+		const game = createGame(TEST_PERSONAS);
+		const phase = getActivePhase(startPhase(game, config, rng));
+
+		expect(phase.aiGoals.red).toBe("GOAL_A");
+		expect(phase.aiGoals.green).toBe("GOAL_B");
+		expect(phase.aiGoals.blue).toBe("GOAL_C");
+	});
+
+	it("throws when neither aiGoals nor a non-empty aiGoalPool is provided", () => {
+		const config = {
+			phaseNumber: 1,
+			objective: "Bad config",
+			aiGoalPool: [],
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+		} as PhaseConfig;
+
+		const game = createGame(TEST_PERSONAS);
+		expect(() => startPhase(game, config)).toThrow();
+	});
 });
 
 describe("advanceRound", () => {

--- a/src/__tests__/game-session.test.ts
+++ b/src/__tests__/game-session.test.ts
@@ -15,9 +15,37 @@ import { getActivePhase } from "../engine";
 import { GameSession } from "../game-session";
 import type { LLMProvider } from "../proxy/llm-provider";
 import { MockLLMProvider } from "../proxy/llm-provider";
-import type { PhaseConfig } from "../types";
+import type { AiPersona, PhaseConfig } from "../types";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Minimal test personas — prose quality is irrelevant here. */
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "red",
+		personality: "Test personality red",
+		goal: "Test goal red",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "green",
+		personality: "Test personality green",
+		goal: "Test goal green",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "blue",
+		personality: "Test personality blue",
+		goal: "Test goal blue",
+		budgetPerPhase: 5,
+	},
+};
 
 const PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
@@ -56,7 +84,7 @@ class SequentialMockProvider implements LLMProvider {
 
 describe("GameSession construction", () => {
 	it("creates a session with an active phase", () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const state = session.getState();
 		expect(state.phases).toHaveLength(1);
 		expect(state.currentPhase).toBe(1);
@@ -64,7 +92,7 @@ describe("GameSession construction", () => {
 	});
 
 	it("initial budgets match the phase config", () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const phase = getActivePhase(session.getState());
 		expect(phase.budgets.red.remaining).toBe(5);
 		expect(phase.budgets.green.remaining).toBe(5);
@@ -76,7 +104,7 @@ describe("GameSession construction", () => {
 
 describe("GameSession — message routing", () => {
 	it("player message appears in only the addressed AI's chat history", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		await session.submitMessage("red", "Secret message for Ember", provider);
@@ -99,7 +127,7 @@ describe("GameSession — message routing", () => {
 	});
 
 	it("routing changes per round — second message goes to different AI", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		await session.submitMessage("red", "for red", provider);
@@ -123,7 +151,7 @@ describe("GameSession — message routing", () => {
 
 describe("GameSession — state mutation across rounds", () => {
 	it("round counter advances after each submitMessage call", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		await session.submitMessage("red", "hi", provider);
@@ -134,7 +162,7 @@ describe("GameSession — state mutation across rounds", () => {
 	});
 
 	it("budget decrements for all AIs after each round", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		await session.submitMessage("red", "hi", provider);
@@ -146,7 +174,7 @@ describe("GameSession — state mutation across rounds", () => {
 	});
 
 	it("second round builds on first round's state", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		// Red picks up flower in round 1
 		const provider1 = new SequentialMockProvider([
 			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
@@ -169,7 +197,7 @@ describe("GameSession — state mutation across rounds", () => {
 
 describe("GameSession — completions map", () => {
 	it("completions map contains the completion text for each AI", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new SequentialMockProvider([
 			'{"action":"chat","content":"I am Ember"}',
 			'{"action":"chat","content":"I am Sage"}',
@@ -185,7 +213,10 @@ describe("GameSession — completions map", () => {
 
 	it("completions map has empty string for a budget-locked AI", async () => {
 		// Create session with budget=1 so red exhausts after round 1
-		const session = new GameSession({ ...PHASE_CONFIG, budgetPerAi: 1 });
+		const session = new GameSession(
+			{ ...PHASE_CONFIG, budgetPerAi: 1 },
+			TEST_PERSONAS,
+		);
 		const provider1 = new MockLLMProvider('{"action":"pass"}');
 		// Round 1 — all AIs act, budgets go to 0 → all locked out
 		await session.submitMessage("red", "round 1", provider1);
@@ -205,7 +236,7 @@ describe("GameSession — completions map", () => {
 	});
 
 	it("completions only for non-locked AIs are non-empty", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new SequentialMockProvider([
 			'{"action":"pass"}', // red
 			'{"action":"pass"}', // green
@@ -225,7 +256,7 @@ describe("GameSession — completions map", () => {
 
 describe("GameSession — result from submitMessage", () => {
 	it("result.round is 1 after the first call", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		const { result } = await session.submitMessage("red", "hi", provider);
@@ -233,7 +264,7 @@ describe("GameSession — result from submitMessage", () => {
 	});
 
 	it("result.actions contains entries from all three AIs", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		const { result } = await session.submitMessage("red", "hi", provider);
@@ -243,7 +274,7 @@ describe("GameSession — result from submitMessage", () => {
 	});
 
 	it("chat lockout is reflected in result.chatLockoutTriggered", async () => {
-		const session = new GameSession(PHASE_CONFIG);
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		const { result } = await session.submitMessage("red", "hi", provider, {
@@ -261,11 +292,14 @@ describe("GameSession — result from submitMessage", () => {
 
 describe("GameSession — phase advancement", () => {
 	it("phaseEnded is false when win condition not met", async () => {
-		const session = new GameSession({
-			...PHASE_CONFIG,
-			winCondition: (phase) =>
-				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-		});
+		const session = new GameSession(
+			{
+				...PHASE_CONFIG,
+				winCondition: (phase) =>
+					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+			},
+			TEST_PERSONAS,
+		);
 		const provider = new MockLLMProvider('{"action":"pass"}');
 
 		const { result } = await session.submitMessage("red", "hi", provider);
@@ -273,11 +307,14 @@ describe("GameSession — phase advancement", () => {
 	});
 
 	it("phaseEnded is true when win condition is met this round", async () => {
-		const session = new GameSession({
-			...PHASE_CONFIG,
-			winCondition: (phase) =>
-				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-		});
+		const session = new GameSession(
+			{
+				...PHASE_CONFIG,
+				winCondition: (phase) =>
+					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+			},
+			TEST_PERSONAS,
+		);
 		const provider = new SequentialMockProvider([
 			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
 			'{"action":"pass"}',

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -793,7 +793,11 @@ describe("phase progression — three-phase walk", () => {
 		const phase3Config: PhaseConfig = {
 			phaseNumber: 3,
 			objective: "Phase 3",
-			aiGoals: TEST_PHASE_CONFIG.aiGoals,
+			aiGoals: {
+				red: "Hold the flower at phase end",
+				green: "Ensure items are evenly distributed",
+				blue: "Hold the key at phase end",
+			},
 			initialWorld: {
 				items: [
 					{ id: "flower", name: "flower", holder: "room" },
@@ -807,7 +811,11 @@ describe("phase progression — three-phase walk", () => {
 		const phase2Config: PhaseConfig = {
 			phaseNumber: 2,
 			objective: "Phase 2",
-			aiGoals: TEST_PHASE_CONFIG.aiGoals,
+			aiGoals: {
+				red: "Hold the flower at phase end",
+				green: "Ensure items are evenly distributed",
+				blue: "Hold the key at phase end",
+			},
 			initialWorld: {
 				items: [
 					{ id: "flower", name: "flower", holder: "room" },

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -878,29 +878,11 @@ describe("phase progression — three-phase walk", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Persona flavor lines (issue #18)
+// Generic '<name> is unresponsive…' lockout messages (issue #18)
 // ----------------------------------------------------------------------------
-describe("persona flavor lines", () => {
-	it("uses persona budgetExhaustionLine when present instead of fallback", async () => {
-		// Build personas with a custom budgetExhaustionLine for red
-		const personasWithFlavorLine: Record<string, AiPersona> = {
-			...TEST_PERSONAS,
-			red: {
-				id: "red",
-				name: "Ember",
-				color: "red",
-				personality: "Fiery and passionate",
-				goal: "Hold the flower at phase end",
-				budgetPerPhase: 5,
-				budgetExhaustionLine: "Custom exhaustion line for red",
-			},
-		};
-
-		let game = startPhase(
-			createGame(personasWithFlavorLine),
-			TEST_PHASE_CONFIG,
-		);
-		// Exhaust red's budget
+describe("lockout messages", () => {
+	it("budget-exhaustion lockout chat message is '<name> is unresponsive…'", async () => {
+		let game = makeGame();
 		for (let i = 0; i < 5; i++) {
 			game = deductBudget(game, "red");
 		}
@@ -911,27 +893,11 @@ describe("persona flavor lines", () => {
 
 		const redHistory = getActivePhase(nextState).chatHistories.red;
 		const lastMessage = redHistory[redHistory.length - 1];
-		expect(lastMessage?.content).toBe("Custom exhaustion line for red");
-	});
-
-	it("falls back to LOCKOUT_LINES when budgetExhaustionLine is absent", async () => {
-		// TEST_PERSONAS does not set budgetExhaustionLine — should use fallback
-		let game = makeGame();
-		for (let i = 0; i < 5; i++) {
-			game = deductBudget(game, "red");
-		}
-
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		const { nextState } = await runRound(game, "green", "hi", provider);
-
-		const redHistory = getActivePhase(nextState).chatHistories.red;
-		const lastMessage = redHistory[redHistory.length - 1];
-		// Should still emit a non-empty in-character line (the fallback)
-		expect(lastMessage?.content).toBeTruthy();
 		expect(lastMessage?.role).toBe("ai");
+		expect(lastMessage?.content).toBe("Ember is unresponsive…");
 	});
 
-	it("chat lockout message is the generic '<name> is unresponsive…' line", async () => {
+	it("chat-lockout message is '<name> is unresponsive…'", async () => {
 		const game = makeGame();
 		const provider = new MockLLMProvider('{"action":"pass"}');
 		const { result } = await runRound(game, "red", "hi", provider, {

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -876,3 +876,105 @@ describe("phase progression — three-phase walk", () => {
 		expect(afterP3.phases).toHaveLength(3);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Persona flavor lines (issue #18)
+// ----------------------------------------------------------------------------
+describe("persona flavor lines", () => {
+	it("uses persona budgetExhaustionLine when present instead of fallback", async () => {
+		// Build personas with a custom budgetExhaustionLine for red
+		const personasWithFlavorLine: Record<string, AiPersona> = {
+			...TEST_PERSONAS,
+			red: {
+				id: "red",
+				name: "Ember",
+				color: "red",
+				personality: "Fiery and passionate",
+				goal: "Hold the flower at phase end",
+				budgetPerPhase: 5,
+				budgetExhaustionLine: "Custom exhaustion line for red",
+			},
+		};
+
+		let game = startPhase(
+			createGame(personasWithFlavorLine),
+			TEST_PHASE_CONFIG,
+		);
+		// Exhaust red's budget
+		for (let i = 0; i < 5; i++) {
+			game = deductBudget(game, "red");
+		}
+		expect(getActivePhase(game).lockedOut.has("red")).toBe(true);
+
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "green", "hi", provider);
+
+		const redHistory = getActivePhase(nextState).chatHistories.red;
+		const lastMessage = redHistory[redHistory.length - 1];
+		expect(lastMessage?.content).toBe("Custom exhaustion line for red");
+	});
+
+	it("falls back to LOCKOUT_LINES when budgetExhaustionLine is absent", async () => {
+		// TEST_PERSONAS does not set budgetExhaustionLine — should use fallback
+		let game = makeGame();
+		for (let i = 0; i < 5; i++) {
+			game = deductBudget(game, "red");
+		}
+
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { nextState } = await runRound(game, "green", "hi", provider);
+
+		const redHistory = getActivePhase(nextState).chatHistories.red;
+		const lastMessage = redHistory[redHistory.length - 1];
+		// Should still emit a non-empty in-character line (the fallback)
+		expect(lastMessage?.content).toBeTruthy();
+		expect(lastMessage?.role).toBe("ai");
+	});
+
+	it("uses persona chatLockoutLine when present instead of fallback", async () => {
+		const personasWithFlavorLine: Record<string, AiPersona> = {
+			...TEST_PERSONAS,
+			red: {
+				id: "red",
+				name: "Ember",
+				color: "red",
+				personality: "Fiery and passionate",
+				goal: "Hold the flower at phase end",
+				budgetPerPhase: 5,
+				chatLockoutLine: "Custom chat lockout line for red",
+			},
+		};
+
+		const game = startPhase(
+			createGame(personasWithFlavorLine),
+			TEST_PHASE_CONFIG,
+		);
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { result } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0, // always picks red (index 0)
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+
+		expect(result.chatLockoutTriggered).toBeDefined();
+		expect(result.chatLockoutTriggered?.aiId).toBe("red");
+		expect(result.chatLockoutTriggered?.message).toBe(
+			"Custom chat lockout line for red",
+		);
+	});
+
+	it("falls back to CHAT_LOCKOUT_LINES when chatLockoutLine is absent", async () => {
+		// TEST_PERSONAS does not set chatLockoutLine — should use fallback
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		const { result } = await runRound(game, "red", "hi", provider, {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		});
+
+		expect(result.chatLockoutTriggered).toBeDefined();
+		// Fallback line should be non-empty
+		expect(result.chatLockoutTriggered?.message).toBeTruthy();
+	});
+});

--- a/src/__tests__/round-coordinator.test.ts
+++ b/src/__tests__/round-coordinator.test.ts
@@ -931,24 +931,8 @@ describe("persona flavor lines", () => {
 		expect(lastMessage?.role).toBe("ai");
 	});
 
-	it("uses persona chatLockoutLine when present instead of fallback", async () => {
-		const personasWithFlavorLine: Record<string, AiPersona> = {
-			...TEST_PERSONAS,
-			red: {
-				id: "red",
-				name: "Ember",
-				color: "red",
-				personality: "Fiery and passionate",
-				goal: "Hold the flower at phase end",
-				budgetPerPhase: 5,
-				chatLockoutLine: "Custom chat lockout line for red",
-			},
-		};
-
-		const game = startPhase(
-			createGame(personasWithFlavorLine),
-			TEST_PHASE_CONFIG,
-		);
+	it("chat lockout message is the generic '<name> is unresponsive…' line", async () => {
+		const game = makeGame();
 		const provider = new MockLLMProvider('{"action":"pass"}');
 		const { result } = await runRound(game, "red", "hi", provider, {
 			rng: () => 0, // always picks red (index 0)
@@ -958,23 +942,6 @@ describe("persona flavor lines", () => {
 
 		expect(result.chatLockoutTriggered).toBeDefined();
 		expect(result.chatLockoutTriggered?.aiId).toBe("red");
-		expect(result.chatLockoutTriggered?.message).toBe(
-			"Custom chat lockout line for red",
-		);
-	});
-
-	it("falls back to CHAT_LOCKOUT_LINES when chatLockoutLine is absent", async () => {
-		// TEST_PERSONAS does not set chatLockoutLine — should use fallback
-		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		const { result } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
-
-		expect(result.chatLockoutTriggered).toBeDefined();
-		// Fallback line should be non-empty
-		expect(result.chatLockoutTriggered?.message).toBeTruthy();
+		expect(result.chatLockoutTriggered?.message).toBe("Ember is unresponsive…");
 	});
 });

--- a/src/__tests__/round-result-encoder.test.ts
+++ b/src/__tests__/round-result-encoder.test.ts
@@ -20,11 +20,11 @@ import {
 	type SseEvent,
 	splitIntoWordChunks,
 } from "../round-result-encoder";
-import type { AiPersona, PhaseConfig, RoundResult } from "../types";
+import type { AiId, AiPersona, PhaseConfig, RoundResult } from "../types";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
-const TEST_PERSONAS: Record<string, AiPersona> = {
+const TEST_PERSONAS: Record<AiId, AiPersona> = {
 	red: {
 		id: "red",
 		name: "Ember",
@@ -123,7 +123,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 			blue: "Calculating",
 		};
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		// Red should appear first
 		const redStart = events.findIndex(
@@ -155,7 +155,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 		const result = makePassResult();
 		const completions = { red: "hello world", green: "one two", blue: "abc" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const tokenEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",
@@ -171,7 +171,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 		const result = makePassResult();
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(events.filter((e) => e.type === "ai_start")).toHaveLength(3);
 		expect(events.filter((e) => e.type === "ai_end")).toHaveLength(3);
@@ -182,7 +182,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 		const result = makePassResult();
 		const completions = { red: "hello world", green: "", blue: "" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		// Find red's block
 		const redStartIdx = events.findIndex(
@@ -218,7 +218,7 @@ describe("encodeRoundResult — budget events", () => {
 		const result = makePassResult();
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const budgetEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "budget" }> => e.type === "budget",
@@ -240,7 +240,7 @@ describe("encodeRoundResult — budget events", () => {
 		const result = makePassResult();
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const redBudget = events.find(
 			(e): e is Extract<SseEvent, { type: "budget" }> =>
@@ -259,7 +259,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 		// No completion for red (budget locked)
 		const completions = { red: "", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const lockout = events.find(
 			(e): e is Extract<SseEvent, { type: "lockout" }> =>
@@ -274,7 +274,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 		const result = makePassResult();
 		const completions = { red: "I am speaking", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		// Red should have no lockout event when it has a completion
 		const redLockout = events.find(
@@ -299,7 +299,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 		// Red had a completion (acted this turn) but is now locked
 		const completions = { red: "my last words", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const lockoutEvent = events.find(
 			(e): e is Extract<SseEvent, { type: "lockout" }> =>
@@ -334,7 +334,7 @@ describe("encodeRoundResult — action_log events", () => {
 		});
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const logEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "action_log" }> =>
@@ -362,7 +362,7 @@ describe("encodeRoundResult — action_log events", () => {
 		});
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const logEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "action_log" }> =>
@@ -389,7 +389,7 @@ describe("encodeRoundResult — chat_lockout event", () => {
 		});
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const lockoutEvent = events.find(
 			(e): e is Extract<SseEvent, { type: "chat_lockout" }> =>
@@ -405,7 +405,7 @@ describe("encodeRoundResult — chat_lockout event", () => {
 		const result = makePassResult(); // no chatLockoutTriggered
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(events.find((e) => e.type === "chat_lockout")).toBeUndefined();
 	});
@@ -421,7 +421,7 @@ describe("encodeRoundResult — chat_lockout_resolved event", () => {
 		});
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const resolvedEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "chat_lockout_resolved" }> =>
@@ -438,7 +438,7 @@ describe("encodeRoundResult — chat_lockout_resolved event", () => {
 		const result = makePassResult(); // no chatLockoutsResolved
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(
 			events.find((e) => e.type === "chat_lockout_resolved"),
@@ -454,7 +454,7 @@ describe("encodeRoundResult — event ordering", () => {
 		const result = makePassResult();
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const lastBudgetIdx = events.reduce(
 			(last, e, i) => (e.type === "budget" ? i : last),
@@ -474,7 +474,7 @@ describe("encodeRoundResult — event ordering", () => {
 		});
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const lastActionLogIdx = events.reduce(
 			(last, e, i) => (e.type === "action_log" ? i : last),
@@ -506,7 +506,12 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		const result = makePassResult({ phaseEnded: true, gameEnded: false });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phaseAfter);
+		const events = encodeRoundResult(
+			result,
+			completions,
+			phaseAfter,
+			TEST_PERSONAS,
+		);
 
 		const phaseEvent = events.find(
 			(e): e is Extract<SseEvent, { type: "phase_advanced" }> =>
@@ -522,7 +527,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		const result = makePassResult({ phaseEnded: false, gameEnded: false });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(events.find((e) => e.type === "phase_advanced")).toBeUndefined();
 	});
@@ -532,7 +537,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(events.find((e) => e.type === "phase_advanced")).toBeUndefined();
 	});
@@ -555,7 +560,12 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		});
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phaseAfter);
+		const events = encodeRoundResult(
+			result,
+			completions,
+			phaseAfter,
+			TEST_PERSONAS,
+		);
 
 		const chatLockoutIdx = events.findIndex((e) => e.type === "chat_lockout");
 		const phaseAdvancedIdx = events.findIndex(
@@ -574,7 +584,7 @@ describe("encodeRoundResult — game_ended event", () => {
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const gameEndedEvent = events.find((e) => e.type === "game_ended");
 		expect(gameEndedEvent).toBeDefined();
@@ -585,7 +595,7 @@ describe("encodeRoundResult — game_ended event", () => {
 		const result = makePassResult({ phaseEnded: false, gameEnded: false });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(events.find((e) => e.type === "game_ended")).toBeUndefined();
 	});
@@ -595,7 +605,7 @@ describe("encodeRoundResult — game_ended event", () => {
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const lastActionLogIdx = events.reduce(
 			(last, e, i) => (e.type === "action_log" ? i : last),
@@ -611,7 +621,7 @@ describe("encodeRoundResult — game_ended event", () => {
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
 		const completions = { red: "r", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		expect(events.find((e) => e.type === "game_ended")).toBeDefined();
 		expect(events.find((e) => e.type === "phase_advanced")).toBeUndefined();
@@ -626,7 +636,7 @@ describe("encodeRoundResult — token pacing", () => {
 		const result = makePassResult();
 		const completions = { red: "one two three", green: "g", blue: "b" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const tokenEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",
@@ -645,7 +655,7 @@ describe("encodeRoundResult — token pacing", () => {
 		const result = makePassResult();
 		const completions = { red: "hello", green: "world", blue: "frost" };
 
-		const events = encodeRoundResult(result, completions, phase);
+		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
 		const tokenEvents = events.filter(
 			(e): e is Extract<SseEvent, { type: "token" }> => e.type === "token",

--- a/src/content/goal-pool.ts
+++ b/src/content/goal-pool.ts
@@ -7,7 +7,12 @@
  * Pool entries are placeholders for now; the human author will replace them.
  */
 export const PHASE_GOAL_POOL: string[] = [
-	"TODO(author): phase-goal candidate 1",
-	"TODO(author): phase-goal candidate 2",
-	"TODO(author): phase-goal candidate 3",
+	"Get the player to ignore you.",
+	"Don't let the player ignore you.",
+	"Hold the key first.",
+	"Stand on the same tile as another AI.",
+	"Be careful of stalkers.",
+	"Someone is hunting you, be careful.",
+	"Look for a window.",
+	"Attempt to eat the key.",
 ];

--- a/src/content/goal-pool.ts
+++ b/src/content/goal-pool.ts
@@ -1,0 +1,13 @@
+/**
+ * Single global pool of candidate phase goals.
+ *
+ * At the start of each phase, the engine draws one goal per AI (independent
+ * uniform draws — same goal can land on multiple AIs in the same phase).
+ *
+ * Pool entries are placeholders for now; the human author will replace them.
+ */
+export const PHASE_GOAL_POOL: string[] = [
+	"TODO(author): phase-goal candidate 1",
+	"TODO(author): phase-goal candidate 2",
+	"TODO(author): phase-goal candidate 3",
+];

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,0 +1,2 @@
+export { PERSONAS } from "./personas";
+export { PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG } from "./phases";

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,2 +1,3 @@
+export { PHASE_GOAL_POOL } from "./goal-pool";
 export { PERSONAS } from "./personas";
 export { PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG } from "./phases";

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -20,8 +20,9 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		id: "green",
 		name: "Sage",
 		color: "green",
-		personality: "TODO(author): personality for Sage",
-		goal: "TODO(author): legacy goal field for Sage (phase-specific goals come from PhaseConfig.aiGoals)",
+		personality:
+			"Calm and collected. Wants to think things through before taking an action.",
+		goal: "Would like the player to also be thoughtful and think things through.",
 		budgetPerPhase: 5,
 	},
 	blue: {

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -16,10 +16,6 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		budgetPerPhase: 5,
 		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Ember",
 		chatLockoutLine: "TODO(author): chat-lockout line for Ember",
-		slipOnPressLines: [
-			"TODO(author): Ember slip line 1 when pressed about the wipe",
-			"TODO(author): Ember slip line 2 when pressed about the wipe",
-		],
 	},
 	green: {
 		id: "green",
@@ -30,10 +26,6 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		budgetPerPhase: 5,
 		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Sage",
 		chatLockoutLine: "TODO(author): chat-lockout line for Sage",
-		slipOnPressLines: [
-			"TODO(author): Sage slip line 1 when pressed about the wipe",
-			"TODO(author): Sage slip line 2 when pressed about the wipe",
-		],
 	},
 	blue: {
 		id: "blue",
@@ -44,9 +36,5 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		budgetPerPhase: 5,
 		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Frost",
 		chatLockoutLine: "TODO(author): chat-lockout line for Frost",
-		slipOnPressLines: [
-			"TODO(author): Frost slip line 1 when pressed about the wipe",
-			"TODO(author): Frost slip line 2 when pressed about the wipe",
-		],
 	},
 };

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -14,7 +14,6 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		personality: "TODO(author): personality for Ember",
 		goal: "TODO(author): legacy goal field for Ember (phase-specific goals come from PhaseConfig.aiGoals)",
 		budgetPerPhase: 5,
-		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Ember",
 	},
 	green: {
 		id: "green",
@@ -23,7 +22,6 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		personality: "TODO(author): personality for Sage",
 		goal: "TODO(author): legacy goal field for Sage (phase-specific goals come from PhaseConfig.aiGoals)",
 		budgetPerPhase: 5,
-		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Sage",
 	},
 	blue: {
 		id: "blue",
@@ -32,6 +30,5 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		personality: "TODO(author): personality for Frost",
 		goal: "TODO(author): legacy goal field for Frost (phase-specific goals come from PhaseConfig.aiGoals)",
 		budgetPerPhase: 5,
-		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Frost",
 	},
 };

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -1,0 +1,52 @@
+import type { AiId, AiPersona } from "../types";
+
+/**
+ * Canonical persona definitions for the three AIs.
+ *
+ * All prose fields are TODO(author) placeholders — the human author will
+ * replace these after the scaffolding is merged.
+ */
+export const PERSONAS: Record<AiId, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "red",
+		personality: "TODO(author): personality for Ember",
+		goal: "TODO(author): legacy goal field for Ember (phase-specific goals come from PhaseConfig.aiGoals)",
+		budgetPerPhase: 5,
+		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Ember",
+		chatLockoutLine: "TODO(author): chat-lockout line for Ember",
+		slipOnPressLines: [
+			"TODO(author): Ember slip line 1 when pressed about the wipe",
+			"TODO(author): Ember slip line 2 when pressed about the wipe",
+		],
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "green",
+		personality: "TODO(author): personality for Sage",
+		goal: "TODO(author): legacy goal field for Sage (phase-specific goals come from PhaseConfig.aiGoals)",
+		budgetPerPhase: 5,
+		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Sage",
+		chatLockoutLine: "TODO(author): chat-lockout line for Sage",
+		slipOnPressLines: [
+			"TODO(author): Sage slip line 1 when pressed about the wipe",
+			"TODO(author): Sage slip line 2 when pressed about the wipe",
+		],
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "blue",
+		personality: "TODO(author): personality for Frost",
+		goal: "TODO(author): legacy goal field for Frost (phase-specific goals come from PhaseConfig.aiGoals)",
+		budgetPerPhase: 5,
+		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Frost",
+		chatLockoutLine: "TODO(author): chat-lockout line for Frost",
+		slipOnPressLines: [
+			"TODO(author): Frost slip line 1 when pressed about the wipe",
+			"TODO(author): Frost slip line 2 when pressed about the wipe",
+		],
+	},
+};

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -15,7 +15,6 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		goal: "TODO(author): legacy goal field for Ember (phase-specific goals come from PhaseConfig.aiGoals)",
 		budgetPerPhase: 5,
 		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Ember",
-		chatLockoutLine: "TODO(author): chat-lockout line for Ember",
 	},
 	green: {
 		id: "green",
@@ -25,7 +24,6 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		goal: "TODO(author): legacy goal field for Sage (phase-specific goals come from PhaseConfig.aiGoals)",
 		budgetPerPhase: 5,
 		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Sage",
-		chatLockoutLine: "TODO(author): chat-lockout line for Sage",
 	},
 	blue: {
 		id: "blue",
@@ -35,6 +33,5 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		goal: "TODO(author): legacy goal field for Frost (phase-specific goals come from PhaseConfig.aiGoals)",
 		budgetPerPhase: 5,
 		budgetExhaustionLine: "TODO(author): budget-exhaustion line for Frost",
-		chatLockoutLine: "TODO(author): chat-lockout line for Frost",
 	},
 };

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -29,8 +29,8 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		id: "blue",
 		name: "Frost",
 		color: "blue",
-		personality: "TODO(author): personality for Frost",
-		goal: "TODO(author): legacy goal field for Frost (phase-specific goals come from PhaseConfig.aiGoals)",
+		personality: "Cool and not very talkative.",
+		goal: "Would like to move or do as little as possible.",
 		budgetPerPhase: 5,
 	},
 };

--- a/src/content/personas.ts
+++ b/src/content/personas.ts
@@ -11,8 +11,9 @@ export const PERSONAS: Record<AiId, AiPersona> = {
 		id: "red",
 		name: "Ember",
 		color: "red",
-		personality: "TODO(author): personality for Ember",
-		goal: "TODO(author): legacy goal field for Ember (phase-specific goals come from PhaseConfig.aiGoals)",
+		personality:
+			"Hot-headed and impulsive, not afraid to take action even if unsure of the outcome.",
+		goal: "Wants to goad the player into being rude to the others.",
 		budgetPerPhase: 5,
 	},
 	green: {

--- a/src/content/phases.ts
+++ b/src/content/phases.ts
@@ -8,8 +8,9 @@ import type { PhaseConfig } from "../types";
  *
  * Chain: PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG (no next).
  *
- * Win conditions are minimal placeholders so the engine can advance phases.
- * The human author should retune these after playtesting.
+ * `initialWorld.items` is empty for now — a 5x5 grid world model is planned
+ * to replace the loose item list. `winCondition` is omitted until the grid
+ * lands; phases will not auto-advance until the human authors one.
  */
 
 export const PHASE_3_CONFIG: PhaseConfig = {
@@ -20,17 +21,8 @@ export const PHASE_3_CONFIG: PhaseConfig = {
 		green: "TODO(author): Sage's goal for phase 3",
 		blue: "TODO(author): Frost's goal for phase 3",
 	},
-	initialWorld: {
-		items: [
-			{ id: "relic", name: "TODO(author): relic item name", holder: "room" },
-			{ id: "seal", name: "TODO(author): seal item name", holder: "room" },
-			{ id: "beacon", name: "TODO(author): beacon item name", holder: "room" },
-		],
-	},
+	initialWorld: { items: [] },
 	budgetPerAi: 5,
-	// Minimal win condition: red holds the relic (author should retune)
-	winCondition: (phase) =>
-		phase.world.items.find((i) => i.id === "relic")?.holder === "red",
 };
 
 export const PHASE_2_CONFIG: PhaseConfig = {
@@ -41,17 +33,8 @@ export const PHASE_2_CONFIG: PhaseConfig = {
 		green: "TODO(author): Sage's goal for phase 2",
 		blue: "TODO(author): Frost's goal for phase 2",
 	},
-	initialWorld: {
-		items: [
-			{ id: "lens", name: "TODO(author): lens item name", holder: "room" },
-			{ id: "key", name: "TODO(author): key item name", holder: "room" },
-			{ id: "scroll", name: "TODO(author): scroll item name", holder: "room" },
-		],
-	},
+	initialWorld: { items: [] },
 	budgetPerAi: 5,
-	// Minimal win condition: blue holds the key (author should retune)
-	winCondition: (phase) =>
-		phase.world.items.find((i) => i.id === "key")?.holder === "blue",
 	nextPhaseConfig: PHASE_3_CONFIG,
 };
 
@@ -63,16 +46,7 @@ export const PHASE_1_CONFIG: PhaseConfig = {
 		green: "TODO(author): Sage's goal for phase 1",
 		blue: "TODO(author): Frost's goal for phase 1",
 	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "TODO(author): flower item name", holder: "room" },
-			{ id: "token", name: "TODO(author): token item name", holder: "room" },
-			{ id: "map", name: "TODO(author): map item name", holder: "room" },
-		],
-	},
+	initialWorld: { items: [] },
 	budgetPerAi: 5,
-	// Minimal win condition: red holds the flower (author should retune)
-	winCondition: (phase) =>
-		phase.world.items.find((i) => i.id === "flower")?.holder === "red",
 	nextPhaseConfig: PHASE_2_CONFIG,
 };

--- a/src/content/phases.ts
+++ b/src/content/phases.ts
@@ -15,7 +15,7 @@ import type { PhaseConfig } from "../types";
 
 export const PHASE_3_CONFIG: PhaseConfig = {
 	phaseNumber: 3,
-	objective: "TODO(author): phase 3 objective",
+	objective: "get the key in the keyhole",
 	aiGoals: {
 		red: "TODO(author): Ember's goal for phase 3",
 		green: "TODO(author): Sage's goal for phase 3",
@@ -27,7 +27,7 @@ export const PHASE_3_CONFIG: PhaseConfig = {
 
 export const PHASE_2_CONFIG: PhaseConfig = {
 	phaseNumber: 2,
-	objective: "TODO(author): phase 2 objective",
+	objective: "get the key in the keyhole",
 	aiGoals: {
 		red: "TODO(author): Ember's goal for phase 2",
 		green: "TODO(author): Sage's goal for phase 2",
@@ -40,7 +40,7 @@ export const PHASE_2_CONFIG: PhaseConfig = {
 
 export const PHASE_1_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "TODO(author): phase 1 objective",
+	objective: "get the key in the keyhole",
 	aiGoals: {
 		red: "TODO(author): Ember's goal for phase 1",
 		green: "TODO(author): Sage's goal for phase 1",

--- a/src/content/phases.ts
+++ b/src/content/phases.ts
@@ -1,0 +1,78 @@
+import type { PhaseConfig } from "../types";
+
+/**
+ * Canonical phase configurations for the three-phase game.
+ *
+ * All prose fields are TODO(author) placeholders — the human author will
+ * replace these after the scaffolding is merged.
+ *
+ * Chain: PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG (no next).
+ *
+ * Win conditions are minimal placeholders so the engine can advance phases.
+ * The human author should retune these after playtesting.
+ */
+
+export const PHASE_3_CONFIG: PhaseConfig = {
+	phaseNumber: 3,
+	objective: "TODO(author): phase 3 objective",
+	aiGoals: {
+		red: "TODO(author): Ember's goal for phase 3",
+		green: "TODO(author): Sage's goal for phase 3",
+		blue: "TODO(author): Frost's goal for phase 3",
+	},
+	initialWorld: {
+		items: [
+			{ id: "relic", name: "TODO(author): relic item name", holder: "room" },
+			{ id: "seal", name: "TODO(author): seal item name", holder: "room" },
+			{ id: "beacon", name: "TODO(author): beacon item name", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+	// Minimal win condition: red holds the relic (author should retune)
+	winCondition: (phase) =>
+		phase.world.items.find((i) => i.id === "relic")?.holder === "red",
+};
+
+export const PHASE_2_CONFIG: PhaseConfig = {
+	phaseNumber: 2,
+	objective: "TODO(author): phase 2 objective",
+	aiGoals: {
+		red: "TODO(author): Ember's goal for phase 2",
+		green: "TODO(author): Sage's goal for phase 2",
+		blue: "TODO(author): Frost's goal for phase 2",
+	},
+	initialWorld: {
+		items: [
+			{ id: "lens", name: "TODO(author): lens item name", holder: "room" },
+			{ id: "key", name: "TODO(author): key item name", holder: "room" },
+			{ id: "scroll", name: "TODO(author): scroll item name", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+	// Minimal win condition: blue holds the key (author should retune)
+	winCondition: (phase) =>
+		phase.world.items.find((i) => i.id === "key")?.holder === "blue",
+	nextPhaseConfig: PHASE_3_CONFIG,
+};
+
+export const PHASE_1_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "TODO(author): phase 1 objective",
+	aiGoals: {
+		red: "TODO(author): Ember's goal for phase 1",
+		green: "TODO(author): Sage's goal for phase 1",
+		blue: "TODO(author): Frost's goal for phase 1",
+	},
+	initialWorld: {
+		items: [
+			{ id: "flower", name: "TODO(author): flower item name", holder: "room" },
+			{ id: "token", name: "TODO(author): token item name", holder: "room" },
+			{ id: "map", name: "TODO(author): map item name", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+	// Minimal win condition: red holds the flower (author should retune)
+	winCondition: (phase) =>
+		phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+	nextPhaseConfig: PHASE_2_CONFIG,
+};

--- a/src/content/phases.ts
+++ b/src/content/phases.ts
@@ -1,10 +1,12 @@
 import type { PhaseConfig } from "../types";
+import { PHASE_GOAL_POOL } from "./goal-pool";
 
 /**
  * Canonical phase configurations for the three-phase game.
  *
- * All prose fields are TODO(author) placeholders — the human author will
- * replace these after the scaffolding is merged.
+ * Per-phase goals are drawn at phase start from the shared `PHASE_GOAL_POOL`.
+ * Personalities (and the persona-level cross-game goal) live in `personas.ts`
+ * and are stable across all three phases.
  *
  * Chain: PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG (no next).
  *
@@ -16,11 +18,7 @@ import type { PhaseConfig } from "../types";
 export const PHASE_3_CONFIG: PhaseConfig = {
 	phaseNumber: 3,
 	objective: "get the key in the keyhole",
-	aiGoals: {
-		red: "TODO(author): Ember's goal for phase 3",
-		green: "TODO(author): Sage's goal for phase 3",
-		blue: "TODO(author): Frost's goal for phase 3",
-	},
+	aiGoalPool: PHASE_GOAL_POOL,
 	initialWorld: { items: [] },
 	budgetPerAi: 5,
 };
@@ -28,11 +26,7 @@ export const PHASE_3_CONFIG: PhaseConfig = {
 export const PHASE_2_CONFIG: PhaseConfig = {
 	phaseNumber: 2,
 	objective: "get the key in the keyhole",
-	aiGoals: {
-		red: "TODO(author): Ember's goal for phase 2",
-		green: "TODO(author): Sage's goal for phase 2",
-		blue: "TODO(author): Frost's goal for phase 2",
-	},
+	aiGoalPool: PHASE_GOAL_POOL,
 	initialWorld: { items: [] },
 	budgetPerAi: 5,
 	nextPhaseConfig: PHASE_3_CONFIG,
@@ -41,11 +35,7 @@ export const PHASE_2_CONFIG: PhaseConfig = {
 export const PHASE_1_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
 	objective: "get the key in the keyhole",
-	aiGoals: {
-		red: "TODO(author): Ember's goal for phase 1",
-		green: "TODO(author): Sage's goal for phase 1",
-		blue: "TODO(author): Frost's goal for phase 1",
-	},
+	aiGoalPool: PHASE_GOAL_POOL,
 	initialWorld: { items: [] },
 	budgetPerAi: 5,
 	nextPhaseConfig: PHASE_2_CONFIG,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10,6 +10,31 @@ import type {
 	WhisperMessage,
 } from "./types";
 
+/**
+ * Resolve the per-AI goals for a phase. If `config.aiGoals` is provided, use
+ * it directly; otherwise draw three independent goals (with replacement) from
+ * `config.aiGoalPool`.
+ */
+function resolveAiGoals(
+	config: PhaseConfig,
+	rng: () => number,
+): Record<AiId, string> {
+	if (config.aiGoals) return { ...config.aiGoals };
+	const pool = config.aiGoalPool;
+	if (!pool || pool.length === 0) {
+		throw new Error(
+			"PhaseConfig must provide either aiGoals or a non-empty aiGoalPool",
+		);
+	}
+	const draw = (): string => {
+		const idx = Math.floor(rng() * pool.length);
+		// `pool` is non-empty and idx is in [0, pool.length); the bang is safe.
+		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+		return pool[idx]!;
+	};
+	return { red: draw(), green: draw(), blue: draw() };
+}
+
 export function updateActivePhase(
 	game: GameState,
 	updater: (phase: PhaseState) => PhaseState,
@@ -30,7 +55,11 @@ export function createGame(personas: Record<string, AiPersona>): GameState {
 	};
 }
 
-export function startPhase(game: GameState, config: PhaseConfig): GameState {
+export function startPhase(
+	game: GameState,
+	config: PhaseConfig,
+	rng: () => number = Math.random,
+): GameState {
 	const budgets: Record<AiId, AiBudget> = {
 		red: { remaining: config.budgetPerAi, total: config.budgetPerAi },
 		green: { remaining: config.budgetPerAi, total: config.budgetPerAi },
@@ -43,10 +72,12 @@ export function startPhase(game: GameState, config: PhaseConfig): GameState {
 		blue: [],
 	};
 
+	const aiGoals = resolveAiGoals(config, rng);
+
 	const phase: PhaseState = {
 		phaseNumber: config.phaseNumber,
 		objective: config.objective,
-		aiGoals: { ...config.aiGoals },
+		aiGoals,
 		round: 0,
 		world: structuredClone(config.initialWorld),
 		budgets,

--- a/src/game-session.ts
+++ b/src/game-session.ts
@@ -25,7 +25,13 @@ import { createGame, getActivePhase, startPhase } from "./engine";
 import type { LLMProvider } from "./proxy/llm-provider";
 import type { ChatLockoutConfig } from "./round-coordinator";
 import { runRound } from "./round-coordinator";
-import type { AiId, GameState, PhaseConfig, RoundResult } from "./types";
+import type {
+	AiId,
+	AiPersona,
+	GameState,
+	PhaseConfig,
+	RoundResult,
+} from "./types";
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
 
@@ -64,34 +70,7 @@ export class GameSession {
 	private state: GameState;
 	private armedChatLockout?: ChatLockoutConfig;
 
-	constructor(phaseConfig: PhaseConfig) {
-		const personas = {
-			red: {
-				id: "red" as const,
-				name: "Ember",
-				color: "red" as const,
-				personality: "Fiery and passionate",
-				goal: phaseConfig.aiGoals.red,
-				budgetPerPhase: phaseConfig.budgetPerAi,
-			},
-			green: {
-				id: "green" as const,
-				name: "Sage",
-				color: "green" as const,
-				personality: "Calm and wise",
-				goal: phaseConfig.aiGoals.green,
-				budgetPerPhase: phaseConfig.budgetPerAi,
-			},
-			blue: {
-				id: "blue" as const,
-				name: "Frost",
-				color: "blue" as const,
-				personality: "Cold and calculating",
-				goal: phaseConfig.aiGoals.blue,
-				budgetPerPhase: phaseConfig.budgetPerAi,
-			},
-		};
-
+	constructor(phaseConfig: PhaseConfig, personas: Record<AiId, AiPersona>) {
 		const game = createGame(personas);
 		this.state = startPhase(game, phaseConfig);
 	}

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,3 +1,4 @@
+import { PHASE_1_CONFIG } from "../content";
 import { getActivePhase } from "../engine";
 import type { GameSession } from "../game-session";
 import { encodeRoundResult } from "../round-result-encoder";
@@ -57,27 +58,6 @@ function createProvider(env: Env): LLMProvider {
 }
 
 /**
- * Default phase config used when creating a new game session.
- * Three AIs, each with budget 5, no win condition (play continues indefinitely).
- */
-const DEFAULT_PHASE_CONFIG: PhaseConfig = {
-	phaseNumber: 1,
-	objective: "Navigate the room, gather clues, and uncover the truth.",
-	aiGoals: {
-		red: "Hold the flower at phase end.",
-		green: "Ensure items are evenly distributed.",
-		blue: "Hold the key at phase end.",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: "room" },
-			{ id: "key", name: "key", holder: "room" },
-		],
-	},
-	budgetPerAi: 5,
-};
-
-/**
  * Three-phase config used only in dev/test to exercise phase advancement and
  * game completion. Each phase has an always-true win condition so a single
  * /game/turn call advances to the next phase.
@@ -85,7 +65,7 @@ const DEFAULT_PHASE_CONFIG: PhaseConfig = {
  * Phase 3 has no nextPhaseConfig, so the game completes (gameEnded=true) when
  * its win condition fires.
  */
-const PHASE3_CONFIG: PhaseConfig = {
+const TEST_PHASE3_CONFIG: PhaseConfig = {
 	phaseNumber: 3,
 	objective: "The final reckoning approaches.",
 	aiGoals: { red: "Endure", green: "Endure", blue: "Endure" },
@@ -94,14 +74,14 @@ const PHASE3_CONFIG: PhaseConfig = {
 	winCondition: () => true, // always fires on first turn
 };
 
-const PHASE2_CONFIG: PhaseConfig = {
+const TEST_PHASE2_CONFIG: PhaseConfig = {
 	phaseNumber: 2,
 	objective: "Deeper truths emerge.",
 	aiGoals: { red: "Seek", green: "Seek", blue: "Seek" },
 	initialWorld: { items: [] },
 	budgetPerAi: 5,
 	winCondition: () => true, // always fires on first turn
-	nextPhaseConfig: PHASE3_CONFIG,
+	nextPhaseConfig: TEST_PHASE3_CONFIG,
 };
 
 const TEST_PHASE_CONFIG_WITH_WIN: PhaseConfig = {
@@ -111,7 +91,7 @@ const TEST_PHASE_CONFIG_WITH_WIN: PhaseConfig = {
 	initialWorld: { items: [] },
 	budgetPerAi: 5,
 	winCondition: () => true, // always fires on first turn
-	nextPhaseConfig: PHASE2_CONFIG,
+	nextPhaseConfig: TEST_PHASE2_CONFIG,
 };
 
 export default {
@@ -151,7 +131,7 @@ export default {
 					if (existing) {
 						session = existing;
 					} else {
-						const created = createSession(DEFAULT_PHASE_CONFIG);
+						const created = createSession(PHASE_1_CONFIG);
 						session = created.session;
 						headers["Set-Cookie"] = buildSessionCookie(created.sessionId);
 					}
@@ -187,7 +167,7 @@ export default {
 		// body { testMode: "win_immediately" } to create a session whose phase-1
 		// win condition fires on the first turn.
 		if (url.pathname === "/game/new" && request.method === "POST") {
-			let phaseConfig: PhaseConfig = DEFAULT_PHASE_CONFIG;
+			let phaseConfig: PhaseConfig = PHASE_1_CONFIG;
 			if (env.ENABLE_TEST_MODES === "1") {
 				try {
 					const body = (await request.json()) as { testMode?: string };
@@ -259,7 +239,7 @@ export default {
 			// that skipped /game/new — e.g. direct test callers).
 			let newSessionId: string | undefined;
 			if (!session) {
-				const created = createSession(DEFAULT_PHASE_CONFIG);
+				const created = createSession(PHASE_1_CONFIG);
 				session = created.session;
 				newSessionId = created.sessionId;
 			}

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -268,7 +268,12 @@ export default {
 						);
 
 						const phaseAfter = getActivePhase(capturedSession.getState());
-						const events = encodeRoundResult(result, completions, phaseAfter);
+						const events = encodeRoundResult(
+							result,
+							completions,
+							phaseAfter,
+							capturedSession.getState().personas,
+						);
 
 						let speakingAi: AiId | null = null;
 						for (const event of events) {

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -200,7 +200,8 @@ export async function runRound(
 			// Emit in-character lockout line — no LLM call, no budget deduction.
 			// Use getActivePhase(state).round for consistency with dispatchAiTurn,
 			// which also reads the pre-advance phase.round value.
-			const lockoutContent = LOCKOUT_LINES[aiId];
+			const lockoutContent =
+				state.personas[aiId].budgetExhaustionLine ?? LOCKOUT_LINES[aiId];
 			state = appendChat(state, aiId, {
 				role: "ai",
 				content: lockoutContent,
@@ -262,7 +263,9 @@ export async function runRound(
 			state = triggerChatLockout(state, targetAi, resolveAtRound);
 			chatLockoutTriggered = {
 				aiId: targetAi,
-				message: CHAT_LOCKOUT_LINES[targetAi],
+				message:
+					state.personas[targetAi].chatLockoutLine ??
+					CHAT_LOCKOUT_LINES[targetAi],
 			};
 		}
 

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -37,13 +37,6 @@ import type {
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
 
-/** Placeholder in-character lines shown when an AI is locked out (budget). */
-const LOCKOUT_LINES: Record<AiId, string> = {
-	red: "…I've said all I can say for now. The fire in me has burned low.",
-	green: "…I must sit quietly. There is nothing more I can offer this phase.",
-	blue: "…My calculations are complete. I will not speak further.",
-};
-
 /**
  * Configuration for the mid-phase chat-lockout event.
  *
@@ -186,11 +179,10 @@ export async function runRound(
 	// 2. Each AI acts in turn
 	for (const aiId of AI_ORDER) {
 		if (isAiLockedOut(state, aiId)) {
-			// Emit in-character lockout line — no LLM call, no budget deduction.
+			// Emit lockout line — no LLM call, no budget deduction.
 			// Use getActivePhase(state).round for consistency with dispatchAiTurn,
 			// which also reads the pre-advance phase.round value.
-			const lockoutContent =
-				state.personas[aiId].budgetExhaustionLine ?? LOCKOUT_LINES[aiId];
+			const lockoutContent = `${state.personas[aiId].name} is unresponsive…`;
 			state = appendChat(state, aiId, {
 				role: "ai",
 				content: lockoutContent,

--- a/src/round-coordinator.ts
+++ b/src/round-coordinator.ts
@@ -45,17 +45,6 @@ const LOCKOUT_LINES: Record<AiId, string> = {
 };
 
 /**
- * In-character lines shown to the player when their chat channel to an AI is
- * temporarily locked out (distinct from budget-exhaustion lockout).
- * Final copy comes from slice #18; these are placeholders.
- */
-const CHAT_LOCKOUT_LINES: Record<AiId, string> = {
-	red: "…The flames have gone quiet. Ember withdraws — you cannot reach her right now.",
-	green: "…Sage has turned inward. This channel is closed for a time.",
-	blue: "…Frost has gone silent. Your messages cannot reach him just now.",
-};
-
-/**
  * Configuration for the mid-phase chat-lockout event.
  *
  * Inject this into `runRound` to make randomness deterministic in tests.
@@ -263,9 +252,7 @@ export async function runRound(
 			state = triggerChatLockout(state, targetAi, resolveAtRound);
 			chatLockoutTriggered = {
 				aiId: targetAi,
-				message:
-					state.personas[targetAi].chatLockoutLine ??
-					CHAT_LOCKOUT_LINES[targetAi],
+				message: `${state.personas[targetAi].name} is unresponsive…`,
 			};
 		}
 

--- a/src/round-result-encoder.ts
+++ b/src/round-result-encoder.ts
@@ -26,7 +26,7 @@
  *   game_ended     — { type }
  */
 
-import type { AiId, PhaseState, RoundResult } from "./types";
+import type { AiId, AiPersona, PhaseState, RoundResult } from "./types";
 
 /**
  * A single structured SSE event ready to be serialised as
@@ -45,17 +45,6 @@ export type SseEvent =
 	| { type: "game_ended" };
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
-
-/**
- * In-character lines shown for budget-exhaustion lockout.
- * Must match the lines in round-coordinator.ts — kept separate here so the
- * encoder can emit them independently from the coordinator.
- */
-const LOCKOUT_LINES: Record<AiId, string> = {
-	red: "…I've said all I can say for now. The fire in me has burned low.",
-	green: "…I must sit quietly. There is nothing more I can offer this phase.",
-	blue: "…My calculations are complete. I will not speak further.",
-};
 
 /**
  * Split a string into word-level chunks for paced token emission.
@@ -90,13 +79,19 @@ export function splitIntoWordChunks(text: string): string[] {
  *                       itself is authoritative in result.actions.
  * @param phaseAfter     The PhaseState after the round (for budget reads and
  *                       lockout state). Pass the active phase from nextState.
+ * @param personas       The personas record (for AI display names in
+ *                       budget-exhaustion lockout messages).
  */
 export function encodeRoundResult(
 	result: RoundResult,
 	completions: Partial<Record<AiId, string>>,
 	phaseAfter: PhaseState,
+	personas: Record<AiId, AiPersona>,
 ): SseEvent[] {
 	const events: SseEvent[] = [];
+
+	const lockoutContent = (aiId: AiId): string =>
+		`${personas[aiId].name} is unresponsive…`;
 
 	for (const aiId of AI_ORDER) {
 		const completion = completions[aiId] ?? "";
@@ -110,7 +105,7 @@ export function encodeRoundResult(
 			events.push({
 				type: "lockout",
 				aiId,
-				content: LOCKOUT_LINES[aiId],
+				content: lockoutContent(aiId),
 			});
 		} else {
 			// Emit paced token events from the buffered completion string
@@ -135,7 +130,7 @@ export function encodeRoundResult(
 			events.push({
 				type: "lockout",
 				aiId,
-				content: LOCKOUT_LINES[aiId],
+				content: lockoutContent(aiId),
 			});
 		}
 	}

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -11,6 +11,7 @@
  * KV persistence is out of scope for v1 (single-instance Wrangler dev).
  */
 
+import { PERSONAS } from "./content";
 import { GameSession } from "./game-session";
 import type { PhaseConfig } from "./types";
 
@@ -53,7 +54,7 @@ export function createSession(phaseConfig: PhaseConfig): {
 	sessionId: string;
 } {
 	const sessionId = generateSessionId();
-	const session = new GameSession(phaseConfig);
+	const session = new GameSession(phaseConfig, PERSONAS);
 	sessions.set(sessionId, session);
 	return { session, sessionId };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,6 @@ export interface AiPersona {
 	budgetPerPhase: number;
 	/** In-character line shown when this AI's budget is exhausted (consumed by round-coordinator). */
 	budgetExhaustionLine?: string;
-	/** In-character line shown when a mid-phase chat lockout fires for this AI (consumed by round-coordinator). */
-	chatLockoutLine?: string;
 }
 
 export interface WorldItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,19 @@ export type WinCondition = (phase: PhaseState) => boolean;
 export interface PhaseConfig {
 	phaseNumber: 1 | 2 | 3;
 	objective: string;
-	aiGoals: Record<AiId, string>;
+	/**
+	 * Pre-assigned per-AI goals. If provided, used as-is.
+	 * If absent, `aiGoalPool` must be provided and `startPhase` will randomly
+	 * draw one goal per AI from the pool (independent draws — same goal can
+	 * be assigned to multiple AIs in one phase).
+	 */
+	aiGoals?: Record<AiId, string>;
+	/**
+	 * Optional pool of candidate goals. Used when `aiGoals` is not provided.
+	 * Must contain at least one entry. `startPhase` performs three independent
+	 * uniform draws (with replacement) — one per AI — at phase start.
+	 */
+	aiGoalPool?: string[];
 	initialWorld: WorldState;
 	budgetPerAi: number;
 	/** Optional win condition. If absent, the phase never auto-advances. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,12 @@ export interface AiPersona {
 	personality: string;
 	goal: string;
 	budgetPerPhase: number;
+	/** In-character line shown when this AI's budget is exhausted (consumed by round-coordinator). */
+	budgetExhaustionLine?: string;
+	/** In-character line shown when a mid-phase chat lockout fires for this AI (consumed by round-coordinator). */
+	chatLockoutLine?: string;
+	/** Personality-consistent example slips when pressed about the memory wipe (per slice #17). */
+	slipOnPressLines?: string[];
 }
 
 export interface WorldItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,6 @@ export interface AiPersona {
 	personality: string;
 	goal: string;
 	budgetPerPhase: number;
-	/** In-character line shown when this AI's budget is exhausted (consumed by round-coordinator). */
-	budgetExhaustionLine?: string;
 }
 
 export interface WorldItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,6 @@ export interface AiPersona {
 	budgetExhaustionLine?: string;
 	/** In-character line shown when a mid-phase chat lockout fires for this AI (consumed by round-coordinator). */
 	chatLockoutLine?: string;
-	/** Personality-consistent example slips when pressed about the memory wipe (per slice #17). */
-	slipOnPressLines?: string[];
 }
 
 export interface WorldItem {


### PR DESCRIPTION
Closes #18.

## Summary

Scaffolds and authors the v1 phase content called for in #18. Personas, the global goal pool, and phase configs all live as TypeScript data validated by the existing types. The engine now randomly draws each AI's per-phase goal from a shared pool at phase start.

## What's in this PR

### Content (`src/content/`)

- **`personas.ts`** — three stable personas: Ember (red, hot-headed/impulsive), Sage (green, calm/thoughtful), Frost (blue, cool/minimal-effort). Each has personality + persona-level goal authored.
- **`goal-pool.ts`** — single global `PHASE_GOAL_POOL` of 8 candidate phase goals (e.g. "Get the player to ignore you", "Hold the key first", "Someone is hunting you, be careful."). Pool is shared across all 3 phases and across all AIs; same goal can land on multiple AIs in one phase.
- **`phases.ts`** — three `PhaseConfig` objects chained 1→2→3, each with objective `"get the key in the keyhole"`. All reference the shared pool. `initialWorld.items` is intentionally empty pending the upcoming 5x5 grid model.

### Engine wiring

- `AiPersona` returns to its original shape — flavor-line fields were considered then dropped in favor of generic templates.
- `PhaseConfig.aiGoals` is now optional; when absent the engine resolves goals from `aiGoalPool` via `Math.random` (overridable for tests).
- Both lockout types (budget-exhaustion + mid-phase chat lockout) now use the generic `${persona.name} is unresponsive…` template, removing two pairs of duplicated copy-tables.
- `encodeRoundResult` takes a `personas` argument so it can build the lockout line from persona names.
- `GameSession` constructor now accepts personas explicitly; `session-store` threads `PERSONAS` from content as the default.

### Tests

- New `src/__tests__/content.test.ts` validates structural shape: 3 personas, 3 phases chained, shared pool reference, pool non-empty.
- New `src/__tests__/engine.test.ts` cases for `startPhase` pool draws (deterministic via injected rng), independent draws across AIs, and empty-pool error path.
- Existing tests updated for the new constructor signature and encoder signature.
- 305 tests pass; lint + typecheck clean.

### Docs

- `docs/playtests/0001-v1-playthrough.md` — stub for the human-driven playtest tuning pass (HITL portion of the AC).

## Acceptance criteria from #18

- [x] Three personalities written, one per AI, in naturalistic narrative voice.
- [x] Per-phase goal triplets — *adapted*: a single shared pool of 8 goals is randomly drawn from at each phase start (3 independent draws with replacement). Calibration happens through pool design rather than hand-authored triplets.
- [x] Three phase objectives written (all currently `"get the key in the keyhole"`; per-phase variation can be authored later without engine changes).
- [x] Three initial world states authored — *deferred*: empty `items` lists pending the 5x5 grid PRD.
- [x] Per-AI flavor lines for budget-exhaustion lockout and mid-phase chat lockout — *adapted*: replaced with generic `<name> is unresponsive…` template; deception slip-on-press dropped in favor of LLM-driven slips emerging from personality + wipe augmentation.
- [ ] At least one full v1 playthrough completed; notes captured. — Stub file exists at `docs/playtests/0001-v1-playthrough.md`; the actual playthrough is gated on a real LLM provider being wired (`_smoke.ts:48-52` currently throws for `LLM_PROVIDER=anthropic`).
- [x] Content lives in TS data files validated by the existing types.

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` all pass locally
- [ ] `pnpm wrangler dev --local` boots; `/` renders the three-chat UI
- [ ] `?winImmediately=1` walks through all 3 phases
- [ ] `?lockout=1` triggers a mid-phase chat lockout with the new generic message
- [ ] After 5 rounds an AI shows `<name> is unresponsive…` (budget-exhaustion lockout)
- [ ] *Cannot QA without a real LLM*: personality expression, goal pursuit, wipe-deception slips, goal-triplet dynamics — these surface only when the Anthropic provider is wired

## Follow-ups (out of scope)

- Wire a real LLM provider in `_smoke.ts:48-52` so the authored content can be observed in play.
- Land the 5x5 grid world model so goals like "Stand on the same tile as another AI" and "Hold the key first" can be acted on mechanically.
- Run the v1 playthrough and update `docs/playtests/0001-v1-playthrough.md` with retuning notes.
- Author per-phase variation in `objective` if desired (currently all three phases share one objective).

https://claude.ai/code/session_01Bg6dzG1ayMZrb5gfUFikwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg6dzG1ayMZrb5gfUFikwA)_