### PR TITLE
OpenAI-compat endpoint: forward POST /v1/chat/completions to OpenRouter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ pnpm-debug.log*
 .env
 .env.local
 .env.*.local
+.dev.vars
 
 # Editors / IDE
 .vscode/

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -11,6 +11,7 @@ import {
 import type { AiId, PhaseConfig } from "../types";
 import type { LLMProvider } from "./llm-provider";
 import { MockLLMProvider } from "./llm-provider";
+import { handleChatCompletions } from "./openai-proxy";
 import { capHitStream, checkAndCharge, configFromEnv } from "./rate-guard";
 import { renderChatPage, renderEndgamePage } from "./ui";
 
@@ -21,6 +22,12 @@ interface Env {
 	/** Optional: set to "anthropic" to use the real provider. */
 	LLM_PROVIDER?: string;
 	ANTHROPIC_API_KEY?: string;
+	/**
+	 * Secret for the OpenRouter API. Provision via:
+	 *   wrangler secret put OPENROUTER_API_KEY
+	 * Intentionally not committed in vars.
+	 */
+	OPENROUTER_API_KEY?: string;
 	/** Rate-guard configuration knobs (all optional; defaults in configFromEnv). */
 	RATE_LIMIT_MAX?: string;
 	RATE_LIMIT_WINDOW_SEC?: string;
@@ -159,6 +166,13 @@ export default {
 			return new Response(renderEndgamePage(), {
 				headers: { "Content-Type": "text/html; charset=utf-8" },
 			});
+		}
+
+		// ── POST /v1/chat/completions ─────────────────────────────────────────────
+		// OpenAI-compatible endpoint: pins model to z-ai/glm-4.7-flash and
+		// forwards the request to OpenRouter. Streams the response back unchanged.
+		if (url.pathname === "/v1/chat/completions" && request.method === "POST") {
+			return handleChatCompletions(request, env);
 		}
 
 		// ── POST /game/new ────────────────────────────────────────────────────

--- a/src/proxy/openai-proxy.test.ts
+++ b/src/proxy/openai-proxy.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for POST /v1/chat/completions — OpenRouter proxy (issue #36).
+ *
+ * Uses SELF.fetch (cloudflare:test) so the full worker route-table is
+ * exercised. The outbound fetch to OpenRouter is intercepted via
+ * vi.stubGlobal('fetch', ...) — the worker isolate shares globalThis with
+ * the test runner in vitest-pool-workers, so the stub is observable inside
+ * the worker.
+ */
+import { reset, SELF } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OPENROUTER_URL, PINNED_MODEL } from "./openai-proxy";
+
+const ENDPOINT = "https://example.com/v1/chat/completions";
+
+const VALID_BODY = JSON.stringify({
+	model: "gpt-4o",
+	messages: [{ role: "user", content: "Hello" }],
+});
+
+function makeUpstreamMock(
+	body: BodyInit,
+	status = 200,
+	headers: Record<string, string> = { "Content-Type": "text/event-stream" },
+): typeof fetch {
+	// Use mockImplementation (not mockResolvedValue) so the Response is
+	// created lazily inside the worker's fetch call — avoids the Cloudflare
+	// Workers cross-request I/O isolation error that fires when a Response
+	// body (ReadableStreamSource) is constructed in the test context and then
+	// consumed in a different request handler context.
+	return vi
+		.fn()
+		.mockImplementation(() =>
+			Promise.resolve(new Response(body, { status, headers })),
+		);
+}
+
+afterEach(async () => {
+	vi.unstubAllGlobals();
+	await reset();
+});
+
+// ── 1. 200 streaming pass-through ────────────────────────────────────────────
+
+describe("POST /v1/chat/completions — streaming pass-through", () => {
+	it("returns 200 with text/event-stream when upstream does", async () => {
+		const stream = "data: {}\n\ndata: [DONE]\n\n";
+		vi.stubGlobal("fetch", makeUpstreamMock(stream));
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: VALID_BODY,
+		});
+
+		expect(resp.status).toBe(200);
+		expect(resp.headers.get("Content-Type")).toContain("text/event-stream");
+		const text = await resp.text();
+		expect(text).toBe(stream);
+	});
+});
+
+// ── 2. Model pinning — caller sends different model ───────────────────────────
+
+describe("POST /v1/chat/completions — model pinning", () => {
+	it("pins model to PINNED_MODEL even when caller sends gpt-4o", async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		const mockFetch = vi
+			.fn()
+			.mockImplementation(async (_url: string, init: RequestInit) => {
+				capturedBody = JSON.parse(init.body as string) as Record<
+					string,
+					unknown
+				>;
+				return new Response("{}", {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+		vi.stubGlobal("fetch", mockFetch);
+
+		await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				model: "gpt-4o",
+				messages: [{ role: "user", content: "hi" }],
+			}),
+		});
+
+		expect(capturedBody?.model).toBe(PINNED_MODEL);
+	});
+
+	it("pins model to PINNED_MODEL when caller omits model", async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		const mockFetch = vi
+			.fn()
+			.mockImplementation(async (_url: string, init: RequestInit) => {
+				capturedBody = JSON.parse(init.body as string) as Record<
+					string,
+					unknown
+				>;
+				return new Response("{}", {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+		vi.stubGlobal("fetch", mockFetch);
+
+		await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		expect(capturedBody?.model).toBe(PINNED_MODEL);
+	});
+});
+
+// ── 3. Authorization header forwarding ───────────────────────────────────────
+
+describe("POST /v1/chat/completions — auth header forwarding", () => {
+	it("forwards Authorization: Bearer <secret> to OpenRouter", async () => {
+		let capturedHeaders: Record<string, string> | undefined;
+		const mockFetch = vi
+			.fn()
+			.mockImplementation(async (_url: string, init: RequestInit) => {
+				capturedHeaders = init.headers as Record<string, string>;
+				return new Response("{}", {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+		vi.stubGlobal("fetch", mockFetch);
+
+		await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: VALID_BODY,
+		});
+
+		// vitest.config.ts sets OPENROUTER_API_KEY = "test-openrouter-key"
+		expect(capturedHeaders?.Authorization).toBe("Bearer test-openrouter-key");
+	});
+});
+
+// ── 4. Correct OpenRouter URL ─────────────────────────────────────────────────
+
+describe("POST /v1/chat/completions — upstream URL", () => {
+	it("forwards POST to the correct OpenRouter URL", async () => {
+		let capturedUrl: string | undefined;
+		const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+			capturedUrl = url;
+			return new Response("{}", {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", mockFetch);
+
+		await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: VALID_BODY,
+		});
+
+		expect(capturedUrl).toBe(OPENROUTER_URL);
+	});
+});
+
+// ── 5. 400 for invalid JSON body ──────────────────────────────────────────────
+
+describe("POST /v1/chat/completions — input validation", () => {
+	it("returns 400 invalid_request_error for invalid JSON body", async () => {
+		// No mock needed — handler should reject before calling fetch
+		vi.stubGlobal("fetch", makeUpstreamMock("{}"));
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "not-json",
+		});
+
+		expect(resp.status).toBe(400);
+		const json = (await resp.json()) as {
+			error: { type: string; message: string };
+		};
+		expect(json.error.type).toBe("invalid_request_error");
+	});
+
+	it("returns 400 invalid_request_error for missing messages array", async () => {
+		vi.stubGlobal("fetch", makeUpstreamMock("{}"));
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ model: "gpt-4o" }),
+		});
+
+		expect(resp.status).toBe(400);
+		const json = (await resp.json()) as { error: { type: string } };
+		expect(json.error.type).toBe("invalid_request_error");
+	});
+
+	it("returns 400 invalid_request_error for empty messages array", async () => {
+		vi.stubGlobal("fetch", makeUpstreamMock("{}"));
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ messages: [] }),
+		});
+
+		expect(resp.status).toBe(400);
+		const json = (await resp.json()) as { error: { type: string } };
+		expect(json.error.type).toBe("invalid_request_error");
+	});
+});
+
+// ── 6. 502 when upstream returns 5xx ─────────────────────────────────────────
+
+describe("POST /v1/chat/completions — upstream errors", () => {
+	it("returns 502 upstream_error when upstream returns 5xx", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeUpstreamMock("Internal Server Error", 500, {
+				"Content-Type": "text/plain",
+			}),
+		);
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: VALID_BODY,
+		});
+
+		expect(resp.status).toBe(502);
+		const json = (await resp.json()) as { error: { type: string } };
+		expect(json.error.type).toBe("upstream_error");
+	});
+
+	it("returns 502 upstream_error when fetch throws (network failure)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockRejectedValue(new Error("Network error")),
+		);
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: VALID_BODY,
+		});
+
+		expect(resp.status).toBe(502);
+		const json = (await resp.json()) as { error: { type: string } };
+		expect(json.error.type).toBe("upstream_error");
+	});
+});
+
+// ── 7. stream:true preserved in outbound body ─────────────────────────────────
+
+describe("POST /v1/chat/completions — stream flag passthrough", () => {
+	it("preserves stream:true in the outbound body", async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		const mockFetch = vi
+			.fn()
+			.mockImplementation(async (_url: string, init: RequestInit) => {
+				capturedBody = JSON.parse(init.body as string) as Record<
+					string,
+					unknown
+				>;
+				return new Response("data: [DONE]\n\n", {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			});
+		vi.stubGlobal("fetch", mockFetch);
+
+		await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				model: "gpt-4o",
+				messages: [{ role: "user", content: "hi" }],
+				stream: true,
+			}),
+		});
+
+		expect(capturedBody?.stream).toBe(true);
+	});
+});
+
+// ── 8. Non-POST verbs fall through to 404 ────────────────────────────────────
+
+describe("POST /v1/chat/completions — method guard", () => {
+	it("GET /v1/chat/completions returns 404 (falls through to catch-all)", async () => {
+		const resp = await SELF.fetch(ENDPOINT, { method: "GET" });
+		expect(resp.status).toBe(404);
+	});
+
+	it("PUT /v1/chat/completions returns 404 (falls through to catch-all)", async () => {
+		const resp = await SELF.fetch(ENDPOINT, { method: "PUT" });
+		expect(resp.status).toBe(404);
+	});
+});

