### PR TITLE
Fix: preserve #send disabled state when game_ended

### DIFF
--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression test for issue #89:
+ *
+ * The form-submit handler's `finally` block was unconditionally re-enabling
+ * `#send`, undoing the disable that fires on the `game_ended` SSE event.
+ *
+ * Fix: hoist `let gameEnded = false` above the `try`, gate the `finally`'s
+ * re-enable on `if (!gameEnded)`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Provide globals before importing the module
+vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+
+// ---------------------------------------------------------------------------
+// Module-level mock: GameSession always returns gameEnded:true so we don't
+// need a real win-condition in the phase config.
+// ---------------------------------------------------------------------------
+const AI_BUDGET = { remaining: 4, total: 5 };
+const FAKE_PHASE_STATE = {
+	phaseNumber: 1,
+	objective: "get the key in the keyhole",
+	round: 1,
+	budgets: { red: AI_BUDGET, green: AI_BUDGET, blue: AI_BUDGET },
+	chatHistories: { red: [], green: [], blue: [] },
+	whispers: [],
+	actionLog: [],
+	lockedOut: new Set<string>(),
+	chatLockouts: new Map<string, number>(),
+	world: { items: [] },
+	aiGoals: { red: "test goal", green: "test goal", blue: "test goal" },
+};
+
+const FAKE_GAME_STATE = {
+	isComplete: true,
+	currentPhase: 1,
+	phases: [FAKE_PHASE_STATE],
+	personas: {},
+};
+
+const GAME_ENDED_RESULT = {
+	result: {
+		round: 1,
+		actions: [],
+		phaseEnded: true,
+		gameEnded: true,
+	},
+	// Non-empty completions prevent the lockout branch which needs personas.name
+	completions: { red: "done", green: "done", blue: "done" },
+	nextState: FAKE_GAME_STATE,
+};
+
+vi.mock("../game/game-session.js", () => {
+	class MockGameSession {
+		submitMessage = vi.fn().mockResolvedValue(GAME_ENDED_RESULT);
+		getState = vi.fn().mockReturnValue(FAKE_GAME_STATE);
+		static restore = vi.fn().mockReturnValue({
+			submitMessage: vi.fn().mockResolvedValue(GAME_ENDED_RESULT),
+			getState: vi.fn().mockReturnValue(FAKE_GAME_STATE),
+		});
+	}
+	return { GameSession: MockGameSession };
+});
+
+// Matches the body content of src/spa/index.html (three-panel layout)
+const INDEX_BODY_HTML = `
+<main>
+  <div id="panels">
+    <article class="ai-panel" data-ai="red">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="red"></div>
+    </article>
+    <article class="ai-panel" data-ai="green">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="green"></div>
+    </article>
+    <article class="ai-panel" data-ai="blue">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="blue"></div>
+    </article>
+  </div>
+  <form id="composer">
+    <select id="address" aria-label="Address AI">
+      <option value="red">Ember (red)</option>
+      <option value="green">Sage (green)</option>
+      <option value="blue">Frost (blue)</option>
+    </select>
+    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+    <button id="send" type="submit">Send</button>
+  </form>
+  <section id="cap-hit" hidden></section>
+  <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
+  <aside id="action-log" hidden>
+    <h3>Action Log (debug)</h3>
+    <ul id="action-log-list"></ul>
+  </aside>
+</main>
+<script type="module" src="./assets/index.js"></script>
+`;
+
+function getEl<T extends HTMLElement>(selector: string): T {
+	const el = document.querySelector<T>(selector);
+	if (!el) throw new Error(`Element not found: ${selector}`);
+	return el;
+}
+
+describe("renderGame — game_ended disables #send permanently (regression #89)", () => {
+	beforeEach(() => {
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("#send stays disabled after game_ended fires (finally block must not re-enable it)", async () => {
+		vi.stubGlobal("localStorage", {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		});
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "finish the game";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+
+		// Wait for the async submit handler to complete
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Bug: the finally block was unconditionally setting sendBtn.disabled = false,
+		// undoing the game_ended handler's sendBtn.disabled = true.
+		// Fix: finally only re-enables if !gameEnded.
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		expect(sendBtn.disabled).toBe(true);
+
+		// #prompt must also remain disabled (set in the game_ended branch)
+		const promptEl = getEl<HTMLInputElement>("#prompt");
+		expect(promptEl.disabled).toBe(true);
+	});
+});

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -221,6 +221,8 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		// Roll initiative for this round
 		const initiative = shuffle(AI_ORDER);
 
+		let gameEnded = false;
+
 		try {
 			const provider = new BrowserLLMProvider();
 			const { result, completions, nextState } = await session.submitMessage(
@@ -242,7 +244,6 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			);
 
 			let speakingAi: AiId | null = null;
-			let gameEnded = false;
 
 			for (const event of events) {
 				switch (event.type) {
@@ -323,7 +324,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			}
 		} finally {
 			stripPlaceholder();
-			sendBtn.disabled = false;
+			if (!gameEnded) sendBtn.disabled = false;
 		}
 	});
 }


### PR DESCRIPTION
## What this fixes

The form-submit handler's `finally` block unconditionally called `sendBtn.disabled = false`, undoing the `sendBtn.disabled = true` set by the `game_ended` event handler. After a phase-3 win the player could continue typing and submitting, contradicting the intended "game over" UX and risking a stale state turn.

**Root cause:** `let gameEnded = false` was declared *inside* the `try` block, making it inaccessible to the `finally` clause.

**Fix (3 lines in `src/spa/routes/game.ts`):**
- Hoist `let gameEnded = false` above the `try` block (line ~222)
- Gate the `finally`'s re-enable: `if (!gameEnded) sendBtn.disabled = false`

## QA steps

1. Start the dev server (`pnpm dev`).
2. Play through to a phase-3 win.
3. Verify `#send` and `#prompt` remain disabled — the composer is inert.
4. Confirm mid-round behaviour is unaffected: `#send` re-enables normally after non-game-ending turns.

## Automated coverage

- **New test:** `src/spa/__tests__/game-ended.test.ts` — mocks `GameSession` to return `gameEnded: true`, submits the form, asserts `#send.disabled === true` after the async handler settles.
- All 546 Vitest tests pass (up from 545).
- All 4 Playwright e2e specs pass.
- `pnpm typecheck` and `pnpm lint` clean.

Closes #89

https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_