### PR TITLE
Browser LLM client: free-tier vs BYOK routing

### DIFF
--- a/src/spa/__tests__/llm-client.test.ts
+++ b/src/spa/__tests__/llm-client.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	PERSONA_PLACEHOLDER,
+	resolveLLMTarget,
+	streamChat,
+} from "../llm-client.js";
+
+// Provide __WORKER_BASE_URL__ global before importing the module
+// biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
+(globalThis as any).__WORKER_BASE_URL__ = "http://localhost:8787";
+
+const WORKER_COMPLETIONS_URL = "http://localhost:8787/v1/chat/completions";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(encoder.encode(chunk));
+			}
+			controller.close();
+		},
+	});
+}
+
+function makeFetchResponse(
+	body: ReadableStream<Uint8Array>,
+	ok = true,
+): Response {
+	return {
+		ok,
+		status: ok ? 200 : 500,
+		statusText: ok ? "OK" : "Internal Server Error",
+		body,
+	} as unknown as Response;
+}
+
+describe("resolveLLMTarget", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns OpenRouter URL and Bearer header when key present", () => {
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue("sk-test-key"),
+		});
+
+		const { url, headers } = resolveLLMTarget();
+
+		expect(url).toBe(OPENROUTER_URL);
+		expect(headers.Authorization).toBe("Bearer sk-test-key");
+		expect(headers["Content-Type"]).toBe("application/json");
+	});
+
+	it("returns Worker URL and no Authorization header when key absent", () => {
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		const { url, headers } = resolveLLMTarget();
+
+		expect(url).toBe(WORKER_COMPLETIONS_URL);
+		expect(headers).not.toHaveProperty("Authorization");
+		expect(headers["Content-Type"]).toBe("application/json");
+	});
+
+	it("treats empty-string key as absent (falls back to free-tier)", () => {
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(""),
+		});
+
+		const { url, headers } = resolveLLMTarget();
+
+		expect(url).toBe(WORKER_COMPLETIONS_URL);
+		expect(headers).not.toHaveProperty("Authorization");
+	});
+
+	it("falls back to free-tier when localStorage.getItem throws (no exception)", () => {
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockImplementation(() => {
+				throw new Error("SecurityError: access denied");
+			}),
+		});
+
+		let result: ReturnType<typeof resolveLLMTarget> | undefined;
+		expect(() => {
+			result = resolveLLMTarget();
+		}).not.toThrow();
+
+		expect(result?.url).toBe(WORKER_COMPLETIONS_URL);
+		expect(result?.headers).not.toHaveProperty("Authorization");
+	});
+});
+
+describe("streamChat", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("prepends persona placeholder as messages[0]", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await streamChat({ message: "hello", onDelta: vi.fn() });
+
+		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		const body = JSON.parse(init.body as string);
+		expect(body.messages[0]).toEqual({
+			role: "system",
+			content: PERSONA_PLACEHOLDER,
+		});
+		expect(body.messages[1]).toEqual({ role: "user", content: "hello" });
+	});
+
+	it("POSTs to OpenRouter with Authorization when BYOK key is set (kill-line: not the Worker)", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue("sk-byok-key"),
+		});
+
+		await streamChat({ message: "hello", onDelta: vi.fn() });
+
+		const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(OPENROUTER_URL);
+		expect(url).not.toContain("localhost:8787");
+		expect((init.headers as Record<string, string>).Authorization).toBe(
+			"Bearer sk-byok-key",
+		);
+	});
+
+	it("POSTs to Worker URL with no Authorization header when no key", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await streamChat({ message: "hello", onDelta: vi.fn() });
+
+		const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(WORKER_COMPLETIONS_URL);
+		expect(init.headers as Record<string, string>).not.toHaveProperty(
+			"Authorization",
+		);
+	});
+
+	it("emits a delta via parseSSEStream (happy-path wiring check)", async () => {
+		const sseData = `data: ${JSON.stringify({ choices: [{ delta: { content: "hi!" } }] })}\n\ndata: [DONE]\n\n`;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([sseData]))),
+		);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		const deltas: string[] = [];
+		await streamChat({ message: "test", onDelta: (t) => deltas.push(t) });
+
+		expect(deltas).toEqual(["hi!"]);
+	});
+
+	it("throws on non-ok response with HTTP status", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([]), false)),
+		);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await expect(
+			streamChat({ message: "test", onDelta: vi.fn() }),
+		).rejects.toThrow(/HTTP 500/);
+	});
+});

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { streamCompletion } from "../streaming.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseSSEStream } from "../streaming.js";
 
 // __WORKER_BASE_URL__ is a build-time constant; provide a stub for tests
 // biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
@@ -17,55 +17,9 @@ function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
 	});
 }
 
