### PR TITLE
SPA: show "thinking…" placeholder during reasoning-model SSE phase

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -37,6 +37,10 @@ function makeSseChunk(content: string): string {
 	return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`;
 }
 
+function makeReasoningChunk(reasoning: string): string {
+	return `data: ${JSON.stringify({ choices: [{ delta: { reasoning } }] })}\n\n`;
+}
+
 describe("renderGame (game route)", () => {
 	beforeEach(() => {
 		document.body.innerHTML = INDEX_BODY_HTML;
@@ -48,8 +52,8 @@ describe("renderGame (game route)", () => {
 	});
 
 	it("accumulates transcript across two messages with streamed AI tokens", async () => {
-		const sseData1 = makeSseChunk("reply one") + "data: [DONE]\n\n";
-		const sseData2 = makeSseChunk("reply two") + "data: [DONE]\n\n";
+		const sseData1 = `${makeSseChunk("reply one")}data: [DONE]\n\n`;
+		const sseData2 = `${makeSseChunk("reply two")}data: [DONE]\n\n`;
 
 		const mockFetch = vi
 			.fn()
@@ -95,5 +99,69 @@ describe("renderGame (game route)", () => {
 		expect(output.textContent).toContain("[you] second message");
 		expect(output.textContent).toContain("reply one");
 		expect(output.textContent).toContain("reply two");
+	});
+
+	it("shows 'thinking…' placeholder during reasoning phase, then replaces it with the answer", async () => {
+		const encoder = new TextEncoder();
+		const captured: {
+			controller: ReadableStreamDefaultController<Uint8Array> | null;
+		} = { controller: null };
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				captured.controller = controller;
+			},
+		});
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				body: stream,
+			}),
+		);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const form = getEl<HTMLFormElement>("#composer");
+		const output = getEl<HTMLPreElement>("#output");
+
+		promptInput.value = "hello";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		// Give a tick for the fetch call
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// At this point only reasoning deltas will arrive — placeholder should be visible
+		captured.controller?.enqueue(
+			encoder.encode(makeReasoningChunk("thinking hard")),
+		);
+		captured.controller?.enqueue(
+			encoder.encode(makeReasoningChunk(" and harder")),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(output.textContent).toContain("thinking…");
+
+		// Now send a content delta — placeholder should disappear
+		captured.controller?.enqueue(
+			encoder.encode(makeSseChunk("The answer is 42")),
+		);
+		captured.controller?.enqueue(encoder.encode("data: [DONE]\n\n"));
+		captured.controller?.close();
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(output.textContent).toContain("The answer is 42");
+		expect(output.textContent).not.toContain("thinking…");
 	});
 });

--- a/src/spa/__tests__/home.test.ts
+++ b/src/spa/__tests__/home.test.ts
@@ -346,4 +346,67 @@ describe("renderHome (home route)", () => {
 		expect(anchor).not.toBeNull();
 		expect(anchor?.getAttribute("href")).toBe("#/byok");
 	});
+
+	it("shows 'thinking…' placeholder during reasoning phase, then replaces it with the answer", async () => {
+		const encoder = new TextEncoder();
+		const captured: {
+			controller: ReadableStreamDefaultController<Uint8Array> | null;
+		} = { controller: null };
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				captured.controller = controller;
+			},
+		});
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				body: stream,
+			}),
+		);
+
+		vi.resetModules();
+		const { renderHome } = await import("../routes/home.js");
+
+		renderHome(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const form = getEl<HTMLFormElement>("#composer");
+		const output = getEl<HTMLPreElement>("#output");
+
+		promptInput.value = "hello";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		// Give a tick for the fetch call
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// At this point only reasoning chunks arrive — placeholder should be visible
+		captured.controller?.enqueue(
+			encoder.encode(
+				`data: ${JSON.stringify({ choices: [{ delta: { reasoning: "thinking…" } }] })}\n\n`,
+			),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(output.textContent).toContain("thinking…");
+
+		// Now send a content delta — placeholder should be replaced
+		captured.controller?.enqueue(
+			encoder.encode(
+				`data: ${JSON.stringify({ choices: [{ delta: { content: "here is the answer" } }] })}\n\ndata: [DONE]\n\n`,
+			),
+		);
+		captured.controller?.close();
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(output.textContent).toContain("here is the answer");
+		expect(output.textContent).not.toContain("thinking…");
+	});
 });

--- a/src/spa/__tests__/llm-client.test.ts
+++ b/src/spa/__tests__/llm-client.test.ts
@@ -455,4 +455,29 @@ describe("streamCompletion", () => {
 			"Bearer sk-byok-key",
 		);
 	});
+
+	it("forwards reasoning deltas to onReasoning callback", async () => {
+		const reasoningChunk = `data: ${JSON.stringify({ choices: [{ delta: { reasoning: "internal thought" } }] })}\n\n`;
+		const contentChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: "final answer" } }] })}\n\n`;
+		const sseData = `${reasoningChunk}${contentChunk}data: [DONE]\n\n`;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([sseData]))),
+		);
+		vi.stubGlobal("localStorage", { getItem: vi.fn().mockReturnValue(null) });
+
+		const onDelta = vi.fn();
+		const onReasoning = vi.fn();
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta,
+			onReasoning,
+		});
+
+		expect(onReasoning).toHaveBeenCalledTimes(1);
+		expect(onReasoning).toHaveBeenCalledWith("internal thought");
+		expect(onDelta).toHaveBeenCalledTimes(1);
+		expect(onDelta).toHaveBeenCalledWith("final answer");
+	});
 });

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -73,4 +73,39 @@ describe("parseSSEStream", () => {
 
 		expect(onDelta).not.toHaveBeenCalled();
 	});