--- a/src/proxy/openai-proxy.ts
+++ b/src/proxy/openai-proxy.ts
@@ -1,0 +1,102 @@
+export const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+export const PINNED_MODEL = "z-ai/glm-4.7-flash";
+
+export function openAiError(
+	status: number,
+	type: "invalid_request_error" | "upstream_error",
+	message: string,
+): Response {
+	return new Response(
+		JSON.stringify({
+			error: {
+				message,
+				type,
+				code: null,
+			},
+		}),
+		{
+			status,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+export async function handleChatCompletions(
+	request: Request,
+	env: { OPENROUTER_API_KEY?: string },
+): Promise<Response> {
+	// 1. Require the API key
+	if (!env.OPENROUTER_API_KEY) {
+		return openAiError(
+			502,
+			"upstream_error",
+			"OpenRouter API key not configured",
+		);
+	}
+
+	// 2. Parse JSON body
+	let body: Record<string, unknown>;
+	try {
+		body = (await request.json()) as Record<string, unknown>;
+	} catch {
+		return openAiError(
+			400,
+			"invalid_request_error",
+			"Invalid JSON in request body",
+		);
+	}
+
+	// 3. Validate messages array
+	if (
+		typeof body !== "object" ||
+		body === null ||
+		!Array.isArray(body.messages) ||
+		body.messages.length < 1
+	) {
+		return openAiError(
+			400,
+			"invalid_request_error",
+			"Request body must include a non-empty messages array",
+		);
+	}
+
+	// 4. Pin the model
+	const modifiedBody = { ...body, model: PINNED_MODEL };
+
+	// 5. Forward to OpenRouter
+	let upstream: Response;
+	try {
+		upstream = await fetch(OPENROUTER_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(modifiedBody),
+		});
+	} catch (err) {
+		const message =
+			err instanceof Error
+				? err.message
+				: "Network error forwarding to OpenRouter";
+		return openAiError(502, "upstream_error", message);
+	}
+
+	// 6. Non-2xx from upstream → 502
+	if (!upstream.ok) {
+		return openAiError(
+			502,
+			"upstream_error",
+			`OpenRouter returned ${upstream.status} ${upstream.statusText}`,
+		);
+	}
+
+	// 7. Stream response back unchanged
+	const contentType =
+		upstream.headers.get("Content-Type") ?? "application/octet-stream";
+	return new Response(upstream.body, {
+		status: upstream.status,
+		headers: { "Content-Type": contentType },
+	});
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,11 @@ export default defineConfig({
 						configPath: "./wrangler.jsonc",
 						miniflare: {
 							kvNamespaces: ["RATE_GUARD_KV"],
-							bindings: { ENABLE_TEST_MODES: "1", TOKEN_PACE_MS: "0" },
+							bindings: {
+								ENABLE_TEST_MODES: "1",
+								TOKEN_PACE_MS: "0",
+								OPENROUTER_API_KEY: "test-openrouter-key",
+							},
 						},
 					}),
 				],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,6 +12,8 @@
 			"id": "rate-guard-kv-placeholder-replace-in-production"
 		}
 	],