-function makeFetchResponse(
-	body: ReadableStream<Uint8Array>,
-	ok = true,
-): Response {
-	return {
-		ok,
-		status: ok ? 200 : 500,
-		statusText: ok ? "OK" : "Internal Server Error",
-		body,
-	} as unknown as Response;
-}
-
-describe("streamCompletion", () => {
-	beforeEach(() => {
-		vi.stubGlobal("fetch", vi.fn());
-	});
-
+describe("parseSSEStream", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
-	});
-
-	it("calls fetch with correct URL and body", async () => {
-		const mockFetch = vi
-			.fn()
-			.mockResolvedValue(
-				makeFetchResponse(
-					makeSSEStream([
-						`data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\n\ndata: [DONE]\n\n`,
-					]),
-				),
-			);
-		vi.stubGlobal("fetch", mockFetch);
-
-		await streamCompletion({
-			baseUrl: "http://localhost:8787",
-			message: "hello",
-			onDelta: vi.fn(),
-		});
-
-		expect(mockFetch).toHaveBeenCalledOnce();
-		const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-		expect(url).toBe("http://localhost:8787/v1/chat/completions");
-		expect(init.method).toBe("POST");
-		const bodyParsed = JSON.parse(init.body as string);
-		expect(bodyParsed).toEqual({
-			messages: [{ role: "user", content: "hello" }],
-			stream: true,
-		});
-		expect(bodyParsed).not.toHaveProperty("model");
 	});
 
 	it("emits deltas in order", async () => {
@@ -75,17 +29,8 @@ describe("streamCompletion", () => {
 			`data: [DONE]\n\n`,
 		].join("");
 
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([sseData]))),
-		);
-
 		const deltas: string[] = [];
-		await streamCompletion({
-			baseUrl: "http://localhost:8787",
-			message: "test",
-			onDelta: (text) => deltas.push(text),
-		});
+		await parseSSEStream(makeSSEStream([sseData]), (text) => deltas.push(text));
 
 		expect(deltas).toEqual(["Hello", " world"]);
 	});
@@ -97,19 +42,10 @@ describe("streamCompletion", () => {
 		const chunk1 = fullEvent.slice(0, midpoint);
 		const chunk2 = fullEvent.slice(midpoint);
 
-		vi.stubGlobal(
-			"fetch",
-			vi
-				.fn()
-				.mockResolvedValue(makeFetchResponse(makeSSEStream([chunk1, chunk2]))),
-		);
-
 		const deltas: string[] = [];
-		await streamCompletion({
-			baseUrl: "http://localhost:8787",
-			message: "test",
-			onDelta: (text) => deltas.push(text),
-		});
+		await parseSSEStream(makeSSEStream([chunk1, chunk2]), (text) =>
+			deltas.push(text),
+		);
 
 		expect(deltas).toEqual(["split"]);
 	});
@@ -120,23 +56,11 @@ describe("streamCompletion", () => {
 			usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
 		});
 
-		vi.stubGlobal(
-			"fetch",
-			vi
-				.fn()
-				.mockResolvedValue(
-					makeFetchResponse(
-						makeSSEStream([`data: ${usageChunk}\n\ndata: [DONE]\n\n`]),
-					),
-				),
-		);
-
 		const onDelta = vi.fn();
-		await streamCompletion({
-			baseUrl: "http://localhost:8787",
-			message: "test",
+		await parseSSEStream(
+			makeSSEStream([`data: ${usageChunk}\n\ndata: [DONE]\n\n`]),
 			onDelta,
-		});
+		);
 
 		expect(onDelta).not.toHaveBeenCalled();
 	});
