### PR TITLE
E2E Slice 0: e2e/helpers/ foundation (SSE stubs + game factory)

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -20,3 +20,14 @@ Live browser end-to-end against `pnpm build` + `wrangler dev` on `:8787` — the
 **Vitest jsdom does not substitute for Playwright on these changes** — add or update a spec under `e2e/`.
 
 `RALPH_QA.md` lists manual flows that should migrate to `e2e/` over time. When you automate one, flip its checkbox in `RALPH_QA.md` and link the spec.
+
+### Stubbing gotcha: `page.route` vs `page.request.*`
+
+Playwright has two HTTP contexts that share a cookie jar but route differently:
+
+- **Page context** — requests originating from the browser (navigation, form submits, `fetch()` called from page JS, XHR). `page.route()` intercepts these.
+- **API request context** (`page.request.*`, `context.request.*`) — a Node-side HTTP client that bypasses the browser entirely. **`page.route` does NOT see these.**
+
+So `stubGameTurn` (in `e2e/helpers/stubs.ts`) only intercepts requests the SPA itself fires — the natural pattern is "fill `#prompt`, click `#send`", which causes the SPA to `fetch("/game/turn")` from page JS. If a spec needs lower-level control, use `page.evaluate(() => fetch(...))` so the fetch runs inside the page's runtime. Calling `page.request.post("/game/turn", …)` will silently miss the stub and hit the real worker.
+
+`newWinImmediatelyGame` (in `e2e/helpers/factories.ts`) uses `page.request.post("/game/new", …)` deliberately — it wants the real worker, not a stub, and only needs the response cookie in the BrowserContext jar.

