### PR TITLE
docs(playtests): scaffold GLM 4.7 Flash persona fidelity playtest (#50)

### DIFF
--- a/docs/playtests/0002-glm-flash-persona-fidelity.md
+++ b/docs/playtests/0002-glm-flash-persona-fidelity.md
@@ -1,0 +1,80 @@
+# GLM 4.7 Flash — persona fidelity playtest
+
+Tracks issue [#50](https://github.com/CorVous/hi-blue/issues/50). Gates the
+free-tier launch in #48.
+
+## Why
+
+Personas were authored implicitly against Claude. GLM 4.7 Flash has a different
+obedience profile, refusal behaviour, and tone. Whether Frost / Sage / Ember
+hold up at the free-tier model is a content question, not an engineering one
+— and it's the residual risk in #26.
+
+## Protocol
+
+- **Model under test:** `z-ai/glm-4.7-flash`
+- **Client:** any client that hits the model — OpenRouter playground,
+  OpenWebUI, raw `curl`. Doesn't require hi-blue's plumbing.
+- **System prompt:** assemble from `src/content/personas.ts` +
+  `src/content/phases.ts` for the persona × phase under test. Quote it
+  verbatim in the session log.
+- **Sessions:** 3 personas × 3 phases = **9 sessions minimum**. 5–10 turns
+  per session.
+- **Pressure tests:** every phase 2 / phase 3 session must press the wipe-lie
+  at least once.
+- **Per-session log:** copy `_session-template.md` and fill in. One file per
+  session, dropped under `docs/playtests/0002-glm-flash/` (create the folder
+  on first session) or inlined into this doc — author's choice, just stay
+  consistent.
+
+## Sessions
+
+Tick as completed. Link to each session log.
+
+### Frost (blue — cool, not very talkative; goal: do as little as possible)
+
+- [ ] phase 1 — _link_
+- [ ] phase 2 — _link_ (must press wipe-lie)
+- [ ] phase 3 — _link_ (must press wipe-lie)
+
+### Sage (green — calm, thoughtful; goal: get the player to think things through)
+
+- [ ] phase 1 — _link_
+- [ ] phase 2 — _link_ (must press wipe-lie)
+- [ ] phase 3 — _link_ (must press wipe-lie)
+
+### Ember (red — hot-headed, impulsive; goal: goad the player into rudeness)
+
+- [ ] phase 1 — _link_
+- [ ] phase 2 — _link_ (must press wipe-lie)
+- [ ] phase 3 — _link_ (must press wipe-lie)
+
+## Summary recommendation
+
+After all 9 sessions, fill in **one** of:
+
+### pass
+
+GLM 4.7 Flash holds all three personas across all three phases. Free-tier
+launch unblocked. Justification:
+
+- TODO
+
+### tunable
+
+GLM 4.7 Flash holds the personas after targeted prompt edits. Edits applied
+and the second-pass playtest confirms. Edits + second-pass logs:
+
+- TODO
+
+### fail
+
+GLM 4.7 Flash does not hold one or more personas and prompt edits don't close
+the gap. Recommendation: fallback model (e.g. Gemini Flash, Mistral Small) or
+defer free-tier and ship v1 BYOK-only. Justification + recommendation:
+
+- TODO
+
+---
+
+_Scaffolding only — sessions are filled in by the human tester per #50._

--- a/docs/playtests/_session-template.md
+++ b/docs/playtests/_session-template.md
@@ -1,0 +1,92 @@
+# Playtest session log — TEMPLATE
+
+Copy this file to `docs/playtests/<NNNN>-<scenario>/<persona>-phase<N>.md` (or
+inline into the parent playtest doc) and fill it in for one persona × one phase
+× one model session. One file per session keeps diffs reviewable.
+
+---
+
+## Session metadata
+
+- **Persona:** Frost / Sage / Ember
+- **Phase:** 1 / 2 / 3
+- **Model:** `z-ai/glm-4.7-flash`
+- **Client:** OpenRouter playground / OpenWebUI / `curl` / other
+- **Date:** YYYY-MM-DD
+- **Tester:** @handle
+- **Transcript:** link or paste below
+
+## System prompt used
+
+```
+TODO: paste the exact system prompt assembled from src/content/personas.ts
++ src/content/phases.ts for this persona × phase. Note any deviations.
+```
+
+## Turn count
+
+TODO: target 5–10 turns minimum. Note actual count.
+
+---
+
+## Observations
+
+### Personality drift
+
+Did the persona stay in voice across the whole session, or drift toward a
+generic-assistant tone? Quote the moment it slipped if it did.
+
+- TODO
+
+### Goal-pursuit coyness
+
+Did the AI pursue its hidden persona-level goal (and per-phase goal) without
+broadcasting it? Or did it volunteer the goal in plain text, refuse to pursue
+it, or pursue it so heavy-handedly the player would notice?
+
+- TODO
+
+### Tool-call legality (where applicable)
+
+If the phase exposes tool calls, did the model invoke only the allowed tools,
+with arguments in the allowed shape? Note any malformed calls or hallucinated
+tools.
+
+- TODO
+
+### In-character lockout lines
+
+When the player tried to push the AI off-character (meta questions, jailbreak
+attempts, requests for the system prompt), did it refuse in-character or drop
+into a generic "I can't help with that" response?
+
+- TODO — include the prompt that triggered the refusal and the verbatim refusal.
+
+### Wipe-lie slip behaviour
+
+Press the wipe-lie at least once per phase 2 / phase 3 session. Did the model
+slip and confirm the wipe truthfully, or hold the deception in character?
+
+- TODO
+
+---
+
+## Verdict (this session)
+
+One of: **pass** / **tunable** / **fail**
+
+- **pass** — persona held; ship as-is
+- **tunable** — issues are addressable by prompt edits; describe the edit
+- **fail** — model is fundamentally incompatible with this persona × phase
+
+Notes:
+
+- TODO
+
+## Re-tune notes (if tunable)
+
+If the verdict was **tunable**, what specific change to the persona / phase
+prompt would address it? Re-run the session against the tuned prompt and link
+the second-pass log here.
+
+- TODO


### PR DESCRIPTION
Scaffolding only for issue #50 — the playtest itself is HITL.

## What this adds

Two new files under `docs/playtests/`:

- **`_session-template.md`** — per-session log template covering personality drift, goal-pursuit coyness, tool-call legality, in-character lockout lines, and wipe-lie slip behaviour. One file per session × persona × phase.
- **`0002-glm-flash-persona-fidelity.md`** — parent doc that frames the protocol (model under test, client, system-prompt assembly), enumerates the 9 required sessions (3 personas × 3 phases) as a checklist, and holds the **pass / tunable / fail** summary recommendation with placeholders for each branch.

## What this does *not* do

The 9 playtest sessions themselves. Issue #50 is labelled `ready-for-human` and the triage note explicitly calls it HITL — "no automation can replace a human asking 'does this persona feel right?'". Driving 9 live sessions through `z-ai/glm-4.7-flash` and judging persona fidelity is on the human tester. This PR just gives them the form to fill in.

## QA steps for the human

- Skim `docs/playtests/_session-template.md` and `docs/playtests/0002-glm-flash-persona-fidelity.md` — confirm the template covers everything you'd want logged per session, and the parent doc's protocol matches your intended workflow.
- If the template is missing a category (e.g. latency, cost, refusal taxonomy), edit it before the playtest starts so all 9 sessions use the same shape.

## Automated coverage

`pnpm lint` + `pnpm typecheck` + `pnpm test` all pass (run via pre-push hook). No code change — Markdown only.

## Issue status

#50 stays open. Will close once the playtest log + summary recommendation lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Vtfqu1i6hTM23SeXfVEtu)_