### PR TITLE
Game-loop migration: full round (three AIs, action log, budgets, lockouts)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,9 @@
-export type { AiContext } from "./context-builder";
-export { buildAiContext } from "./context-builder";
-export type { DispatchResult, ValidationResult } from "./dispatcher";
+export type { DispatchResult, ValidationResult } from "./spa/game/dispatcher";
 export {
 	dispatchAiTurn,
 	executeToolCall,
 	validateToolCall,
-} from "./dispatcher";
+} from "./spa/game/dispatcher";
 export {
 	advancePhase,
 	advanceRound,
@@ -17,6 +15,8 @@ export {
 	getActivePhase,
 	startPhase,
 } from "./spa/game/engine";
+export type { AiContext } from "./spa/game/prompt-builder";
+export { buildAiContext } from "./spa/game/prompt-builder";
 export type {
 	ActionLogEntry,
 	AiBudget,

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -1,5 +1,4 @@
 import { PHASE_1_CONFIG } from "../content";
-import { encodeRoundResult } from "../round-result-encoder";
 import {
 	buildSessionCookie,
 	createSession,
@@ -8,7 +7,9 @@ import {
 } from "../session-store";
 import { getActivePhase } from "../spa/game/engine";
 import type { GameSession } from "../spa/game/game-session";
+import { encodeRoundResult } from "../spa/game/round-result-encoder";
 import type { AiId, PhaseConfig } from "../spa/game/types";
+import { AI_TYPING_SPEED } from "../spa/game/typing-rhythm";
 import {
 	buildPreflightResponse,
 	parseAllowedOrigins,
@@ -52,16 +53,6 @@ interface Env {
 	 */
 	ALLOWED_ORIGINS?: string;
 }
-
-/**
- * Per-AI multipliers on TOKEN_PACE_MS to give each AI a distinct typing rhythm.
- * Lower = faster. Red is impulsive, blue is deliberate, green sits between.
- */
-const AI_TYPING_SPEED: Record<AiId, number> = {
-	red: 0.7,
-	green: 1.0,
-	blue: 1.4,
-};
 
 function createProvider(env: Env): LLMProvider {
 	if (env.LLM_PROVIDER === "anthropic") {

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -3,14 +3,46 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Provide globals before importing the module
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 
-// Matches the body content of src/spa/index.html
+// Matches the body content of src/spa/index.html (three-panel layout)
 const INDEX_BODY_HTML = `
 <main>
+  <div id="panels">
+    <article class="ai-panel" data-ai="red">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="red"></div>
+    </article>
+    <article class="ai-panel" data-ai="green">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="green"></div>
+    </article>
+    <article class="ai-panel" data-ai="blue">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="blue"></div>
+    </article>
+  </div>
   <form id="composer">
+    <select id="address" aria-label="Address AI">
+      <option value="red">Ember (red)</option>
+      <option value="green">Sage (green)</option>
+      <option value="blue">Frost (blue)</option>
+    </select>
     <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
     <button id="send" type="submit">Send</button>
   </form>
-  <pre id="output"></pre>
+  <section id="cap-hit" hidden></section>
+  <aside id="action-log" hidden>
+    <h3>Action Log (debug)</h3>
+    <ul id="action-log-list"></ul>
+  </aside>
 </main>
 <script type="module" src="./assets/index.js"></script>
 `;
@@ -33,135 +65,282 @@ function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
 	});
 }
 
-function makeSseChunk(content: string): string {
-	return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`;
+/**
+ * Creates an SSE response body that yields a single JSON action as an OpenAI delta event.
+ * The runRound coordinator collects all delta tokens into one string and parses as JSON.
+ */
+function makeAiSseStream(jsonAction: string): ReadableStream<Uint8Array> {
+	const sseData = `data: ${JSON.stringify({ choices: [{ delta: { content: jsonAction } }] })}\n\ndata: [DONE]\n\n`;
+	return makeSSEStream([sseData]);
 }
 
-function makeReasoningChunk(reasoning: string): string {
-	return `data: ${JSON.stringify({ choices: [{ delta: { reasoning } }] })}\n\n`;
+/** Returns a fresh fetch mock that serves three AI responses in sequence. */
+function makeThreeAiFetchMock(
+	redAction: string,
+	greenAction: string,
+	blueAction: string,
+) {
+	return vi
+		.fn()
+		.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeAiSseStream(redAction),
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeAiSseStream(greenAction),
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeAiSseStream(blueAction),
+		});
 }
 
-describe("renderGame (game route)", () => {
+/** passAiResponse: used when we just want all AIs to pass (budget deduction still fires). */
+const PASS_ACTION = '{"action":"pass"}';
+const RED_ACTION = '{"action":"chat","content":"RED_RESPONSE_UNIQUE_TAG"}';
+const GREEN_ACTION = '{"action":"chat","content":"GREEN_RESPONSE_UNIQUE_TAG"}';
+const BLUE_ACTION = '{"action":"chat","content":"BLUE_RESPONSE_UNIQUE_TAG"}';
+
+describe("renderGame (game route — three-AI)", () => {
 	beforeEach(() => {
 		document.body.innerHTML = INDEX_BODY_HTML;
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		vi.resetModules();
 		document.body.innerHTML = "";
 	});
 
-	it("accumulates transcript across two messages with streamed AI tokens", async () => {
-		const sseData1 = `${makeSseChunk("reply one")}data: [DONE]\n\n`;
-		const sseData2 = `${makeSseChunk("reply two")}data: [DONE]\n\n`;
-
-		const mockFetch = vi
-			.fn()
-			.mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				statusText: "OK",
-				body: makeSSEStream([sseData1]),
-			})
-			.mockResolvedValueOnce({
-				ok: true,
-				status: 200,
-				statusText: "OK",
-				body: makeSSEStream([sseData2]),
-			});
+	it("after one submit, all three transcript panels have content", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			RED_ACTION,
+			GREEN_ACTION,
+			BLUE_ACTION,
+		);
 		vi.stubGlobal("fetch", mockFetch);
 		vi.stubGlobal("localStorage", { getItem: () => null });
+		// Math.random=0.9 produces identity shuffle: ["red","green","blue"]
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-
 		renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
-
-		// Submit first message
-		promptInput.value = "first message";
+		promptInput.value = "hello world";
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
-		await new Promise((resolve) => setTimeout(resolve, 50));
 
-		// Submit second message
-		promptInput.value = "second message";
-		form.dispatchEvent(
-			new Event("submit", { bubbles: true, cancelable: true }),
-		);
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		const output = getEl<HTMLPreElement>("#output");
-		expect(output.textContent).toContain("[you] first message");
-		expect(output.textContent).toContain("[you] second message");
-		expect(output.textContent).toContain("reply one");
-		expect(output.textContent).toContain("reply two");
+		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
+		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
+		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
+
+		expect(redTranscript.textContent?.trim()).toBeTruthy();
+		expect(greenTranscript.textContent?.trim()).toBeTruthy();
+		expect(blueTranscript.textContent?.trim()).toBeTruthy();
 	});
 
-	it("shows 'thinking…' placeholder during reasoning phase, then replaces it with the answer", async () => {
-		const encoder = new TextEncoder();
-		const captured: {
-			controller: ReadableStreamDefaultController<Uint8Array> | null;
-		} = { controller: null };
-
-		const stream = new ReadableStream<Uint8Array>({
-			start(controller) {
-				captured.controller = controller;
-			},
-		});
-
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue({
-				ok: true,
-				status: 200,
-				statusText: "OK",
-				body: stream,
-			}),
+	it("each panel only contains its own AI's completion text", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			RED_ACTION,
+			GREEN_ACTION,
+			BLUE_ACTION,
 		);
+		vi.stubGlobal("fetch", mockFetch);
 		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "hi";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
+		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
+		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
+
+		// Each panel should contain its AI's unique tag
+		expect(redTranscript.textContent).toContain("RED_RESPONSE_UNIQUE_TAG");
+		expect(greenTranscript.textContent).toContain("GREEN_RESPONSE_UNIQUE_TAG");
+		expect(blueTranscript.textContent).toContain("BLUE_RESPONSE_UNIQUE_TAG");
+
+		// Red panel should not contain green or blue content
+		expect(redTranscript.textContent).not.toContain(
+			"GREEN_RESPONSE_UNIQUE_TAG",
+		);
+		expect(redTranscript.textContent).not.toContain("BLUE_RESPONSE_UNIQUE_TAG");
+	});
+
+	it("action-log is hidden by default and visible with debug=1", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 
+		// Without debug param: action log should be hidden
+		renderGame(getEl<HTMLElement>("main"));
+		const actionLog = getEl<HTMLElement>("#action-log");
+		expect(actionLog.hasAttribute("hidden")).toBe(true);
+
+		// With debug=1: action log should be visible
+		const params = new URLSearchParams("debug=1");
+		renderGame(getEl<HTMLElement>("main"), params);
+		expect(actionLog.hasAttribute("hidden")).toBe(false);
+	});
+
+	it("action-log entries are populated after a round (hidden or visible)", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+
+		// Show debug so we can verify entries
+		const params = new URLSearchParams("debug=1");
+		renderGame(getEl<HTMLElement>("main"), params);
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "test";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const logList = getEl<HTMLUListElement>("#action-log-list");
+		expect(logList.children.length).toBeGreaterThan(0);
+	});
+
+	it("budgets decrement after a round (5 -> 4 for all AIs)", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		// Initial budgets should show 5
+		const redBudget = document.querySelector<HTMLSpanElement>(
+			'.ai-panel[data-ai="red"] .panel-budget',
+		);
+		const greenBudget = document.querySelector<HTMLSpanElement>(
+			'.ai-panel[data-ai="green"] .panel-budget',
+		);
+		const blueBudget = document.querySelector<HTMLSpanElement>(
+			'.ai-panel[data-ai="blue"] .panel-budget',
+		);
+		expect(redBudget?.textContent).toContain("5");
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "test";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// After one round, budgets should be 4
+		expect(redBudget?.textContent).toContain("4");
+		expect(greenBudget?.textContent).toContain("4");
+		expect(blueBudget?.textContent).toContain("4");
+	});
+
+	it("fetch is called exactly three times per round (once per AI)", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "test";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(mockFetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("shows 'thinking…' placeholder in the addressed panel during the round, stripped after responses arrive", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			RED_ACTION,
+			GREEN_ACTION,
+			BLUE_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
 		renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
-		const output = getEl<HTMLPreElement>("#output");
+		// Address the green panel
+		const addressSelect = getEl<HTMLSelectElement>("#address");
+		addressSelect.value = "green";
 
 		promptInput.value = "hello";
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 
-		// Give a tick for the fetch call
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		// Synchronously after submit (before fetch resolves), the placeholder is visible
+		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
+		expect(greenTranscript.textContent).toContain("thinking…");
 
-		// At this point only reasoning deltas will arrive — placeholder should be visible
-		captured.controller?.enqueue(
-			encoder.encode(makeReasoningChunk("thinking hard")),
-		);
-		captured.controller?.enqueue(
-			encoder.encode(makeReasoningChunk(" and harder")),
-		);
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		expect(output.textContent).toContain("thinking…");
-
-		// Now send a content delta — placeholder should disappear
-		captured.controller?.enqueue(
-			encoder.encode(makeSseChunk("The answer is 42")),
-		);
-		captured.controller?.enqueue(encoder.encode("data: [DONE]\n\n"));
-		captured.controller?.close();
-
-		await new Promise((resolve) => setTimeout(resolve, 50));
-
-		expect(output.textContent).toContain("The answer is 42");
-		expect(output.textContent).not.toContain("thinking…");
+		// After the round resolves, the placeholder is gone and the response is rendered
+		expect(greenTranscript.textContent).not.toContain("thinking…");
+		expect(greenTranscript.textContent).toContain("GREEN_RESPONSE_UNIQUE_TAG");
 	});
 });

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -9,13 +9,8 @@ import {
 	deductBudget,
 	getActivePhase,
 	startPhase,
-} from "../spa/game/engine";
-import type {
-	AiPersona,
-	AiTurnAction,
-	PhaseConfig,
-	ToolCall,
-} from "../spa/game/types";
+} from "../engine";
+import type { AiPersona, AiTurnAction, PhaseConfig, ToolCall } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {

--- a/src/spa/game/__tests__/game-loop.test.ts
+++ b/src/spa/game/__tests__/game-loop.test.ts
@@ -91,8 +91,8 @@ describe("runSingleAiRound", () => {
 	});
 
 	it("round 2: messages[] includes round 1 exchange", async () => {
-		const sseData1 = makeSseChunk("round one reply") + "data: [DONE]\n\n";
-		const sseData2 = makeSseChunk("round two reply") + "data: [DONE]\n\n";
+		const sseData1 = `${makeSseChunk("round one reply")}data: [DONE]\n\n`;
+		const sseData2 = `${makeSseChunk("round two reply")}data: [DONE]\n\n`;
 
 		const mockFetch = vi
 			.fn()
@@ -121,8 +121,7 @@ describe("runSingleAiRound", () => {
 	});
 
 	it("onDelta receives streamed chunks in order", async () => {
-		const sseData =
-			makeSseChunk("hi ") + makeSseChunk("there") + "data: [DONE]\n\n";
+		const sseData = `${makeSseChunk("hi ")}${makeSseChunk("there")}data: [DONE]\n\n`;
 		vi.stubGlobal(
 			"fetch",
 			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([sseData]))),
@@ -140,7 +139,7 @@ describe("runSingleAiRound", () => {
 	});
 
 	it("session.history accumulates player and ai entries on success", async () => {
-		const sseData = makeSseChunk("hi there") + "data: [DONE]\n\n";
+		const sseData = `${makeSseChunk("hi there")}data: [DONE]\n\n`;
 		vi.stubGlobal(
 			"fetch",
 			vi.fn().mockResolvedValue(makeFetchResponse(makeSSEStream([sseData]))),

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { buildAiContext } from "../context-builder";
 import {
 	appendActionLog,
 	appendChat,
 	appendWhisper,
 	createGame,
 	startPhase,
-} from "../spa/game/engine";
-import type { ActionLogEntry, AiPersona, PhaseConfig } from "../spa/game/types";
+} from "../engine";
+import { buildAiContext } from "../prompt-builder";
+import type { ActionLogEntry, AiPersona, PhaseConfig } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -11,10 +11,8 @@
  * All tests use MockLLMProvider with canned responses.
  */
 import { describe, expect, it } from "vitest";
-import { buildAiContext } from "../context-builder";
-import type { LLMProvider } from "../proxy/llm-provider";
-import { MockLLMProvider } from "../proxy/llm-provider";
-import { runRound } from "../round-coordinator";
+import type { LLMProvider } from "../../../proxy/llm-provider";
+import { MockLLMProvider } from "../../../proxy/llm-provider";
 import {
 	createGame,
 	deductBudget,
@@ -22,8 +20,10 @@ import {
 	isAiLockedOut,
 	isPlayerChatLockedOut,
 	startPhase,
-} from "../spa/game/engine";
-import type { AiPersona, PhaseConfig } from "../spa/game/types";
+} from "../engine";
+import { buildAiContext } from "../prompt-builder";
+import { runRound } from "../round-coordinator";
+import type { AiId, AiPersona, PhaseConfig } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -917,5 +917,72 @@ describe("lockout messages", () => {
 		expect(result.chatLockoutTriggered).toBeDefined();
 		expect(result.chatLockoutTriggered?.aiId).toBe("red");
 		expect(result.chatLockoutTriggered?.message).toBe("Ember is unresponsive…");
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Initiative parameter (issue #43)
+// ----------------------------------------------------------------------------
+describe("initiative parameter", () => {
+	it("respects the initiative parameter — order of actions matches the supplied permutation", async () => {
+		const game = makeGame();
+		// Use SequentialMockProvider: first call → blue's response, second → red, third → green
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"I am blue"}',
+			'{"action":"chat","content":"I am red"}',
+			'{"action":"chat","content":"I am green"}',
+		]);
+		const initiative: AiId[] = ["blue", "red", "green"];
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			initiative,
+		);
+		const phase = getActivePhase(nextState);
+		// blue acted first — should have chat content "I am blue"
+		expect(
+			phase.chatHistories.blue.some((m) => m.content === "I am blue"),
+		).toBe(true);
+		// action log first entry should be from blue
+		expect(phase.actionLog[0]?.actor).toBe("blue");
+	});
+
+	it("missing initiative falls back to red→green→blue", async () => {
+		const game = makeGame();
+		const provider = new SequentialMockProvider([
+			'{"action":"chat","content":"I am red"}',
+			'{"action":"chat","content":"I am green"}',
+			'{"action":"chat","content":"I am blue"}',
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const phase = getActivePhase(nextState);
+		// Default order is red first
+		expect(phase.actionLog[0]?.actor).toBe("red");
+	});
+
+	it("throws if initiative is not a permutation of red/green/blue", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		await expect(
+			runRound(game, "red", "hi", provider, undefined, [
+				"red",
+				"green",
+			] as AiId[]),
+		).rejects.toThrow(/permutation/);
+	});
+
+	it("throws if initiative contains duplicate AI ids", async () => {
+		const game = makeGame();
+		const provider = new MockLLMProvider('{"action":"pass"}');
+		await expect(
+			runRound(game, "red", "hi", provider, undefined, [
+				"red",
+				"red",
+				"blue",
+			] as AiId[]),
+		).rejects.toThrow(/permutation/);
 	});
 });

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -10,22 +10,17 @@
  */
 import { describe, expect, it } from "vitest";
 import {
-	encodeRoundResult,
-	type SseEvent,
-	splitIntoWordChunks,
-} from "../round-result-encoder";
-import {
 	createGame,
 	deductBudget,
 	getActivePhase,
 	startPhase,
-} from "../spa/game/engine";
-import type {
-	AiId,
-	AiPersona,
-	PhaseConfig,
-	RoundResult,
-} from "../spa/game/types";
+} from "../engine";
+import {
+	encodeRoundResult,
+	type SseEvent,
+	splitIntoWordChunks,
+} from "../round-result-encoder";
+import type { AiId, AiPersona, PhaseConfig, RoundResult } from "../types";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 

--- a/src/spa/game/__tests__/typing-rhythm.test.ts
+++ b/src/spa/game/__tests__/typing-rhythm.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { AI_TYPING_SPEED } from "../typing-rhythm";
+
+describe("AI_TYPING_SPEED", () => {
+	it("red types faster than green (red < green)", () => {
+		expect(AI_TYPING_SPEED.red).toBeLessThan(AI_TYPING_SPEED.green);
+	});
+
+	it("green types faster than blue (green < blue)", () => {
+		expect(AI_TYPING_SPEED.green).toBeLessThan(AI_TYPING_SPEED.blue);
+	});
+
+	it("all three AIs have distinct typing speeds", () => {
+		const speeds = [
+			AI_TYPING_SPEED.red,
+			AI_TYPING_SPEED.green,
+			AI_TYPING_SPEED.blue,
+		];
+		const unique = new Set(speeds);
+		expect(unique.size).toBe(3);
+	});
+});

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -1,0 +1,55 @@
+/**
+ * BrowserLLMProvider
+ *
+ * Adapts the browser-side `streamCompletion` (which uses `fetch` + SSE)
+ * to the `LLMProvider` interface expected by `runRound` / `GameSession`.
+ *
+ * The adapter bridges the callback-based `streamCompletion` into an
+ * `AsyncIterable<string>` by queuing tokens and resuming the generator
+ * via a shared resolve handle.
+ */
+
+import type { LLMProvider } from "../../proxy/llm-provider";
+import { streamCompletion } from "../llm-client.js";
+
+export class BrowserLLMProvider implements LLMProvider {
+	async *streamCompletion(prompt: string): AsyncIterable<string> {
+		const queue: string[] = [];
+		let resolveNext: (() => void) | null = null;
+		let done = false;
+		let err: unknown;
+
+		streamCompletion({
+			messages: [{ role: "system", content: prompt }],
+			onDelta: (text) => {
+				queue.push(text);
+				resolveNext?.();
+			},
+		}).then(
+			() => {
+				done = true;
+				resolveNext?.();
+			},
+			(e: unknown) => {
+				err = e;
+				done = true;
+				resolveNext?.();
+			},
+		);
+
+		while (true) {
+			if (queue.length > 0) {
+				const token = queue.shift();
+				if (token !== undefined) yield token;
+				continue;
+			}
+			if (done) {
+				if (err) throw err;
+				return;
+			}
+			await new Promise<void>((r) => {
+				resolveNext = r;
+			});
+		}
+	}
+}

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -6,14 +6,14 @@ import {
 	getActivePhase,
 	isAiLockedOut,
 	updateActivePhase,
-} from "./spa/game/engine";
+} from "./engine";
 import type {
 	ActionLogEntry,
 	AiId,
 	AiTurnAction,
 	GameState,
 	ToolCall,
-} from "./spa/game/types";
+} from "./types";
 
 export interface ValidationResult {
 	valid: boolean;

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -22,9 +22,9 @@
  */
 
 import type { LLMProvider } from "../../proxy/llm-provider";
-import type { ChatLockoutConfig } from "../../round-coordinator";
-import { runRound } from "../../round-coordinator";
 import { createGame, getActivePhase, startPhase } from "./engine";
+import type { ChatLockoutConfig } from "./round-coordinator";
+import { runRound } from "./round-coordinator";
 import type {
 	AiId,
 	AiPersona,
@@ -97,12 +97,15 @@ export class GameSession {
 	 * @param provider   LLM provider (mock or real).
 	 * @param chatLockoutConfig  Optional chat-lockout configuration for deterministic testing.
 	 *   When omitted, any config previously set via armChatLockout is consumed once.
+	 * @param initiative  Optional turn-order permutation for this round.
+	 *   Must be a permutation of all three AI ids. When absent, coordinator uses default order.
 	 */
 	async submitMessage(
 		addressed: AiId,
 		message: string,
 		provider: LLMProvider,
 		chatLockoutConfig?: ChatLockoutConfig,
+		initiative?: AiId[],
 	): Promise<SubmitMessageResult> {
 		let effectiveConfig = chatLockoutConfig;
 		if (!effectiveConfig && this.armedChatLockout) {
@@ -110,10 +113,12 @@ export class GameSession {
 			delete this.armedChatLockout;
 		}
 		// Wrap the provider to capture completions per call.
-		// The coordinator calls the provider once per non-locked AI in AI_ORDER
-		// (red, green, blue). Locked AIs are skipped by the coordinator, so
-		// the capture array may have fewer entries than 3.
+		// The coordinator calls the provider once per non-locked AI in turn order.
+		// Locked AIs are skipped by the coordinator, so the capture array may have
+		// fewer entries than 3.
 		const capturing = new CompletionCapturingProvider(provider);
+
+		const turnOrder = initiative ?? AI_ORDER;
 
 		const { nextState, result } = await runRound(
 			this.state,
@@ -121,15 +126,16 @@ export class GameSession {
 			message,
 			capturing,
 			effectiveConfig,
+			initiative,
 		);
 
 		// Map captured completions back to AI IDs.
-		// The coordinator processes AI_ORDER and skips locked-out AIs. We need
+		// The coordinator processes turnOrder and skips locked-out AIs. We need
 		// to match call-order index to AI ID accounting for lockouts.
 		const phaseBeforeRound = getActivePhase(this.state);
 		const completions: Partial<Record<AiId, string>> = {};
 		let captureIdx = 0;
-		for (const aiId of AI_ORDER) {
+		for (const aiId of turnOrder) {
 			if (phaseBeforeRound.lockedOut.has(aiId)) {
 				// This AI was skipped by the coordinator — no completion
 				completions[aiId] = "";

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -1,4 +1,4 @@
-import { getActivePhase } from "./spa/game/engine";
+import { getActivePhase } from "./engine";
 import type {
 	ActionLogEntry,
 	AiBudget,
@@ -7,7 +7,7 @@ import type {
 	GameState,
 	WhisperMessage,
 	WorldState,
-} from "./spa/game/types";
+} from "./types";
 
 export interface AiContext {
 	name: string;

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -13,9 +13,8 @@
  * before the round begins. Non-addressed AIs do not see the player message.
  */
 
-import { buildAiContext } from "./context-builder";
+import type { LLMProvider } from "../../proxy/llm-provider";
 import { dispatchAiTurn } from "./dispatcher";
-import type { LLMProvider } from "./proxy/llm-provider";
 import {
 	advancePhase,
 	advanceRound,
@@ -25,7 +24,8 @@ import {
 	isAiLockedOut,
 	resolveChatLockouts,
 	triggerChatLockout,
-} from "./spa/game/engine";
+} from "./engine";
+import { buildAiContext } from "./prompt-builder";
 import type {
 	ActionLogEntry,
 	AiId,
@@ -33,7 +33,7 @@ import type {
 	GameState,
 	RoundResult,
 	ToolName,
-} from "./spa/game/types";
+} from "./types";
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
 
@@ -156,6 +156,8 @@ async function collectCompletion(
  * @param chatLockoutConfig  Optional config for the mid-phase chat-lockout event.
  *   When provided, the coordinator will trigger a lockout at `lockoutTriggerRound`
  *   using `rng` to select which AI to lock, lasting `lockoutDuration` rounds.
+ * @param initiative  Optional turn-order permutation. Must be a permutation of
+ *   all three AI ids ["red","green","blue"]. When absent, defaults to AI_ORDER.
  */
 export async function runRound(
 	game: GameState,
@@ -163,7 +165,24 @@ export async function runRound(
 	playerMessage: string,
 	provider: LLMProvider,
 	chatLockoutConfig?: ChatLockoutConfig,
+	initiative?: AiId[],
 ): Promise<RunRoundResult> {
+	// Validate initiative if provided.
+	if (initiative !== undefined) {
+		const sorted = [...initiative].sort();
+		const expected = [...AI_ORDER].sort();
+		if (
+			sorted.length !== expected.length ||
+			sorted.some((id, i) => id !== expected[i])
+		) {
+			throw new Error(
+				`initiative must be a permutation of ["red","green","blue"], got: ${JSON.stringify(initiative)}`,
+			);
+		}
+	}
+
+	const turnOrder = initiative ?? AI_ORDER;
+
 	// 1. Record player message in the addressed AI's history
 	let state = appendChat(game, addressed, {
 		role: "player",
@@ -177,7 +196,7 @@ export async function runRound(
 	const roundActions: ActionLogEntry[] = [];
 
 	// 2. Each AI acts in turn
-	for (const aiId of AI_ORDER) {
+	for (const aiId of turnOrder) {
 		if (isAiLockedOut(state, aiId)) {
 			// Emit lockout line — no LLM call, no budget deduction.
 			// Use getActivePhase(state).round for consistency with dispatchAiTurn,

--- a/src/spa/game/round-result-encoder.ts
+++ b/src/spa/game/round-result-encoder.ts
@@ -26,12 +26,7 @@
  *   game_ended     — { type }
  */
 
-import type {
-	AiId,
-	AiPersona,
-	PhaseState,
-	RoundResult,
-} from "./spa/game/types";
+import type { AiId, AiPersona, PhaseState, RoundResult } from "./types";
 
 /**
  * A single structured SSE event ready to be serialised as

--- a/src/spa/game/typing-rhythm.ts
+++ b/src/spa/game/typing-rhythm.ts
@@ -1,0 +1,14 @@
+import type { AiId } from "./types";
+
+/**
+ * Per-AI multipliers on TOKEN_PACE_MS to give each AI a distinct typing rhythm.
+ * Lower = faster. Red is impulsive, blue is deliberate, green sits between.
+ */
+export const AI_TYPING_SPEED: Record<AiId, number> = {
+	red: 0.7,
+	green: 1.0,
+	blue: 1.4,
+};
+
+/** Base pace between token emissions in milliseconds. */
+export const TOKEN_PACE_MS = 60;

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -11,17 +11,48 @@
 		  <button id="byok-cog" type="button" aria-label="Settings" title="Settings">⚙</button>
 		</header>
 		<main>
+		  <div id="panels">
+		    <article class="ai-panel" data-ai="red">
+		      <header class="panel-header">
+		        <span class="panel-name"></span>
+		        <span class="panel-budget" data-budget=""></span>
+		      </header>
+		      <div class="transcript" data-transcript="red"></div>
+		    </article>
+		    <article class="ai-panel" data-ai="green">
+		      <header class="panel-header">
+		        <span class="panel-name"></span>
+		        <span class="panel-budget" data-budget=""></span>
+		      </header>
+		      <div class="transcript" data-transcript="green"></div>
+		    </article>
+		    <article class="ai-panel" data-ai="blue">
+		      <header class="panel-header">
+		        <span class="panel-name"></span>
+		        <span class="panel-budget" data-budget=""></span>
+		      </header>
+		      <div class="transcript" data-transcript="blue"></div>
+		    </article>
+		  </div>
 		  <form id="composer">
+		    <select id="address" aria-label="Address AI">
+		      <option value="red">Ember (red)</option>
+		      <option value="green">Sage (green)</option>
+		      <option value="blue">Frost (blue)</option>
+		    </select>
 		    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
 		    <button id="send" type="submit">Send</button>
 		  </form>
-		  <pre id="output"></pre>
 		  <section id="cap-hit" hidden>
 		    <h2>the AIs are sleeping</h2>
 		    <pre class="cap-hit-body">the AIs are sleeping.
 come back tomorrow — they wake at midnight UTC.</pre>
 		    <p class="cap-hit-byok"><a href="#/byok" data-byok-placeholder>or paste your own OpenRouter key to keep playing — coming soon.</a></p>
 		  </section>
+		  <aside id="action-log" hidden>
+		    <h3>Action Log (debug)</h3>
+		    <ul id="action-log-list"></ul>
+		  </aside>
 		</main>
 		<dialog id="byok-dialog" aria-labelledby="byok-title">
 		  <form method="dialog" id="byok-form">

--- a/src/spa/main.ts
+++ b/src/spa/main.ts
@@ -2,10 +2,9 @@ import "./styles.css";
 import { initByokModal } from "./byok-modal.js";
 import { registerRoute, start } from "./router.js";
 import { renderGame } from "./routes/game.js";
-import { renderHome } from "./routes/home.js";
 
-registerRoute("#/", (root) => renderHome(root));
-registerRoute("#/game", (root) => renderGame(root));
+registerRoute("#/", (root, params) => renderGame(root, params));
+registerRoute("#/game", (root, params) => renderGame(root, params));
 
 start();
 initByokModal();

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1,60 +1,230 @@
-import { PERSONAS } from "../../content";
-import {
-	createSingleAiSession,
-	runSingleAiRound,
-	type SingleAiSession,
-} from "../game/game-loop.js";
+import { PERSONAS, PHASE_1_CONFIG } from "../../content";
+import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
+import { getActivePhase } from "../game/engine.js";
+import { GameSession } from "../game/game-session.js";
+import { encodeRoundResult } from "../game/round-result-encoder.js";
+import type { AiId } from "../game/types";
+import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";
+import { CapHitError } from "../llm-client.js";
 
-let session: SingleAiSession | null = null;
+const AI_ORDER: AiId[] = ["red", "green", "blue"];
 
-export function renderGame(root: HTMLElement): void {
-	const form = root.ownerDocument.querySelector<HTMLFormElement>("#composer");
-	const promptInput =
-		root.ownerDocument.querySelector<HTMLInputElement>("#prompt");
-	const sendBtn = root.ownerDocument.querySelector<HTMLButtonElement>("#send");
-	const outputEl = root.ownerDocument.querySelector<HTMLPreElement>("#output");
-	if (!form || !promptInput || !sendBtn || !outputEl) return;
+/** Fisher-Yates shuffle (returns a new array). */
+function shuffle<T>(arr: T[]): T[] {
+	const out = [...arr];
+	for (let i = out.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		const tmp = out[i] as T;
+		out[i] = out[j] as T;
+		out[j] = tmp;
+	}
+	return out;
+}
 
-	if (!session) session = createSingleAiSession(PERSONAS.blue);
+let session: GameSession | null = null;
 
-	form.addEventListener("submit", (evt) => {
+export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
+	const doc = root.ownerDocument;
+	const form = doc.querySelector<HTMLFormElement>("#composer");
+	const promptInput = doc.querySelector<HTMLInputElement>("#prompt");
+	const sendBtn = doc.querySelector<HTMLButtonElement>("#send");
+	const addressSelect = doc.querySelector<HTMLSelectElement>("#address");
+	const capHitEl = doc.querySelector<HTMLElement>("#cap-hit");
+	const actionLogEl = doc.querySelector<HTMLElement>("#action-log");
+	const actionLogList = doc.querySelector<HTMLUListElement>("#action-log-list");
+
+	if (!form || !promptInput || !sendBtn || !addressSelect) return;
+
+	// Lazy-init session
+	if (!session) {
+		session = new GameSession(PHASE_1_CONFIG, PERSONAS);
+	}
+
+	// Populate panel headers from PERSONAS so renames don't require HTML edits
+	for (const aiId of AI_ORDER) {
+		const panel = doc.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
+		if (!panel) continue;
+		const nameEl = panel.querySelector<HTMLSpanElement>(".panel-name");
+		const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
+		const persona = PERSONAS[aiId];
+		if (nameEl) nameEl.textContent = persona.name;
+		const phase = getActivePhase(session.getState());
+		if (budgetEl) {
+			const budget = phase.budgets[aiId];
+			budgetEl.dataset.budget = String(budget.remaining);
+			budgetEl.textContent = `${budget.remaining}/${budget.total}`;
+		}
+	}
+
+	// Debug toggle: show action log if ?debug=1
+	const debug = params?.get("debug") === "1";
+	if (actionLogEl) {
+		if (debug) {
+			actionLogEl.removeAttribute("hidden");
+		} else {
+			actionLogEl.setAttribute("hidden", "");
+		}
+	}
+
+	// Helper: get transcript element for an AI
+	function getTranscript(aiId: AiId): HTMLElement | null {
+		return doc.querySelector<HTMLElement>(`[data-transcript="${aiId}"]`);
+	}
+
+	// Helper: append text to a transcript
+	function appendToTranscript(aiId: AiId, text: string): void {
+		const el = getTranscript(aiId);
+		if (el) el.textContent += text;
+	}
+
+	// Helper: pace token emission
+	function pace(aiId: AiId): Promise<void> {
+		const ms = TOKEN_PACE_MS * AI_TYPING_SPEED[aiId] * (0.5 + Math.random());
+		return new Promise((r) => setTimeout(r, ms));
+	}
+
+	// Helper: update budget display
+	function updateBudget(aiId: AiId, remaining: number): void {
+		const panel = doc.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
+		if (!panel) return;
+		const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
+		if (!budgetEl) return;
+		// session is guaranteed non-null here (checked at top of renderGame)
+		const currentSession = session;
+		if (!currentSession) return;
+		const phase = getActivePhase(currentSession.getState());
+		const total = phase.budgets[aiId]?.total ?? 5;
+		budgetEl.dataset.budget = String(remaining);
+		budgetEl.textContent = `${remaining}/${total}`;
+	}
+
+	// Helper: update chat lockout status in dropdown
+	function setChatLockout(aiId: AiId, locked: boolean): void {
+		const option = addressSelect?.querySelector<HTMLOptionElement>(
+			`option[value="${aiId}"]`,
+		);
+		if (option) option.disabled = locked;
+	}
+
+	form.addEventListener("submit", async (evt) => {
 		evt.preventDefault();
 		const message = promptInput.value.trim();
 		if (!message || !session) return;
+
+		const addressed = addressSelect.value as AiId;
 		promptInput.value = "";
 		sendBtn.disabled = true;
 
-		// Append the user's turn + a fresh AI label (don't clear — accumulate transcript)
-		outputEl.textContent += `\n[you] ${message}\n[${session.persona.name}] `;
+		// Append player's message to the addressed panel
+		appendToTranscript(addressed, `\n[you] ${message}\n`);
 
-		// Show "thinking…" placeholder while waiting for first content delta
-		const placeholderStart = outputEl.textContent.length;
-		outputEl.textContent += "thinking…";
+		// Show a global "thinking…" placeholder in the addressed panel while
+		// the round runs (round-coordinator buffers all three AI responses
+		// before the encoder splits them into per-panel token events).
+		const addressedTranscript = getTranscript(addressed);
+		const placeholderStart = addressedTranscript?.textContent?.length ?? 0;
+		if (addressedTranscript) addressedTranscript.textContent += "thinking…";
 		let placeholderShown = true;
+		const stripPlaceholder = (): void => {
+			if (!placeholderShown || !addressedTranscript) return;
+			addressedTranscript.textContent =
+				(addressedTranscript.textContent ?? "").slice(0, placeholderStart);
+			placeholderShown = false;
+		};
 
-		runSingleAiRound({
-			session,
-			message,
-			onDelta: (text) => {
-				if (placeholderShown) {
-					outputEl.textContent = outputEl.textContent.slice(
-						0,
-						placeholderStart,
-					);
-					placeholderShown = false;
+		// Roll initiative for this round
+		const initiative = shuffle(AI_ORDER);
+
+		try {
+			const provider = new BrowserLLMProvider();
+			const { result, completions, nextState } = await session.submitMessage(
+				addressed,
+				message,
+				provider,
+				undefined,
+				initiative,
+			);
+
+			stripPlaceholder();
+
+			const phaseAfter = getActivePhase(nextState);
+			const events = encodeRoundResult(
+				result,
+				completions,
+				phaseAfter,
+				nextState.personas,
+			);
+
+			let speakingAi: AiId | null = null;
+
+			for (const event of events) {
+				switch (event.type) {
+					case "ai_start":
+						speakingAi = event.aiId;
+						appendToTranscript(event.aiId, `[${PERSONAS[event.aiId].name}] `);
+						break;
+
+					case "token":
+						if (speakingAi) {
+							appendToTranscript(speakingAi, event.text);
+							await pace(speakingAi);
+						}
+						break;
+
+					case "ai_end":
+						if (speakingAi) {
+							appendToTranscript(speakingAi, "\n");
+						}
+						speakingAi = null;
+						break;
+
+					case "budget":
+						updateBudget(event.aiId, event.remaining);
+						break;
+
+					case "lockout":
+						appendToTranscript(event.aiId, `[${event.content}]\n`);
+						break;
+
+					case "chat_lockout":
+						setChatLockout(event.aiId, true);
+						break;
+
+					case "chat_lockout_resolved":
+						setChatLockout(event.aiId, false);
+						break;
+
+					case "action_log":
+						// Always accumulate in the DOM (even if hidden) so ?debug=1 shows history
+						if (actionLogList) {
+							const li = doc.createElement("li");
+							li.textContent = `[Round ${event.entry.round}] ${event.entry.description}`;
+							actionLogList.appendChild(li);
+						}
+						break;
+
+					case "phase_advanced":
+						// TODO(#45): phase progression UI
+						break;
+
+					case "game_ended":
+						sendBtn.disabled = true;
+						promptInput.disabled = true;
+						break;
 				}
-				outputEl.textContent += text;
-			},
-			onReasoning: () => {
-				// Keep the placeholder visible while only reasoning deltas arrive
-			},
-		}).finally(() => {
-			// If no content deltas arrived at all, strip the placeholder
-			if (placeholderShown) {
-				outputEl.textContent = outputEl.textContent.slice(0, placeholderStart);
-				placeholderShown = false;
 			}
+		} catch (err) {
+			stripPlaceholder();
+			if (err instanceof CapHitError && capHitEl) {
+				capHitEl.removeAttribute("hidden");
+			}
+		} finally {
+			stripPlaceholder();
 			sendBtn.disabled = false;
-		});
+		}
 	});
 }

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -131,8 +131,9 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		let placeholderShown = true;
 		const stripPlaceholder = (): void => {
 			if (!placeholderShown || !addressedTranscript) return;
-			addressedTranscript.textContent =
-				(addressedTranscript.textContent ?? "").slice(0, placeholderStart);
+			addressedTranscript.textContent = (
+				addressedTranscript.textContent ?? ""
+			).slice(0, placeholderStart);
 			placeholderShown = false;
 		};
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -48,17 +48,104 @@ main {
 	cursor: not-allowed;
 }
 
-#output {
-	white-space: pre-wrap;
-	word-break: break-word;
-	font-family: monospace;
-	font-size: 0.9rem;
-	line-height: 1.5;
-	padding: 1rem;
-	background: #f8f8f8;
+/* Three-AI chat panels */
+#panels {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1rem;
+}
+
+.ai-panel {
+	display: flex;
+	flex-direction: column;
 	border: 1px solid #ddd;
 	border-radius: 4px;
-	min-height: 4rem;
+	overflow: hidden;
+}
+
+.panel-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.4rem 0.75rem;
+	font-size: 0.85rem;
+	font-weight: bold;
+	color: #fff;
+}
+
+.ai-panel[data-ai="red"] .panel-header {
+	background: #b83232;
+}
+
+.ai-panel[data-ai="green"] .panel-header {
+	background: #2e7a3e;
+}
+
+.ai-panel[data-ai="blue"] .panel-header {
+	background: #2458a0;
+}
+
+.panel-budget {
+	font-weight: normal;
+	font-size: 0.8rem;
+	opacity: 0.9;
+}
+
+.transcript {
+	flex: 1;
+	overflow-y: auto;
+	padding: 0.75rem;
+	background: #f8f8f8;
+	font-family: monospace;
+	font-size: 0.85rem;
+	line-height: 1.5;
+	min-height: 10rem;
+	max-height: 30rem;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+/* Action log (hidden by default; visible behind ?debug=1) */
+#action-log {
+	margin-top: 1rem;
+	padding: 0.75rem;
+	background: #1a1a1a;
+	color: #a8d8a8;
+	border: 1px solid #333;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 0.8rem;
+}
+
+#action-log h3 {
+	margin: 0 0 0.5rem;
+	font-size: 0.85rem;
+	color: #d8d8a8;
+}
+
+#action-log-list {
+	margin: 0;
+	padding-left: 1.2rem;
+	list-style: disc;
+}
+
+#action-log-list li {
+	margin-bottom: 0.25rem;
+}
+
+/* Address select */
+#address {
+	padding: 0.5rem 0.75rem;
+	font-size: 1rem;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	background: #fff;
+}
+
+@media (max-width: 700px) {
+	#panels {
+		grid-template-columns: 1fr;
+	}
 }
 
 #cap-hit {
@@ -103,7 +190,7 @@ main {
 }
 
 [hidden] {
-	display: none !important;
+	display: none;
 }
 
 header {


### PR DESCRIPTION
## What this fixes

Completes the browser-side game-loop migration started in #42. Moves the deterministic core of round coordination — `dispatcher`, `round-coordinator`, `round-result-encoder`, and `context-builder` (renamed `prompt-builder`) — out of the worker-shared root and into `src/spa/game/`, where the browser now owns them. The SPA's game route is rewritten to drive a full three-AI round through `GameSession` + `encodeRoundResult` rather than the old single-AI loop, and the chat surface becomes three independently scrolling panels rendered from `PERSONAS`.

A few new pieces glue the SPA to the deterministic core:

- `src/spa/game/typing-rhythm.ts` exposes `AI_TYPING_SPEED` + `TOKEN_PACE_MS` so both the browser and the legacy worker (`src/proxy/_smoke.ts`) share one definition of per-AI pacing.
- `src/spa/game/browser-llm-provider.ts` adapts the SPA's existing callback-based `streamCompletion` to the `LLMProvider` async-iterable interface that `runRound` expects.
- `runRound` (and `GameSession.submitMessage`) gain an optional `initiative?: AiId[]` parameter, validated as a permutation of red/green/blue. `routes/game.ts` rolls a fresh Fisher-Yates permutation per round, so AIs no longer always go red→green→blue.
- The action log is rendered into `<aside id="action-log" hidden>`; the route flips `hidden` based on `URLSearchParams.get("debug") === "1"`. A second commit (`bba3169`) plumbs `URLSearchParams` from the router through `main.ts` so the toggle actually reaches the renderer.

The round-coordinator already wired chat-lockout and budget-exhaustion events through `encodeRoundResult`; the SPA route now translates each event into a DOM op (disable address-dropdown option, append in-character lockout line, decrement `[data-budget]`).

## QA steps for the human

The automated suite covers the deterministic flow end-to-end (initiative ordering at the unit level, three-panel rendering at the SPA level). Eyes-on-screen checks worth running with a real LLM:

- Open the deployed SPA and confirm three panels render with persona names + budgets, all three respond per round, and panel scrolling is independent.
- Hit `#/game?debug=1` and confirm the action-log panel appears with cumulative entries; remove the param and confirm it disappears (existing entries persist in the DOM, just hidden).
- Burn through one AI's budget and confirm the in-character lockout line surfaces in *that* AI's panel only; address-dropdown disables/re-enables on chat-lockout events.
- Watch token pacing and confirm red types fastest, blue slowest, with mild jitter — not all-at-once.

## Automated coverage

`pnpm typecheck`, `pnpm lint`, `pnpm test` (25 files / 477 tests), and `pnpm build` all pass on `claude/ralph-one-issue-43-wSEdY`. The four migrated pure-function test files run from their new locations under `src/spa/game/__tests__/` with assertions unchanged.

Closes #43

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmkWaNgULYJMFtX5GpRY4i)_