### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 
 # Ralph loop worktrees
 .ralph-worktrees/
+.claude/worktrees/
 
 # Logs
 *.log


### PR DESCRIPTION
One-line addition. The Agent harness creates locked worktrees under `.claude/worktrees/` when running parallel agents with `isolation: "worktree"` — those directories are runtime artifacts (cleaned up when the harness releases them) and shouldn't appear in `git status`. Mirrors the existing `.ralph-worktrees/` entry just above.

Quality of life only — no functional change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_