### PR TITLE
local server method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ corepack enable && pnpm install
 
 | Command | Description |
 | ------- | ----------- |
-| `pnpm lint` | Lint        |
-| _TBD_   | Typecheck   |
-| _TBD_   | Test        |
+| `pnpm lint` | Lint |
+| `pnpm typecheck` | Typecheck |
+| `pnpm test` | Test |
+| `pnpm build` | Build the static SPA into `dist/` |
+| `pnpm dev` | Run the SPA + Worker dev loop (press **b** to open the SPA). SPA source edits trigger an esbuild rebuild; refresh the browser. Worker source edits live-reload through Wrangler. |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
 	"packageManager": "pnpm@10.33.2",
 	"scripts": {
 		"build": "node scripts/build-spa.mjs",
+		"build:watch": "node scripts/build-spa.mjs --watch",
+		"dev": "pnpm build && concurrently -k -n spa,worker -c blue,magenta \"pnpm build:watch\" \"wrangler dev\"",
 		"sandcastle": "npx tsx .sandcastle/main.mts",
 		"lint": "biome ci .",
 		"typecheck": "tsgo --noEmit -p tsconfig.json && tsgo --noEmit -p src/proxy/tsconfig.json",
@@ -27,6 +29,7 @@
 		"@cloudflare/vitest-pool-workers": "0.15.1",
 		"@cloudflare/workers-types": "4.20260430.1",
 		"@typescript/native-preview": "7.0.0-dev.20260430.1",
+		"concurrently": "^9.1.2",
 		"esbuild": "^0.27.3",
 		"husky": "^9.1.7",
 		"jsdom": "29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260430.1
         version: 7.0.0-dev.20260430.1
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.2.1
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -993,6 +996,14 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1007,8 +1018,28 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1035,6 +1066,9 @@ packages:
   effect@3.21.2:
     resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1049,6 +1083,10 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1087,6 +1125,14 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1103,6 +1149,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1273,6 +1323,10 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1281,6 +1335,9 @@ packages:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -1294,6 +1351,10 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1311,9 +1372,25 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1350,6 +1427,10 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1494,6 +1575,10 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -1525,10 +1610,22 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -2236,6 +2333,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   assertion-error@2.0.1: {}
 
   bidi-js@1.0.3:
@@ -2246,7 +2349,33 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   cjs-module-lexer@1.4.3: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   convert-source-map@2.0.0: {}
 
@@ -2272,6 +2401,8 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
+
+  emoji-regex@8.0.0: {}
 
   entities@8.0.0: {}
 
@@ -2308,6 +2439,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2337,6 +2470,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-caller-file@2.0.5: {}
+
+  has-flag@4.0.0: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
@@ -2348,6 +2485,8 @@ snapshots:
   ini@4.1.3: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -2507,6 +2646,8 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   rolldown@1.0.0-rc.17:
@@ -2529,6 +2670,10 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   saxes@6.0.0:
     dependencies:
@@ -2567,6 +2712,8 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  shell-quote@1.8.3: {}
+
   siginfo@2.0.0: {}
 
   sisteransi@1.0.5: {}
@@ -2577,7 +2724,25 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   supports-color@10.2.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -2608,8 +2773,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.8.1:
-    optional: true
+  tree-kill@1.2.2: {}
+
+  tslib@2.8.1: {}
 
   typescript@6.0.3: {}
 
@@ -2708,6 +2874,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.18.0: {}
 
   ws@8.20.0: {}
@@ -2716,7 +2888,21 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   youch-core@0.3.3:
     dependencies:

--- a/scripts/__tests__/build-spa.test.ts
+++ b/scripts/__tests__/build-spa.test.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "../..");
+const script = path.join(root, "scripts/build-spa.mjs");
+
+describe("build-spa.mjs (one-shot, no --watch)", () => {
+	it("exits with code 0 and creates dist/index.html, dist/assets/index.js, dist/assets/index.css", () => {
+		const result = spawnSync("node", [script], {
+			cwd: root,
+			encoding: "utf-8",
+			timeout: 30_000,
+		});
+
+		expect(result.status).toBe(0);
+		expect(
+			fs.existsSync(path.join(root, "dist/index.html")),
+			"dist/index.html should exist",
+		).toBe(true);
+		expect(
+			fs.existsSync(path.join(root, "dist/assets/index.js")),
+			"dist/assets/index.js should exist",
+		).toBe(true);
+		expect(
+			fs.existsSync(path.join(root, "dist/assets/index.css")),
+			"dist/assets/index.css should exist",
+		).toBe(true);
+	});
+});

