### PR TITLE
E2E Slice 2: token streaming arrives word-by-word

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,4 +1,9 @@
 export type { SseEvent } from "../../src/spa/game/round-result-encoder";
 export { newWinImmediatelyGame } from "./factories";
 export { eventsToSseBody } from "./sse";
-export { type EventsFactory, stubGameTurn } from "./stubs";
+export {
+	type EventsFactory,
+	streamChatCompletion,
+	stubGameTurn,
+	wordsToOpenAiSseBody,
+} from "./stubs";

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -11,6 +11,56 @@ export type EventsFactory = (
 ) => SseEvent[] | Promise<SseEvent[]>;
 
 /**
+ * Build a minimal OpenAI-compatible SSE body that streams the given word
+ * chunks as delta content events, followed by a [DONE] sentinel.
+ *
+ * Wire format mirrors what src/proxy/openai-proxy.ts forwards from OpenRouter:
+ *   data: {"choices":[{"delta":{"content":"<text>"},"finish_reason":null}]}\n\n
+ *   data: [DONE]\n\n
+ */
+export function wordsToOpenAiSseBody(words: string[]): string {
+	const lines: string[] = words.map(
+		(word) =>
+			`data: ${JSON.stringify({ choices: [{ delta: { content: word }, finish_reason: null }] })}\n\n`,
+	);
+	lines.push("data: [DONE]\n\n");
+	return lines.join("");
+}
+
+/**
+ * Register a Playwright route stub for the /v1/chat/completions endpoint that
+ * responds with a synthetic streaming OpenAI SSE body built from the given word
+ * chunks. The SPA's own token-pacing loop (TOKEN_PACE_MS × AI_TYPING_SPEED) will
+ * produce observable inter-token delays in the transcript after the fetch completes.
+ *
+ * @param page     The Playwright Page to install the route on.
+ * @param words    Word-level chunks to stream as `delta.content` events.
+ *
+ * @remarks
+ * - Matches **\/v1/chat/completions so it covers the worker-proxied URL.
+ * - The stub is installed as a last-route-wins Playwright route; calling it
+ *   again replaces the previous stub because Playwright prepends new routes.
+ * - Only intercepts requests fired from the page context (SPA fetch). See
+ *   stubGameTurn remarks for full gotchas.
+ */
+export async function streamChatCompletion(
+	page: Page,
+	words: string[],
+): Promise<void> {
+	await page.route("**/v1/chat/completions", async (route) => {
+		await route.fulfill({
+			status: 200,
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+				"X-Content-Type-Options": "nosniff",
+			},
+			body: wordsToOpenAiSseBody(words),
+		});
+	});
+}
+
+/**
  * Register a Playwright route stub for the game/turn endpoint that responds
  * with a synthetic SSE body.
  *

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "@playwright/test";
+import { streamChatCompletion } from "./helpers";
+
+// Word chunks yielded for every AI call.  Red gets these tokens and we
+// sample its transcript; green / blue responses use the same stub so all
+// three LLM calls resolve quickly.
+// 20 words × ≈42 ms/word (TOKEN_PACE_MS 60 × red-speed 0.7 × avg 1.0)
+// ≈ 840 ms total display window — well beyond the 500 ms sample point.
+const WORDS = [
+	"one ",
+	"two ",
+	"three ",
+	"four ",
+	"five ",
+	"six ",
+	"seven ",
+	"eight ",
+	"nine ",
+	"ten ",
+	"eleven ",
+	"twelve ",
+	"thirteen ",
+	"fourteen ",
+	"fifteen ",
+	"sixteen ",
+	"seventeen ",
+	"eighteen ",
+	"nineteen ",
+	"twenty.",
+];
+
+// The expected final text appended to red's transcript by the token loop.
+// game.ts prepends "[<PersonaName>] " before token emission and appends "\n"
+// on ai_end.  We only assert the token portion here.
+const EXPECTED_TOKENS = WORDS.join("");
+
+/**
+ * E2E Slice 2 — Token pacing
+ *
+ * Verifies that the SPA's token-pacing loop (TOKEN_PACE_MS × AI_TYPING_SPEED)
+ * delivers `[data-transcript="red"]` content word-by-word rather than as a
+ * single synchronous dump.
+ *
+ * Approach
+ * --------
+ * 1. Stub *\/v1/chat/completions to return a synthetic 7-word OpenAI SSE body
+ *    for all three AI calls.  The SPA processes each response, assembles
+ *    per-AI completions, then iterates the encoded token events with a
+ *    pace() delay of ~42 ms per token (TOKEN_PACE_MS 60 × red-speed 0.7 ×
+ *    random[0.5–1.5]).  Seven tokens spread across ~150–630 ms gives us
+ *    ample room to capture strictly-monotonic intermediate snapshots.
+ * 2. After submitting the form we wait for the "thinking…" placeholder to
+ *    clear (signals that all LLM calls have resolved and the pacing loop has
+ *    started), then record four snapshots of [data-transcript="red"] length
+ *    at ≈50 ms / ≈200 ms / ≈500 ms / final.
+ * 3. Assert strict monotonic growth and ≥ 3 distinct intermediate snapshots.
+ */
+test("token streaming arrives word-by-word, not as a single dump", async ({
+	page,
+}) => {
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	// Stub every /v1/chat/completions call (one per AI per round).
+	await streamChatCompletion(page, WORDS);
+
+	await page.goto("/");
+
+	// Ensure the game page is ready.
+	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
+
+	// ── Submit a message addressed to red ────────────────────────────────────
+	await page.selectOption("#address", "red");
+	await page.fill("#prompt", "Hello");
+
+	const redTranscript = page.locator('[data-transcript="red"]');
+
+	// Capture pre-submit baseline length.
+	const baselineText = (await redTranscript.textContent()) ?? "";
+
+	await page.click("#send");
+
+	// ── Wait for pacing loop to start ────────────────────────────────────────
+	// The SPA appends "thinking…" to the addressed panel immediately on submit
+	// and removes it once all LLM calls resolve and the token loop begins.
+	// We wait until "thinking…" is absent from red's transcript AND red's
+	// transcript has grown beyond the baseline + player message, meaning at
+	// least one token has been appended.
+	const playerMsg = `\n[you] Hello\n`;
+	const afterPlayerLength = baselineText.length + playerMsg.length;
+
+	// Wait for first token to appear: transcript longer than baseline + player message.
+	await expect(redTranscript).not.toHaveText(/thinking…/, { timeout: 15_000 });
+
+	// Poll until at least one token character arrives after the player message.
+	await page.waitForFunction(
+		({ selector, minLen }: { selector: string; minLen: number }) => {
+			const el = document.querySelector(selector);
+			return el != null && (el.textContent ?? "").length > minLen;
+		},
+		{ selector: '[data-transcript="red"]', minLen: afterPlayerLength },
+		{ timeout: 10_000 },
+	);
+
+	// ── Capture four snapshots during pacing ─────────────────────────────────
+	const snap0 = (await redTranscript.textContent()) ?? "";
+
+	await page.waitForTimeout(50);
+	const snap50 = (await redTranscript.textContent()) ?? "";
+
+	await page.waitForTimeout(150); // cumulative ~200 ms
+	const snap200 = (await redTranscript.textContent()) ?? "";
+
+	await page.waitForTimeout(300); // cumulative ~500 ms
+	const snap500 = (await redTranscript.textContent()) ?? "";
+
+	// ── Wait for all tokens to finish (send re-enables on completion) ─────────
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 10_000 });
+	const snapFinal = (await redTranscript.textContent()) ?? "";
+
+	// ── Assertions ────────────────────────────────────────────────────────────
+
+	const lengths = [
+		snap0.length,
+		snap50.length,
+		snap200.length,
+		snap500.length,
+		snapFinal.length,
+	];
+
+	// 1. Strictly monotonically increasing length across the 4 timed samples
+	//    (snap0 → snap50 → snap200 → snap500) plus the final snapshot.
+	for (let i = 1; i < lengths.length; i++) {
+		expect(
+			lengths[i],
+			`snapshot[${i}] length ${lengths[i]} must be > snapshot[${i - 1}] length ${lengths[i - 1]}`,
+		).toBeGreaterThan(lengths[i - 1] as number);
+	}
+
+	// 2. At least 3 distinct intermediate snapshots (snap0 / snap50 / snap200
+	//    before reaching the final), ruling out "all-at-once then pause".
+	const intermediates = new Set([snap0, snap50, snap200, snap500]);
+	expect(
+		intermediates.size,
+		`expected ≥ 3 distinct intermediate snapshots, got ${intermediates.size}`,
+	).toBeGreaterThanOrEqual(3);
+
+	// 3. Final transcript contains the expected token text.
+	expect(snapFinal).toContain(EXPECTED_TOKENS);
+
+	// 4. No page errors fired.
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `e2e/token-pacing.spec.ts`: stubs `/v1/chat/completions` with a 20-word OpenAI streaming SSE body, submits a form to "red", and samples `[data-transcript="red"]` at four time points (~0/50/200/500 ms after first token arrives) to assert that the SPA's `TOKEN_PACE_MS` pacing loop delivers tokens word-by-word.
- Extends `e2e/helpers/stubs.ts` with `streamChatCompletion(page, words)` and `wordsToOpenAiSseBody(words)` for use by future slices that need to exercise the LLM call path.
- Exports both new helpers from `e2e/helpers/index.ts`.

All assertions satisfied:
- ≥5 word chunks (20 words used) with the SPA's natural ~42 ms/token pacing giving ~840 ms total window
- Strictly monotonically increasing transcript length across 4 samples
- ≥3 distinct intermediate snapshots
- Final transcript contains concatenated token text
- No `pageerror` events

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test` green (545 unit tests)
- [x] `pnpm lint` green
- [x] `pnpm test:e2e` green (2/2 specs pass on port 8789)
- [x] `playwright.config.ts` restored to port 8787 before commit (`git diff playwright.config.ts` empty)

Closes #78

https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_