@@ -144,33 +68,9 @@ describe("streamCompletion", () => {
 	it("[DONE] terminates stream without emitting", async () => {
 		const sseData = `data: [DONE]\n\n`;
 
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([sseData]))),
-		);
-
 		const onDelta = vi.fn();
-		await streamCompletion({
-			baseUrl: "http://localhost:8787",
-			message: "test",
-			onDelta,
-		});
+		await parseSSEStream(makeSSEStream([sseData]), onDelta);
 
 		expect(onDelta).not.toHaveBeenCalled();
-	});
-
-	it("throws on non-ok response", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([]), false)),
-		);
-
-		await expect(
-			streamCompletion({
-				baseUrl: "http://localhost:8787",
-				message: "test",
-				onDelta: vi.fn(),
-			}),
-		).rejects.toThrow(/HTTP 500/);
 	});
 });

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -1,0 +1,66 @@
+import { parseSSEStream } from "./streaming.js";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const LOCALSTORAGE_KEY = "openrouter_key";
+
+export const PERSONA_PLACEHOLDER =
+	"[placeholder persona — replaced by real persona content in #43]";
+
+export function resolveLLMTarget(): {
+	url: string;
+	headers: Record<string, string>;
+} {
+	let key: string | null = null;
+	try {
+		key = localStorage.getItem(LOCALSTORAGE_KEY);
+	} catch {
+		// silently fall through — privacy mode or storage unavailable
+	}
+
+	// Treat empty string the same as null
+	if (key) {
+		return {
+			url: OPENROUTER_URL,
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${key}`,
+			},
+		};
+	}
+
+	return {
+		url: `${__WORKER_BASE_URL__}/v1/chat/completions`,
+		headers: { "Content-Type": "application/json" },
+	};
+}
+
+export async function streamChat(opts: {
+	message: string;
+	signal?: AbortSignal;
+	onDelta: (text: string) => void;
+}): Promise<void> {
+	const { message, signal, onDelta } = opts;
+	const { url, headers } = resolveLLMTarget();
+
+	const messages = [
+		{ role: "system", content: PERSONA_PLACEHOLDER },
+		{ role: "user", content: message },
+	];
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ messages, stream: true }),
+		...(signal != null ? { signal } : {}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+	}
+
+	if (!response.body) {
+		throw new Error("Response body is null");
+	}
+
+	await parseSSEStream(response.body, onDelta);
+}

--- a/src/spa/routes/home.ts
+++ b/src/spa/routes/home.ts
@@ -1,4 +1,4 @@
-import { streamCompletion } from "../streaming.js";
+import { streamChat } from "../llm-client.js";
 
 export function renderHome(root: HTMLElement): void {
 	const form = root.ownerDocument.querySelector<HTMLFormElement>("#composer");
@@ -18,8 +18,7 @@ export function renderHome(root: HTMLElement): void {
 		outputEl.textContent = "";
 		sendBtn.disabled = true;
 
-		streamCompletion({
-			baseUrl: __WORKER_BASE_URL__,
+		streamChat({
 			message,
 			onDelta: (text) => {
 				outputEl.textContent += text;

--- a/src/spa/streaming.ts
+++ b/src/spa/streaming.ts
@@ -1,30 +1,8 @@
-export async function streamCompletion(opts: {
-	baseUrl: string;
-	message: string;
-	signal?: AbortSignal;
-	onDelta: (text: string) => void;
-}): Promise<void> {
-	const { baseUrl, message, signal, onDelta } = opts;
-
-	const response = await fetch(`${baseUrl}/v1/chat/completions`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			messages: [{ role: "user", content: message }],
-			stream: true,
-		}),
-		...(signal != null ? { signal } : {}),
-	});
-
-	if (!response.ok) {
-		throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-	}
-
-	if (!response.body) {
-		throw new Error("Response body is null");
-	}
-
-	const reader = response.body.getReader();
+export async function parseSSEStream(
+	body: ReadableStream<Uint8Array>,
+	onDelta: (text: string) => void,
+): Promise<void> {
+	const reader = body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
 


### PR DESCRIPTION
## What this fixes

Adds the browser-side `streamChat` function that decides whether the chat request goes directly to OpenRouter (BYOK) or through the Worker (free tier). The decision is a pure read of `localStorage.getItem("openrouter_key")` in `src/spa/llm-client.ts`: a non-empty key returns the OpenRouter URL plus an `Authorization: Bearer <key>` header; absent / empty / unreadable key returns the Worker URL with no auth header. The localStorage read is wrapped in a silent try/catch so privacy-mode and cross-origin-iframe failures fall back to the free-tier path without console noise. Both branches prepend a placeholder `{ role: "system", content: PERSONA_PLACEHOLDER }` at `messages[0]` (real persona content lands at #43).

The old `streamCompletion` in `src/spa/streaming.ts` was the inline fetch from #39 that this issue calls out. Its SSE-parsing core is now the standalone `parseSSEStream(body, onDelta)` in the same file, and `streamChat` calls `fetch` itself before delegating the response body to it. `src/spa/routes/home.ts` was migrated to the new entry point and no longer plumbs `baseUrl`.

## QA steps for the human

- Open the deployed SPA with no `openrouter_key` in localStorage. Network tab: the `/v1/chat/completions` request should hit the Worker base URL (no `Authorization` header).
- `localStorage.setItem("openrouter_key", "sk-…test…")`, reload, send a message. Network tab: the request should hit `https://openrouter.ai/api/v1/chat/completions` and carry `Authorization: Bearer sk-…test…`. **Crucially: no request to the Worker URL.**
- Clear the key, set localStorage to throw (e.g. open in a context that blocks storage), and send a message. The request should still go to the Worker URL with no auth header — no console errors.

## Automated coverage

`pnpm typecheck && pnpm test && pnpm lint` — all green (404/404 tests). `pnpm build` produces `dist/` with the OpenRouter URL, `openrouter_key`, and the routing ternary preserved through minification.

Closes #40

---
_Generated by [Claude Code](https://claude.ai/code/session_014A7Qoap4Nn2bb1HTUCpCDU)_