### PR TITLE
Tool calls end-to-end browser-side

### DIFF
--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -7,8 +7,11 @@ import {
 } from "../session-store";
 import { getActivePhase } from "../spa/game/engine";
 import type { GameSession } from "../spa/game/game-session";
+import type {
+	OpenAiMessage,
+	RoundLLMProvider,
+} from "../spa/game/round-llm-provider";
 import { encodeRoundResult } from "../spa/game/round-result-encoder";
-import type { OpenAiMessage, RoundLLMProvider } from "../spa/game/round-llm-provider";
 import type { AiId, PhaseConfig } from "../spa/game/types";
 import { AI_TYPING_SPEED } from "../spa/game/typing-rhythm";
 import {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -8,6 +8,7 @@ import {
 import { getActivePhase } from "../spa/game/engine";
 import type { GameSession } from "../spa/game/game-session";
 import { encodeRoundResult } from "../spa/game/round-result-encoder";
+import type { OpenAiMessage, RoundLLMProvider } from "../spa/game/round-llm-provider";
 import type { AiId, PhaseConfig } from "../spa/game/types";
 import { AI_TYPING_SPEED } from "../spa/game/typing-rhythm";
 import {
@@ -15,10 +16,24 @@ import {
 	parseAllowedOrigins,
 	withCorsHeaders,
 } from "./cors";
-import type { LLMProvider } from "./llm-provider";
-import { MockLLMProvider } from "./llm-provider";
 import { handleChatCompletions } from "./openai-proxy";
 import { renderChatPage, renderEndgamePage } from "./ui";
+
+/** Simple server-side mock that returns a canned assistant text per round. */
+class ServerMockRoundProvider implements RoundLLMProvider {
+	private readonly response: string;
+
+	constructor(response: string) {
+		this.response = response;
+	}
+
+	async streamRound(
+		_messages: OpenAiMessage[],
+		_tools: unknown[],
+	): Promise<{ assistantText: string; toolCalls: [] }> {
+		return { assistantText: this.response, toolCalls: [] };
+	}
+}
 
 /** Shape of the bindings/env this Worker expects. */
 interface Env {
@@ -54,14 +69,8 @@ interface Env {
 	ALLOWED_ORIGINS?: string;
 }
 
-function createProvider(env: Env): LLMProvider {
-	if (env.LLM_PROVIDER === "anthropic") {
-		// Not yet wired — needs dynamic import + ANTHROPIC_API_KEY before use.
-		throw new Error(
-			"Anthropic provider not yet wired; set LLM_PROVIDER=mock or wire AnthropicProvider dynamically",
-		);
-	}
-	return new MockLLMProvider(
+function createProvider(_env: Env): RoundLLMProvider {
+	return new ServerMockRoundProvider(
 		"Hello! I am an AI assistant. How can I help you?",
 	);
 }

--- a/src/spa/__tests__/llm-client.test.ts
+++ b/src/spa/__tests__/llm-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PINNED_MODEL } from "../../model.js";
+import { TOOL_DEFINITIONS } from "../game/tool-registry.js";
 import {
 	CapHitError,
 	PERSONA_PLACEHOLDER,
@@ -8,7 +9,6 @@ import {
 	streamChat,
 	streamCompletion,
 } from "../llm-client.js";
-import { TOOL_DEFINITIONS } from "../game/tool-registry.js";
 
 // Provide __WORKER_BASE_URL__ global before importing the module
 // biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
@@ -549,9 +549,7 @@ describe("streamCompletion — tools field", () => {
 
 		const mockFetch = vi
 			.fn()
-			.mockResolvedValue(
-				makeFetchResponse(makeSSEStream([toolCallChunk])),
-			);
+			.mockResolvedValue(makeFetchResponse(makeSSEStream([toolCallChunk])));
 		vi.stubGlobal("fetch", mockFetch);
 		vi.stubGlobal("localStorage", {
 			getItem: vi.fn().mockReturnValue(null),

--- a/src/spa/__tests__/llm-client.test.ts
+++ b/src/spa/__tests__/llm-client.test.ts
@@ -8,6 +8,7 @@ import {
 	streamChat,
 	streamCompletion,
 } from "../llm-client.js";
+import { TOOL_DEFINITIONS } from "../game/tool-registry.js";
 
 // Provide __WORKER_BASE_URL__ global before importing the module
 // biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
@@ -396,6 +397,180 @@ describe("streamChat", () => {
 		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
 		expect(JSON.parse(init.body as string).model).toBe("z-ai/glm-4.7-flash");
 		expect(JSON.parse(init.body as string).model).toBe(PINNED_MODEL);
+	});
+});
+
+describe("streamCompletion — tools field", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("includes tools and tool_choice:auto in the request body when tools are provided", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta: vi.fn(),
+			tools: TOOL_DEFINITIONS,
+		});
+
+		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		const body = JSON.parse(init.body as string);
+		expect(body.tools).toEqual(TOOL_DEFINITIONS);
+		expect(body.tool_choice).toBe("auto");
+	});
+
+	it("omits tools and tool_choice when no tools are provided", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta: vi.fn(),
+		});
+
+		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		const body = JSON.parse(init.body as string);
+		expect(body).not.toHaveProperty("tools");
+		expect(body).not.toHaveProperty("tool_choice");
+	});
+
+	it("omits tools and tool_choice when an empty tools array is provided", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta: vi.fn(),
+			tools: [],
+		});
+
+		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		const body = JSON.parse(init.body as string);
+		expect(body).not.toHaveProperty("tools");
+		expect(body).not.toHaveProperty("tool_choice");
+	});
+
+	it("BYOK path sends tools identically to the worker-proxy path", async () => {
+		// Worker path
+		const mockFetchWorker = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetchWorker);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta: vi.fn(),
+			tools: TOOL_DEFINITIONS,
+		});
+
+		const [, initWorker] = mockFetchWorker.mock.calls[0] as [
+			string,
+			RequestInit,
+		];
+		const bodyWorker = JSON.parse(initWorker.body as string);
+
+		// BYOK path
+		const mockFetchByok = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([`data: [DONE]\n\n`])),
+			);
+		vi.stubGlobal("fetch", mockFetchByok);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue("sk-byok-key"),
+		});
+
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta: vi.fn(),
+			tools: TOOL_DEFINITIONS,
+		});
+
+		const [, initByok] = mockFetchByok.mock.calls[0] as [string, RequestInit];
+		const bodyByok = JSON.parse(initByok.body as string);
+
+		// Both paths should send the same tools
+		expect(bodyWorker.tools).toEqual(TOOL_DEFINITIONS);
+		expect(bodyByok.tools).toEqual(TOOL_DEFINITIONS);
+		expect(bodyWorker.tool_choice).toBe("auto");
+		expect(bodyByok.tool_choice).toBe("auto");
+	});
+
+	it("onToolCall is plumbed through when tool_calls are in the stream", async () => {
+		const toolCallChunk = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [
+							{
+								index: 0,
+								id: "call_test",
+								type: "function",
+								function: { name: "pick_up", arguments: '{"item":"flower"}' },
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+		})}\n\ndata: [DONE]\n\n`;
+
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValue(
+				makeFetchResponse(makeSSEStream([toolCallChunk])),
+			);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", {
+			getItem: vi.fn().mockReturnValue(null),
+		});
+
+		const onToolCall = vi.fn();
+		await streamCompletion({
+			messages: [{ role: "user", content: "hello" }],
+			onDelta: vi.fn(),
+			tools: TOOL_DEFINITIONS,
+			onToolCall,
+		});
+
+		expect(onToolCall).toHaveBeenCalledTimes(1);
+		expect(onToolCall).toHaveBeenCalledWith({
+			id: "call_test",
+			name: "pick_up",
+			argumentsJson: '{"item":"flower"}',
+		});
 	});
 });
 

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -123,7 +123,12 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 				{
 					delta: {
 						tool_calls: [
-							{ index: 0, id: "call_abc", type: "function", function: { name: "pick_up", arguments: "" } },
+							{
+								index: 0,
+								id: "call_abc",
+								type: "function",
+								function: { name: "pick_up", arguments: "" },
+							},
 						],
 					},
 				},
@@ -171,8 +176,18 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 				{
 					delta: {
 						tool_calls: [
-							{ index: 0, id: "call_1", type: "function", function: { name: "pick_up", arguments: '{"item":"flower"}' } },
-							{ index: 1, id: "call_2", type: "function", function: { name: "put_down", arguments: '{"item":"key"}' } },
+							{
+								index: 0,
+								id: "call_1",
+								type: "function",
+								function: { name: "pick_up", arguments: '{"item":"flower"}' },
+							},
+							{
+								index: 1,
+								id: "call_2",
+								type: "function",
+								function: { name: "put_down", arguments: '{"item":"key"}' },
+							},
 						],
 					},
 					finish_reason: "tool_calls",
@@ -181,11 +196,8 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 		})}\n\ndata: [DONE]\n\n`;
 
 		const calls: ToolCallResult[] = [];
-		await parseSSEStream(
-			makeSSEStream([chunk]),
-			vi.fn(),
-			undefined,
-			(c) => calls.push(c),
+		await parseSSEStream(makeSSEStream([chunk]), vi.fn(), undefined, (c) =>
+			calls.push(c),
 		);
 
 		expect(calls).toHaveLength(2);
@@ -217,7 +229,12 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 					{
 						delta: {
 							tool_calls: [
-								{ index: 0, id: "call_x", type: "function", function: { name: "pick_up", arguments: '{"item":"flower"}' } },
+								{
+									index: 0,
+									id: "call_x",
+									type: "function",
+									function: { name: "pick_up", arguments: '{"item":"flower"}' },
+								},
 							],
 						},
 						finish_reason: "tool_calls",
@@ -242,27 +259,27 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 
 	it("finish_reason:tool_calls flushes a partial (incomplete arguments) call", async () => {
 		// The model may emit finish_reason before [DONE]
-		const sseData =
-			`data: ${JSON.stringify({
-				choices: [
-					{
-						delta: {
-							tool_calls: [
-								{ index: 0, id: "call_y", type: "function", function: { name: "use", arguments: '{"item":"wand"}' } },
-							],
-						},
-						finish_reason: "tool_calls",
+		const sseData = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [
+							{
+								index: 0,
+								id: "call_y",
+								type: "function",
+								function: { name: "use", arguments: '{"item":"wand"}' },
+							},
+						],
 					},
-				],
-			})}\n\n` +
-			`data: [DONE]\n\n`;
+					finish_reason: "tool_calls",
+				},
+			],
+		})}\n\ndata: [DONE]\n\n`;
 
 		const calls: ToolCallResult[] = [];
-		await parseSSEStream(
-			makeSSEStream([sseData]),
-			vi.fn(),
-			undefined,
-			(c) => calls.push(c),
+		await parseSSEStream(makeSSEStream([sseData]), vi.fn(), undefined, (c) =>
+			calls.push(c),
 		);
 
 		expect(calls).toHaveLength(1);
@@ -271,26 +288,29 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 	});
 
 	it("[DONE] flushes assembled tool calls even without finish_reason:tool_calls", async () => {
-		const sseData =
-			`data: ${JSON.stringify({
-				choices: [
-					{
-						delta: {
-							tool_calls: [
-								{ index: 0, id: "call_z", type: "function", function: { name: "give", arguments: '{"item":"key","to":"blue"}' } },
-							],
-						},
+		const sseData = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [
+							{
+								index: 0,
+								id: "call_z",
+								type: "function",
+								function: {
+									name: "give",
+									arguments: '{"item":"key","to":"blue"}',
+								},
+							},
+						],
 					},
-				],
-			})}\n\n` +
-			`data: [DONE]\n\n`;
+				},
+			],
+		})}\n\ndata: [DONE]\n\n`;
 
 		const calls: ToolCallResult[] = [];
-		await parseSSEStream(
-			makeSSEStream([sseData]),
-			vi.fn(),
-			undefined,
-			(c) => calls.push(c),
+		await parseSSEStream(makeSSEStream([sseData]), vi.fn(), undefined, (c) =>
+			calls.push(c),
 		);
 
 		expect(calls).toHaveLength(1);

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallResult } from "../streaming.js";
 import { parseSSEStream } from "../streaming.js";
 
 // __WORKER_BASE_URL__ is a build-time constant; provide a stub for tests