+	// Secrets (not committed here — provision via `wrangler secret put <NAME>`):
+	//   OPENROUTER_API_KEY — API key for OpenRouter (POST /v1/chat/completions)
 	"vars": {
 		// Per-IP token-bucket: max tokens (= max burst requests per window).
 		"RATE_LIMIT_MAX": "20",


### PR DESCRIPTION
## What this fixes

Adds the first slice of #26's thin-proxy build: a new `POST /v1/chat/completions` route on the Worker that mimics OpenAI's chat-completions API but pins the upstream model to `z-ai/glm-4.7-flash` and forwards to OpenRouter using a server-held `OPENROUTER_API_KEY`. The handler lives in a new module `src/proxy/openai-proxy.ts` (`handleChatCompletions`), wired into `src/proxy/_smoke.ts` ahead of the catch-all 404 and alongside the untouched `/game/*` routes. Validation rejects bad JSON / missing `messages` as 400 `invalid_request_error`; upstream non-2xx responses and network failures are wrapped to 502 `upstream_error` via the `openAiError` helper. The model pin is unconditional (spread-then-overwrite at every call) — the wallet-protection invariant the issue calls out. Streaming uses the upstream `ReadableStream` directly (no buffering), so SSE bodies stream through unchanged.

## QA steps for the human

1. Provision the secret: `wrangler secret put OPENROUTER_API_KEY` (use a real OpenRouter key with $1+ credit).
2. `pnpm wrangler dev` and from another terminal:
   ```
   curl -N -X POST http://127.0.0.1:8787/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"Say hi in 3 words."}]}'
   ```
   Expect a streamed `text/event-stream` response. Confirm the OpenRouter dashboard shows the request hitting `z-ai/glm-4.7-flash` (not `gpt-4o`) — that's the wallet-protection invariant in production.
3. Sanity-check error shapes: `curl -X POST .../v1/chat/completions -d 'not-json'` → 400 `invalid_request_error`; `curl -X POST .../v1/chat/completions -d '{}'` → 400 `invalid_request_error` (missing messages).
4. Confirm `/game/new` and `/game/turn` still work (open `/` in a browser and play a turn).

## Automated coverage

`pnpm typecheck` + `pnpm test` (318/318 across 15 files including 11 new tests in `src/proxy/openai-proxy.test.ts`) + `pnpm lint` all pass clean.

## Follow-ups (deferred per issue)

- Rate-guard wrapping the route — #37
- CORS for browser callers — #38
- Delete `LLMProvider` / `MockLLMProvider` / `AnthropicProvider` — #48

Closes #36

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToZwzYq4jdqJ93juqT1huP)_