--- a/scripts/build-spa.mjs
+++ b/scripts/build-spa.mjs
@@ -7,13 +7,31 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
 
 const WORKER_BASE_URL = process.env.WORKER_BASE_URL ?? "http://localhost:8787";
+const watchMode = process.argv.includes("--watch");
 
 console.log(`Building SPA with WORKER_BASE_URL=${WORKER_BASE_URL}`);
 
 // Ensure dist/ and dist/assets/ exist
 await fs.mkdir(path.join(root, "dist", "assets"), { recursive: true });
 
-await esbuild.build({
+/** esbuild plugin: re-copy index.html after every (re)build. */
+const copyHtmlPlugin = {
+	name: "copy-html",
+	setup(build) {
+		build.onEnd(async () => {
+			try {
+				await fs.copyFile(
+					path.join(root, "src/spa/index.html"),
+					path.join(root, "dist/index.html"),
+				);
+			} catch (err) {
+				console.error("[copy-html] failed to copy index.html:", err);
+			}
+		});
+	},
+};
+
+const ctx = await esbuild.context({
 	entryPoints: { index: path.join(root, "src/spa/main.ts") },
 	bundle: true,
 	outdir: path.join(root, "dist/assets"),
@@ -25,11 +43,15 @@ await esbuild.build({
 	define: {
 		__WORKER_BASE_URL__: JSON.stringify(WORKER_BASE_URL),
 	},
+	plugins: [copyHtmlPlugin],
 });
 
-await fs.copyFile(
-	path.join(root, "src/spa/index.html"),
-	path.join(root, "dist/index.html"),
-);
-
-console.log("Build complete: dist/index.html + dist/assets/index.{js,css}");
+if (watchMode) {
+	await ctx.watch();
+	console.log("watching SPA sources…");
+	// Keep the process alive — ctrl-C to stop.
+} else {
+	await ctx.rebuild();
+	await ctx.dispose();
+	console.log("Build complete: dist/index.html + dist/assets/index.{js,css}");
+}

--- a/src/proxy/_smoke.test.ts
+++ b/src/proxy/_smoke.test.ts
@@ -1,6 +1,9 @@
 import { reset, SELF } from "cloudflare:test";
 import { afterEach, describe, expect, it } from "vitest";
 
+// ALLOWED_ORIGINS is set in vitest.config.ts miniflare bindings:
+// "https://app.example,http://localhost:5173"
+
 afterEach(async () => {
 	// Clear all KV state so rate-guard tests don't interfere with each other.
 	await reset();
@@ -49,6 +52,40 @@ describe("GET /endgame dev route (issue #30)", () => {
 		const response = await SELF.fetch("https://example.com/endgame");
 		const html = await response.text();
 		expect(html).toContain("data-save-payload");
+	});
+});
+
+describe("OPTIONS /v1/chat/completions — CORS preflight (issue #66)", () => {
+	it("returns 204 for allowed origin with Access-Control-Allow-Origin echoed", async () => {
+		const response = await SELF.fetch(
+			"https://example.com/v1/chat/completions",
+			{
+				method: "OPTIONS",
+				headers: {
+					Origin: "https://app.example",
+					"Access-Control-Request-Method": "POST",
+				},
+			},
+		);
+		expect(response.status).toBe(204);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+			"https://app.example",
+		);
+	});
+
+	it("returns 204 for disallowed origin with no Access-Control-Allow-Origin", async () => {
+		const response = await SELF.fetch(
+			"https://example.com/v1/chat/completions",
+			{
+				method: "OPTIONS",
+				headers: {
+					Origin: "https://evil.com",
+					"Access-Control-Request-Method": "POST",
+				},
+			},
+		);
+		expect(response.status).toBe(204);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
 	});
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 				extends: true,
 				test: {
 					name: "browser",
-					include: ["src/**/*.test.ts"],
+					include: ["src/**/*.test.ts", "scripts/__tests__/**/*.test.ts"],
 					exclude: ["src/proxy/**"],
 					environment: "jsdom",
 				},

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,13 @@
 	"main": "src/proxy/_smoke.ts",
 	"compatibility_date": "2025-12-01",
 	"compatibility_flags": ["nodejs_compat"],
+	// Static assets (SPA). Wrangler serves matching paths from dist/ first;
+	// unmatched paths fall through to the Worker fetch handler (API routes).
+	// Run `pnpm build` before `wrangler dev` so the dist/ directory exists.
+	"assets": {
+		"directory": "./dist",
+		"not_found_handling": "single-page-application"
+	},
 	"kv_namespaces": [
 		{
 			// per-IP and global daily token counters (issue #37)


### PR DESCRIPTION
## What this fixes

Wires the new static SPA into `wrangler dev` so the local dev loop is one command and pressing **b** in the Wrangler TUI opens the SPA — not the legacy server-rendered chat page.

The change has three moving parts:

- **`wrangler.jsonc`** gets an `assets` block (`directory: "./dist"`, `not_found_handling: "single-page-application"`). Wrangler serves matching asset paths first and falls through to the Worker for unmatched paths, so `POST /v1/chat/completions`, `POST /diagnostics`, the OPTIONS preflight handler, and the `/game/*` + `/endgame` routes keep working unchanged. The Worker entry (`src/proxy/_smoke.ts`) is untouched — `/` is shadowed by `dist/index.html` in dev, but the existing handler stays reachable as a direct hit and via `cloudflare:test`'s `SELF.fetch` (which doesn't route through the assets layer). The legacy `/` → server-rendered chat path will be removed by the #48 cutover.
- **`scripts/build-spa.mjs`** moves from `esbuild.build(...)` to `esbuild.context(...)` and gates on a `--watch` argv flag. An inline `copyHtmlPlugin` re-copies `src/spa/index.html` after every (re)build's `onEnd`, so HTML-only edits also propagate. Without `--watch` it does `ctx.rebuild(); ctx.dispose()` and exits cleanly — `pnpm build` and CI behaviour are unchanged.
- **`package.json`** adds `build:watch` and a `dev` script that runs `pnpm build` once to seed `dist/`, then `concurrently -k -n spa,worker` runs `pnpm build:watch` and `wrangler dev` together. `concurrently@^9` is the only new devDependency. `-k` ensures Ctrl-C in the Wrangler TUI also kills the watcher.

Tests: a new `scripts/__tests__/build-spa.test.ts` smoke verifies the one-shot build produces `dist/index.html`, `dist/assets/index.js`, `dist/assets/index.css`. `src/proxy/_smoke.test.ts` gains CORS-preflight cases for `OPTIONS /v1/chat/completions` (allowed and disallowed origins). `vitest.config.ts` extends the browser project's `include` to pick up the new scripts test.

README's commands table now documents `pnpm dev` and `pnpm build`, and the `_TBD_` typecheck/test rows are filled in.

## QA steps for the human

The acceptance criteria were exercised by an automated live smoke against `wrangler dev` — see "Automated coverage" below. The remaining manual checks worth doing:

- `pnpm install` (the lockfile changed; `concurrently` is new).
- `pnpm dev`, then press **b** — confirm the SPA renders (panels with `data-ai="ember|sage|frost"`, BYOK cog), not the old `<form>/<textarea>/<output>` page.
- Live-edit `src/spa/main.ts` (a real code change, not a comment-only edit — esbuild dedupes minified output when the post-strip bytes are identical) and refresh the browser to see it pick up.
- Live-edit `src/proxy/_smoke.ts` and confirm Wrangler's built-in live reload still fires.

**Note for the team:** `wrangler dev` may need the `--local` flag if you're not logged into Cloudflare, because the configured KV has `remote: true`. The smoke ran with `--local`. If `pnpm dev` complains about KV auth on a fresh checkout, that's the cause; not introduced by this change.

## Automated coverage

`pnpm typecheck`, `pnpm test` (545 tests / 29 files), and `pnpm lint` (biome) all pass. The live smoke exercised: `pnpm build` produces non-empty `dist/` outputs; `wrangler dev --local` serves `dist/index.html` at `/` (verified byte-for-byte, contains `data-ai` / `byok-cog`, no `<textarea>`); `OPTIONS /v1/chat/completions` returns 204 with the allowed `Access-Control-Allow-Origin` echoed via the Worker (and omitted for disallowed origins); `POST /diagnostics` reaches the Worker; SPA fallback fires for browser document navigations to deep links (`Sec-Fetch-Dest: document`); and `pnpm build:watch` rebuilds `dist/assets/index.js` within ~1s of a real source change.

Closes #66

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHUokQWPQD76YmL89i9t78)_