### PR TITLE
Refactor e2e/helpers: stubChatCompletions, drop TOKEN_PACE_MS

### DIFF
--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -28,6 +28,35 @@ Playwright has two HTTP contexts that share a cookie jar but route differently:
 - **Page context** — requests originating from the browser (navigation, form submits, `fetch()` called from page JS, XHR). `page.route()` intercepts these.
 - **API request context** (`page.request.*`, `context.request.*`) — a Node-side HTTP client that bypasses the browser entirely. **`page.route` does NOT see these.**
 
-So `stubGameTurn` (in `e2e/helpers/stubs.ts`) only intercepts requests the SPA itself fires — the natural pattern is "fill `#prompt`, click `#send`", which causes the SPA to `fetch("/game/turn")` from page JS. If a spec needs lower-level control, use `page.evaluate(() => fetch(...))` so the fetch runs inside the page's runtime. Calling `page.request.post("/game/turn", …)` will silently miss the stub and hit the real worker.
+#### Stubbing LLM calls: use `stubChatCompletions`
+
+The SPA's `BrowserLLMProvider` (via `src/spa/llm-client.ts`) calls
+`${__WORKER_BASE_URL__}/v1/chat/completions` — **not** `/game/turn`. Use
+`stubChatCompletions` from `e2e/helpers` to intercept these:
+
+```ts
+import { stubChatCompletions } from "./helpers";
+
+// Static word array — same reply for every AI call:
+await stubChatCompletions(page, ["hello ", "world"]);
+
+// Request-aware factory — distinct reply per successive call:
+let callIndex = 0;
+await stubChatCompletions(page, (_request) => {
+  return COMPLETIONS[callIndex++ % COMPLETIONS.length].split(" ");
+});
+```
+
+`stubChatCompletions` fulfils with `Content-Type: text/event-stream` and
+OpenAI-format delta chunks (`choices[0].delta.content`), matching what the
+SPA's streaming parser expects. The SPA's own token-pacing loop
+(`TOKEN_PACE_MS × AI_TYPING_SPEED` in `src/spa/routes/game.ts`) drives the
+observable inter-token animation after the fetch resolves — the stub does
+**not** need to throttle delivery.
+
+`stubChatCompletions` only intercepts requests the SPA itself fires. If a spec
+needs lower-level control, use `page.evaluate(() => fetch(...))` so the fetch
+runs inside the page's runtime. Calling `page.request.post("/v1/chat/completions", …)`
+will silently miss the stub and hit the real worker.
 
 `newWinImmediatelyGame` (in `e2e/helpers/factories.ts`) uses `page.request.post("/game/new", …)` deliberately — it wants the real worker, not a stub, and only needs the response cookie in the BrowserContext jar.

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,9 +1,7 @@
-export type { SseEvent } from "../../src/spa/game/round-result-encoder";
 export { newWinImmediatelyGame } from "./factories";
-export { eventsToSseBody } from "./sse";
 export {
-	type EventsFactory,
+	type WordsFactory,
 	streamChatCompletion,
-	stubGameTurn,
+	stubChatCompletions,
 	wordsToOpenAiSseBody,
 } from "./stubs";

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,7 +1,7 @@
 export { newWinImmediatelyGame } from "./factories";
 export {
-	type WordsFactory,
 	streamChatCompletion,
 	stubChatCompletions,
+	type WordsFactory,
 	wordsToOpenAiSseBody,
 } from "./stubs";

--- a/e2e/helpers/sse.ts
+++ b/e2e/helpers/sse.ts
@@ -1,18 +1,4 @@
-import type { SseEvent } from "../../src/spa/game/round-result-encoder";
-
-/**
- * Serialise an array of SSE events into a complete SSE response body.
- *
- * Each event is emitted as `data: <JSON>\n\n`, mirroring the worker's wire
- * format (see `src/proxy/_smoke.ts` lines 311 and 327). A terminating
- * `data: [DONE]\n\n` sentinel is appended automatically.
- *
- * @param events  The ordered list of SSE events to emit.
- * @returns       A complete SSE body string. Callers MUST NOT append anything
- *                further — the `[DONE]` sentinel is already included.
- */
-export function eventsToSseBody(events: SseEvent[]): string {
-	const lines = events.map((event) => `data: ${JSON.stringify(event)}\n\n`);
-	lines.push("data: [DONE]\n\n");
-	return lines.join("");
-}
+// This file is intentionally empty.
+// `eventsToSseBody` and its `SseEvent` dependency were removed in #92:
+// the SPA uses OpenAI-format chunks (`wordsToOpenAiSseBody` in stubs.ts),
+// not the legacy worker's SSE event union.

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -4,9 +4,7 @@ import type { Page, Request } from "@playwright/test";
  * A factory function that produces word chunks for a `/v1/chat/completions`
  * response, optionally inspecting the intercepted request.  May be async.
  */
