### PR TITLE
Install Playwright for integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ pnpm-debug.log*
 .AppleDouble
 .LSOverride
 Thumbs.db
+
+# Playwright
+/playwright-report/
+/test-results/
+/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ Default vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-
 ### Domain docs
 
 Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Testing
+
+Three surfaces — Vitest workers (`src/proxy/`), Vitest jsdom (`src/spa/`), and Playwright e2e (`e2e/`). SPA changes that affect rendered DOM or user interaction need a Playwright spec — jsdom unit tests don't substitute. See `docs/agents/testing.md`.

--- a/RALPH_QA.md
+++ b/RALPH_QA.md
@@ -1,5 +1,7 @@
 # Ralph QA Checklist — Rounds 1–3 merged into `claude/review-issues-ralph-loop-dt49w`
 
+> Items with an automated equivalent live in `e2e/`; run `pnpm test:e2e`.
+
 Final integration smoke: ✅ passed — `pnpm lint` clean, `pnpm typecheck` clean, 269/269 tests pass on the merged tip.
 
 > Issues #29, #30, #31, #32 below are still **open**. After you merge the round PR into the long-lived branch, run the close-out agent (`close.md`) to close them with commit references.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ corepack enable && pnpm install
 | `pnpm test` | Test |
 | `pnpm build` | Build the static SPA into `dist/` |
 | `pnpm dev` | Run the SPA + Worker dev loop (press **b** to open the SPA). SPA source edits trigger an esbuild rebuild; refresh the browser. Worker source edits live-reload through Wrangler. |