+
+	it("invokes onReasoning for delta.reasoning chunks and not onDelta", async () => {
+		const reasoningChunk1 = `data: ${JSON.stringify({ choices: [{ delta: { reasoning: "let me think" } }] })}\n\n`;
+		const reasoningChunk2 = `data: ${JSON.stringify({ choices: [{ delta: { reasoning: " about this" } }] })}\n\n`;
+		const contentChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: "answer" } }] })}\n\n`;
+		const doneChunk = `data: [DONE]\n\n`;
+
+		const sseData =
+			reasoningChunk1 + reasoningChunk2 + contentChunk + doneChunk;
+
+		const onDelta = vi.fn();
+		const onReasoning = vi.fn();
+		await parseSSEStream(makeSSEStream([sseData]), onDelta, onReasoning);
+
+		expect(onReasoning).toHaveBeenCalledTimes(2);
+		expect(onReasoning).toHaveBeenNthCalledWith(1, "let me think");
+		expect(onReasoning).toHaveBeenNthCalledWith(2, " about this");
+		expect(onDelta).toHaveBeenCalledTimes(1);
+		expect(onDelta).toHaveBeenCalledWith("answer");
+	});
+
+	it("works without onReasoning — reasoning chunks are silently ignored", async () => {
+		const reasoningChunk = `data: ${JSON.stringify({ choices: [{ delta: { reasoning: "internal thought" } }] })}\n\n`;
+		const contentChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\n\n`;
+		const doneChunk = `data: [DONE]\n\n`;
+
+		const sseData = reasoningChunk + contentChunk + doneChunk;
+
+		const onDelta = vi.fn();
+		// Call without third argument — must not throw
+		await parseSSEStream(makeSSEStream([sseData]), onDelta);
+
+		expect(onDelta).toHaveBeenCalledTimes(1);
+		expect(onDelta).toHaveBeenCalledWith("hi");
+	});
 });