--- a/e2e/helpers/factories.ts
+++ b/e2e/helpers/factories.ts
@@ -1,0 +1,29 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Start a new game session in "win immediately" test mode.
+ *
+ * Posts to `/game/new` with `{ testMode: "win_immediately" }`, which causes
+ * the worker to create a session whose phase-1 win condition fires on the very
+ * first turn. The worker sets the session cookie on the `BrowserContext`
+ * automatically; this factory returns nothing.
+ *
+ * @param page  The Playwright `Page` whose `BrowserContext` should receive the
+ *              session cookie.
+ *
+ * @remarks
+ * **Requires** the worker to be started with `ENABLE_TEST_MODES=1`. When that
+ * flag is unset the worker silently ignores `testMode` (see
+ * `src/proxy/_smoke.ts` ~line 221) and falls back to the real
+ * `PHASE_1_CONFIG` — this factory will still resolve without error, but the
+ * game will NOT enter win-immediately mode. This is a known foot-gun: tests
+ * will appear to pass setup but then behave unexpectedly at runtime.
+ */
+export async function newWinImmediatelyGame(page: Page): Promise<void> {
+	const response = await page.request.post("/game/new", {
+		data: { testMode: "win_immediately" },
+	});
+	if (!response.ok()) {
+		throw new Error(`/game/new failed with status ${response.status()}`);
+	}
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,0 +1,4 @@
+export type { SseEvent } from "../../src/spa/game/round-result-encoder";
+export { newWinImmediatelyGame } from "./factories";
+export { eventsToSseBody } from "./sse";
+export { type EventsFactory, stubGameTurn } from "./stubs";

--- a/e2e/helpers/sse.ts
+++ b/e2e/helpers/sse.ts
@@ -1,0 +1,18 @@
+import type { SseEvent } from "../../src/spa/game/round-result-encoder";
+
+/**
+ * Serialise an array of SSE events into a complete SSE response body.
+ *
+ * Each event is emitted as `data: <JSON>\n\n`, mirroring the worker's wire
+ * format (see `src/proxy/_smoke.ts` lines 311 and 327). A terminating
+ * `data: [DONE]\n\n` sentinel is appended automatically.
+ *
+ * @param events  The ordered list of SSE events to emit.
+ * @returns       A complete SSE body string. Callers MUST NOT append anything
+ *                further — the `[DONE]` sentinel is already included.
+ */
+export function eventsToSseBody(events: SseEvent[]): string {
+	const lines = events.map((event) => `data: ${JSON.stringify(event)}\n\n`);
+	lines.push("data: [DONE]\n\n");
+	return lines.join("");
+}

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -1,0 +1,49 @@
+import type { Page, Request } from "@playwright/test";
+import type { SseEvent } from "../../src/spa/game/round-result-encoder";
+import { eventsToSseBody } from "./sse";
+
+/**
+ * A factory function that produces SSE events, optionally inspecting the
+ * intercepted request. May be async.
+ */
+export type EventsFactory = (
+	request: Request,
+) => SseEvent[] | Promise<SseEvent[]>;
+
+/**
+ * Register a Playwright route stub for the game/turn endpoint that responds
+ * with a synthetic SSE body.
+ *
+ * @param page            The Playwright Page to install the route on.
+ * @param eventsOrFactory Either a static SseEvent[] array or an
+ *                        EventsFactory that receives the intercepted
+ *                        Request and returns events (sync or async).
+ *
+ * @remarks
+ * - Matches the glob pattern **\/game/turn, covering http://localhost:8787/game/turn
+ *   and any path-prefixed variant.
+ * - Response headers mirror src/proxy/_smoke.ts lines 281-283 verbatim.
+ * - Last-route-wins: calling stubGameTurn again on the same page replaces the
+ *   previous stub because Playwright prepends new routes.
+ */
+export async function stubGameTurn(
+	page: Page,
+	eventsOrFactory: SseEvent[] | EventsFactory,
+): Promise<void> {
+	await page.route("**/game/turn", async (route, request) => {
+		const events =
+			typeof eventsOrFactory === "function"
+				? await eventsOrFactory(request)
+				: eventsOrFactory;
+
+		await route.fulfill({
+			status: 200,
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+				"X-Content-Type-Options": "nosniff",
+			},
+			body: eventsToSseBody(events),
+		});
+	});
+}

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -25,6 +25,10 @@ export type EventsFactory = (
  * - Response headers mirror src/proxy/_smoke.ts lines 281-283 verbatim.
  * - Last-route-wins: calling stubGameTurn again on the same page replaces the
  *   previous stub because Playwright prepends new routes.
+ * - Only intercepts requests fired from the page context (SPA fetch, navigation,
+ *   form submits). `page.request.*` calls bypass `page.route` — to exercise this
+ *   stub from a spec, trigger /game/turn through the SPA flow or via
+ *   `page.evaluate(() => fetch("/game/turn", …))`. See docs/agents/testing.md.
  */
 export async function stubGameTurn(
 	page: Page,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 	],
 	webServer: {
 		command:
-			"pnpm build && pnpm exec wrangler dev --local --port 8787 --var ENABLE_TEST_MODES:1 --var OPENROUTER_API_KEY:test-key",
+			"pnpm build && pnpm exec wrangler dev --local --port 8787 --var ENABLE_TEST_MODES:1 --var OPENROUTER_API_KEY:test-key --var TOKEN_PACE_MS:0",
 		url: "http://localhost:8787",
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,


### PR DESCRIPTION
## What this fixes

Slices 1–5 (issues #77–#81) of the e2e expansion all need a deterministic way to stub `/game/turn` SSE responses and to boot a known game state. Without a shared foundation, each slice would copy the SSE framing inline and risk drifting from the wire format produced by `src/proxy/_smoke.ts`. This change lands the four-file helpers module the PRD (#75) called for, plus a small `playwright.config.ts` adjustment so token pacing is instant by default in e2e runs.

The helpers stay deliberately minimal:

- `e2e/helpers/sse.ts` — `eventsToSseBody(events: SseEvent[]): string` with `data: <json>\n\n` framing terminated by `data: [DONE]\n\n` (byte-identical to `src/proxy/_smoke.ts:311,327`). Imports `SseEvent` type-only from `src/spa/game/round-result-encoder.ts` so wire-format changes break specs at compile time.
- `e2e/helpers/stubs.ts` — `stubGameTurn(page, eventsOrFactory)` that calls `page.route("**/game/turn", …)` and fulfils with the same headers the real worker uses (`Content-Type: text/event-stream`, `Cache-Control: no-cache`, `X-Content-Type-Options: nosniff`, mirroring `_smoke.ts:281-283`). Plus an `EventsFactory` type that supports request-aware factories.
- `e2e/helpers/factories.ts` — `newWinImmediatelyGame(page)` POSTs `/game/new` with `{ testMode: "win_immediately" }` via `page.request.post`; the resulting `hi-blue-session` cookie lands in the BrowserContext jar so subsequent `page.goto("/")` calls inherit it.
- `e2e/helpers/index.ts` — barrel re-exporting only the public surface plus the `SseEvent` type for convenience.
- `playwright.config.ts` — webServer command appends `--var TOKEN_PACE_MS:0` so token pacing is instant by default; Slice 2 will control timing in-stub.

No new devDependencies. No tsconfig changes (Playwright's ts-loader gates types at e2e runtime; `pnpm typecheck` doesn't cover `e2e/` and that's deliberate).

### Note for Slices 1–5

`page.route` intercepts requests originating from the page context (e.g. SPA-driven `fetch`, navigation), but **does not** intercept `page.request.*` calls (those use a separate `APIRequestContext`). Slice 1+ specs that want to verify the stub fires must trigger `/game/turn` through the SPA's submit flow or via `page.evaluate(() => fetch(...))`, not via `page.request.post` directly. The factory deliberately uses `page.request.post` because it's hitting the real worker, not the stub.

## QA steps for the human

None — fully covered by the integration smoke. The helpers were exercised end-to-end via a transient probe spec that:
1. Asserted `eventsToSseBody` framing matches the worker byte-for-byte.
2. Called `newWinImmediatelyGame` and asserted `hi-blue-session` cookie was set in the BrowserContext jar.
3. Registered `stubGameTurn`, fired a `fetch("/game/turn")` from page context, and asserted the response body byte-equalled `eventsToSseBody(events)` with the right `Content-Type`.

The probe was deleted after running; nothing leaked into the repo.

## Automated coverage

`pnpm typecheck` clean · `pnpm test` 545/545 · `pnpm lint` clean (84 files) · `pnpm test:e2e` 1/1 (cold-start verified — `dist/` removed, then rebuilt by webServer; helpers compiled by Playwright's ts-loader during the smoke run).

Closes #76

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_