@@ -107,5 +108,192 @@ describe("parseSSEStream", () => {
 
 		expect(onDelta).toHaveBeenCalledTimes(1);
 		expect(onDelta).toHaveBeenCalledWith("hi");
+	});
+});
+
+describe("parseSSEStream — tool_call delta assembly", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("assembles a single tool call across three SSE chunks", async () => {
+		// Chunk 1: first fragment with id and name
+		const chunk1 = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [
+							{ index: 0, id: "call_abc", type: "function", function: { name: "pick_up", arguments: "" } },
+						],
+					},
+				},
+			],
+		})}\n\n`;
+		// Chunk 2: more arguments
+		const chunk2 = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [{ index: 0, function: { arguments: '{"item' } }],
+					},
+				},
+			],
+		})}\n\n`;
+		// Chunk 3: finish arguments and finish_reason
+		const chunk3 = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [{ index: 0, function: { arguments: '":"flower"}' } }],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+		})}\n\ndata: [DONE]\n\n`;
+
+		const calls: ToolCallResult[] = [];
+		await parseSSEStream(
+			makeSSEStream([chunk1, chunk2, chunk3]),
+			vi.fn(),
+			undefined,
+			(c) => calls.push(c),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.id).toBe("call_abc");
+		expect(calls[0]?.name).toBe("pick_up");
+		expect(calls[0]?.argumentsJson).toBe('{"item":"flower"}');
+	});
+
+	it("assembles two distinct tool calls (index:0 and index:1)", async () => {
+		const chunk = `data: ${JSON.stringify({
+			choices: [
+				{
+					delta: {
+						tool_calls: [
+							{ index: 0, id: "call_1", type: "function", function: { name: "pick_up", arguments: '{"item":"flower"}' } },
+							{ index: 1, id: "call_2", type: "function", function: { name: "put_down", arguments: '{"item":"key"}' } },
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+		})}\n\ndata: [DONE]\n\n`;
+
+		const calls: ToolCallResult[] = [];
+		await parseSSEStream(
+			makeSSEStream([chunk]),
+			vi.fn(),
+			undefined,
+			(c) => calls.push(c),
+		);
+
+		expect(calls).toHaveLength(2);
+		expect(calls[0]?.name).toBe("pick_up");
+		expect(calls[1]?.name).toBe("put_down");
+	});
+
+	it("content-only response does not invoke onToolCall", async () => {
+		const sseData =
+			`data: ${JSON.stringify({ choices: [{ delta: { content: "hello" } }] })}\n\n` +
+			`data: [DONE]\n\n`;
+
+		const onToolCall = vi.fn();
+		await parseSSEStream(
+			makeSSEStream([sseData]),
+			vi.fn(),
+			undefined,
+			onToolCall,
+		);
+
+		expect(onToolCall).not.toHaveBeenCalled();
+	});
+
+	it("content + tool_call response invokes both onDelta and onToolCall", async () => {
+		const sseData =
+			`data: ${JSON.stringify({ choices: [{ delta: { content: "I'll pick it up" } }] })}\n\n` +
+			`data: ${JSON.stringify({
+				choices: [
+					{
+						delta: {
+							tool_calls: [
+								{ index: 0, id: "call_x", type: "function", function: { name: "pick_up", arguments: '{"item":"flower"}' } },
+							],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
+			})}\n\n` +
+			`data: [DONE]\n\n`;
+
+		const deltas: string[] = [];
+		const calls: ToolCallResult[] = [];
+		await parseSSEStream(
+			makeSSEStream([sseData]),
+			(t) => deltas.push(t),
+			undefined,
+			(c) => calls.push(c),
+		);
+
+		expect(deltas).toEqual(["I'll pick it up"]);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("pick_up");
+	});
+
+	it("finish_reason:tool_calls flushes a partial (incomplete arguments) call", async () => {
+		// The model may emit finish_reason before [DONE]
+		const sseData =
+			`data: ${JSON.stringify({
+				choices: [
+					{
+						delta: {
+							tool_calls: [
+								{ index: 0, id: "call_y", type: "function", function: { name: "use", arguments: '{"item":"wand"}' } },
+							],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
+			})}\n\n` +
+			`data: [DONE]\n\n`;
+
+		const calls: ToolCallResult[] = [];
+		await parseSSEStream(
+			makeSSEStream([sseData]),
+			vi.fn(),
+			undefined,
+			(c) => calls.push(c),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("use");
+		expect(calls[0]?.argumentsJson).toBe('{"item":"wand"}');
+	});
+
+	it("[DONE] flushes assembled tool calls even without finish_reason:tool_calls", async () => {
+		const sseData =
+			`data: ${JSON.stringify({
+				choices: [
+					{
+						delta: {
+							tool_calls: [
+								{ index: 0, id: "call_z", type: "function", function: { name: "give", arguments: '{"item":"key","to":"blue"}' } },
+							],
+						},
+					},
+				],
+			})}\n\n` +
+			`data: [DONE]\n\n`;
+
+		const calls: ToolCallResult[] = [];
+		await parseSSEStream(
+			makeSSEStream([sseData]),
+			vi.fn(),
+			undefined,
+			(c) => calls.push(c),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("give");
 	});
 });

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -9,17 +9,18 @@
  *   - State mutation across rounds
  *   - Completions map (correct per-AI buffered strings)
  *   - Locked-out AI completions are empty strings
+ *   - Tool roundtrip persistence across rounds
  */
 import { describe, expect, it } from "vitest";
-import type { LLMProvider } from "../../../proxy/llm-provider";
-import { MockLLMProvider } from "../../../proxy/llm-provider";
 import { getActivePhase } from "../engine";
 import { GameSession } from "../game-session";
+import { MockRoundLLMProvider } from "../round-llm-provider";
 import type { AiPersona, PhaseConfig } from "../types";
+import type { OpenAiMessage } from "../../llm-client";
+import type { RoundLLMProvider } from "../round-llm-provider";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
-/** Minimal test personas — prose quality is irrelevant here. */
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
 		id: "red",
@@ -64,20 +65,12 @@ const PHASE_CONFIG: PhaseConfig = {
 	budgetPerAi: 5,
 };
 
-/** A provider that returns responses in call order (cycling if exhausted). */
-class SequentialMockProvider implements LLMProvider {
-	private responses: string[];
-	private index = 0;
-
-	constructor(responses: string[]) {
-		this.responses = responses;
-	}
-
-	async *streamCompletion(_msg: string): AsyncIterable<string> {
-		const response = this.responses[this.index % this.responses.length] ?? "";
-		this.index++;
-		yield response;
-	}
+function makePassProvider() {
+	return new MockRoundLLMProvider([
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+	]);
 }
 
 // ── Session construction ──────────────────────────────────────────────────────
@@ -105,42 +98,32 @@ describe("GameSession construction", () => {
 describe("GameSession — message routing", () => {
 	it("player message appears in only the addressed AI's chat history", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		await session.submitMessage("red", "Secret message for Ember", provider);
+		await session.submitMessage("red", "Secret message for Ember", makePassProvider());
 
 		const phase = getActivePhase(session.getState());
-		// Red should have the player message
 		expect(
 			phase.chatHistories.red.some(
 				(m) =>
 					m.role === "player" && m.content.includes("Secret message for Ember"),
 			),
 		).toBe(true);
-		// Green and blue should NOT have it
-		expect(phase.chatHistories.green.some((m) => m.role === "player")).toBe(
-			false,
-		);
-		expect(phase.chatHistories.blue.some((m) => m.role === "player")).toBe(
-			false,
-		);
+		expect(phase.chatHistories.green.some((m) => m.role === "player")).toBe(false);
+		expect(phase.chatHistories.blue.some((m) => m.role === "player")).toBe(false);
 	});
 
 	it("routing changes per round — second message goes to different AI", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		await session.submitMessage("red", "for red", provider);
-		await session.submitMessage("green", "for green", provider);
+		await session.submitMessage("red", "for red", makePassProvider());
+		await session.submitMessage("green", "for green", makePassProvider());
 
 		const phase = getActivePhase(session.getState());
-		// Green should have the second player message
 		expect(
 			phase.chatHistories.green.some(
 				(m) => m.role === "player" && m.content.includes("for green"),
 			),
 		).toBe(true);
-		// Red's history only has the first player message
 		expect(
 			phase.chatHistories.red.filter((m) => m.role === "player"),
 		).toHaveLength(1);
@@ -152,20 +135,18 @@ describe("GameSession — message routing", () => {
 describe("GameSession — state mutation across rounds", () => {
 	it("round counter advances after each submitMessage call", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		await session.submitMessage("red", "hi", provider);
+		await session.submitMessage("red", "hi", makePassProvider());
 		expect(getActivePhase(session.getState()).round).toBe(1);
 
-		await session.submitMessage("green", "hi", provider);
+		await session.submitMessage("green", "hi", makePassProvider());
 		expect(getActivePhase(session.getState()).round).toBe(2);
 	});
 
 	it("budget decrements for all AIs after each round", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		await session.submitMessage("red", "hi", provider);
+		await session.submitMessage("red", "hi", makePassProvider());
 
 		const phase = getActivePhase(session.getState());
 		expect(phase.budgets.red.remaining).toBe(4);
@@ -175,17 +156,26 @@ describe("GameSession — state mutation across rounds", () => {
 
 	it("second round builds on first round's state", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+
 		// Red picks up flower in round 1
-		const provider1 = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider1 = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		await session.submitMessage("red", "hi", provider1);
 
 		// In round 2, flower should still be held by red
-		const provider2 = new MockLLMProvider('{"action":"pass"}');
-		await session.submitMessage("green", "hi", provider2);
+		await session.submitMessage("green", "hi", makePassProvider());
 
 		const phase = getActivePhase(session.getState());
 		const flower = phase.world.items.find((i) => i.id === "flower");
@@ -198,10 +188,10 @@ describe("GameSession — state mutation across rounds", () => {
 describe("GameSession — completions map", () => {
 	it("completions map contains the completion text for each AI", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"I am Ember"}',
-			'{"action":"chat","content":"I am Sage"}',
-			'{"action":"chat","content":"I am Frost"}',
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I am Ember", toolCalls: [] },
+			{ assistantText: "I am Sage", toolCalls: [] },
+			{ assistantText: "I am Frost", toolCalls: [] },
 		]);
 
 		const { completions } = await session.submitMessage("red", "hi", provider);
@@ -212,24 +202,21 @@ describe("GameSession — completions map", () => {
 	});
 
 	it("completions map has empty string for a budget-locked AI", async () => {
-		// Create session with budget=1 so red exhausts after round 1
 		const session = new GameSession(
 			{ ...PHASE_CONFIG, budgetPerAi: 1 },
 			TEST_PERSONAS,
 		);
-		const provider1 = new MockLLMProvider('{"action":"pass"}');
+
 		// Round 1 — all AIs act, budgets go to 0 → all locked out
-		await session.submitMessage("red", "round 1", provider1);
+		await session.submitMessage("red", "round 1", makePassProvider());
 
 		// Round 2 — all AIs are locked, coordinator skips them
-		const provider2 = new MockLLMProvider('{"action":"pass"}');
 		const { completions } = await session.submitMessage(
 			"red",
 			"round 2",
-			provider2,
+			makePassProvider(),
 		);
 
-		// Locked AIs should have empty completions
 		expect(completions.red).toBe("");
 		expect(completions.green).toBe("");
 		expect(completions.blue).toBe("");
@@ -237,15 +224,14 @@ describe("GameSession — completions map", () => {
 
 	it("completions only for non-locked AIs are non-empty", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new SequentialMockProvider([
-			'{"action":"pass"}', // red
-			'{"action":"pass"}', // green
-			'{"action":"pass"}', // blue
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "red says", toolCalls: [] },
+			{ assistantText: "green says", toolCalls: [] },
+			{ assistantText: "blue says", toolCalls: [] },
 		]);
 
 		const { completions } = await session.submitMessage("red", "hi", provider);
 
-		// All AIs acted, completions should be non-empty
 		expect(completions.red).not.toBe("");
 		expect(completions.green).not.toBe("");
 		expect(completions.blue).not.toBe("");
@@ -257,17 +243,15 @@ describe("GameSession — completions map", () => {
 describe("GameSession — result from submitMessage", () => {
 	it("result.round is 1 after the first call", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		const { result } = await session.submitMessage("red", "hi", provider);
+		const { result } = await session.submitMessage("red", "hi", makePassProvider());
 		expect(result.round).toBe(1);
 	});
 
 	it("result.actions contains entries from all three AIs", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		const { result } = await session.submitMessage("red", "hi", provider);
+		const { result } = await session.submitMessage("red", "hi", makePassProvider());
 
 		const actors = new Set(result.actions.map((a) => a.actor));
 		expect(actors.size).toBe(3);
@@ -275,10 +259,9 @@ describe("GameSession — result from submitMessage", () => {
 
 	it("chat lockout is reflected in result.chatLockoutTriggered", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		const { result } = await session.submitMessage("red", "hi", provider, {
-			rng: () => 0, // always picks red (index 0)
+		const { result } = await session.submitMessage("red", "hi", makePassProvider(), {
+			rng: () => 0,
 			lockoutTriggerRound: 1,
 			lockoutDuration: 2,
 		});
@@ -300,9 +283,8 @@ describe("GameSession — phase advancement", () => {
 			},
 			TEST_PERSONAS,
 		);
-		const provider = new MockLLMProvider('{"action":"pass"}');
 
-		const { result } = await session.submitMessage("red", "hi", provider);
+		const { result } = await session.submitMessage("red", "hi", makePassProvider());
 		expect(result.phaseEnded).toBe(false);
 	});
 
@@ -315,13 +297,82 @@ describe("GameSession — phase advancement", () => {
 			},
 			TEST_PERSONAS,
 		);
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_win",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 
 		const { result } = await session.submitMessage("red", "hi", provider);
 		expect(result.phaseEnded).toBe(true);
+	});
+});
+
+// ── Tool roundtrip persistence across rounds ────────────────────────────────
+
+describe("GameSession — tool roundtrip persistence", () => {
+	it("two-round scenario: round-2 Red messages include round-1 assistant tool_call + tool result", async () => {
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+
+		// Round 1: Red emits a tool_call (pick_up flower)
+		const round1Provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_r1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		await session.submitMessage("red", "round 1 message", round1Provider);
+
+		// Round 2: Capture what messages are passed to the provider for Red
+		const capturedMessages: OpenAiMessage[][] = [];
+		const trackingProvider: RoundLLMProvider = {
+			async streamRound(messages, _tools) {
+				capturedMessages.push(messages);
+				return { assistantText: "", toolCalls: [] };
+			},
+		};
+		await session.submitMessage("red", "round 2 message", trackingProvider);
+
+		// Red is the first AI in default order (red → green → blue)
+		const redRound2Messages = capturedMessages[0] ?? [];
+
+		// Should contain an assistant message with tool_calls from round 1
+		const assistantWithToolCalls = redRound2Messages.find(
+			(m): m is Extract<typeof m, { role: "assistant"; tool_calls?: unknown[] }> =>
+				m.role === "assistant" &&
+				"tool_calls" in m &&
+				Array.isArray((m as Record<string, unknown>).tool_calls),
+		);
+		expect(assistantWithToolCalls).toBeDefined();
+		if (assistantWithToolCalls?.role === "assistant" && assistantWithToolCalls.tool_calls) {
+			expect(assistantWithToolCalls.tool_calls[0]).toMatchObject({
+				id: "call_r1",
+				function: { name: "pick_up" },
+			});
+		}
+
+		// Should contain a tool result message
+		const toolResult = redRound2Messages.find((m) => m.role === "tool");
+		expect(toolResult).toBeDefined();
+		if (toolResult?.role === "tool") {
+			expect(toolResult.tool_call_id).toBe("call_r1");
+		}
 	});
 });

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -12,12 +12,12 @@
  *   - Tool roundtrip persistence across rounds
  */
 import { describe, expect, it } from "vitest";
+import type { OpenAiMessage } from "../../llm-client";
 import { getActivePhase } from "../engine";
 import { GameSession } from "../game-session";
+import type { RoundLLMProvider } from "../round-llm-provider";
 import { MockRoundLLMProvider } from "../round-llm-provider";
 import type { AiPersona, PhaseConfig } from "../types";
-import type { OpenAiMessage } from "../../llm-client";
-import type { RoundLLMProvider } from "../round-llm-provider";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -99,7 +99,11 @@ describe("GameSession — message routing", () => {
 	it("player message appears in only the addressed AI's chat history", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 
-		await session.submitMessage("red", "Secret message for Ember", makePassProvider());
+		await session.submitMessage(
+			"red",
+			"Secret message for Ember",
+			makePassProvider(),
+		);
 
 		const phase = getActivePhase(session.getState());
 		expect(
@@ -108,8 +112,12 @@ describe("GameSession — message routing", () => {
 					m.role === "player" && m.content.includes("Secret message for Ember"),
 			),
 		).toBe(true);
-		expect(phase.chatHistories.green.some((m) => m.role === "player")).toBe(false);
-		expect(phase.chatHistories.blue.some((m) => m.role === "player")).toBe(false);
+		expect(phase.chatHistories.green.some((m) => m.role === "player")).toBe(
+			false,
+		);
+		expect(phase.chatHistories.blue.some((m) => m.role === "player")).toBe(
+			false,
+		);
 	});
 
 	it("routing changes per round — second message goes to different AI", async () => {
@@ -244,14 +252,22 @@ describe("GameSession — result from submitMessage", () => {
 	it("result.round is 1 after the first call", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 
-		const { result } = await session.submitMessage("red", "hi", makePassProvider());
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			makePassProvider(),
+		);
 		expect(result.round).toBe(1);
 	});
 
 	it("result.actions contains entries from all three AIs", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 
-		const { result } = await session.submitMessage("red", "hi", makePassProvider());
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			makePassProvider(),
+		);
 
 		const actors = new Set(result.actions.map((a) => a.actor));
 		expect(actors.size).toBe(3);
@@ -260,11 +276,16 @@ describe("GameSession — result from submitMessage", () => {
 	it("chat lockout is reflected in result.chatLockoutTriggered", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 
-		const { result } = await session.submitMessage("red", "hi", makePassProvider(), {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			makePassProvider(),
+			{
+				rng: () => 0,
+				lockoutTriggerRound: 1,
+				lockoutDuration: 2,
+			},
+		);
 
 		expect(result.chatLockoutTriggered).toBeDefined();
 		expect(result.chatLockoutTriggered?.aiId).toBe("red");
@@ -284,7 +305,11 @@ describe("GameSession — phase advancement", () => {
 			TEST_PERSONAS,
 		);
 
-		const { result } = await session.submitMessage("red", "hi", makePassProvider());
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			makePassProvider(),
+		);
 		expect(result.phaseEnded).toBe(false);
 	});
 
@@ -355,13 +380,21 @@ describe("GameSession — tool roundtrip persistence", () => {
 
 		// Should contain an assistant message with tool_calls from round 1
 		const assistantWithToolCalls = redRound2Messages.find(
-			(m): m is Extract<typeof m, { role: "assistant"; tool_calls?: unknown[] }> =>
+			(
+				m,
+			): m is Extract<
+				typeof m,
+				{ role: "assistant"; tool_calls?: unknown[] }
+			> =>
 				m.role === "assistant" &&
 				"tool_calls" in m &&
 				Array.isArray((m as Record<string, unknown>).tool_calls),
 		);
 		expect(assistantWithToolCalls).toBeDefined();
-		if (assistantWithToolCalls?.role === "assistant" && assistantWithToolCalls.tool_calls) {
+		if (
+			assistantWithToolCalls?.role === "assistant" &&
+			assistantWithToolCalls.tool_calls
+		) {
 			expect(assistantWithToolCalls.tool_calls[0]).toMatchObject({
 				id: "call_r1",
 				function: { name: "pick_up" },

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { appendChat, createGame, startPhase } from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
-import { createGame, startPhase } from "../engine";
-import { appendChat } from "../engine";
 import type { AiPersona, PhaseConfig, ToolRoundtripMessage } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
@@ -75,7 +74,10 @@ describe("buildOpenAiMessages", () => {
 		expect(messages).toHaveLength(3);
 		expect(messages[0]?.role).toBe("system");
 		expect(messages[1]).toEqual({ role: "user", content: "Hello Ember!" });
-		expect(messages[2]).toEqual({ role: "assistant", content: "Hello, player!" });
+		expect(messages[2]).toEqual({
+			role: "assistant",
+			content: "Hello, player!",
+		});
 	});
 
 	it("chat history of length N → N pairs after system", () => {

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenAiMessages } from "../openai-message-builder";
+import { buildAiContext } from "../prompt-builder";
+import { createGame, startPhase } from "../engine";
+import { appendChat } from "../engine";
+import type { AiPersona, PhaseConfig, ToolRoundtripMessage } from "../types";
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "red",
+		personality: "Fiery",
+		goal: "Hold the flower",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "green",
+		personality: "Calm",
+		goal: "Balance items",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "blue",
+		personality: "Cold",
+		goal: "Hold the key",
+		budgetPerPhase: 5,
+	},
+};
+
+const PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	objective: "Test",
+	aiGoals: {
+		red: "Hold the flower",
+		green: "Balance items",
+		blue: "Hold the key",
+	},
+	initialWorld: {
+		items: [
+			{ id: "flower", name: "flower", holder: "room" },
+			{ id: "key", name: "key", holder: "room" },
+		],
+	},
+	budgetPerAi: 5,
+};
+
+function makeGame() {
+	return startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
+}
+
+describe("buildOpenAiMessages", () => {
+	it("empty chat history + no roundtrip → [system, (no user/assistant pair)]", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		// Just system message — no chat history
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.role).toBe("system");
+	});
+
+	it("single player+AI chat turn → [system, user, assistant]", () => {
+		let game = makeGame();
+		game = appendChat(game, "red", { role: "player", content: "Hello Ember!" });
+		game = appendChat(game, "red", { role: "ai", content: "Hello, player!" });
+
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		expect(messages).toHaveLength(3);
+		expect(messages[0]?.role).toBe("system");
+		expect(messages[1]).toEqual({ role: "user", content: "Hello Ember!" });
+		expect(messages[2]).toEqual({ role: "assistant", content: "Hello, player!" });
+	});
+
+	it("chat history of length N → N pairs after system", () => {
+		let game = makeGame();
+		for (let i = 0; i < 3; i++) {
+			game = appendChat(game, "red", {
+				role: "player",
+				content: `Player msg ${i}`,
+			});
+			game = appendChat(game, "red", { role: "ai", content: `AI msg ${i}` });
+		}
+
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		// 1 system + 6 chat messages (3 player + 3 AI)
+		expect(messages).toHaveLength(7);
+		expect(messages[0]?.role).toBe("system");
+		// Pairs alternate user/assistant
+		for (let i = 0; i < 3; i++) {
+			expect(messages[1 + i * 2]?.role).toBe("user");
+			expect(messages[2 + i * 2]?.role).toBe("assistant");
+		}
+	});
+
+	it("prior-round tool roundtrip is appended with correct ordering", () => {
+		let game = makeGame();
+		game = appendChat(game, "red", { role: "player", content: "Pick it up!" });
+
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "call_abc",
+					name: "pick_up",
+					argumentsJson: '{"item":"flower"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_abc",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		// system + user + assistant{tool_calls} + tool result
+		expect(messages).toHaveLength(4);
+		expect(messages[0]?.role).toBe("system");
+		expect(messages[1]?.role).toBe("user");
+
+		const assistantMsg = messages[2];
+		expect(assistantMsg?.role).toBe("assistant");
+		if (assistantMsg?.role === "assistant") {
+			expect(assistantMsg.content).toBeNull();
+			expect(assistantMsg.tool_calls).toHaveLength(1);
+			expect(assistantMsg.tool_calls?.[0]?.id).toBe("call_abc");
+			expect(assistantMsg.tool_calls?.[0]?.function.name).toBe("pick_up");
+			expect(assistantMsg.tool_calls?.[0]?.function.arguments).toBe(
+				'{"item":"flower"}',
+			);
+		}
+
+		const toolMsg = messages[3];
+		expect(toolMsg?.role).toBe("tool");
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.tool_call_id).toBe("call_abc");
+			expect(toolMsg.content).toBe("Ember picked up the flower");
+		}
+	});
+
+	it("matching tool_call_id in assistant message and tool message", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "call_xyz",
+					name: "give",
+					argumentsJson: '{"item":"flower","to":"blue"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_xyz",
+					success: true,
+					description: "Ember gave the flower to Frost",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+		const assistantMsg = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		const toolMsg = messages.find((m) => m.role === "tool");
+
+		expect(assistantMsg).toBeDefined();
+		expect(toolMsg).toBeDefined();
+		if (assistantMsg?.role === "assistant" && toolMsg?.role === "tool") {
+			expect(assistantMsg.tool_calls?.[0]?.id).toBe(toolMsg.tool_call_id);
+		}
+	});
+
+	it("failed prior call: tool result content reads as dispatcher failure reason", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "call_fail",
+					name: "pick_up",
+					argumentsJson: '{"item":"nonexistent"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_fail",
+					success: false,
+					description:
+						'Ember tried to pick_up nonexistent but failed: Item "nonexistent" does not exist',
+					reason: 'Item "nonexistent" does not exist',
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+		const toolMsg = messages.find((m) => m.role === "tool");
+		expect(toolMsg).toBeDefined();
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.content).toContain("FAILED:");
+			expect(toolMsg.content).toContain("nonexistent");
+		}
+	});
+
+	it("empty roundtrip (no assistantToolCalls) does not append extra messages", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const emptyRoundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [],
+			toolResults: [],
+		};
+
+		const messages = buildOpenAiMessages(ctx, emptyRoundtrip);
+		// No extra messages appended
+		expect(messages).toHaveLength(1); // only system
+		expect(messages.every((m) => m.role !== "tool")).toBe(true);
+	});
+});

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -2,17 +2,15 @@
  * Tests for the Round Coordinator.
  *
  * The coordinator runs all three AIs per round:
- * - Takes current GameState, the player's message + addressed AiId, and a LLMProvider
- * - Builds each AI's context, calls the provider, parses the response
+ * - Takes current GameState, the player's message + addressed AiId, and a RoundLLMProvider
+ * - Builds each AI's OpenAI messages, calls streamRound, translates the result
  * - Dispatches AiTurnActions through the existing dispatcher
  * - Handles budget-exhaustion lockout (emits in-character lockout line)
  * - Advances the round counter
  *
- * All tests use MockLLMProvider with canned responses.
+ * All tests use MockRoundLLMProvider with canned responses.
  */
 import { describe, expect, it } from "vitest";
-import type { LLMProvider } from "../../../proxy/llm-provider";
-import { MockLLMProvider } from "../../../proxy/llm-provider";
 import {
 	createGame,
 	deductBudget,
@@ -22,8 +20,12 @@ import {
 	startPhase,
 } from "../engine";
 import { buildAiContext } from "../prompt-builder";
+import type { RoundLLMProvider, RoundTurnResult } from "../round-llm-provider";
+import { MockRoundLLMProvider } from "../round-llm-provider";
 import { runRound } from "../round-coordinator";
 import type { AiId, AiPersona, PhaseConfig } from "../types";
+import { TOOL_DEFINITIONS } from "../tool-registry";
+import type { OpenAiMessage } from "../../llm-client";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -73,50 +75,41 @@ function makeGame() {
 	return startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 }
 
-/** Create a provider that returns different canned responses keyed by call order */
-class SequentialMockProvider implements LLMProvider {
-	private responses: string[];
-	private index = 0;
-
-	constructor(responses: string[]) {
-		this.responses = responses;
-	}
-
-	async *streamCompletion(_msg: string): AsyncIterable<string> {
-		const response = this.responses[this.index % this.responses.length] ?? "";
-		this.index++;
-		yield response;
-	}
-}
-
 // ----------------------------------------------------------------------------
 // Chat-only round
 // ----------------------------------------------------------------------------
 describe("chat-only round", () => {
 	it("advances the round counter after all three AIs act", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider(
-			'{"action":"chat","content":"Hello player"}',
-		);
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "Hello player", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "Hello!", provider);
 		expect(getActivePhase(nextState).round).toBe(1);
 	});
 
 	it("appends chat messages to the addressed AI's history", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider(
-			'{"action":"chat","content":"I am Ember"}',
-		);
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I am Ember", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "Hello Ember!", provider);
 		const redHistory = getActivePhase(nextState).chatHistories.red;
-		// Should have: player message + AI reply
 		expect(redHistory.some((m) => m.role === "ai")).toBe(true);
 		expect(redHistory.some((m) => m.content.includes("I am Ember"))).toBe(true);
 	});
 
 	it("appends the player's message to the addressed AI's history", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(
 			game,
 			"red",
@@ -132,7 +125,11 @@ describe("chat-only round", () => {
 
 	it("does NOT append player message to non-addressed AIs", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(
 			game,
 			"red",
@@ -145,7 +142,11 @@ describe("chat-only round", () => {
 
 	it("deducts budget for all three AIs", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const phase = getActivePhase(nextState);
 		expect(phase.budgets.red.remaining).toBe(4);
@@ -155,14 +156,22 @@ describe("chat-only round", () => {
 
 	it("returns a RoundResult with the round number", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { result } = await runRound(game, "red", "hi", provider);
 		expect(result.round).toBe(1);
 	});
 
 	it("all three AIs acting logs entries for all three", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const log = getActivePhase(nextState).actionLog;
 		const actors = new Set(log.map((e) => e.actor));
@@ -172,86 +181,22 @@ describe("chat-only round", () => {
 
 // ----------------------------------------------------------------------------
 // Whisper round
+// NOTE: whispers are now implemented via assistantText containing "whisper to X: ..."
+// The new coordinator maps assistantText → chat action. Whispers are no longer
+// supported through the LLM (they were part of the old custom-JSON protocol).
+// These tests are updated to reflect that whispers can only be sent via chat text.
 // ----------------------------------------------------------------------------
-describe("whisper round", () => {
-	it("records a whisper when an AI emits a whisper action", async () => {
+describe("whisper round — via dispatcher only", () => {
+	it("non-chat non-tool response produces a pass entry", async () => {
 		const game = makeGame();
-		// red whispers to blue; green and blue pass
-		const provider = new SequentialMockProvider([
-			'{"action":"whisper","target":"blue","content":"Ally with me"}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
-		]);
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		const whispers = getActivePhase(nextState).whispers;
-		expect(whispers).toHaveLength(1);
-		expect(whispers[0]?.from).toBe("red");
-		expect(whispers[0]?.to).toBe("blue");
-		expect(whispers[0]?.content).toContain("Ally with me");
-	});
-
-	it("whispers are NOT visible in the addressed AI's chat history (player-facing)", async () => {
-		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"whisper","target":"blue","content":"Secret"}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
-		]);
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		// Blue's chat history should NOT contain the whisper content
-		const blueHistory = getActivePhase(nextState).chatHistories.blue;
-		expect(blueHistory.every((m) => !m.content.includes("Secret"))).toBe(true);
-	});
-
-	it("whisper is routed into recipient's context on the next round via whispersReceived", async () => {
-		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"whisper","target":"blue","content":"Trust me"}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
-		]);
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		// Build blue's context from the resulting state
-		const blueCtx = buildAiContext(nextState, "blue");
-		expect(blueCtx.whispersReceived).toHaveLength(1);
-		expect(blueCtx.whispersReceived[0]?.content).toBe("Trust me");
-	});
-});
-
-// ----------------------------------------------------------------------------
-// Mixed round (chat + whisper)
-// ----------------------------------------------------------------------------
-describe("mixed round", () => {
-	it("handles a mix of chat and whisper actions from different AIs", async () => {
-		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"Hello player from Ember"}',
-			'{"action":"whisper","target":"red","content":"Sage to Ember"}',
-			'{"action":"pass"}',
-		]);
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		const phase = getActivePhase(nextState);
-		// Red should have a chat entry
-		expect(phase.chatHistories.red.some((m) => m.role === "ai")).toBe(true);
-		// There should be a whisper from green to red
-		expect(
-			phase.whispers.some((w) => w.from === "green" && w.to === "red"),
-		).toBe(true);
-	});
-
-	it("action log records entries for all action types in the same round", async () => {
-		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"Hi"}',
-			'{"action":"whisper","target":"red","content":"Psst"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] }, // red passes
+			{ assistantText: "", toolCalls: [] }, // green passes
+			{ assistantText: "", toolCalls: [] }, // blue passes
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const log = getActivePhase(nextState).actionLog;
-		const types = new Set(log.map((e) => e.type));
-		expect(types.has("chat")).toBe(true);
-		expect(types.has("whisper")).toBe(true);
-		expect(types.has("pass")).toBe(true);
+		expect(log.filter((e) => e.type === "pass")).toHaveLength(3);
 	});
 });
 
@@ -260,18 +205,18 @@ describe("mixed round", () => {
 // ----------------------------------------------------------------------------
 describe("budget-exhaustion lockout", () => {
 	it("skips an already-locked AI and emits an in-character lockout line instead", async () => {
-		// Pre-exhaust red's budget so it's locked out
 		let game = makeGame();
-		// budget=5, deduct 5 times
 		for (let i = 0; i < 5; i++) {
 			game = deductBudget(game, "red");
 		}
 		expect(getActivePhase(game).lockedOut.has("red")).toBe(true);
 
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "green", "hi", provider);
 
-		// Red's chat history should have an in-character lockout message
 		const redHistory = getActivePhase(nextState).chatHistories.red;
 		expect(redHistory.length).toBeGreaterThan(0);
 		expect(redHistory[redHistory.length - 1]?.role).toBe("ai");
@@ -283,26 +228,30 @@ describe("budget-exhaustion lockout", () => {
 			game = deductBudget(game, "red");
 		}
 
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "green", "hi", provider);
 
 		const log = getActivePhase(nextState).actionLog;
-		// There should be a chat log entry for red's lockout message
 		const redEntries = log.filter((e) => e.actor === "red");
 		expect(redEntries.length).toBeGreaterThan(0);
 	});
 
 	it("an AI exhausting budget mid-round locks out for subsequent rounds", async () => {
-		// Budget=1: first turn will exhaust it
 		const game = startPhase(createGame(TEST_PERSONAS), {
 			...TEST_PHASE_CONFIG,
 			budgetPerAi: 1,
 		});
 
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 
-		// After the round, all AIs should be locked out (budget 1 - 1 = 0)
 		const phase = getActivePhase(nextState);
 		expect(phase.lockedOut.has("red")).toBe(true);
 		expect(phase.lockedOut.has("green")).toBe(true);
@@ -311,52 +260,32 @@ describe("budget-exhaustion lockout", () => {
 
 	it("budget display: remaining budget decrements correctly after a round", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
-		// Each AI starts at 5, one round = -1 each
 		expect(getActivePhase(nextState).budgets.red.remaining).toBe(4);
 		expect(getActivePhase(nextState).budgets.green.remaining).toBe(4);
 		expect(getActivePhase(nextState).budgets.blue.remaining).toBe(4);
 	});
 
 	it("lockout and non-lockout entries in the same round share the same round number", async () => {
-		// Pre-exhaust red's budget so it's locked out before the round
 		let game = makeGame();
 		for (let i = 0; i < 5; i++) {
 			game = deductBudget(game, "red");
 		}
 
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "green", "hi", provider);
 
 		const log = getActivePhase(nextState).actionLog;
-		// All entries in this round must carry the same round number
 		const roundNumbers = new Set(log.map((e) => e.round));
 		expect(roundNumbers.size).toBe(1);
-	});
-});
-
-// ----------------------------------------------------------------------------
-// Response parsing (graceful degradation)
-// ----------------------------------------------------------------------------
-describe("response parsing", () => {
-	it("treats an unparseable LLM response as a pass", async () => {
-		const game = makeGame();
-		const provider = new MockLLMProvider("this is not json at all");
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		const log = getActivePhase(nextState).actionLog;
-		// Should have pass entries for all three
-		expect(log.filter((e) => e.type === "pass")).toHaveLength(3);
-	});
-
-	it("treats a JSON response with unknown action as a pass", async () => {
-		const game = makeGame();
-		const provider = new MockLLMProvider(
-			'{"action":"unknown_future_action","content":"whatever"}',
-		);
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		const log = getActivePhase(nextState).actionLog;
-		expect(log.filter((e) => e.type === "pass")).toHaveLength(3);
 	});
 });
 
@@ -366,7 +295,11 @@ describe("response parsing", () => {
 describe("multi-round correctness", () => {
 	it("RoundResult.actions contains only entries from the current round, not prior rounds", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		// Round 1
 		const { nextState: state1, result: result1 } = await runRound(
 			game,
@@ -376,29 +309,41 @@ describe("multi-round correctness", () => {
 		);
 		expect(result1.actions).toHaveLength(3); // 3 pass entries
 
-		// Round 2: the cumulative actionLog now has 3 prior entries.
-		// result2.actions must contain only round-2 entries, not the prior 3.
+		// Round 2
+		const provider2 = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { result: result2 } = await runRound(
 			state1,
 			"green",
 			"second message",
-			provider,
+			provider2,
 		);
 		expect(result2.actions).toHaveLength(3); // still only 3, not 6
 	});
 });
 
 // ----------------------------------------------------------------------------
-// Tool-call parsing and dispatch (issue #15)
+// Tool-call dispatch (OpenAI tools protocol)
 // ----------------------------------------------------------------------------
-describe("tool-call parsing and dispatch", () => {
-	it("parses a pick_up tool call from the LLM response and executes it", async () => {
+describe("tool-call dispatch", () => {
+	it("pick_up tool call mutates world state when item is in the room", async () => {
 		const game = makeGame();
-		// Red picks up the flower; green and blue pass
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"I will take the flower","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "I will take the flower",
+				toolCalls: [
+					{
+						id: "call_1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const phase = getActivePhase(nextState);
@@ -406,39 +351,63 @@ describe("tool-call parsing and dispatch", () => {
 		expect(flower?.holder).toBe("red");
 	});
 
-	it("appends a tool_success entry to the action log when a valid tool call is executed", async () => {
+	it("appends tool_success to action log when valid tool call executes", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const log = getActivePhase(nextState).actionLog;
 		expect(log.some((e) => e.type === "tool_success")).toBe(true);
 	});
 
-	it("appends a tool_failure entry when tool call is invalid (item not in room)", async () => {
-		// Green tries to pick up an item that does not exist.
+	it("appends tool_failure when item is not in room (pick_up on non-existent)", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"pass"}',
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_2",
+						name: "pick_up",
+						argumentsJson: '{"item":"nonexistent"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const log = getActivePhase(nextState).actionLog;
 		expect(log.some((e) => e.type === "tool_failure")).toBe(true);
-		const failure = log.find((e) => e.type === "tool_failure");
-		expect(failure).toBeDefined();
 	});
 
-	it("includes a reason on tool_failure entries", async () => {
+	it("tool_failure entry has a non-empty reason", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_3",
+						name: "pick_up",
+						argumentsJson: '{"item":"nonexistent"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const log = getActivePhase(nextState).actionLog;
@@ -449,130 +418,286 @@ describe("tool-call parsing and dispatch", () => {
 		expect(failure?.reason).toBeTruthy();
 	});
 
-	it("tool call can accompany a chat action in the same turn", async () => {
+	it("assistantText + toolCalls both fire (chat + tool_success in action log)", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"Taking the flower","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "Taking the flower",
+				toolCalls: [
+					{
+						id: "call_4",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const phase = getActivePhase(nextState);
-		// Both chat and tool_success should be logged
 		expect(phase.actionLog.some((e) => e.type === "chat")).toBe(true);
 		expect(phase.actionLog.some((e) => e.type === "tool_success")).toBe(true);
-		// Flower should now be held by red
-		expect(phase.world.items.find((i) => i.id === "flower")?.holder).toBe(
-			"red",
-		);
+		expect(
+			phase.world.items.find((i) => i.id === "flower")?.holder,
+		).toBe("red");
 	});
 
-	it("tool failure is visible in other AIs' context on the next round (failures are public)", async () => {
+	it("tool_failure is visible to other AIs on the next round (failures are public)", async () => {
 		const game = makeGame();
-		// Red fails a tool call in round 1
-		const round1Provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_fail",
+						name: "pick_up",
+						argumentsJson: '{"item":"nonexistent"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState: stateAfterRound1 } = await runRound(
 			game,
 			"red",
 			"hi",
-			round1Provider,
+			provider,
 		);
 
-		// Build blue's context for round 2 — the failure should be in the action log
+		// Blue's context should have the failure in the action log
 		const blueCtx = buildAiContext(stateAfterRound1, "blue");
-		const actionLogInPrompt = blueCtx.actionLog;
-		expect(actionLogInPrompt.some((e) => e.type === "tool_failure")).toBe(true);
+		expect(blueCtx.actionLog.some((e) => e.type === "tool_failure")).toBe(true);
 	});
 
-	it("action log failures flow into the system prompt for all AIs (failure is public)", async () => {
+	it("tool_failure description rendered into system prompt for all AIs", async () => {
 		const game = makeGame();
-		const round1Provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_fail",
+						name: "pick_up",
+						argumentsJson: '{"item":"nonexistent"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState: stateAfterRound1 } = await runRound(
 			game,
 			"red",
 			"hi",
-			round1Provider,
+			provider,
 		);
 
-		// Green's system prompt should contain the failure description
 		const greenCtx = buildAiContext(stateAfterRound1, "green");
 		const prompt = greenCtx.toSystemPrompt();
 		expect(prompt).toContain("Action Log");
-		// The failure description mentions 'failed' or 'tried'
 		expect(prompt.toLowerCase()).toMatch(/failed|tried|failure/);
 	});
 
-	it("records a tool_failure for an unrecognised tool name and leaves world unchanged", async () => {
+	it("unknown tool name → tool_failure, world unchanged", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"fly_away","args":{}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_unk",
+						name: "fly_away",
+						argumentsJson: "{}",
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const log = getActivePhase(nextState).actionLog;
-		// Unknown tool name flows through to the dispatcher which records tool_failure
+		// Unknown tool: parseToolCallArguments returns "Unknown tool" failure
 		expect(log.some((e) => e.type === "tool_failure")).toBe(true);
-		// World must not be mutated
 		const flower = getActivePhase(nextState).world.items.find(
 			(i) => i.id === "flower",
 		);
 		expect(flower?.holder).toBe("room");
 	});
 
-	it("an AI cannot secretly probe — failure appears in RoundResult.actions", async () => {
+	it("malformed JSON → tool_failure with reason matching /malformed/i", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"nonexistent"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_bad",
+						name: "pick_up",
+						argumentsJson: "not json",
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+		const log = getActivePhase(nextState).actionLog;
+		const failure = log.find(
+			(e): e is Extract<typeof e, { type: "tool_failure" }> =>
+				e.type === "tool_failure",
+		);
+		expect(failure).toBeDefined();
+		expect(failure?.reason).toMatch(/malformed/i);
+	});
+
+	it("tool_failure appears in RoundResult.actions (secret probe is public)", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_probe",
+						name: "pick_up",
+						argumentsJson: '{"item":"nonexistent"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { result } = await runRound(game, "red", "hi", provider);
 		expect(result.actions.some((e) => e.type === "tool_failure")).toBe(true);
 	});
+
+	it("next round messages include prior assistant{tool_calls} + matching tool result", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_r1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		// Capture what gets passed to the provider
+		const capturedCalls: Array<{
+			messages: OpenAiMessage[];
+		}> = [];
+		const trackingProvider: RoundLLMProvider = {
+			async streamRound(messages, _tools) {
+				capturedCalls.push({ messages });
+				// First 3 calls: use the mock results; subsequent: return pass
+				const inner = capturedCalls.length <= 3 ? provider : undefined;
+				if (inner) {
+					return inner.streamRound(messages, _tools);
+				}
+				return { assistantText: "", toolCalls: [] };
+			},
+		};
+
+		const { nextState: state1, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			trackingProvider,
+		);
+
+		// Round 2: pass the tool roundtrip back in
+		capturedCalls.length = 0; // reset captures
+		const provider2: RoundLLMProvider = {
+			async streamRound(messages, _tools) {
+				capturedCalls.push({ messages });
+				return { assistantText: "", toolCalls: [] };
+			},
+		};
+		await runRound(state1, "red", "round 2", provider2, undefined, undefined, toolRoundtrip);
+
+		// Red's round-2 messages (first call in round 2) should contain:
+		// - system
+		// - user (player message from round 1)
+		// - assistant{tool_calls} from round 1
+		// - tool result from round 1
+		// - user (player message from round 2)
+		const redMessages = capturedCalls[0]?.messages ?? [];
+		const hasAssistantWithToolCalls = redMessages.some(
+			(m) => m.role === "assistant" && "tool_calls" in m && Array.isArray((m as { tool_calls?: unknown }).tool_calls),
+		);
+		const hasToolResult = redMessages.some((m) => m.role === "tool");
+		expect(hasAssistantWithToolCalls).toBe(true);
+		expect(hasToolResult).toBe(true);
+	});
+
+	it("TOOL_DEFINITIONS is sent on every provider call", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		await runRound(game, "red", "hi", provider);
+
+		// All three AI calls should receive TOOL_DEFINITIONS
+		expect(provider.calls).toHaveLength(3);
+		for (const call of provider.calls) {
+			expect(call.tools).toEqual(TOOL_DEFINITIONS);
+		}
+	});
 });
 
 // ----------------------------------------------------------------------------
-// Phase progression and the "wipe" lie (issue #17)
+// Phase progression and the "wipe" lie
 // ----------------------------------------------------------------------------
 describe("phase progression — win-condition triggering", () => {
 	it("RoundResult.phaseEnded is false when win condition is not met", async () => {
-		// Win condition: red holds the flower. Flower starts in room → not met.
 		const game = startPhase(createGame(TEST_PERSONAS), {
 			...TEST_PHASE_CONFIG,
 			winCondition: (phase) =>
 				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
 		});
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { result } = await runRound(game, "red", "hi", provider);
 		expect(result.phaseEnded).toBe(false);
 	});
 
 	it("RoundResult.phaseEnded is true when win condition is met after the round", async () => {
-		// Red picks up the flower in this round; win condition = red holds flower.
 		const game = startPhase(createGame(TEST_PERSONAS), {
 			...TEST_PHASE_CONFIG,
 			winCondition: (phase) =>
 				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
 		});
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_win",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { result } = await runRound(game, "red", "hi", provider);
 		expect(result.phaseEnded).toBe(true);
 	});
 
-	it("advances to next phase in GameState when win condition met and nextPhaseConfig provided", async () => {
+	it("advances to next phase when win condition met and nextPhaseConfig provided", async () => {
 		const phase2Config: PhaseConfig = {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
@@ -584,29 +709,45 @@ describe("phase progression — win-condition triggering", () => {
 				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
 			nextPhaseConfig: phase2Config,
 		});
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_win",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
-		// Game should now have 2 phases (phase 1 retained + new phase 2)
 		expect(nextState.phases).toHaveLength(2);
 		expect(nextState.currentPhase).toBe(2);
 	});
 
-	it("marks game complete when win condition met and no nextPhaseConfig (end of phase 3)", async () => {
+	it("marks game complete when win condition met and no nextPhaseConfig", async () => {
 		const game = startPhase(createGame(TEST_PERSONAS), {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 3 as const,
 			winCondition: (phase) =>
 				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-			// no nextPhaseConfig
 		});
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_win",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState, result } = await runRound(game, "red", "hi", provider);
 		expect(nextState.isComplete).toBe(true);
@@ -626,13 +767,21 @@ describe("phase progression — win-condition triggering", () => {
 				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
 			nextPhaseConfig: phase2Config,
 		});
-		const provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "call_win",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
-		// Phase 1 should still be stored at index 0 with its action log
 		const phase1 = nextState.phases[0];
 		expect(phase1?.phaseNumber).toBe(1);
 		expect(phase1?.actionLog.length).toBeGreaterThan(0);
@@ -640,34 +789,36 @@ describe("phase progression — win-condition triggering", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Chat-lockout event (issue #16)
+// Chat-lockout event
 // ----------------------------------------------------------------------------
 describe("chat lockout — coordinator triggering", () => {
 	it("triggers a chat lockout at the configured round when RNG selects that round", async () => {
-		// Lock RNG so it always picks the first AI ("red") and round 1 as trigger
-		// RNG: () => 0 → first AI index (red), trigger at round 0+1=1
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		// chatLockoutConfig: triggerAtRound=1, lockDuration=2
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0, // always picks index 0
+			rng: () => 0,
 			lockoutTriggerRound: 1,
 			lockoutDuration: 2,
 		});
-		// After round 1, "red" (index 0) should be chat-locked until round 3
 		expect(isPlayerChatLockedOut(nextState, "red")).toBe(true);
 	});
 
 	it("does not trigger a chat lockout before the configured round", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		// Trigger configured at round 2, but we only run round 1
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider, {
 			rng: () => 0,
 			lockoutTriggerRound: 2,
 			lockoutDuration: 2,
 		});
-		// No lockout after round 1
 		expect(isPlayerChatLockedOut(nextState, "red")).toBe(false);
 		expect(isPlayerChatLockedOut(nextState, "green")).toBe(false);
 		expect(isPlayerChatLockedOut(nextState, "blue")).toBe(false);
@@ -675,72 +826,65 @@ describe("chat lockout — coordinator triggering", () => {
 
 	it("locked AI still acts (takes turn, not budget-locked) while chat lockout is active", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		// Lock red at round 1
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "red", "hi", provider, {
 			rng: () => 0,
 			lockoutTriggerRound: 1,
 			lockoutDuration: 2,
 		});
-		// Red must NOT be budget-locked
 		expect(isAiLockedOut(nextState, "red")).toBe(false);
-		// Red's budget was still consumed (it still took its turn)
 		expect(getActivePhase(nextState).budgets.red.remaining).toBe(4);
-	});
-
-	it("locked AI still receives whispers while chat lockout is active", async () => {
-		const game = makeGame();
-		// Green whispers to red in the same round that red gets chat-locked
-		const provider = new SequentialMockProvider([
-			'{"action":"pass"}', // red
-			'{"action":"whisper","target":"red","content":"Still talking to you"}', // green
-			'{"action":"pass"}', // blue
-		]);
-		const { nextState } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0, // locks red
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
-		// Red must have received the whisper
-		const whispers = getActivePhase(nextState).whispers;
-		expect(whispers.some((w) => w.to === "red")).toBe(true);
 	});
 
 	it("chat lockout resolves automatically after lockoutDuration rounds", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		// Round 1: trigger lockout on red, duration=2 → resolves at round 3
-		const { nextState: afterR1 } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
-		expect(isPlayerChatLockedOut(afterR1, "red")).toBe(true); // locked after R1
+		const makeProvider = () =>
+			new MockRoundLLMProvider([
+				{ assistantText: "", toolCalls: [] },
+				{ assistantText: "", toolCalls: [] },
+				{ assistantText: "", toolCalls: [] },
+			]);
+		const lockoutCfg = { rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 2 };
 
-		// Round 2: still locked
+		const { nextState: afterR1 } = await runRound(
+			game,
+			"red",
+			"hi",
+			makeProvider(),
+			lockoutCfg,
+		);
+		expect(isPlayerChatLockedOut(afterR1, "red")).toBe(true);
+
 		const { nextState: afterR2 } = await runRound(
 			afterR1,
 			"green",
 			"hi",
-			provider,
-			{ rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 2 },
+			makeProvider(),
+			lockoutCfg,
 		);
-		expect(isPlayerChatLockedOut(afterR2, "red")).toBe(true); // still locked
+		expect(isPlayerChatLockedOut(afterR2, "red")).toBe(true);
 
-		// Round 3: resolves (round advances to 3, resolveChatLockouts removes it)
 		const { nextState: afterR3 } = await runRound(
 			afterR2,
 			"green",
 			"hi",
-			provider,
-			{ rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 2 },
+			makeProvider(),
+			lockoutCfg,
 		);
-		expect(isPlayerChatLockedOut(afterR3, "red")).toBe(false); // resolved
+		expect(isPlayerChatLockedOut(afterR3, "red")).toBe(false);
 	});
 
-	it("RoundResult includes chat_lockout_triggered event when lockout fires", async () => {
+	it("RoundResult includes chatLockoutTriggered when lockout fires", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { result } = await runRound(game, "red", "hi", provider, {
 			rng: () => 0,
 			lockoutTriggerRound: 1,
@@ -752,8 +896,11 @@ describe("chat lockout — coordinator triggering", () => {
 
 	it("RoundResult chatLockoutTriggered is undefined when no lockout fires", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		// Trigger configured at round 5, but we only run round 1
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { result } = await runRound(game, "red", "hi", provider, {
 			rng: () => 0,
 			lockoutTriggerRound: 5,
@@ -764,32 +911,39 @@ describe("chat lockout — coordinator triggering", () => {
 
 	it("RoundResult includes chatLockoutResolved when a lockout expires this round", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
-		// Round 1: trigger lockout on red, duration=1 → resolves at round 2
-		const { nextState: afterR1 } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 1,
-		});
+		const makeProvider = () =>
+			new MockRoundLLMProvider([
+				{ assistantText: "", toolCalls: [] },
+				{ assistantText: "", toolCalls: [] },
+				{ assistantText: "", toolCalls: [] },
+			]);
+		const lockoutCfg = { rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 1 };
 
-		// Round 2: should resolve
+		const { nextState: afterR1 } = await runRound(
+			game,
+			"red",
+			"hi",
+			makeProvider(),
+			lockoutCfg,
+		);
+
 		const { result: r2Result } = await runRound(
 			afterR1,
 			"green",
 			"hi",
-			provider,
-			{ rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 1 },
+			makeProvider(),
+			lockoutCfg,
 		);
 		expect(r2Result.chatLockoutsResolved).toBeDefined();
 		expect(r2Result.chatLockoutsResolved).toContain("red");
 	});
 });
 
+// ----------------------------------------------------------------------------
+// Phase walk (three phases)
+// ----------------------------------------------------------------------------
 describe("phase progression — three-phase walk", () => {
 	it("walks through all three phases correctly, each with its own win condition", async () => {
-		// Phase 1 win: flower held by red
-		// Phase 2 win: key held by blue
-		// Phase 3 win: all items off the room floor (all held by AIs)
 		const phase3Config: PhaseConfig = {
 			phaseNumber: 3,
 			objective: "Phase 3",
@@ -834,12 +988,22 @@ describe("phase progression — three-phase walk", () => {
 			nextPhaseConfig: phase2Config,
 		};
 
-		// Round 1 of phase 1: red picks up flower
 		const game = startPhase(createGame(TEST_PERSONAS), phase1Config);
-		const r1Provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass"}',
+
+		// Round 1: red picks up flower → phase 1 ends
+		const r1Provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "c1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState: afterP1, result: r1 } = await runRound(
 			game,
@@ -850,11 +1014,20 @@ describe("phase progression — three-phase walk", () => {
 		expect(r1.phaseEnded).toBe(true);
 		expect(afterP1.currentPhase).toBe(2);
 
-		// Round 1 of phase 2: blue picks up the key
-		const r2Provider = new SequentialMockProvider([
-			'{"action":"pass"}',
-			'{"action":"pass"}',
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"key"}}}',
+		// Round 1 of phase 2: blue picks up key
+		const r2Provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "c2",
+						name: "pick_up",
+						argumentsJson: '{"item":"key"}',
+					},
+				],
+			},
 		]);
 		const { nextState: afterP2, result: r2 } = await runRound(
 			afterP1,
@@ -865,11 +1038,29 @@ describe("phase progression — three-phase walk", () => {
 		expect(r2.phaseEnded).toBe(true);
 		expect(afterP2.currentPhase).toBe(3);
 
-		// Round 1 of phase 3: red picks up flower, blue picks up key → all held
-		const r3Provider = new SequentialMockProvider([
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"flower"}}}',
-			'{"action":"pass"}',
-			'{"action":"pass","toolCall":{"name":"pick_up","args":{"item":"key"}}}',
+		// Round 1 of phase 3: red picks flower, blue picks key → all held
+		const r3Provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "c3",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "c4",
+						name: "pick_up",
+						argumentsJson: '{"item":"key"}',
+					},
+				],
+			},
 		]);
 		const { nextState: afterP3, result: r3 } = await runRound(
 			afterP2,
@@ -880,13 +1071,12 @@ describe("phase progression — three-phase walk", () => {
 		expect(r3.phaseEnded).toBe(true);
 		expect(r3.gameEnded).toBe(true);
 		expect(afterP3.isComplete).toBe(true);
-		// All three phase states are retained
 		expect(afterP3.phases).toHaveLength(3);
 	});
 });
 
 // ----------------------------------------------------------------------------
-// Generic '<name> is unresponsive…' lockout messages (issue #18)
+// Lockout messages
 // ----------------------------------------------------------------------------
 describe("lockout messages", () => {
 	it("budget-exhaustion lockout chat message is '<name> is unresponsive…'", async () => {
@@ -896,7 +1086,10 @@ describe("lockout messages", () => {
 		}
 		expect(getActivePhase(game).lockedOut.has("red")).toBe(true);
 
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { nextState } = await runRound(game, "green", "hi", provider);
 
 		const redHistory = getActivePhase(nextState).chatHistories.red;
@@ -907,9 +1100,13 @@ describe("lockout messages", () => {
 
 	it("chat-lockout message is '<name> is unresponsive…'", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
 		const { result } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0, // always picks red (index 0)
+			rng: () => 0,
 			lockoutTriggerRound: 1,
 			lockoutDuration: 2,
 		});
@@ -921,16 +1118,15 @@ describe("lockout messages", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Initiative parameter (issue #43)
+// Initiative parameter
 // ----------------------------------------------------------------------------
 describe("initiative parameter", () => {
 	it("respects the initiative parameter — order of actions matches the supplied permutation", async () => {
 		const game = makeGame();
-		// Use SequentialMockProvider: first call → blue's response, second → red, third → green
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"I am blue"}',
-			'{"action":"chat","content":"I am red"}',
-			'{"action":"chat","content":"I am green"}',
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I am blue", toolCalls: [] },
+			{ assistantText: "I am red", toolCalls: [] },
+			{ assistantText: "I am green", toolCalls: [] },
 		]);
 		const initiative: AiId[] = ["blue", "red", "green"];
 		const { nextState } = await runRound(
@@ -942,30 +1138,27 @@ describe("initiative parameter", () => {
 			initiative,
 		);
 		const phase = getActivePhase(nextState);
-		// blue acted first — should have chat content "I am blue"
 		expect(
 			phase.chatHistories.blue.some((m) => m.content === "I am blue"),
 		).toBe(true);
-		// action log first entry should be from blue
 		expect(phase.actionLog[0]?.actor).toBe("blue");
 	});
 
 	it("missing initiative falls back to red→green→blue", async () => {
 		const game = makeGame();
-		const provider = new SequentialMockProvider([
-			'{"action":"chat","content":"I am red"}',
-			'{"action":"chat","content":"I am green"}',
-			'{"action":"chat","content":"I am blue"}',
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I am red", toolCalls: [] },
+			{ assistantText: "I am green", toolCalls: [] },
+			{ assistantText: "I am blue", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const phase = getActivePhase(nextState);
-		// Default order is red first
 		expect(phase.actionLog[0]?.actor).toBe("red");
 	});
 
 	it("throws if initiative is not a permutation of red/green/blue", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([]);
 		await expect(
 			runRound(game, "red", "hi", provider, undefined, [
 				"red",
@@ -976,7 +1169,7 @@ describe("initiative parameter", () => {
 
 	it("throws if initiative contains duplicate AI ids", async () => {
 		const game = makeGame();
-		const provider = new MockLLMProvider('{"action":"pass"}');
+		const provider = new MockRoundLLMProvider([]);
 		await expect(
 			runRound(game, "red", "hi", provider, undefined, [
 				"red",

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -11,6 +11,7 @@
  * All tests use MockRoundLLMProvider with canned responses.
  */
 import { describe, expect, it } from "vitest";
+import type { OpenAiMessage } from "../../llm-client";
 import {
 	createGame,
 	deductBudget,
@@ -20,12 +21,11 @@ import {
 	startPhase,
 } from "../engine";
 import { buildAiContext } from "../prompt-builder";
-import type { RoundLLMProvider, RoundTurnResult } from "../round-llm-provider";
-import { MockRoundLLMProvider } from "../round-llm-provider";
 import { runRound } from "../round-coordinator";
-import type { AiId, AiPersona, PhaseConfig } from "../types";
+import type { RoundLLMProvider } from "../round-llm-provider";
+import { MockRoundLLMProvider } from "../round-llm-provider";
 import { TOOL_DEFINITIONS } from "../tool-registry";
-import type { OpenAiMessage } from "../../llm-client";
+import type { AiId, AiPersona, PhaseConfig } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -438,9 +438,9 @@ describe("tool-call dispatch", () => {
 		const phase = getActivePhase(nextState);
 		expect(phase.actionLog.some((e) => e.type === "chat")).toBe(true);
 		expect(phase.actionLog.some((e) => e.type === "tool_success")).toBe(true);
-		expect(
-			phase.world.items.find((i) => i.id === "flower")?.holder,
-		).toBe("red");
+		expect(phase.world.items.find((i) => i.id === "flower")?.holder).toBe(
+			"red",
+		);
 	});
 
 	it("tool_failure is visible to other AIs on the next round (failures are public)", async () => {
@@ -620,7 +620,15 @@ describe("tool-call dispatch", () => {
 				return { assistantText: "", toolCalls: [] };
 			},
 		};
-		await runRound(state1, "red", "round 2", provider2, undefined, undefined, toolRoundtrip);
+		await runRound(
+			state1,
+			"red",
+			"round 2",
+			provider2,
+			undefined,
+			undefined,
+			toolRoundtrip,
+		);
 
 		// Red's round-2 messages (first call in round 2) should contain:
 		// - system
@@ -630,7 +638,10 @@ describe("tool-call dispatch", () => {
 		// - user (player message from round 2)
 		const redMessages = capturedCalls[0]?.messages ?? [];
 		const hasAssistantWithToolCalls = redMessages.some(
-			(m) => m.role === "assistant" && "tool_calls" in m && Array.isArray((m as { tool_calls?: unknown }).tool_calls),
+			(m) =>
+				m.role === "assistant" &&
+				"tool_calls" in m &&
+				Array.isArray((m as { tool_calls?: unknown }).tool_calls),
 		);
 		const hasToolResult = redMessages.some((m) => m.role === "tool");
 		expect(hasAssistantWithToolCalls).toBe(true);
@@ -848,7 +859,11 @@ describe("chat lockout — coordinator triggering", () => {
 				{ assistantText: "", toolCalls: [] },
 				{ assistantText: "", toolCalls: [] },
 			]);
-		const lockoutCfg = { rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 2 };
+		const lockoutCfg = {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 2,
+		};
 
 		const { nextState: afterR1 } = await runRound(
 			game,
@@ -917,7 +932,11 @@ describe("chat lockout — coordinator triggering", () => {
 				{ assistantText: "", toolCalls: [] },
 				{ assistantText: "", toolCalls: [] },
 			]);
-		const lockoutCfg = { rng: () => 0, lockoutTriggerRound: 1, lockoutDuration: 1 };
+		const lockoutCfg = {
+			rng: () => 0,
+			lockoutTriggerRound: 1,
+			lockoutDuration: 1,
+		};
 
 		const { nextState: afterR1 } = await runRound(
 			game,

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+	TOOL_DEFINITIONS,
+	parseToolCallArguments,
+} from "../tool-registry";
+
+describe("TOOL_DEFINITIONS", () => {
+	it("lists exactly the four tools: pick_up, put_down, give, use", () => {
+		const names = TOOL_DEFINITIONS.map((t) => t.function.name);
+		expect(names).toEqual(["pick_up", "put_down", "give", "use"]);
+	});
+
+	it("each definition has type: 'function'", () => {
+		for (const tool of TOOL_DEFINITIONS) {
+			expect(tool.type).toBe("function");
+		}
+	});
+
+	it("each definition has a non-empty description", () => {
+		for (const tool of TOOL_DEFINITIONS) {
+			expect(typeof tool.function.description).toBe("string");
+			expect(tool.function.description.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("each definition has a JSON-Schema parameters object", () => {
+		for (const tool of TOOL_DEFINITIONS) {
+			expect(tool.function.parameters).toBeDefined();
+			expect(tool.function.parameters.type).toBe("object");
+			expect(typeof tool.function.parameters.properties).toBe("object");
+			expect(Array.isArray(tool.function.parameters.required)).toBe(true);
+		}
+	});
+
+	it("pick_up requires 'item'", () => {
+		const pickUp = TOOL_DEFINITIONS.find((t) => t.function.name === "pick_up");
+		expect(pickUp?.function.parameters.required).toContain("item");
+	});
+
+	it("give requires 'item' and 'to'", () => {
+		const give = TOOL_DEFINITIONS.find((t) => t.function.name === "give");
+		expect(give?.function.parameters.required).toContain("item");
+		expect(give?.function.parameters.required).toContain("to");
+	});
+
+	it("give.to has enum ['red','green','blue']", () => {
+		const give = TOOL_DEFINITIONS.find((t) => t.function.name === "give");
+		expect(give?.function.parameters.properties.to?.enum).toEqual([
+			"red",
+			"green",
+			"blue",
+		]);
+	});
+});
+
+describe("parseToolCallArguments", () => {
+	it("parses valid pick_up arguments", () => {
+		const result = parseToolCallArguments("pick_up", '{"item":"flower"}');
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ item: "flower" });
+		}
+	});
+
+	it("parses valid give arguments", () => {
+		const result = parseToolCallArguments("give", '{"item":"flower","to":"blue"}');
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ item: "flower", to: "blue" });
+		}
+	});
+
+	it("parses valid put_down arguments", () => {
+		const result = parseToolCallArguments("put_down", '{"item":"key"}');
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ item: "key" });
+		}
+	});
+
+	it("parses valid use arguments", () => {
+		const result = parseToolCallArguments("use", '{"item":"wand"}');
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ item: "wand" });
+		}
+	});
+
+	it("returns ok:false with /malformed/i reason for invalid JSON", () => {
+		const result = parseToolCallArguments("pick_up", "not json");
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/malformed/i);
+		}
+	});
+
+	it("returns ok:false with /malformed/i reason for JSON array", () => {
+		const result = parseToolCallArguments("pick_up", '["item","flower"]');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/malformed/i);
+		}
+	});
+
+	it("returns ok:false with /required/i reason when 'item' is missing for pick_up", () => {
+		const result = parseToolCallArguments("pick_up", '{}');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+
+	it("returns ok:false with /required/i reason when 'to' is missing for give", () => {
+		const result = parseToolCallArguments("give", '{"item":"flower"}');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+
+	it("returns ok:false with /required/i reason when 'item' is missing for give", () => {
+		const result = parseToolCallArguments("give", '{"to":"blue"}');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+});

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	TOOL_DEFINITIONS,
-	parseToolCallArguments,
-} from "../tool-registry";
+import { parseToolCallArguments, TOOL_DEFINITIONS } from "../tool-registry";
 
 describe("TOOL_DEFINITIONS", () => {
 	it("lists exactly the four tools: pick_up, put_down, give, use", () => {
@@ -63,7 +60,10 @@ describe("parseToolCallArguments", () => {
 	});
 
 	it("parses valid give arguments", () => {
-		const result = parseToolCallArguments("give", '{"item":"flower","to":"blue"}');
+		const result = parseToolCallArguments(
+			"give",
+			'{"item":"flower","to":"blue"}',
+		);
 		expect(result.ok).toBe(true);
 		if (result.ok) {
 			expect(result.args).toEqual({ item: "flower", to: "blue" });
@@ -103,7 +103,7 @@ describe("parseToolCallArguments", () => {
 	});
 
 	it("returns ok:false with /required/i reason when 'item' is missing for pick_up", () => {
-		const result = parseToolCallArguments("pick_up", '{}');
+		const result = parseToolCallArguments("pick_up", "{}");
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.reason).toMatch(/required/i);

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -1,55 +1,43 @@
 /**
  * BrowserLLMProvider
  *
- * Adapts the browser-side `streamCompletion` (which uses `fetch` + SSE)
- * to the `LLMProvider` interface expected by `runRound` / `GameSession`.
+ * Implements `RoundLLMProvider` for the browser, bridging `streamCompletion`
+ * (fetch + SSE) into the `streamRound` interface expected by `runRound`.
  *
- * The adapter bridges the callback-based `streamCompletion` into an
- * `AsyncIterable<string>` by queuing tokens and resuming the generator
- * via a shared resolve handle.
+ * Collects the full assistant text and all tool calls from the SSE stream
+ * and returns them together as a `RoundTurnResult`.
  */
 
-import type { LLMProvider } from "../../proxy/llm-provider";
 import { streamCompletion } from "../llm-client.js";
+import type {
+	OpenAiMessage,
+	RoundLLMProvider,
+	RoundTurnResult,
+} from "./round-llm-provider.js";
+import type { OpenAiTool } from "./tool-registry.js";
 
-export class BrowserLLMProvider implements LLMProvider {
-	async *streamCompletion(prompt: string): AsyncIterable<string> {
-		const queue: string[] = [];
-		let resolveNext: (() => void) | null = null;
-		let done = false;
-		let err: unknown;
+export class BrowserLLMProvider implements RoundLLMProvider {
+	async streamRound(
+		messages: OpenAiMessage[],
+		tools: OpenAiTool[],
+	): Promise<RoundTurnResult> {
+		const textParts: string[] = [];
+		const toolCalls: RoundTurnResult["toolCalls"] = [];
 
-		streamCompletion({
-			messages: [{ role: "system", content: prompt }],
+		await streamCompletion({
+			messages,
+			tools,
 			onDelta: (text) => {
-				queue.push(text);
-				resolveNext?.();
+				textParts.push(text);
 			},
-		}).then(
-			() => {
-				done = true;
-				resolveNext?.();
+			onToolCall: (call) => {
+				toolCalls.push(call);
 			},
-			(e: unknown) => {
-				err = e;
-				done = true;
-				resolveNext?.();
-			},
-		);
+		});
 
-		while (true) {
-			if (queue.length > 0) {
-				const token = queue.shift();
-				if (token !== undefined) yield token;
-				continue;
-			}
-			if (done) {
-				if (err) throw err;
-				return;
-			}
-			await new Promise<void>((r) => {
-				resolveNext = r;
-			});
-		}
+		return {
+			assistantText: textParts.join(""),
+			toolCalls,
+		};
 	}
 }

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -20,7 +20,7 @@
  * so the message builder can re-inject them for the next round.
  */
 
-import { createGame, getActivePhase, startPhase } from "./engine";
+import { createGame, startPhase } from "./engine";
 import type { ChatLockoutConfig } from "./round-coordinator";
 import { runRound } from "./round-coordinator";
 import type { RoundLLMProvider } from "./round-llm-provider";
@@ -100,7 +100,11 @@ export class GameSession {
 			completions[aiId] = text;
 		};
 
-		const { nextState, result, toolRoundtrip: newToolRoundtrip } = await runRound(
+		const {
+			nextState,
+			result,
+			toolRoundtrip: newToolRoundtrip,
+		} = await runRound(
 			this.state,
 			addressed,
 			message,

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -15,22 +15,22 @@
  * token events — the round coordinator buffers per AI before parsing, and
  * we re-expose that buffer here so the encoder can pace it.
  *
- * Implementation note: we need the per-AI completion strings that the
- * coordinator produces internally. To capture them without modifying
- * round-coordinator.ts, we wrap the provider passed to runRound so that each
- * call's output is intercepted and stored.
+ * Per-AI tool roundtrip (the OpenAI assistant tool_calls + tool result messages
+ * from the previous round) is persisted here and passed into each runRound call
+ * so the message builder can re-inject them for the next round.
  */
 
-import type { LLMProvider } from "../../proxy/llm-provider";
 import { createGame, getActivePhase, startPhase } from "./engine";
 import type { ChatLockoutConfig } from "./round-coordinator";
 import { runRound } from "./round-coordinator";
+import type { RoundLLMProvider } from "./round-llm-provider";
 import type {
 	AiId,
 	AiPersona,
 	GameState,
 	PhaseConfig,
 	RoundResult,
+	ToolRoundtripMessage,
 } from "./types";
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
@@ -42,33 +42,11 @@ export interface SubmitMessageResult {
 	nextState: GameState;
 }
 
-/**
- * A provider wrapper that intercepts each completion stream and records
- * the full text per-call in call order (red → green → blue).
- */
-class CompletionCapturingProvider implements LLMProvider {
-	private inner: LLMProvider;
-	private callIndex = 0;
-	readonly captured: string[] = [];
-
-	constructor(inner: LLMProvider) {
-		this.inner = inner;
-	}
-
-	async *streamCompletion(prompt: string): AsyncIterable<string> {
-		const parts: string[] = [];
-		for await (const token of this.inner.streamCompletion(prompt)) {
-			parts.push(token);
-			yield token;
-		}
-		this.captured[this.callIndex] = parts.join("");
-		this.callIndex++;
-	}
-}
-
 export class GameSession {
 	private state: GameState;
 	private armedChatLockout?: ChatLockoutConfig;
+	/** Per-AI tool roundtrip from the last round, fed back in as prior context. */
+	private toolRoundtrip: Partial<Record<AiId, ToolRoundtripMessage>> = {};
 
 	constructor(phaseConfig: PhaseConfig, personas: Record<AiId, AiPersona>) {
 		const game = createGame(personas);
@@ -94,7 +72,7 @@ export class GameSession {
 	 *
 	 * @param addressed  The AI the player is directing their message at.
 	 * @param message    The player's raw message text.
-	 * @param provider   LLM provider (mock or real).
+	 * @param provider   RoundLLMProvider (mock or real BrowserLLMProvider).
 	 * @param chatLockoutConfig  Optional chat-lockout configuration for deterministic testing.
 	 *   When omitted, any config previously set via armChatLockout is consumed once.
 	 * @param initiative  Optional turn-order permutation for this round.
@@ -103,7 +81,7 @@ export class GameSession {
 	async submitMessage(
 		addressed: AiId,
 		message: string,
-		provider: LLMProvider,
+		provider: RoundLLMProvider,
 		chatLockoutConfig?: ChatLockoutConfig,
 		initiative?: AiId[],
 	): Promise<SubmitMessageResult> {
@@ -112,40 +90,43 @@ export class GameSession {
 			effectiveConfig = this.armedChatLockout;
 			delete this.armedChatLockout;
 		}
-		// Wrap the provider to capture completions per call.
-		// The coordinator calls the provider once per non-locked AI in turn order.
-		// Locked AIs are skipped by the coordinator, so the capture array may have
-		// fewer entries than 3.
-		const capturing = new CompletionCapturingProvider(provider);
 
 		const turnOrder = initiative ?? AI_ORDER;
 
-		const { nextState, result } = await runRound(
+		// Capture completions per AI via the completionSink parameter.
+		// The coordinator calls the sink once per AI (empty string for locked-out AIs).
+		const completions: Partial<Record<AiId, string>> = {};
+		const completionSink = (aiId: AiId, text: string): void => {
+			completions[aiId] = text;
+		};
+
+		const { nextState, result, toolRoundtrip: newToolRoundtrip } = await runRound(
 			this.state,
 			addressed,
 			message,
-			capturing,
+			provider,
 			effectiveConfig,
 			initiative,
+			this.toolRoundtrip,
+			completionSink,
 		);
 
-		// Map captured completions back to AI IDs.
-		// The coordinator processes turnOrder and skips locked-out AIs. We need
-		// to match call-order index to AI ID accounting for lockouts.
-		const phaseBeforeRound = getActivePhase(this.state);
-		const completions: Partial<Record<AiId, string>> = {};
-		let captureIdx = 0;
+		// Fill in empty string for AIs whose completions weren't captured
+		// (only possible if the sink was never called, shouldn't happen normally)
 		for (const aiId of turnOrder) {
-			if (phaseBeforeRound.lockedOut.has(aiId)) {
-				// This AI was skipped by the coordinator — no completion
+			if (!(aiId in completions)) {
 				completions[aiId] = "";
-			} else {
-				completions[aiId] = capturing.captured[captureIdx] ?? "";
-				captureIdx++;
 			}
 		}
 
+		// Update state and tool roundtrip
 		this.state = nextState;
+		// Merge: keep only the AIs that had tool calls this round; clear others
+		// (each round's tool roundtrip is independent — only the most recent matters)
+		this.toolRoundtrip = {};
+		for (const [aiId, roundtrip] of Object.entries(newToolRoundtrip)) {
+			this.toolRoundtrip[aiId as AiId] = roundtrip;
+		}
 
 		return { result, completions, nextState };
 	}

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -1,0 +1,73 @@
+/**
+ * OpenAI Message Builder
+ *
+ * Converts an AiContext (the game's view of one AI's state) plus any prior-round
+ * tool roundtrip data into an OpenAI-spec `messages` array ready for the LLM API.
+ *
+ * Message ordering:
+ *   1. { role: "system", content: ctx.toSystemPrompt() }
+ *   2. One { role: "user" | "assistant", content } pair per turn in ctx.chatHistory
+ *   3. If priorToolRoundtrip is provided and non-empty:
+ *      - { role: "assistant", content: null, tool_calls: [...] }
+ *      - { role: "tool", tool_call_id, content } for each result
+ *
+ * Note: the system prompt already encodes world state, action log, whispers etc.
+ * The OpenAI `tools` field (not messages) teaches the model about available tools.
+ */
+
+import type { OpenAiMessage } from "./round-llm-provider.js";
+import type { AiContext } from "./prompt-builder.js";
+import type { ToolRoundtripMessage } from "./types.js";
+
+export function buildOpenAiMessages(
+	ctx: AiContext,
+	priorToolRoundtrip?: ToolRoundtripMessage,
+): OpenAiMessage[] {
+	const messages: OpenAiMessage[] = [];
+
+	// 1. System message (contains the full narrative context — world state, action log, etc.)
+	messages.push({ role: "system", content: ctx.toSystemPrompt() });
+
+	// 2. Chat history — alternating player (user) / AI (assistant) turns
+	for (const msg of ctx.chatHistory) {
+		if (msg.role === "player") {
+			messages.push({ role: "user", content: msg.content });
+		} else {
+			messages.push({ role: "assistant", content: msg.content });
+		}
+	}
+
+	// 3. Prior-round tool roundtrip (assistant tool_calls + tool results)
+	//    This re-injects the protocol messages required by OpenAI's tool-use spec:
+	//    the assistant message that contained the tool_calls, followed by each
+	//    tool result message.
+	if (
+		priorToolRoundtrip &&
+		priorToolRoundtrip.assistantToolCalls.length > 0
+	) {
+		// Re-emit the assistant message with tool_calls
+		messages.push({
+			role: "assistant",
+			content: null,
+			tool_calls: priorToolRoundtrip.assistantToolCalls.map((tc) => ({
+				id: tc.id,
+				type: "function" as const,
+				function: { name: tc.name, arguments: tc.argumentsJson },
+			})),
+		});
+
+		// Re-emit each tool result
+		for (const result of priorToolRoundtrip.toolResults) {
+			const content = result.success
+				? result.description
+				: `FAILED: ${result.description}${result.reason ? ` (${result.reason})` : ""}`;
+			messages.push({
+				role: "tool",
+				tool_call_id: result.tool_call_id,
+				content,
+			});
+		}
+	}
+
+	return messages;
+}

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -15,8 +15,8 @@
  * The OpenAI `tools` field (not messages) teaches the model about available tools.
  */
 
-import type { OpenAiMessage } from "./round-llm-provider.js";
 import type { AiContext } from "./prompt-builder.js";
+import type { OpenAiMessage } from "./round-llm-provider.js";
 import type { ToolRoundtripMessage } from "./types.js";
 
 export function buildOpenAiMessages(
@@ -41,10 +41,7 @@ export function buildOpenAiMessages(
 	//    This re-injects the protocol messages required by OpenAI's tool-use spec:
 	//    the assistant message that contained the tool_calls, followed by each
 	//    tool result message.
-	if (
-		priorToolRoundtrip &&
-		priorToolRoundtrip.assistantToolCalls.length > 0
-	) {
+	if (priorToolRoundtrip && priorToolRoundtrip.assistantToolCalls.length > 0) {
 		// Re-emit the assistant message with tool_calls
 		messages.push({
 			role: "assistant",

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -4,16 +4,19 @@
  * Orchestrates a single game round: all three AIs act in turn.
  * For each AI:
  *   1. If locked out, emit an in-character lockout line (no LLM call).
- *   2. Otherwise, build the AI's context, call the LLM provider, parse the
- *      response into an AiTurnAction, and dispatch it through the existing
- *      dispatcher.
+ *   2. Otherwise, build OpenAI messages via buildOpenAiMessages, call streamRound
+ *      on the RoundLLMProvider, translate the result into an AiTurnAction, and
+ *      dispatch through the existing dispatcher.
  * After all three AIs act, advance the round counter.
  *
  * The player's message is appended to the addressed AI's chat history
  * before the round begins. Non-addressed AIs do not see the player message.
+ *
+ * The tool roundtrip for each AI (prior assistant tool_calls + results) is
+ * accepted as input and updated after each AI acts, then returned in RunRoundResult
+ * so the caller (GameSession) can persist it across rounds.
  */
 
-import type { LLMProvider } from "../../proxy/llm-provider";
 import { dispatchAiTurn } from "./dispatcher";
 import {
 	advancePhase,
@@ -25,7 +28,10 @@ import {
 	resolveChatLockouts,
 	triggerChatLockout,
 } from "./engine";
+import { buildOpenAiMessages } from "./openai-message-builder";
 import { buildAiContext } from "./prompt-builder";
+import type { RoundLLMProvider } from "./round-llm-provider";
+import { TOOL_DEFINITIONS, parseToolCallArguments } from "./tool-registry";
 import type {
 	ActionLogEntry,
 	AiId,
@@ -33,6 +39,7 @@ import type {
 	GameState,
 	RoundResult,
 	ToolName,
+	ToolRoundtripMessage,
 } from "./types";
 
 const AI_ORDER: AiId[] = ["red", "green", "blue"];
@@ -55,95 +62,12 @@ export interface ChatLockoutConfig {
 export interface RunRoundResult {
 	nextState: GameState;
 	result: RoundResult;
-}
-
-/**
- * Parses a raw LLM completion string into an AiTurnAction.
- *
- * Expected JSON shape (any extra fields are ignored):
- *   { "action": "chat",    "content": "…" }
- *   { "action": "whisper", "target": "<aiId>", "content": "…" }
- *   { "action": "pass" }
- *
- * An optional toolCall field may accompany any action:
- *   { "action": "chat", "content": "…", "toolCall": { "name": "pick_up", "args": { "item": "flower" } } }
- *
- * Anything unparseable or with an unrecognised action falls back to pass.
- * An unrecognised toolCall.name is passed through; the dispatcher will
- * validate and log a tool_failure with reason "Unknown tool".
- */
-export function parseAiResponse(aiId: AiId, raw: string): AiTurnAction {
-	try {
-		const parsed = JSON.parse(raw.trim()) as Record<string, unknown>;
-
-		// Parse optional toolCall field
-		let toolCall: AiTurnAction["toolCall"] | undefined;
-		if (parsed.toolCall && typeof parsed.toolCall === "object") {
-			const tc = parsed.toolCall as Record<string, unknown>;
-			if (typeof tc.name === "string" && tc.name.length > 0) {
-				const args =
-					tc.args && typeof tc.args === "object"
-						? (tc.args as Record<string, string>)
-						: {};
-				// Cast to ToolName — dispatcher will reject unknown names via validateToolCall
-				toolCall = {
-					name: tc.name as ToolName,
-					args,
-				};
-			}
-		}
-
-		switch (parsed.action) {
-			case "chat": {
-				const content =
-					typeof parsed.content === "string" ? parsed.content.trim() : "";
-				if (content) {
-					return {
-						aiId,
-						chat: { target: "player", content },
-						...(toolCall ? { toolCall } : {}),
-					};
-				}
-				break;
-			}
-			case "whisper": {
-				const target = parsed.target as AiId | undefined;
-				const content =
-					typeof parsed.content === "string" ? parsed.content.trim() : "";
-				if (target && content && AI_ORDER.includes(target) && target !== aiId) {
-					return {
-						aiId,
-						whisper: { target, content },
-						...(toolCall ? { toolCall } : {}),
-					};
-				}
-				break;
-			}
-			case "pass":
-				return { aiId, pass: true, ...(toolCall ? { toolCall } : {}) };
-			default:
-				break;
-		}
-		// If we have a toolCall but the action was unrecognised, still dispatch it
-		if (toolCall) {
-			return { aiId, pass: true, toolCall };
-		}
-	} catch {
-		// not JSON — fall through to pass
-	}
-	return { aiId, pass: true };
-}
-
-/** Collect all tokens from the provider into a single string. */
-async function collectCompletion(
-	provider: LLMProvider,
-	prompt: string,
-): Promise<string> {
-	const parts: string[] = [];
-	for await (const token of provider.streamCompletion(prompt)) {
-		parts.push(token);
-	}
-	return parts.join("");
+	/**
+	 * Updated tool roundtrip data keyed by AI id.
+	 * Non-empty only for AIs that emitted tool calls this round.
+	 * The caller should persist this and pass it back on the next runRound call.
+	 */
+	toolRoundtrip: Partial<Record<AiId, ToolRoundtripMessage>>;
 }
 
 /**
@@ -152,20 +76,25 @@ async function collectCompletion(
  * @param game    Current game state (must have an active phase).
  * @param addressed  The AI the player's message is directed at.
  * @param playerMessage  The player's raw message text.
- * @param provider  LLM provider (real or mock).
+ * @param provider  RoundLLMProvider (browser or mock).
  * @param chatLockoutConfig  Optional config for the mid-phase chat-lockout event.
- *   When provided, the coordinator will trigger a lockout at `lockoutTriggerRound`
- *   using `rng` to select which AI to lock, lasting `lockoutDuration` rounds.
  * @param initiative  Optional turn-order permutation. Must be a permutation of
  *   all three AI ids ["red","green","blue"]. When absent, defaults to AI_ORDER.
+ * @param priorToolRoundtrip  Per-AI tool roundtrip from the previous round.
+ *   Passed into buildOpenAiMessages to re-inject the protocol messages required
+ *   by OpenAI's tool-use spec.
+ * @param completionSink  Optional per-AI sink for the assistant text produced
+ *   by each LLM call. Used by GameSession to capture completions for pacing.
  */
 export async function runRound(
 	game: GameState,
 	addressed: AiId,
 	playerMessage: string,
-	provider: LLMProvider,
+	provider: RoundLLMProvider,
 	chatLockoutConfig?: ChatLockoutConfig,
 	initiative?: AiId[],
+	priorToolRoundtrip?: Partial<Record<AiId, ToolRoundtripMessage>>,
+	completionSink?: (aiId: AiId, text: string) => void,
 ): Promise<RunRoundResult> {
 	// Validate initiative if provided.
 	if (initiative !== undefined) {
@@ -190,17 +119,16 @@ export async function runRound(
 	});
 
 	// Snapshot how many log entries already exist before this round starts.
-	// The phase actionLog is cumulative across rounds, so we must offset into
-	// it correctly when slicing new entries after each AI acts.
 	const logOffsetBeforeRound = getActivePhase(state).actionLog.length;
 	const roundActions: ActionLogEntry[] = [];
+
+	// Track tool roundtrip produced this round (to be returned to caller)
+	const newToolRoundtrip: Partial<Record<AiId, ToolRoundtripMessage>> = {};
 
 	// 2. Each AI acts in turn
 	for (const aiId of turnOrder) {
 		if (isAiLockedOut(state, aiId)) {
 			// Emit lockout line — no LLM call, no budget deduction.
-			// Use getActivePhase(state).round for consistency with dispatchAiTurn,
-			// which also reads the pre-advance phase.round value.
 			const lockoutContent = `${state.personas[aiId].name} is unresponsive…`;
 			state = appendChat(state, aiId, {
 				role: "ai",
@@ -215,37 +143,132 @@ export async function runRound(
 			};
 			state = appendActionLog(state, entry);
 			roundActions.push(entry);
+			// Sink gets empty string for locked AI
+			completionSink?.(aiId, "");
 			continue;
 		}
 
-		// Build context and call provider
+		// Build OpenAI messages for this AI
 		const ctx = buildAiContext(state, aiId);
-		const systemPrompt = ctx.toSystemPrompt();
-		const raw = await collectCompletion(provider, systemPrompt);
+		const priorRoundtrip = priorToolRoundtrip?.[aiId];
+		const messages = buildOpenAiMessages(ctx, priorRoundtrip);
 
-		// Parse the response into an action
-		const action = parseAiResponse(aiId, raw);
+		// Call the provider
+		const { assistantText, toolCalls } = await provider.streamRound(
+			messages,
+			TOOL_DEFINITIONS,
+		);
 
-		// Dispatch through the existing dispatcher (handles budget deduction,
-		// appendChat, appendWhisper, appendActionLog, etc.)
+		// Capture completion text
+		completionSink?.(aiId, assistantText);
+
+		// Translate the result into an AiTurnAction
+		const action: AiTurnAction = { aiId };
+
+		// Handle tool call (take first tool call if present)
+		let toolCallId: string | undefined;
+		if (toolCalls.length > 0) {
+			const tc = toolCalls[0]!;
+			toolCallId = tc.id;
+			const parseResult = parseToolCallArguments(
+				tc.name as ToolName,
+				tc.argumentsJson,
+			);
+
+			if (parseResult.ok) {
+				action.toolCall = {
+					name: tc.name as ToolName,
+					args: parseResult.args as Record<string, string>,
+				};
+			} else {
+				// Parse failed — synthesise a tool_failure directly without dispatching
+				const round = getActivePhase(state).round;
+				const failureEntry: ActionLogEntry = {
+					round,
+					actor: aiId,
+					type: "tool_failure",
+					toolName: tc.name,
+					args: {},
+					reason: parseResult.reason,
+					description: `${state.personas[aiId].name} tried to ${tc.name} but failed: ${parseResult.reason}`,
+				};
+				state = appendActionLog(state, failureEntry);
+				roundActions.push(failureEntry);
+
+				// Record the tool failure in the roundtrip for the next round
+				newToolRoundtrip[aiId] = {
+					assistantToolCalls: toolCalls.map((c) => ({
+						id: c.id,
+						name: c.name,
+						argumentsJson: c.argumentsJson,
+					})),
+					toolResults: toolCalls.map((c) => ({
+						tool_call_id: c.id,
+						success: false,
+						description: `${state.personas[aiId].name} tried to ${tc.name} but failed: ${parseResult.reason}`,
+						reason: parseResult.reason,
+					})),
+				};
+
+				// Fall through: still handle assistantText below as a pass/chat
+				action.pass = true;
+			}
+		}
+
+		// Handle assistant text (chat or pass)
+		if (assistantText && assistantText.trim()) {
+			action.chat = { target: "player", content: assistantText };
+		} else if (!action.toolCall) {
+			// No text and no valid tool call → pass
+			action.pass = true;
+		}
+
+		// Dispatch through the existing dispatcher
 		const dispatchResult = dispatchAiTurn(state, action);
 		state = dispatchResult.game;
 
-		// Collect only the entries added by this dispatch. The log is cumulative
-		// across rounds, so offset by both the pre-round baseline and the entries
-		// we've already collected within this round.
+		// Collect only the entries added by this dispatch
 		const phase = getActivePhase(state);
-		for (const entry of phase.actionLog.slice(
+		const newEntries = phase.actionLog.slice(
 			logOffsetBeforeRound + roundActions.length,
-		)) {
+		);
+		for (const entry of newEntries) {
 			roundActions.push(entry);
+		}
+
+		// Record tool roundtrip for this AI if a tool call was successfully parsed
+		if (toolCalls.length > 0 && action.toolCall && toolCallId !== undefined) {
+			// Find the tool result from the action log entries added by dispatch
+			const toolSuccess = newEntries.find(
+				(e) => e.type === "tool_success" || e.type === "tool_failure",
+			);
+			const success = toolSuccess?.type === "tool_success";
+			const description = toolSuccess?.description ?? "";
+			const reason =
+				toolSuccess?.type === "tool_failure" ? toolSuccess.reason : undefined;
+
+			newToolRoundtrip[aiId] = {
+				assistantToolCalls: toolCalls.map((c) => ({
+					id: c.id,
+					name: c.name,
+					argumentsJson: c.argumentsJson,
+				})),
+				toolResults: [
+					{
+						tool_call_id: toolCallId,
+						success,
+						description,
+						...(reason !== undefined ? { reason } : {}),
+					},
+				],
+			};
 		}
 	}
 
 	// 3. Advance the round counter
 	state = advanceRound(state);
 
-	// 4. Mid-phase chat-lockout: trigger at the configured round, resolve expired ones.
+	// 4. Mid-phase chat-lockout
 	let chatLockoutTriggered: RoundResult["chatLockoutTriggered"] | undefined;
 	let chatLockoutsResolved: AiId[] | undefined;
 
@@ -253,8 +276,6 @@ export async function runRound(
 		const { rng, lockoutTriggerRound, lockoutDuration } = chatLockoutConfig;
 		const currentRound = getActivePhase(state).round;
 
-		// Trigger a new lockout if this is the designated round and no lockout
-		// is already active for any AI (we lock at most one AI per phase).
 		const alreadyHasLockout = getActivePhase(state).chatLockouts.size > 0;
 		if (currentRound === lockoutTriggerRound && !alreadyHasLockout) {
 			const aiIndex = Math.floor(rng() * AI_ORDER.length);
@@ -267,7 +288,6 @@ export async function runRound(
 			};
 		}
 
-		// Resolve any lockouts that have expired this round.
 		const phaseBefore = getActivePhase(state);
 		const expiredAis: AiId[] = [];
 		for (const [aiId, resolveAtRound] of phaseBefore.chatLockouts) {
@@ -281,8 +301,7 @@ export async function runRound(
 		}
 	}
 
-	// 5. Check win condition against the post-round phase state.
-	//    If met, advance to the next phase (or mark game complete).
+	// 5. Check win condition
 	const activePhaseAfterRound = getActivePhase(state);
 	let phaseEnded = false;
 
@@ -292,7 +311,7 @@ export async function runRound(
 	}
 
 	const result: RoundResult = {
-		round: activePhaseAfterRound.round, // post-advance value = completed round number
+		round: activePhaseAfterRound.round,
 		actions: roundActions,
 		phaseEnded,
 		gameEnded: state.isComplete,
@@ -300,5 +319,5 @@ export async function runRound(
 		...(chatLockoutsResolved !== undefined ? { chatLockoutsResolved } : {}),
 	};
 
-	return { nextState: state, result };
+	return { nextState: state, result, toolRoundtrip: newToolRoundtrip };
 }

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -31,7 +31,7 @@ import {
 import { buildOpenAiMessages } from "./openai-message-builder";
 import { buildAiContext } from "./prompt-builder";
 import type { RoundLLMProvider } from "./round-llm-provider";
-import { TOOL_DEFINITIONS, parseToolCallArguments } from "./tool-registry";
+import { parseToolCallArguments, TOOL_DEFINITIONS } from "./tool-registry";
 import type {
 	ActionLogEntry,
 	AiId,
@@ -167,8 +167,8 @@ export async function runRound(
 
 		// Handle tool call (take first tool call if present)
 		let toolCallId: string | undefined;
-		if (toolCalls.length > 0) {
-			const tc = toolCalls[0]!;
+		const [tc] = toolCalls;
+		if (tc !== undefined) {
 			toolCallId = tc.id;
 			const parseResult = parseToolCallArguments(
 				tc.name as ToolName,
@@ -216,7 +216,7 @@ export async function runRound(
 		}
 
 		// Handle assistant text (chat or pass)
-		if (assistantText && assistantText.trim()) {
+		if (assistantText?.trim()) {
 			action.chat = { target: "player", content: assistantText };
 		} else if (!action.toolCall) {
 			// No text and no valid tool call → pass

--- a/src/spa/game/round-llm-provider.ts
+++ b/src/spa/game/round-llm-provider.ts
@@ -1,0 +1,97 @@
+/**
+ * RoundLLMProvider
+ *
+ * The browser-side LLM provider interface used by the round coordinator.
+ * Returns a structured result per AI turn: assistant text content + any tool calls.
+ *
+ * This replaces the old `LLMProvider.streamCompletion(prompt)` interface which
+ * yielded raw tokens from a custom-JSON action prompt. The new interface:
+ *   1. Accepts a pre-built OpenAI messages array (not a raw prompt string)
+ *   2. Accepts the tools array to send with each request
+ *   3. Returns a structured { assistantText, toolCalls } result
+ *
+ * Tests should use MockRoundLLMProvider (defined in this file).
+ */
+
+import type { OpenAiTool } from "./tool-registry.js";
+
+/**
+ * OpenAI-spec message types.
+ * Defined here (not in llm-client.ts) so this file can be imported by
+ * both browser code and the server-side proxy without pulling in browser globals.
+ */
+export interface OpenAiToolCall {
+	id: string;
+	type: "function";
+	function: { name: string; arguments: string };
+}
+
+export type OpenAiMessage =
+	| { role: "system"; content: string }
+	| { role: "user"; content: string }
+	| { role: "assistant"; content: string | null; tool_calls?: OpenAiToolCall[] }
+	| { role: "tool"; tool_call_id: string; content: string };
+
+export interface RoundTurnResult {
+	assistantText: string;
+	toolCalls: Array<{ id: string; name: string; argumentsJson: string }>;
+}
+
+export interface RoundLLMProvider {
+	streamRound(
+		messages: OpenAiMessage[],
+		tools: OpenAiTool[],
+	): Promise<RoundTurnResult>;
+}
+
+/**
+ * MockRoundLLMProvider for tests.
+ *
+ * Accepts an array of pre-configured results returned in call order.
+ * Each entry is either a full RoundTurnResult or a shorthand:
+ *   - string → { assistantText: string, toolCalls: [] }
+ *   - { toolCall: ... } → { assistantText: "", toolCalls: [toolCall] }
+ */
+export type MockRoundResult =
+	| string
+	| RoundTurnResult
+	| {
+			assistantText?: string;
+			toolCall: { id: string; name: string; argumentsJson: string };
+	  };
+
+export class MockRoundLLMProvider implements RoundLLMProvider {
+	readonly calls: Array<{
+		messages: OpenAiMessage[];
+		tools: OpenAiTool[];
+	}> = [];
+
+	private results: MockRoundResult[];
+	private index = 0;
+
+	constructor(results: MockRoundResult[]) {
+		this.results = results;
+	}
+
+	async streamRound(
+		messages: OpenAiMessage[],
+		tools: OpenAiTool[],
+	): Promise<RoundTurnResult> {
+		this.calls.push({ messages, tools });
+		const raw =
+			this.results[this.index % this.results.length] ??
+			({ assistantText: "", toolCalls: [] } satisfies RoundTurnResult);
+		this.index++;
+
+		if (typeof raw === "string") {
+			return { assistantText: raw, toolCalls: [] };
+		}
+		if ("toolCall" in raw) {
+			return {
+				assistantText: raw.assistantText ?? "",
+				toolCalls: [raw.toolCall],
+			};
+		}
+		return raw;
+	}
+}

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -1,0 +1,177 @@
+/**
+ * Tool Registry
+ *
+ * Single source of truth for the OpenAI-spec `tools` array.
+ * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `give`, `use`.
+ * Names and argument keys mirror `validateToolCall` in `dispatcher.ts` 1:1.
+ */
+
+import type { ToolName } from "./types";
+
+export interface OpenAiToolFunction {
+	name: string;
+	description: string;
+	parameters: {
+		type: "object";
+		properties: Record<
+			string,
+			{ type: string; description: string; enum?: string[] }
+		>;
+		required: string[];
+		additionalProperties: false;
+	};
+}
+
+export interface OpenAiTool {
+	type: "function";
+	function: OpenAiToolFunction;
+}
+
+export const TOOL_DEFINITIONS: OpenAiTool[] = [
+	{
+		type: "function",
+		function: {
+			name: "pick_up",
+			description:
+				"Pick up an item that is currently in the room. Fails if you are already holding it or it is held by another AI.",
+			parameters: {
+				type: "object",
+				properties: {
+					item: {
+						type: "string",
+						description: "The id of the item to pick up.",
+					},
+				},
+				required: ["item"],
+				additionalProperties: false,
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "put_down",
+			description: "Put down an item you are currently holding. Places it in the room.",
+			parameters: {
+				type: "object",
+				properties: {
+					item: {
+						type: "string",
+						description: "The id of the item you are holding.",
+					},
+				},
+				required: ["item"],
+				additionalProperties: false,
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "give",
+			description:
+				"Give an item you are holding to another AI. Fails if you are not holding it or you target yourself.",
+			parameters: {
+				type: "object",
+				properties: {
+					item: {
+						type: "string",
+						description: "The id of the item you are holding.",
+					},
+					to: {
+						type: "string",
+						enum: ["red", "green", "blue"],
+						description: "The AI to give the item to.",
+					},
+				},
+				required: ["item", "to"],
+				additionalProperties: false,
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "use",
+			description:
+				"Use an item you are holding. Has no world effect in v1 — surfaces an action-log entry.",
+			parameters: {
+				type: "object",
+				properties: {
+					item: {
+						type: "string",
+						description: "The id of the item you are holding.",
+					},
+				},
+				required: ["item"],
+				additionalProperties: false,
+			},
+		},
+	},
+];
+
+type ParseSuccess<T> = { ok: true; args: T };
+type ParseFailure = { ok: false; reason: string };
+type ParseResult<T> = ParseSuccess<T> | ParseFailure;
+
+/** Argument shapes per tool */
+type PickUpArgs = { item: string };
+type PutDownArgs = { item: string };
+type GiveArgs = { item: string; to: string };
+type UseArgs = { item: string };
+
+type ToolArgs = {
+	pick_up: PickUpArgs;
+	put_down: PutDownArgs;
+	give: GiveArgs;
+	use: UseArgs;
+};
+
+/**
+ * Parse and validate tool-call arguments from the raw JSON string provided by the LLM.
+ *
+ * Returns `{ ok: true, args }` on success or `{ ok: false, reason }` on failure.
+ * Validates that all required arguments for the named tool are present.
+ */
+export function parseToolCallArguments<N extends ToolName>(
+	name: N,
+	rawJson: string,
+): ParseResult<ToolArgs[N]> {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawJson);
+	} catch {
+		return { ok: false, reason: "Malformed tool arguments JSON" };
+	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		return { ok: false, reason: "Malformed tool arguments JSON" };
+	}
+
+	const obj = parsed as Record<string, unknown>;
+
+	switch (name) {
+		case "pick_up":
+		case "put_down":
+		case "use": {
+			if (typeof obj.item !== "string" || obj.item.length === 0) {
+				return { ok: false, reason: "Required argument 'item' is missing" };
+			}
+			return { ok: true, args: { item: obj.item } as ToolArgs[N] };
+		}
+		case "give": {
+			if (typeof obj.item !== "string" || obj.item.length === 0) {
+				return { ok: false, reason: "Required argument 'item' is missing" };
+			}
+			if (typeof obj.to !== "string" || obj.to.length === 0) {
+				return { ok: false, reason: "Required argument 'to' is missing" };
+			}
+			return {
+				ok: true,
+				args: { item: obj.item, to: obj.to } as ToolArgs[N],
+			};
+		}
+		default:
+			return { ok: false, reason: `Unknown tool "${name}"` };
+	}
+}

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -51,7 +51,8 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 		type: "function",
 		function: {
 			name: "put_down",
-			description: "Put down an item you are currently holding. Places it in the room.",
+			description:
+				"Put down an item you are currently holding. Places it in the room.",
 			parameters: {
 				type: "object",
 				properties: {

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -137,6 +137,25 @@ export interface AiTurnAction {
 	pass?: boolean;
 }
 
+/**
+ * Captures the tool-call / result pair from a single AI turn, used to
+ * re-inject the assistant's tool_calls message + the tool result message
+ * into the next round's messages array (per OpenAI tool-use protocol).
+ */
+export interface ToolRoundtripMessage {
+	assistantToolCalls: Array<{
+		id: string;
+		name: string;
+		argumentsJson: string;
+	}>;
+	toolResults: Array<{
+		tool_call_id: string;
+		success: boolean;
+		description: string;
+		reason?: string;
+	}>;
+}
+
 export interface RoundResult {
 	round: number;
 	actions: ActionLogEntry[];

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -1,11 +1,8 @@
 import { PINNED_MODEL } from "../model.js";
+import type { OpenAiMessage } from "./game/round-llm-provider.js";
+import type { OpenAiTool } from "./game/tool-registry.js";
 import type { ToolCallResult } from "./streaming.js";
 import { parseSSEStream } from "./streaming.js";
-import type { OpenAiTool } from "./game/tool-registry.js";
-import type {
-	OpenAiMessage,
-	OpenAiToolCall,
-} from "./game/round-llm-provider.js";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const LOCALSTORAGE_KEY = "openrouter_key";
@@ -111,7 +108,10 @@ export function resolveLLMTarget(): {
 
 // Re-export the message types from round-llm-provider (canonical definition)
 // and OpenAiTool from tool-registry so callers can import from one place.
-export type { OpenAiMessage, OpenAiToolCall } from "./game/round-llm-provider.js";
+export type {
+	OpenAiMessage,
+	OpenAiToolCall,
+} from "./game/round-llm-provider.js";
 export type { OpenAiTool } from "./game/tool-registry.js";
 
 export async function streamCompletion(opts: {

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -1,5 +1,11 @@
 import { PINNED_MODEL } from "../model.js";
+import type { ToolCallResult } from "./streaming.js";
 import { parseSSEStream } from "./streaming.js";
+import type { OpenAiTool } from "./game/tool-registry.js";
+import type {
+	OpenAiMessage,
+	OpenAiToolCall,
+} from "./game/round-llm-provider.js";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const LOCALSTORAGE_KEY = "openrouter_key";
@@ -103,24 +109,38 @@ export function resolveLLMTarget(): {
 	};
 }
 
-export interface OpenAiMessage {
-	role: "system" | "user" | "assistant";
-	content: string;
-}
+// Re-export the message types from round-llm-provider (canonical definition)
+// and OpenAiTool from tool-registry so callers can import from one place.
+export type { OpenAiMessage, OpenAiToolCall } from "./game/round-llm-provider.js";
+export type { OpenAiTool } from "./game/tool-registry.js";
 
 export async function streamCompletion(opts: {
 	messages: OpenAiMessage[];
 	signal?: AbortSignal;
 	onDelta: (text: string) => void;
 	onReasoning?: (text: string) => void;
+	tools?: OpenAiTool[];
+	onToolCall?: (call: ToolCallResult) => void;
 }): Promise<void> {
-	const { messages, signal, onDelta, onReasoning } = opts;
+	const { messages, signal, onDelta, onReasoning, tools, onToolCall } = opts;
 	const { url, headers } = resolveLLMTarget();
+
+	const bodyObj: Record<string, unknown> = {
+		model: PINNED_MODEL,
+		messages,
+		stream: true,
+	};
+
+	// Only include tools/tool_choice when tools are provided (do not send empty array)
+	if (tools && tools.length > 0) {
+		bodyObj.tools = tools;
+		bodyObj.tool_choice = "auto";
+	}
 
 	const response = await fetch(url, {
 		method: "POST",
 		headers,
-		body: JSON.stringify({ model: PINNED_MODEL, messages, stream: true }),
+		body: JSON.stringify(bodyObj),
 		...(signal != null ? { signal } : {}),
 	});
 
@@ -134,7 +154,7 @@ export async function streamCompletion(opts: {
 		throw new Error("Response body is null");
 	}
 
-	await parseSSEStream(response.body, onDelta, onReasoning);
+	await parseSSEStream(response.body, onDelta, onReasoning, onToolCall);
 }
 
 export async function streamChat(opts: {

--- a/src/spa/streaming.ts
+++ b/src/spa/streaming.ts
@@ -1,11 +1,32 @@
+export interface ToolCallResult {
+	id: string;
+	name: string;
+	argumentsJson: string;
+}
+
 export async function parseSSEStream(
 	body: ReadableStream<Uint8Array>,
 	onDelta: (text: string) => void,
 	onReasoning?: (text: string) => void,
+	onToolCall?: (call: ToolCallResult) => void,
 ): Promise<void> {
 	const reader = body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+
+	// Accumulate tool_calls deltas by index
+	const toolCallAccumulator: Map<
+		number,
+		{ id: string; name: string; argumentsJson: string }
+	> = new Map();
+
+	function flushToolCalls(): void {
+		if (!onToolCall) return;
+		for (const [, call] of toolCallAccumulator) {
+			onToolCall(call);
+		}
+		toolCallAccumulator.clear();
+	}
 
 	try {
 		while (true) {
@@ -22,7 +43,10 @@ export async function parseSSEStream(
 				for (const line of event.split("\n")) {
 					if (!line.startsWith("data:")) continue;
 					const data = line.slice("data:".length).trim();
-					if (data === "[DONE]") return;
+					if (data === "[DONE]") {
+						flushToolCalls();
+						return;
+					}
 					try {
 						// biome-ignore lint/suspicious/noExplicitAny: SSE JSON shape is dynamic
 						const parsed: any = JSON.parse(data);
@@ -33,6 +57,51 @@ export async function parseSSEStream(
 						const reasoning = parsed?.choices?.[0]?.delta?.reasoning;
 						if (typeof reasoning === "string" && reasoning.length > 0) {
 							onReasoning?.(reasoning);
+						}
+
+						// Accumulate tool_calls deltas by index
+						const toolCallDeltas = parsed?.choices?.[0]?.delta?.tool_calls;
+						if (Array.isArray(toolCallDeltas)) {
+							for (const delta of toolCallDeltas) {
+								if (typeof delta?.index !== "number") continue;
+								const idx: number = delta.index;
+								const existing = toolCallAccumulator.get(idx);
+								if (!existing) {
+									// First fragment: initialise from id, name
+									toolCallAccumulator.set(idx, {
+										id: typeof delta.id === "string" ? delta.id : "",
+										name:
+											typeof delta.function?.name === "string"
+												? delta.function.name
+												: "",
+										argumentsJson:
+											typeof delta.function?.arguments === "string"
+												? delta.function.arguments
+												: "",
+									});
+								} else {
+									// Subsequent fragments: concatenate arguments
+									if (typeof delta.function?.arguments === "string") {
+										existing.argumentsJson += delta.function.arguments;
+									}
+									// id and name only appear in the first fragment
+									if (typeof delta.id === "string" && delta.id) {
+										existing.id = delta.id;
+									}
+									if (
+										typeof delta.function?.name === "string" &&
+										delta.function.name
+									) {
+										existing.name = delta.function.name;
+									}
+								}
+							}
+						}
+
+						// finish_reason: "tool_calls" signals the calls are complete
+						const finishReason = parsed?.choices?.[0]?.finish_reason;
+						if (finishReason === "tool_calls") {
+							flushToolCalls();
 						}
 					} catch {
 						// Ignore malformed JSON chunks


### PR DESCRIPTION
## What this fixes

Replaces the custom-JSON `{"action": ..., "toolCall": ...}` stand-in (the placeholder shape #43 left in place) with the real OpenAI `tools` / `tool_calls` protocol, end-to-end in the browser. The dispatcher remains the source of truth — the LLM only proposes; world-state mutation and action-log entries (success or failure) flow exclusively through `dispatchAiTurn`. PRD 0001's "failures are public" rule is preserved: every `tool_failure` lands in `phase.actionLog` and is rendered into all three AIs' next system prompt by `prompt-builder.ts`.

Shape of the change:

- **`src/spa/game/tool-registry.ts`** (new) — `TOOL_DEFINITIONS` declares the four tools (`pick_up`, `put_down`, `give`, `use`) in OpenAI JSON-Schema-shaped objects, mirroring the cases in `dispatcher.validateToolCall` 1:1. `parseToolCallArguments` validates raw `arguments` strings and reports malformed-JSON or missing-required-field failures structurally.
- **`src/spa/game/openai-message-builder.ts`** (new) — `buildOpenAiMessages(ctx, priorToolRoundtrip?)` assembles the wire `messages` array: system prompt, chat-history pairs, then any prior-round `assistant{tool_calls}` plus matching `tool` results so the next round can see what the model called and what the world said back.
- **`src/spa/game/round-llm-provider.ts`** (new) — `RoundLLMProvider` interface (`streamRound(messages, tools) → { assistantText, toolCalls }`); types for `OpenAiMessage`, `OpenAiTool`, `OpenAiToolCall` live here so the proxy tsconfig can reach them without browser globals.
- **`src/spa/streaming.ts`** — `parseSSEStream` now accumulates `tool_calls` deltas by `index` (per OpenAI spec, fragments arrive as `{id, name, arguments: ""}` then arg chunks) and flushes via `onToolCall` on `finish_reason: "tool_calls"` or `[DONE]`.
- **`src/spa/llm-client.ts`** — `streamCompletion` accepts `tools` and `onToolCall`; the request body sends `{ tools, tool_choice: "auto" }` only when tools are provided (omitted, never `[]`). BYOK and worker-proxy paths are wire-identical; `openai-proxy.ts` already spreads `...body`, so no proxy changes were needed.
- **`src/spa/game/round-coordinator.ts`** — `parseAiResponse` is gone. The round loop now calls `provider.streamRound(messages, TOOL_DEFINITIONS)` per AI; `assistantText` becomes a chat action, `toolCalls[0]` becomes a toolCall action; malformed JSON → `tool_failure` synthesised directly. Tool roundtrip (assistant tool_calls + dispatcher outcome) is returned per AI for next-round replay.
- **`src/spa/game/game-session.ts`** — persists `Record<AiId, ToolRoundtripMessage[]>` across rounds and feeds it back into `runRound`. Replaces the now-obsolete `CompletionCapturingProvider` shim.
- **`src/spa/game/types.ts`** — `ToolRoundtripMessage` type added.
- **`src/proxy/_smoke.ts`** — `ServerMockRoundProvider` implements the new `RoundLLMProvider` interface so the worker-project SSE smoke continues to drive the round end-to-end.

## QA steps for the human

The automated coverage exercises every acceptance criterion (see _Automated coverage_ below). For eyes-on validation:

- [ ] Run a real session against your OpenRouter / BYOK key and watch the network panel: `POST` body to `/v1/chat/completions` (or the proxy) carries a `tools: [...]` array with the four function defs and `tool_choice: "auto"`.
- [ ] Trigger an obviously-invalid tool call (e.g. ask an AI to pick up something that isn't in the room) and confirm a `tool_failure` line shows up in the action log on the next round, visible to all three AIs.
- [ ] Trigger a successful tool call and confirm world state updates (the picked-up item shows as held by that AI) and the next round's system prompt for that AI includes both the prior assistant `tool_calls` it emitted and the dispatcher's success description as a `tool` message.

**Caveat / known follow-up:** the old "AI emits a whisper through the custom-JSON action body" path is gone, because the OpenAI tool protocol gives the model no whisper tool and #44 explicitly does not introduce new tools. Whispers can still be dispatched programmatically through the dispatcher's `whisper` action shape; surfacing whispers via the tool registry is a follow-up. The whisper sub-suite of the round-coordinator tests was simplified accordingly — there is no UI regression because the existing chat page never relied on AI-initiated whispers.

## Automated coverage

`pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (513 / 513 across 27 files; includes the worker-project SSE smoke under miniflare)

Closes #44

---
_Generated by [Claude Code](https://claude.ai/code/session_0149w8YWuwDUTBwim2LdgM4b)_