-export type WordsFactory = (
-	request: Request,
-) => string[] | Promise<string[]>;
+export type WordsFactory = (request: Request) => string[] | Promise<string[]>;
 
 /**
  * Build a minimal OpenAI-compatible SSE body that streams the given word

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -1,14 +1,12 @@
 import type { Page, Request } from "@playwright/test";
-import type { SseEvent } from "../../src/spa/game/round-result-encoder";
-import { eventsToSseBody } from "./sse";
 
 /**
- * A factory function that produces SSE events, optionally inspecting the
- * intercepted request. May be async.
+ * A factory function that produces word chunks for a `/v1/chat/completions`
+ * response, optionally inspecting the intercepted request.  May be async.
  */
-export type EventsFactory = (
+export type WordsFactory = (
 	request: Request,
-) => SseEvent[] | Promise<SseEvent[]>;
+) => string[] | Promise<string[]>;
 
 /**
  * Build a minimal OpenAI-compatible SSE body that streams the given word
@@ -28,26 +26,41 @@ export function wordsToOpenAiSseBody(words: string[]): string {
 }
 
 /**
- * Register a Playwright route stub for the /v1/chat/completions endpoint that
- * responds with a synthetic streaming OpenAI SSE body built from the given word
- * chunks. The SPA's own token-pacing loop (TOKEN_PACE_MS × AI_TYPING_SPEED) will
- * produce observable inter-token delays in the transcript after the fetch completes.
+ * Register a Playwright route stub for the `/v1/chat/completions` endpoint
+ * that responds with a synthetic streaming OpenAI SSE body.
  *
- * @param page     The Playwright Page to install the route on.
- * @param words    Word-level chunks to stream as `delta.content` events.
+ * The SPA's `BrowserLLMProvider` (via `src/spa/llm-client.ts`) calls
+ * `${__WORKER_BASE_URL__}/v1/chat/completions` — this is the correct endpoint
+ * to stub for end-to-end specs.  The SPA's own token-pacing loop
+ * (TOKEN_PACE_MS × AI_TYPING_SPEED) drives the observable inter-token
+ * animation after the fetch resolves.
+ *
+ * @param page            The Playwright Page to install the route on.
+ * @param wordsOrFactory  Either a static `string[]` of word chunks, or a
+ *                        `WordsFactory` that receives the intercepted Request
+ *                        and returns word chunks (sync or async).  Use a
+ *                        factory when successive calls need distinct replies
+ *                        (e.g. one completion per AI per round).
  *
  * @remarks
- * - Matches **\/v1/chat/completions so it covers the worker-proxied URL.
- * - The stub is installed as a last-route-wins Playwright route; calling it
- *   again replaces the previous stub because Playwright prepends new routes.
- * - Only intercepts requests fired from the page context (SPA fetch). See
- *   stubGameTurn remarks for full gotchas.
+ * - Matches `**\/v1/chat/completions` so it covers the worker-proxied URL.
+ * - Last-route-wins: calling `stubChatCompletions` again on the same page
+ *   replaces the previous stub because Playwright prepends new routes.
+ * - Only intercepts requests fired from the page context (SPA fetch).
+ *   `page.request.*` calls bypass `page.route` — trigger fetch through
+ *   the SPA flow or via `page.evaluate(() => fetch(...))`.
+ *   See docs/agents/testing.md for full gotchas.
  */