+| `pnpm test:e2e` | Run Playwright integration tests (see below). |
+
+## Integration tests (Playwright)
+
+One-time browser install (after `pnpm install`):
+
+```sh
+pnpm exec playwright install chromium
+```
+
+Run the suite:
+
+```sh
+pnpm test:e2e
+```
+
+The `webServer` config in `playwright.config.ts` automatically runs `pnpm build` and then `wrangler dev --port 8787` before the tests start. No manual dev server needed.
+
+View the HTML report after a run:
+
+```sh
+pnpm exec playwright show-report
+```

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,22 @@
+# Testing
+
+Three test surfaces. Each has a different role; pick the right one when you change code.
+
+## Vitest workers (`src/proxy/**/*.test.ts`)
+
+Cloudflare Worker logic — request/response, KV, SSE encoders, rate-guard. Runs under `@cloudflare/vitest-pool-workers` with Miniflare bindings (see `vitest.config.ts`). Use this when you change anything under `src/proxy/`.
+
+## Vitest jsdom (`src/spa/__tests__/**/*.test.ts` and other `src/**/*.test.ts` outside proxy)
+
+Unit-level coverage for SPA modules — pure logic, encoder/decoder round-trips, persistence, router, streaming math. Fast, but jsdom is **not a real browser**: it does not catch real layout, real-DOM event timing, real-browser API gaps, or build-pipeline regressions.
+
+## Playwright e2e (`e2e/**/*.spec.ts`)
+
+Live browser end-to-end against `pnpm build` + `wrangler dev` on `:8787` — the production-shaped surface (built SPA from `dist/` served by the same Worker that handles the API). Run with `pnpm test:e2e`. Use this when:
+
+- You change anything under `src/spa/` that affects rendered DOM, user interaction, or the loaded-page experience — panel rendering, form behaviour, SSE streaming, phase transitions, endgame overlay, the `/endgame` route, lockouts, cap-hit handling.
+- You touch the `assets` block in `wrangler.jsonc` or `scripts/build-spa.mjs` (the build/serve surface the e2e exercises).
+
+**Vitest jsdom does not substitute for Playwright on these changes** — add or update a spec under `e2e/`.
+
+`RALPH_QA.md` lists manual flows that should migrate to `e2e/` over time. When you automate one, flip its checkbox in `RALPH_QA.md` and link the spec.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test("SPA root renders three AI panels and composer", async ({ page }) => {
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	await page.goto("/");
+
+	await expect(page.locator("article.ai-panel")).toHaveCount(3);
+
+	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
+	await expect(page.locator('article.ai-panel[data-ai="green"]')).toBeVisible();
+	await expect(page.locator('article.ai-panel[data-ai="blue"]')).toBeVisible();
+
+	await expect(page.locator("#composer")).toBeVisible();
+
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
 		"lint": "biome ci .",
 		"typecheck": "tsgo --noEmit -p tsconfig.json && tsgo --noEmit -p src/proxy/tsconfig.json",
 		"test": "vitest run",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
 		"prepare": "husky"
 	},
 	"pnpm": {
@@ -25,6 +27,7 @@
 	},
 	"devDependencies": {
 		"@ai-hero/sandcastle": "^0.5.6",
+		"@playwright/test": "^1.52.0",
 		"@biomejs/biome": "2.4.13",
 		"@cloudflare/vitest-pool-workers": "0.15.1",
 		"@cloudflare/workers-types": "4.20260430.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./e2e",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: [["list"], ["html", { open: "never" }]],
+	use: {
+		baseURL: "http://localhost:8787",
+		trace: "on-first-retry",
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+	webServer: {
+		command:
+			"pnpm build && pnpm exec wrangler dev --local --port 8787 --var ENABLE_TEST_MODES:1 --var OPENROUTER_API_KEY:test-key",
+		url: "http://localhost:8787",
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 4.20260430.1
         version: 4.20260430.1
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.59.1
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260430.1
         version: 7.0.0-dev.20260430.1
@@ -791,6 +794,11 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1120,6 +1128,11 @@ packages:
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1311,6 +1324,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -2178,6 +2201,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -2467,6 +2494,9 @@ snapshots:
 
   find-my-way-ts@0.1.6: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2635,6 +2665,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.12:
     dependencies:


### PR DESCRIPTION
## What this fixes

There was no browser-level test coverage — the manual flows in `RALPH_QA.md` (three-panel render, SSE token streaming, phase transitions, endgame overlay reveal, lockouts/cap-hit) had to be exercised by hand. This change installs Playwright and lands one minimal smoke spec so future PRs can convert RALPH_QA items into automated tests one-by-one.

The integration runs against the production-shaped surface: Playwright's `webServer` runs `pnpm build && pnpm exec wrangler dev --port 8787 --local …`, exercising the same single-origin SPA + Worker setup that #66 wired up via the `assets` block. The smoke spec navigates to `/`, asserts the three `article.ai-panel[data-ai="red|green|blue"]` containers and `#composer` render, and fails on any uncaught `pageerror`.

Files:
- `playwright.config.ts` (new) — chromium-only, testDir `./e2e`, baseURL `:8787`, webServer auto-builds and starts wrangler with `ENABLE_TEST_MODES:1` and a dummy `OPENROUTER_API_KEY`.
- `e2e/smoke.spec.ts` (new) — single test asserting panel render + composer + no page errors.
- `package.json` — adds `@playwright/test` devDep and `test:e2e` / `test:e2e:ui` scripts.
- `.gitignore` — Playwright artifacts.
- `README.md` — Integration tests section.
- `RALPH_QA.md` — pointer to `e2e/`.

Notable decisions:
- `--local` on `wrangler dev` is required because `RATE_GUARD_KV` is `remote: true`; without it wrangler demands an authenticated remote session.
- `pageerror` capture only (no `console.error`) for the first pass to avoid flakes from benign logs.
- README setup uses `pnpm exec playwright install chromium` (not `--with-deps`, which needs sudo on Linux).
- CI integration deferred — `.github/workflows/ci.yml` untouched.

## QA steps for the human

1. One-time browser install: `pnpm exec playwright install chromium`
2. `pnpm test:e2e` — should report `1 passed`. The webServer step builds `dist/` and starts wrangler on `:8787` automatically.
3. (Optional) `pnpm exec playwright show-report` to view the HTML report.
4. (Optional) Confirm `pnpm test` (Vitest, 545/545) and `pnpm dev` are unaffected.

## Automated coverage

`pnpm typecheck` clean · `pnpm test` 545/545 · `pnpm lint` clean (80 files) · `pnpm test:e2e` 1/1 (cold-start verified — `dist/` removed, then rebuilt by webServer).

Closes #73

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_