--- a/src/spa/game/game-loop.ts
+++ b/src/spa/game/game-loop.ts
@@ -20,6 +20,7 @@ export interface RunRoundOptions {
 	message: string;
 	signal?: AbortSignal;
 	onDelta: (text: string) => void;
+	onReasoning?: (text: string) => void;
 }
 
 /**
@@ -32,7 +33,7 @@ export interface RunRoundOptions {
  * 6. Return the full assistant text
  */
 export async function runSingleAiRound(opts: RunRoundOptions): Promise<string> {
-	const { session, message, signal, onDelta } = opts;
+	const { session, message, signal, onDelta, onReasoning } = opts;
 
 	const systemMessage: OpenAiMessage = {
 		role: "system",
@@ -67,6 +68,7 @@ export async function runSingleAiRound(opts: RunRoundOptions): Promise<string> {
 			fullResponse += text;
 			onDelta(text);
 		},
+		...(onReasoning != null ? { onReasoning } : {}),
 	});
 
 	// Only mutate history after successful stream

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -112,8 +112,9 @@ export async function streamCompletion(opts: {
 	messages: OpenAiMessage[];
 	signal?: AbortSignal;
 	onDelta: (text: string) => void;
+	onReasoning?: (text: string) => void;
 }): Promise<void> {
-	const { messages, signal, onDelta } = opts;
+	const { messages, signal, onDelta, onReasoning } = opts;
 	const { url, headers } = resolveLLMTarget();
 
 	const response = await fetch(url, {
@@ -133,13 +134,14 @@ export async function streamCompletion(opts: {
 		throw new Error("Response body is null");
 	}
 
-	await parseSSEStream(response.body, onDelta);
+	await parseSSEStream(response.body, onDelta, onReasoning);
 }
 
 export async function streamChat(opts: {
 	message: string;
 	signal?: AbortSignal;
 	onDelta: (text: string) => void;
+	onReasoning?: (text: string) => void;
 }): Promise<void> {
 	return streamCompletion({
 		messages: [
@@ -148,5 +150,6 @@ export async function streamChat(opts: {
 		],
 		...(opts.signal != null ? { signal: opts.signal } : {}),
 		onDelta: opts.onDelta,
+		...(opts.onReasoning != null ? { onReasoning: opts.onReasoning } : {}),
 	});
 }

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -27,13 +27,33 @@ export function renderGame(root: HTMLElement): void {
 		// Append the user's turn + a fresh AI label (don't clear — accumulate transcript)
 		outputEl.textContent += `\n[you] ${message}\n[${session.persona.name}] `;
 
+		// Show "thinking…" placeholder while waiting for first content delta
+		const placeholderStart = outputEl.textContent.length;
+		outputEl.textContent += "thinking…";
+		let placeholderShown = true;
+
 		runSingleAiRound({
 			session,
 			message,
 			onDelta: (text) => {
+				if (placeholderShown) {
+					outputEl.textContent = outputEl.textContent.slice(
+						0,
+						placeholderStart,
+					);
+					placeholderShown = false;
+				}
 				outputEl.textContent += text;
 			},
+			onReasoning: () => {
+				// Keep the placeholder visible while only reasoning deltas arrive
+			},
 		}).finally(() => {
+			// If no content deltas arrived at all, strip the placeholder
+			if (placeholderShown) {
+				outputEl.textContent = outputEl.textContent.slice(0, placeholderStart);
+				placeholderShown = false;
+			}
 			sendBtn.disabled = false;
 		});
 	});

--- a/src/spa/routes/home.ts
+++ b/src/spa/routes/home.ts
@@ -20,16 +20,29 @@ export function renderHome(root: HTMLElement): void {
 		if (capHitEl) capHitEl.hidden = true;
 
 		promptInput.value = "";
-		outputEl.textContent = "";
+		outputEl.textContent = "thinking…";
 		sendBtn.disabled = true;
+		let placeholderShown = true;
 
 		streamChat({
 			message,
 			onDelta: (text) => {
+				if (placeholderShown) {
+					outputEl.textContent = "";
+					placeholderShown = false;
+				}
 				outputEl.textContent += text;
+			},
+			onReasoning: () => {
+				// Keep the placeholder visible while only reasoning deltas arrive
 			},
 		})
 			.catch((err: unknown) => {
+				// Clear the placeholder on error so it doesn't linger
+				if (placeholderShown) {
+					outputEl.textContent = "";
+					placeholderShown = false;
+				}
 				if (
 					err instanceof CapHitError ||
 					(err as { status?: number }).status === 429
@@ -38,6 +51,11 @@ export function renderHome(root: HTMLElement): void {
 				}
 			})
 			.finally(() => {
+				// If no content deltas arrived at all, strip the placeholder
+				if (placeholderShown) {
+					outputEl.textContent = "";
+					placeholderShown = false;
+				}
 				sendBtn.disabled = false;
 			});
 	});

--- a/src/spa/streaming.ts
+++ b/src/spa/streaming.ts
@@ -1,6 +1,7 @@
 export async function parseSSEStream(
 	body: ReadableStream<Uint8Array>,
 	onDelta: (text: string) => void,
+	onReasoning?: (text: string) => void,
 ): Promise<void> {
 	const reader = body.getReader();
 	const decoder = new TextDecoder();
@@ -28,6 +29,10 @@ export async function parseSSEStream(
 						const content = parsed?.choices?.[0]?.delta?.content;
 						if (typeof content === "string" && content.length > 0) {
 							onDelta(content);
+						}
+						const reasoning = parsed?.choices?.[0]?.delta?.reasoning;
+						if (typeof reasoning === "string" && reasoning.length > 0) {
+							onReasoning?.(reasoning);
 						}
 					} catch {
 						// Ignore malformed JSON chunks


### PR DESCRIPTION
## What this fixes

The free-tier reasoning model (GLM 4.7 Flash) emits SSE chunks with `delta.content === ""` and `delta.reasoning` carrying the chain-of-thought during its thinking phase. `parseSSEStream` in `src/spa/streaming.ts` only forwarded `delta.content` to `onDelta`, so the SPA's `<pre>` stayed empty for the entire reasoning phase, then flooded in once thinking finished — giving the false impression that the wire wasn't streaming.

The fix threads an optional `onReasoning?: (text: string) => void` callback through `parseSSEStream` → `streamCompletion` / `streamChat` (`src/spa/llm-client.ts`) → `runSingleAiRound`'s `RunRoundOptions` (`src/spa/game/game-loop.ts`) without touching any existing two-arg callsite. The `#/game` route (`src/spa/routes/game.ts`) and the debug `#/` route (`src/spa/routes/home.ts`) now append a literal `"thinking…"` placeholder at round start, then strip it on the first `onDelta` call before appending answer text. A `.finally()` cleanup strips the placeholder if the stream produces zero content deltas (error / empty path). Reasoning text is intentionally not buffered into `session.history` — that's out of scope.

## QA steps for the human

- Open `#/game` against a reasoning model (GLM 4.7 Flash via the proxy) and confirm `"thinking…"` shows the moment a round starts and is replaced (not appended-after) by the streaming answer.
- Send a message to a non-reasoning model and confirm `"thinking…"` flashes briefly at round start and the streaming answer reads identically to before.
- Trigger a stream that errors before any content delta arrives and confirm no orphaned `"thinking…"` is left in the transcript.

## Automated coverage

`pnpm lint`, `pnpm typecheck`, `pnpm test` (470 / 470 pass across 24 files), and `pnpm build` all green on `5bdfc09`. New tests cover: `parseSSEStream` reasoning-vs-content callback dispatch and back-compat with the two-arg signature; `streamCompletion` reasoning forwarding; placeholder appears-then-replaced for both `#/game` and `#/`; ad-hoc smoke confirmed pure-content and empty/error paths leave no orphan placeholder.

Closes #62

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mho6vztnief6Ygkyx7Kc89)_