-export async function streamChatCompletion(
+export async function stubChatCompletions(
 	page: Page,
-	words: string[],
+	wordsOrFactory: string[] | WordsFactory,
 ): Promise<void> {
-	await page.route("**/v1/chat/completions", async (route) => {
+	await page.route("**/v1/chat/completions", async (route, request) => {
+		const words =
+			typeof wordsOrFactory === "function"
+				? await wordsOrFactory(request)
+				: wordsOrFactory;
+
 		await route.fulfill({
 			status: 200,
 			headers: {
@@ -61,43 +74,18 @@ export async function streamChatCompletion(
 }
 
 /**
- * Register a Playwright route stub for the game/turn endpoint that responds
- * with a synthetic SSE body.
+ * Register a Playwright route stub for the `/v1/chat/completions` endpoint
+ * that responds with a synthetic streaming OpenAI SSE body built from the
+ * given word chunks.
  *
- * @param page            The Playwright Page to install the route on.
- * @param eventsOrFactory Either a static SseEvent[] array or an
- *                        EventsFactory that receives the intercepted
- *                        Request and returns events (sync or async).
- *
- * @remarks
- * - Matches the glob pattern **\/game/turn, covering http://localhost:8787/game/turn
- *   and any path-prefixed variant.
- * - Response headers mirror src/proxy/_smoke.ts lines 281-283 verbatim.
- * - Last-route-wins: calling stubGameTurn again on the same page replaces the
- *   previous stub because Playwright prepends new routes.
- * - Only intercepts requests fired from the page context (SPA fetch, navigation,
- *   form submits). `page.request.*` calls bypass `page.route` — to exercise this
- *   stub from a spec, trigger /game/turn through the SPA flow or via
- *   `page.evaluate(() => fetch("/game/turn", …))`. See docs/agents/testing.md.
+ * @deprecated Use `stubChatCompletions` instead — it accepts both static
+ * word arrays and request-aware factories, making it strictly more capable.
+ * `streamChatCompletion` is kept for backward compatibility with specs added
+ * by Slice 2 (#86); the spec-refactor follow-up (#93) will migrate them.
  */
-export async function stubGameTurn(
+export async function streamChatCompletion(
 	page: Page,
-	eventsOrFactory: SseEvent[] | EventsFactory,
+	words: string[],
 ): Promise<void> {
-	await page.route("**/game/turn", async (route, request) => {
-		const events =
-			typeof eventsOrFactory === "function"
-				? await eventsOrFactory(request)
-				: eventsOrFactory;
-
-		await route.fulfill({
-			status: 200,
-			headers: {
-				"Content-Type": "text/event-stream",
-				"Cache-Control": "no-cache",
-				"X-Content-Type-Options": "nosniff",
-			},
-			body: eventsToSseBody(events),
-		});
-	});
+	return stubChatCompletions(page, words);
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 	],
 	webServer: {
 		command:
-			"pnpm build && pnpm exec wrangler dev --local --port 8787 --var ENABLE_TEST_MODES:1 --var OPENROUTER_API_KEY:test-key --var TOKEN_PACE_MS:0",
+			"pnpm build && pnpm exec wrangler dev --local --port 8787 --var ENABLE_TEST_MODES:1 --var OPENROUTER_API_KEY:test-key",
 		url: "http://localhost:8787",
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `stubChatCompletions(page, wordsOrFactory)` to `e2e/helpers/stubs.ts` — intercepts `**/v1/chat/completions` (the SPA's real endpoint via `BrowserLLMProvider`/`llm-client.ts`), accepts either a static word array or a request-aware factory for per-call variation.
- Deletes `stubGameTurn` (was targeting `/game/turn`, the legacy worker route the SPA never calls) and `eventsToSseBody` (SseEvent wire format replaced by OpenAI delta chunks).
- Keeps `streamChatCompletion` as a deprecated shim delegating to `stubChatCompletions` (backward-compat for Slice 2 specs; #93 will migrate them).
- Removes `--var TOKEN_PACE_MS:0` from `playwright.config.ts` — dead config, the SPA paces tokens client-side.
- Updates `docs/agents/testing.md` Stubbing gotcha subsection with `stubChatCompletions` usage guide and SPA architecture explanation.

Closes #92

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm test` clean (545 tests passed)
- [ ] `pnpm lint` clean
- [ ] `pnpm test:e2e` all 4 specs green: smoke, addressed-and-parallel, persistence-reload, token-pacing

https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_