### PR TITLE
Refactor e2e specs to use canonical stubChatCompletions; drop deprecated shim

### DIFF
--- a/e2e/addressed-and-parallel.spec.ts
+++ b/e2e/addressed-and-parallel.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { newWinImmediatelyGame } from "./helpers/index";
+import { newWinImmediatelyGame, stubChatCompletions } from "./helpers/index";
 
 /**
  * The three distinct completions served to the three AIs.  Since the SPA
@@ -8,27 +8,6 @@ import { newWinImmediatelyGame } from "./helpers/index";
  * each completion appears in exactly one of the three transcripts.
  */
 const COMPLETIONS = ["alpha beta gamma", "one two", "x y z"] as const;
-
-/**
- * Build an OpenAI-streaming SSE body for a single completion string.
- * Each word is emitted as a separate delta chunk, ending with [DONE].
- */
-function openAiSseBody(text: string): string {
-	const words = text.split(" ");
-	const lines: string[] = [];
-	for (const word of words) {
-		const chunk = JSON.stringify({
-			choices: [{ delta: { content: `${word} ` }, finish_reason: null }],
-		});
-		lines.push(`data: ${chunk}\n\n`);
-	}
-	// Trim trailing space from last token via a final empty-content chunk then DONE
-	lines.push(
-		`data: ${JSON.stringify({ choices: [{ delta: { content: "" }, finish_reason: "stop" }] })}\n\n`,
-	);
-	lines.push("data: [DONE]\n\n");
-	return lines.join("");
-}
 
 type LenPair = { red: number; green: number };
 
@@ -43,20 +22,12 @@ test("addressed message lands only on red panel; all three panels render progres
 	await newWinImmediatelyGame(page);
 
 	// 2. Stub /v1/chat/completions — the SPA calls this once per AI per round.
-	//    Return a distinct completion on each successive call.
+	//    Return a distinct completion on each successive call using a factory.
 	let callIndex = 0;
-	await page.route("**/v1/chat/completions", async (route) => {
-		const completion =
-			COMPLETIONS[callIndex % COMPLETIONS.length] ?? COMPLETIONS[0];
+	await stubChatCompletions(page, () => {
+		const text = COMPLETIONS[callIndex % COMPLETIONS.length] ?? COMPLETIONS[0];
 		callIndex++;
-		await route.fulfill({
-			status: 200,
-			headers: {
-				"Content-Type": "text/event-stream",
-				"Cache-Control": "no-cache",
-			},
-			body: openAiSseBody(completion as string),
-		});
+		return (text as string).split(" ").map((w) => `${w} `);
 	});
 
 	// 3. Address red, fill prompt.

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,6 +1,5 @@
 export { newWinImmediatelyGame } from "./factories";
 export {
-	streamChatCompletion,
 	stubChatCompletions,
 	type WordsFactory,
 	wordsToOpenAiSseBody,

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -70,20 +70,3 @@ export async function stubChatCompletions(
 		});
 	});
 }
-
-/**
- * Register a Playwright route stub for the `/v1/chat/completions` endpoint
- * that responds with a synthetic streaming OpenAI SSE body built from the
- * given word chunks.
- *
- * @deprecated Use `stubChatCompletions` instead — it accepts both static
- * word arrays and request-aware factories, making it strictly more capable.
- * `streamChatCompletion` is kept for backward compatibility with specs added
- * by Slice 2 (#86); the spec-refactor follow-up (#93) will migrate them.
- */
-export async function streamChatCompletion(
-	page: Page,
-	words: string[],
-): Promise<void> {
-	return stubChatCompletions(page, words);
-}

--- a/e2e/persistence-reload.spec.ts
+++ b/e2e/persistence-reload.spec.ts
@@ -1,18 +1,5 @@
 import { expect, test } from "@playwright/test";
-
-/**
- * Build a minimal OpenAI-format SSE response body for the SPA's streaming parser.
- * The SPA calls POST /v1/chat/completions and expects `choices[0].delta.content`.
- */
-function openAiSseBody(text: string): string {
-	const chunk = JSON.stringify({
-		choices: [{ delta: { content: text }, index: 0, finish_reason: null }],
-	});
-	const done = JSON.stringify({
-		choices: [{ delta: {}, index: 0, finish_reason: "stop" }],
-	});
-	return `data: ${chunk}\n\ndata: ${done}\n\ndata: [DONE]\n\n`;
-}
+import { stubChatCompletions } from "./helpers";
 
 /**
  * AI completions returned by the stub, keyed by call index (0 = red, 1 = green, 2 = blue
@@ -28,17 +15,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 
 	// Stub every call to /v1/chat/completions with a deterministic one-token response.
 	// The SPA fires one call per AI per round (red → green → blue in default order).
-	await page.route("**/v1/chat/completions", async (route) => {
-		await route.fulfill({
-			status: 200,
-			headers: {
-				"Content-Type": "text/event-stream",
-				"Cache-Control": "no-cache",
-				"X-Content-Type-Options": "nosniff",
-			},
-			body: openAiSseBody(STUB_COMPLETION),
-		});
-	});
+	await stubChatCompletions(page, [STUB_COMPLETION]);
 
 	await page.goto("/");
 

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { streamChatCompletion } from "./helpers";
+import { stubChatCompletions } from "./helpers";
 
 // Word chunks yielded for every AI call.  Red gets these tokens and we
 // sample its transcript; green / blue responses use the same stub so all
@@ -62,7 +62,7 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	page.on("pageerror", (err) => pageErrors.push(err));
 
 	// Stub every /v1/chat/completions call (one per AI per round).
-	await streamChatCompletion(page, WORDS);
+	await stubChatCompletions(page, WORDS);
 
 	await page.goto("/");
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Migrated `e2e/addressed-and-parallel.spec.ts` from inline `page.route` + local `openAiSseBody` builder to `stubChatCompletions(page, factory)` — the factory captures a `callIndex` counter and returns per-call word-chunk arrays by splitting each completion string.
- Migrated `e2e/persistence-reload.spec.ts` from inline `page.route` + local `openAiSseBody` builder to `stubChatCompletions(page, [STUB_COMPLETION])` — single static chunk, one-liner replacement.
- Migrated `e2e/token-pacing.spec.ts` from `streamChatCompletion(page, WORDS)` (deprecated shim) to `stubChatCompletions(page, WORDS)` — identical semantics, no other changes.
- Deleted the `streamChatCompletion` shim from `e2e/helpers/stubs.ts` and dropped it from the `e2e/helpers/index.ts` barrel export. Zero callers remain after the migration (verified with `grep`).

Net diff: −79 lines / +9 lines — the specs are strictly denser, all assertions unchanged.

## Test plan

- [ ] `pnpm typecheck` — clean
- [ ] `pnpm test` — 547 tests pass
- [ ] `pnpm lint` — clean
- [ ] `pnpm test:e2e` — all 4 specs pass (verified locally on port 8790)

Closes #93

https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYSSrYX9nCR7QfKjAUnCXA)_