### PR TITLE
GH Pages deploy: GitHub Action that publishes the SPA

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,61 @@
+name: Deploy SPA to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build SPA
+        env:
+          WORKER_BASE_URL: ${{ vars.WORKER_BASE_URL }}
+        run: |
+          if [ -z "${WORKER_BASE_URL}" ]; then
+            echo "::warning::WORKER_BASE_URL repo variable is not set — bundle will default to http://localhost:8787 and the deployed SPA will not work. Set it under repo Settings → Secrets and variables → Actions → Variables."
+          fi
+          pnpm run build
+
+      - name: Add .nojekyll
+        run: touch dist/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What this fixes

Adds `.github/workflows/deploy-pages.yml`, a GitHub Action that builds the SPA bundle and publishes it to GitHub Pages on push to `main` (and on manual `workflow_dispatch`). The workflow has two jobs:

- **`build`** — sets up Node from `.nvmrc` + pnpm (mirrors `ci.yml`'s tooling), runs `pnpm install --frozen-lockfile`, calls `actions/configure-pages@v5`, runs `pnpm run build` (which invokes `scripts/build-spa.mjs`), drops a `.nojekyll` so Pages doesn't filter `_`-prefixed files, then uploads `dist/` via `actions/upload-pages-artifact@v3`.
- **`deploy`** — depends on `build`, uses `actions/deploy-pages@v4` against the `github-pages` environment.

`WORKER_BASE_URL` is parameterised via the `vars.WORKER_BASE_URL` repo variable. The build step echoes a `::warning::` annotation if the variable is unset, so a missing config shows up obviously in deploy logs rather than silently shipping a bundle pointed at `http://localhost:8787`.

`src/spa/index.html` already uses relative `./assets/...` paths, so subpath hosting under `/hi-blue/` works without code changes. `wrangler.jsonc` already lists `https://corvous.github.io` in `ALLOWED_ORIGINS`, so the proxy CORS side is wired up too.

Concurrency group `pages` with `cancel-in-progress: false` serialises deploys per the GitHub-recommended Pages template — two rapid pushes queue rather than dropping the first.

## QA steps for the human

The agent cannot toggle repo settings or open a browser. Two one-time setup actions are required, then verification:

1. **Enable Pages from Actions** (required, blocks deploy):
   - Open https://github.com/CorVous/hi-blue/settings/pages
   - Under **Build and deployment** → **Source**, select **GitHub Actions**. Save.

2. **Set the `WORKER_BASE_URL` repo variable** (required for the SPA to talk to the worker; without it the bundle ships pointing at `http://localhost:8787` and the deploy logs will surface a warning):
   - Open https://github.com/CorVous/hi-blue/settings/variables/actions
   - **New repository variable** → Name `WORKER_BASE_URL`, Value the deployed worker URL (e.g. `https://hi-blue-proxy.<account>.workers.dev` per `wrangler.jsonc` `name`). If the worker isn't deployed yet, leave this for a follow-up and re-run the deploy via **Actions → Deploy SPA to GitHub Pages → Run workflow** once it's set.

3. **Verify the deploy**:
   - After this PR merges to `main`, watch the **Deploy SPA to GitHub Pages** run at https://github.com/CorVous/hi-blue/actions.
   - Confirm the `deploy` job finishes in under 2 minutes.
   - Open the environment URL (expected: https://corvous.github.io/hi-blue/). The prompt-composer UI from `src/spa/index.html` should render and assets should resolve under the subpath. With `WORKER_BASE_URL` set, the DevTools Network tab should show requests going there, not localhost.

## Automated coverage

Locally on the branch:
- `pnpm run lint` — clean (58 files, no issues)
- `pnpm run typecheck` — clean (both `tsconfig.json` and `src/proxy/tsconfig.json`)
- `pnpm run test` — 397/397 tests pass
- `pnpm run build` reproduced manually with `WORKER_BASE_URL=https://example.test/foo` confirms the URL is inlined in `dist/assets/index.js` and `localhost:8787` does not leak into the bundle.

The `actions/deploy-pages@v4` step itself can only be exercised via a real GitHub Actions run — that's the verification step in the QA section above.

Closes #41
Re #26

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUmXBtAqQpCgQrNVZYW54B)_