### PR TITLE
Real word-by-word streaming in chat panels

### DIFF
--- a/e2e/diagnose-streaming.spec.ts
+++ b/e2e/diagnose-streaming.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * DIAGNOSTIC: word-by-word streaming feedback loop for issue #102.
+ *
+ * The existing `stubChatCompletions` helper uses `route.fulfill({ body })`
+ * which delivers the entire SSE body in a single TCP-level chunk — so it
+ * cannot exercise the wire-arrival timing path the issue is about. Mock
+ * jsdom tests likewise short-circuit the SSE pipeline. Neither setup can
+ * detect "panel waits for full stream before painting".
+ *
+ * This spec installs a real streaming fetch override (via addInitScript)
+ * that emits SSE chunks at controlled 200ms intervals. It records:
+ *   - when each SSE chunk is produced (wire timeline)
+ *   - when each panel's transcript first/again grows (paint timeline)
+ *   - when each fetch promise resolves
+ *
+ * On the current code (post-PR-#68 revert) this is expected to FAIL the
+ * "live" assertion: panels grow only after all three streams complete and
+ * the synthetic-pacing loop runs. That confirms the architecture, not just
+ * a wire-side issue, gates live streaming.
+ *
+ * Run: `pnpm exec playwright test e2e/diagnose-streaming.spec.ts`
+ */
+
+import { expect, test } from "@playwright/test";
+
+// 5 chunks per AI × 200ms = 1.0s per stream × 3 AIs = ~3.0s total wire time.
+const CHUNK_INTERVAL_MS = 200;
+const CHUNKS_PER_AI: Record<string, string[]> = {
+	"call-1": ["alpha ", "beta ", "gamma ", "delta ", "epsilon."],
+	"call-2": ["uno ", "dos ", "tres ", "quatro ", "cinco."],
+	"call-3": ["one ", "two ", "three ", "four ", "five."],
+};
+
+interface DiagSample {
+	t: number;
+	kind: "fetch" | "chunk" | "fetch_done" | "dom";
+	tag: string;
+	detail?: string;
+}
+
+test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
+	page,
+}) => {
+	// Capture diagnostic samples written to window.__diag.
+	const samples: DiagSample[] = [];
+	page.on("console", (msg) => {
+		const text = msg.text();
+		if (!text.startsWith("[DIAG-7c41]")) return;
+		try {
+			const payload = JSON.parse(text.slice("[DIAG-7c41]".length).trim());
+			samples.push(payload);
+		} catch {
+			// ignore
+		}
+	});
+
+	// addInitScript runs before any page script. We monkey-patch fetch to
+	// intercept /v1/chat/completions and return a real ReadableStream-backed
+	// Response whose chunks emit at known intervals.
+	await page.addInitScript(
+		({ chunkSets, intervalMs }) => {
+			const t0 = performance.now();
+			function diag(payload: Record<string, unknown>): void {
+				const t = Math.round(performance.now() - t0);
+				console.log(`[DIAG-7c41] ${JSON.stringify({ t, ...payload })}`);
+			}
+
+			// MutationObserver on each transcript — fires whenever textContent grows.
+			// We install it once DOM is ready.
+			window.addEventListener("DOMContentLoaded", () => {
+				for (const ai of ["red", "green", "blue"]) {
+					const el = document.querySelector(`[data-transcript="${ai}"]`);
+					if (!el) continue;
+					let lastLen = el.textContent?.length ?? 0;
+					new MutationObserver(() => {
+						const len = el.textContent?.length ?? 0;
+						if (len !== lastLen) {
+							diag({ kind: "dom", tag: ai, detail: `len=${len}` });
+							lastLen = len;
+						}
+					}).observe(el, {
+						childList: true,
+						characterData: true,
+						subtree: true,
+					});
+				}
+			});
+
+			let callIdx = 0;
+			const origFetch = window.fetch.bind(window);
+			window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				if (!url.includes("/v1/chat/completions")) {
+					return origFetch(input, init);
+				}
+
+				callIdx += 1;
+				const tag = `call-${callIdx}`;
+				const chunks =
+					(chunkSets as Record<string, string[]>)[tag] ?? chunkSets["call-1"];
+				diag({ kind: "fetch", tag });
+
+				const encoder = new TextEncoder();
+				const stream = new ReadableStream<Uint8Array>({
+					async start(controller) {
+						for (const word of chunks ?? []) {
+							await new Promise((r) => setTimeout(r, intervalMs));
+							const sse = `data: ${JSON.stringify({
+								choices: [{ delta: { content: word }, finish_reason: null }],
+							})}\n\n`;
+							controller.enqueue(encoder.encode(sse));
+						}
+						await new Promise((r) => setTimeout(r, intervalMs));
+						controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+						controller.close();
+						diag({ kind: "fetch_done", tag });
+					},
+				});
+
+				return Promise.resolve(
+					new Response(stream, {
+						status: 200,
+						headers: {
+							"Content-Type": "text/event-stream",
+							"Cache-Control": "no-cache",
+						},
+					}),
+				);
+			};
+		},
+		{ chunkSets: CHUNKS_PER_AI, intervalMs: CHUNK_INTERVAL_MS },
+	);
+
+	await page.goto("/");
+	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
+
+	await page.selectOption("#address", "red");
+	await page.fill("#prompt", "Hello");
+	await page.click("#send");
+
+	// Wait until the round fully completes (send re-enables) plus a small grace.
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 30_000 });
+	await page.waitForTimeout(300);
+
+	// ── Print the full timeline so the diagnosis is visible in CI logs ────
+	const rows = samples.map(
+		(s) =>
+			`  t=${String(s.t).padStart(5)}ms  ${s.kind.padEnd(11)} ${s.tag.padEnd(10)} ${s.detail ?? ""}`,
+	);
+	console.log(
+		"\n=== DIAGNOSTIC TIMELINE (issue #102) ===\n" +
+			rows.join("\n") +
+			"\n=========================================",
+	);
+
+	// ── Compute key metrics for the assertion ────────────────────────────
+	const firstFetchT = samples.find((s) => s.kind === "fetch")?.t ?? 0;
+	const firstFetchDoneT = samples.find((s) => s.kind === "fetch_done")?.t ?? 0;
+	const lastFetchDoneT =
+		[...samples].reverse().find((s) => s.kind === "fetch_done")?.t ?? 0;
+
+	// Count DOM growth events that happen DURING the stream window of any AI.
+	// Filter out the initial "thinking…" placeholder by requiring growth past
+	// length 30 (player msg "[you] Hello" + "thinking…" ≈ 22 chars).
+	const liveGrowthEvents = samples.filter(
+		(s) =>
+			s.kind === "dom" &&
+			s.t >= firstFetchT &&
+			s.t < lastFetchDoneT &&
+			Number.parseInt((s.detail ?? "len=0").replace("len=", ""), 10) > 30,
+	);
+
+	console.log(
+		`firstFetch=${firstFetchT}ms  firstFetchDone=${firstFetchDoneT}ms  lastFetchDone=${lastFetchDoneT}ms  liveGrowthEvents=${liveGrowthEvents.length}`,
+	);
+
+	// LIVE-STREAMING ASSERTION (expected to FAIL on current code):
+	// At least one panel should grow with real content WHILE another AI's
+	// stream is still running. On the current buffered architecture, no panel
+	// grows until lastFetchDone, so this should produce 0 events.
+	expect(
+		liveGrowthEvents.length,
+		`expected ≥ 1 panel growth event between firstFetch (${firstFetchT}ms) and lastFetchDone (${lastFetchDoneT}ms); got ${liveGrowthEvents.length}. Streams are being buffered and replayed after the round resolves.`,
+	).toBeGreaterThanOrEqual(1);
+});

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -35,25 +35,27 @@ const WORDS = [
 const EXPECTED_TOKENS = WORDS.join("");
 
 /**
- * E2E Slice 2 — Token pacing
+ * E2E Slice 2 — Token delivery
  *
- * Verifies that the SPA's token-pacing loop (TOKEN_PACE_MS × AI_TYPING_SPEED)
- * delivers `[data-transcript="red"]` content word-by-word rather than as a
- * single synchronous dump.
+ * Verifies that the SPA delivers AI content to `[data-transcript="red"]`
+ * correctly when the completion SSE body arrives in a single chunk
+ * (as `route.fulfill` does — the entire body is delivered at once).
  *
- * Approach
- * --------
- * 1. Stub *\/v1/chat/completions to return a synthetic 7-word OpenAI SSE body
- *    for all three AI calls.  The SPA processes each response, assembles
- *    per-AI completions, then iterates the encoded token events with a
- *    pace() delay of ~42 ms per token (TOKEN_PACE_MS 60 × red-speed 0.7 ×
- *    random[0.5–1.5]).  Seven tokens spread across ~150–630 ms gives us
- *    ample room to capture strictly-monotonic intermediate snapshots.
- * 2. After submitting the form we wait for the "thinking…" placeholder to
- *    clear (signals that all LLM calls have resolved and the pacing loop has
- *    started), then record four snapshots of [data-transcript="red"] length
- *    at ≈50 ms / ≈200 ms / ≈500 ms / final.
- * 3. Assert strict monotonic growth and ≥ 3 distinct intermediate snapshots.
+ * With live streaming (issue #102), content is painted via the `onAiDelta`
+ * callback as SSE events arrive — BEFORE `submitMessage` resolves. This means
+ * with a `route.fulfill` stub all content arrives synchronously before the
+ * encoder pacing loop runs, so the pacing loop produces pace() delays but no
+ * new appends for live AIs.
+ *
+ * The per-word monotonic-growth assertion from the pre-#102 implementation
+ * has been replaced: content now arrives live (proved by
+ * `e2e/diagnose-streaming.spec.ts`) rather than through the synthetic pacing
+ * loop, so the meaningful guarantees here are:
+ *
+ * 1. Content reaches the panel before the round completes (snap0 has AI text).
+ * 2. "thinking…" is gone before any AI text is visible (stripped on first delta).
+ * 3. The final transcript contains the full expected token text.
+ * 4. The round fully completes (send re-enables) with no page errors.
  */
 test("token streaming arrives word-by-word, not as a single dump", async ({
 	page,
@@ -80,16 +82,14 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 
 	await page.click("#send");
 
-	// ── Wait for pacing loop to start ────────────────────────────────────────
-	// The SPA appends "thinking…" to the addressed panel immediately on submit
-	// and removes it once all LLM calls resolve and the token loop begins.
-	// We wait until "thinking…" is absent from red's transcript AND red's
-	// transcript has grown beyond the baseline + player message, meaning at
-	// least one token has been appended.
+	// ── Wait for live content to appear ──────────────────────────────────────
+	// With live streaming, "thinking…" is stripped on the first live delta and
+	// replaced immediately by the AI's persona prefix + content. We wait for
+	// thinking… to disappear and the transcript to grow past the player message.
 	const playerMsg = `\n[you] Hello\n`;
 	const afterPlayerLength = baselineText.length + playerMsg.length;
 
-	// Wait for first token to appear: transcript longer than baseline + player message.
+	// Wait for thinking… to clear (first live delta strips it).
 	await expect(redTranscript).not.toHaveText(/thinking…/, { timeout: 15_000 });
 
 	// Poll until at least one token character arrives after the player message.
@@ -102,51 +102,33 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 		{ timeout: 10_000 },
 	);
 
-	// ── Capture four snapshots during pacing ─────────────────────────────────
+	// snap0: capture transcript immediately after first content arrives.
+	// With live streaming + route.fulfill the entire AI response is already
+	// there at this point (all deltas fire synchronously in one SSE read).
 	const snap0 = (await redTranscript.textContent()) ?? "";
 
-	await page.waitForTimeout(50);
-	const snap50 = (await redTranscript.textContent()) ?? "";
-
-	await page.waitForTimeout(150); // cumulative ~200 ms
-	const snap200 = (await redTranscript.textContent()) ?? "";
-
-	await page.waitForTimeout(300); // cumulative ~500 ms
-	const snap500 = (await redTranscript.textContent()) ?? "";
-
-	// ── Wait for all tokens to finish (send re-enables on completion) ─────────
-	await expect(page.locator("#send")).toBeEnabled({ timeout: 10_000 });
+	// ── Wait for the round to fully complete ────────────────────────────────
+	// The encoder pacing loop still runs (pace() awaits) but skips re-appending
+	// text for live AIs. Send re-enables only after the loop finishes.
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 20_000 });
 	const snapFinal = (await redTranscript.textContent()) ?? "";
 
 	// ── Assertions ────────────────────────────────────────────────────────────
 
-	const lengths = [
-		snap0.length,
-		snap50.length,
-		snap200.length,
-		snap500.length,
-		snapFinal.length,
-	];
-
-	// 1. Strictly monotonically increasing length across the 4 timed samples
-	//    (snap0 → snap50 → snap200 → snap500) plus the final snapshot.
-	for (let i = 1; i < lengths.length; i++) {
-		expect(
-			lengths[i],
-			`snapshot[${i}] length ${lengths[i]} must be > snapshot[${i - 1}] length ${lengths[i - 1]}`,
-		).toBeGreaterThan(lengths[i - 1] as number);
-	}
-
-	// 2. At least 3 distinct intermediate snapshots (snap0 / snap50 / snap200
-	//    before reaching the final), ruling out "all-at-once then pause".
-	const intermediates = new Set([snap0, snap50, snap200, snap500]);
+	// 1. Content was present at snap0 — live delivery happened before round end.
 	expect(
-		intermediates.size,
-		`expected ≥ 3 distinct intermediate snapshots, got ${intermediates.size}`,
-	).toBeGreaterThanOrEqual(3);
+		snap0.length,
+		"snap0 should contain AI text (live delivery before round completes)",
+	).toBeGreaterThan(afterPlayerLength);
 
-	// 3. Final transcript contains the expected token text.
+	// 2. Final transcript contains the expected token text.
 	expect(snapFinal).toContain(EXPECTED_TOKENS);
+
+	// 3. snapFinal is at least as long as snap0 (no content removed during pacing).
+	expect(
+		snapFinal.length,
+		`snapFinal length ${snapFinal.length} should be ≥ snap0 length ${snap0.length}`,
+	).toBeGreaterThanOrEqual(snap0.length);
 
 	// 4. No page errors fired.
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);

--- a/src/spa/game/__tests__/browser-llm-provider.test.ts
+++ b/src/spa/game/__tests__/browser-llm-provider.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for BrowserLLMProvider live-delta callback (issue #102).
+ *
+ * Mocks globalThis.fetch with a real ReadableStream that enqueues two SSE
+ * delta events. Asserts that streamRound(messages, tools, onDelta) invokes
+ * onDelta once per delta in order, and that assistantText equals their concat.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { BrowserLLMProvider } from "../browser-llm-provider";
+
+// Provide __WORKER_BASE_URL__ global before importing the module
+// biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
+(globalThis as any).__WORKER_BASE_URL__ = "http://localhost:8787";
+
+function makeSseBody(words: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const word of words) {
+				const line = `data: ${JSON.stringify({ choices: [{ delta: { content: word }, finish_reason: null }] })}\n\n`;
+				controller.enqueue(encoder.encode(line));
+			}
+			controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+			controller.close();
+		},
+	});
+}
+
+describe("BrowserLLMProvider.streamRound — onDelta callback", () => {
+	it("invokes onDelta once per SSE chunk, in order", async () => {
+		const words = ["hello ", "world"];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(makeSseBody(words), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const received: string[] = [];
+
+		const result = await provider.streamRound([], [], (text) => {
+			received.push(text);
+		});
+
+		expect(received).toEqual(words);
+		expect(result.assistantText).toBe("hello world");
+
+		vi.restoreAllMocks();
+	});
+
+	it("invokes onDelta for each of three chunks and concatenates correctly", async () => {
+		const words = ["alpha ", "beta ", "gamma."];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(makeSseBody(words), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const received: string[] = [];
+
+		const result = await provider.streamRound([], [], (text) => {
+			received.push(text);
+		});
+
+		expect(received).toHaveLength(3);
+		expect(received).toEqual(words);
+		expect(result.assistantText).toBe("alpha beta gamma.");
+
+		vi.restoreAllMocks();
+	});
+
+	it("still collects assistantText when onDelta is not provided", async () => {
+		const words = ["one ", "two"];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(makeSseBody(words), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const result = await provider.streamRound([], []);
+
+		expect(result.assistantText).toBe("one two");
+
+		vi.restoreAllMocks();
+	});
+});

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -342,6 +342,68 @@ describe("GameSession — phase advancement", () => {
 	});
 });
 
+// ── onAiDelta propagation (issue #102) ──────────────────────────────────────
+
+describe("GameSession — onAiDelta propagation", () => {
+	it("fires onAiDelta for each delta emitted by a live provider", async () => {
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+
+		// Hand-rolled provider that synchronously calls onDelta with two fragments.
+		const liveProvider: RoundLLMProvider = {
+			async streamRound(_messages, _tools, onDelta) {
+				onDelta?.("chunk1 ");
+				onDelta?.("chunk2");
+				return { assistantText: "chunk1 chunk2", toolCalls: [] };
+			},
+		};
+
+		const received: Array<[string, string]> = [];
+		await session.submitMessage(
+			"red",
+			"hi",
+			liveProvider,
+			undefined,
+			["red", "green", "blue"],
+			(aiId, text) => {
+				received.push([aiId, text]);
+			},
+		);
+
+		// 3 AIs × 2 fragments = 6 delta calls, in initiative order.
+		expect(received).toHaveLength(6);
+		expect(received[0]).toEqual(["red", "chunk1 "]);
+		expect(received[1]).toEqual(["red", "chunk2"]);
+		expect(received[2]).toEqual(["green", "chunk1 "]);
+		expect(received[3]).toEqual(["green", "chunk2"]);
+		expect(received[4]).toEqual(["blue", "chunk1 "]);
+		expect(received[5]).toEqual(["blue", "chunk2"]);
+	});
+
+	it("does not invoke onAiDelta when MockRoundLLMProvider is used", async () => {
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "hello", toolCalls: [] },
+			{ assistantText: "world", toolCalls: [] },
+			{ assistantText: "foo", toolCalls: [] },
+		]);
+
+		const received: Array<[string, string]> = [];
+		await session.submitMessage(
+			"red",
+			"hi",
+			provider,
+			undefined,
+			undefined,
+			(aiId, text) => {
+				received.push([aiId, text]);
+			},
+		);
+
+		// MockRoundLLMProvider ignores onDelta — no live deltas.
+		expect(received).toHaveLength(0);
+	});
+});
+
 // ── Tool roundtrip persistence across rounds ────────────────────────────────
 
 describe("GameSession — tool roundtrip persistence", () => {

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -1245,10 +1245,10 @@ describe("runRound — onAiDelta callback", () => {
 
 	it("does not invoke onAiDelta for locked-out AIs", async () => {
 		// Exhaust budget (budgetPerAi=1) so all AIs lock out after round 1.
-		let state = startPhase(
-			createGame(TEST_PERSONAS),
-			{ ...TEST_PHASE_CONFIG, budgetPerAi: 1 },
-		);
+		let state = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			budgetPerAi: 1,
+		});
 		// Deduct budget 1× per AI to reach remaining=0 → lockedOut.
 		for (const aiId of ["red", "green", "blue"] as AiId[]) {
 			state = deductBudget(state, aiId);
@@ -1265,9 +1265,19 @@ describe("runRound — onAiDelta callback", () => {
 		};
 
 		const received: Array<[AiId, string]> = [];
-		await runRound(state, "red", "hi", liveProvider, undefined, undefined, undefined, undefined, (aiId, text) => {
-			received.push([aiId, text]);
-		});
+		await runRound(
+			state,
+			"red",
+			"hi",
+			liveProvider,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId, text) => {
+				received.push([aiId, text]);
+			},
+		);
 
 		// All AIs locked — no deltas.
 		expect(received).toHaveLength(0);

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -1198,3 +1198,105 @@ describe("initiative parameter", () => {
 		).rejects.toThrow(/permutation/);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// onAiDelta callback routing (issue #102)
+// ----------------------------------------------------------------------------
+describe("runRound — onAiDelta callback", () => {
+	it("fires onAiDelta with (aiId, text) for each delta from a live provider", async () => {
+		const game = makeGame();
+
+		// Hand-rolled provider that synchronously calls onDelta with two fragments.
+		const liveProvider: RoundLLMProvider = {
+			async streamRound(_messages, _tools, onDelta) {
+				onDelta?.("frag1 ");
+				onDelta?.("frag2");
+				return { assistantText: "frag1 frag2", toolCalls: [] };
+			},
+		};
+
+		const received: Array<[AiId, string]> = [];
+		const onAiDelta = (aiId: AiId, text: string): void => {
+			received.push([aiId, text]);
+		};
+
+		const initiative: AiId[] = ["red", "green", "blue"];
+		await runRound(
+			game,
+			"red",
+			"hello",
+			liveProvider,
+			undefined,
+			initiative,
+			undefined,
+			undefined,
+			onAiDelta,
+		);
+
+		// Each AI should have fired two deltas, in initiative order.
+		expect(received).toHaveLength(6);
+		expect(received[0]).toEqual(["red", "frag1 "]);
+		expect(received[1]).toEqual(["red", "frag2"]);
+		expect(received[2]).toEqual(["green", "frag1 "]);
+		expect(received[3]).toEqual(["green", "frag2"]);
+		expect(received[4]).toEqual(["blue", "frag1 "]);
+		expect(received[5]).toEqual(["blue", "frag2"]);
+	});
+
+	it("does not invoke onAiDelta for locked-out AIs", async () => {
+		// Exhaust budget (budgetPerAi=1) so all AIs lock out after round 1.
+		let state = startPhase(
+			createGame(TEST_PERSONAS),
+			{ ...TEST_PHASE_CONFIG, budgetPerAi: 1 },
+		);
+		// Deduct budget 1× per AI to reach remaining=0 → lockedOut.
+		for (const aiId of ["red", "green", "blue"] as AiId[]) {
+			state = deductBudget(state, aiId);
+		}
+		expect(getActivePhase(state).lockedOut.has("red")).toBe(true);
+		expect(getActivePhase(state).lockedOut.has("green")).toBe(true);
+		expect(getActivePhase(state).lockedOut.has("blue")).toBe(true);
+
+		const liveProvider: RoundLLMProvider = {
+			async streamRound(_messages, _tools, onDelta) {
+				onDelta?.("should not fire");
+				return { assistantText: "should not fire", toolCalls: [] };
+			},
+		};
+
+		const received: Array<[AiId, string]> = [];
+		await runRound(state, "red", "hi", liveProvider, undefined, undefined, undefined, undefined, (aiId, text) => {
+			received.push([aiId, text]);
+		});
+
+		// All AIs locked — no deltas.
+		expect(received).toHaveLength(0);
+	});
+
+	it("MockRoundLLMProvider ignores onDelta — no live deltas fired", async () => {
+		const game = makeGame();
+		const mockProvider = new MockRoundLLMProvider([
+			{ assistantText: "red reply", toolCalls: [] },
+			{ assistantText: "green reply", toolCalls: [] },
+			{ assistantText: "blue reply", toolCalls: [] },
+		]);
+
+		const received: Array<[AiId, string]> = [];
+		await runRound(
+			game,
+			"red",
+			"hi",
+			mockProvider,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId, text) => {
+				received.push([aiId, text]);
+			},
+		);
+
+		// MockRoundLLMProvider ignores onDelta — no deltas.
+		expect(received).toHaveLength(0);
+	});
+});

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -26,6 +26,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 	async streamRound(
 		messages: OpenAiMessage[],
 		tools: OpenAiTool[],
+		onDelta?: (text: string) => void,
 	): Promise<RoundTurnResult> {
 		const textParts: string[] = [];
 		const toolCalls: RoundTurnResult["toolCalls"] = [];
@@ -35,6 +36,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 			tools,
 			onDelta: (text) => {
 				textParts.push(text);
+				onDelta?.(text);
 			},
 			onToolCall: (call) => {
 				toolCalls.push(call);

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -89,6 +89,9 @@ export class GameSession {
 	 *   When omitted, any config previously set via armChatLockout is consumed once.
 	 * @param initiative  Optional turn-order permutation for this round.
 	 *   Must be a permutation of all three AI ids. When absent, coordinator uses default order.
+	 * @param onAiDelta  Optional per-AI live-delta callback. Fires synchronously inside
+	 *   the SSE parser loop for each text chunk arriving from the wire.
+	 *   Never called for locked-out AIs or mock providers that ignore onDelta.
 	 */
 	async submitMessage(
 		addressed: AiId,
@@ -96,6 +99,7 @@ export class GameSession {
 		provider: RoundLLMProvider,
 		chatLockoutConfig?: ChatLockoutConfig,
 		initiative?: AiId[],
+		onAiDelta?: (aiId: AiId, text: string) => void,
 	): Promise<SubmitMessageResult> {
 		let effectiveConfig = chatLockoutConfig;
 		if (!effectiveConfig && this.armedChatLockout) {
@@ -125,6 +129,7 @@ export class GameSession {
 			initiative,
 			this.toolRoundtrip,
 			completionSink,
+			onAiDelta,
 		);
 
 		// Fill in empty string for AIs whose completions weren't captured

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -85,6 +85,9 @@ export interface RunRoundResult {
  *   by OpenAI's tool-use spec.
  * @param completionSink  Optional per-AI sink for the assistant text produced
  *   by each LLM call. Used by GameSession to capture completions for pacing.
+ * @param onAiDelta  Optional per-AI live-delta callback. Fires synchronously
+ *   inside the SSE parser loop for each text chunk arriving from the wire.
+ *   Never called for locked-out AIs or mock providers that ignore onDelta.
  */
 export async function runRound(
 	game: GameState,
@@ -95,6 +98,7 @@ export async function runRound(
 	initiative?: AiId[],
 	priorToolRoundtrip?: Partial<Record<AiId, ToolRoundtripMessage>>,
 	completionSink?: (aiId: AiId, text: string) => void,
+	onAiDelta?: (aiId: AiId, text: string) => void,
 ): Promise<RunRoundResult> {
 	// Validate initiative if provided.
 	if (initiative !== undefined) {
@@ -157,6 +161,7 @@ export async function runRound(
 		const { assistantText, toolCalls } = await provider.streamRound(
 			messages,
 			TOOL_DEFINITIONS,
+			onAiDelta ? (text) => onAiDelta(aiId, text) : undefined,
 		);
 
 		// Capture completion text

--- a/src/spa/game/round-llm-provider.ts
+++ b/src/spa/game/round-llm-provider.ts
@@ -41,6 +41,7 @@ export interface RoundLLMProvider {
 	streamRound(
 		messages: OpenAiMessage[],
 		tools: OpenAiTool[],
+		onDelta?: (text: string) => void,
 	): Promise<RoundTurnResult>;
 }
 
@@ -76,6 +77,7 @@ export class MockRoundLLMProvider implements RoundLLMProvider {
 	async streamRound(
 		messages: OpenAiMessage[],
 		tools: OpenAiTool[],
+		_onDelta?: (text: string) => void,
 	): Promise<RoundTurnResult> {
 		this.calls.push({ messages, tools });
 		const raw =

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -337,6 +337,25 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		// Round-local ended flag (distinct from module-level gameEnded)
 		let roundGameEnded = false;
 
+		// Track AIs that have received at least one live delta from the wire.
+		// When an AI is in this set, the encoder skips re-appending token text
+		// (it's already painted live) but still awaits pace() for timing shape.
+		const liveAis = new Set<AiId>();
+		// Track first-delta-seen per AI to emit the persona prefix exactly once.
+		const firstDeltaSeen = new Set<AiId>();
+
+		const onAiDelta = (aiId: AiId, text: string): void => {
+			if (!firstDeltaSeen.has(aiId)) {
+				firstDeltaSeen.add(aiId);
+				// Strip "thinking…" on first live delta for any AI — before painting.
+				stripPlaceholder();
+				// Emit persona prefix live (encoder will skip it for this AI).
+				appendToTranscript(aiId, `[${PERSONAS[aiId].name}] `);
+				liveAis.add(aiId);
+			}
+			appendToTranscript(aiId, text);
+		};
+
 		try {
 			const provider = new BrowserLLMProvider(
 				disableReasoning ? { disableReasoning: true } : {},
@@ -347,8 +366,11 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 				provider,
 				undefined,
 				initiative,
+				onAiDelta,
 			);
 
+			// Safety-net strip: if no live deltas arrived (mock provider, all AIs
+			// locked out, or first delta hasn't fired yet), strip placeholder now.
 			stripPlaceholder();
 
 			const phaseAfter = getActivePhase(nextState);
@@ -365,12 +387,22 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 				switch (event.type) {
 					case "ai_start":
 						speakingAi = event.aiId;
-						appendToTranscript(event.aiId, `[${PERSONAS[event.aiId].name}] `);
+						if (!liveAis.has(event.aiId)) {
+							// Not live — emit persona prefix now (synthetic path).
+							appendToTranscript(event.aiId, `[${PERSONAS[event.aiId].name}] `);
+						}
+						// If live, prefix was already painted; just track speakingAi.
 						break;
 
 					case "token":
 						if (speakingAi) {
-							appendToTranscript(speakingAi, event.text);
+							if (!liveAis.has(speakingAi)) {
+								// Synthetic path: append token and pace.
+								appendToTranscript(speakingAi, event.text);
+							}
+							// Live path: text already painted; still await pace() so the
+							// overall timing shape is preserved (important for token-pacing
+							// tests and consistent UI behaviour).
 							await pace(speakingAi);
 						}
 						break;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -316,9 +316,9 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		// Append player's message to the addressed panel
 		appendToTranscript(addressed, `\n[you] ${message}\n`);
 
-		// Show a global "thinking…" placeholder in the addressed panel while
-		// the round runs (round-coordinator buffers all three AI responses
-		// before the encoder splits them into per-panel token events).
+		// Show a "thinking…" placeholder in the addressed panel while the
+		// first live delta arrives. Stripped on the first onAiDelta call;
+		// the safety-net strip after submitMessage handles mock/locked-AI paths.
 		const addressedTranscript = getTranscript(addressed);
 		const placeholderStart = addressedTranscript?.textContent?.length ?? 0;
 		if (addressedTranscript) addressedTranscript.textContent += "thinking…";
@@ -357,9 +357,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		};
 
 		try {
-			const provider = new BrowserLLMProvider(
-				disableReasoning ? { disableReasoning: true } : {},
-			);
+			const provider = new BrowserLLMProvider({ disableReasoning });
 			const { result, completions, nextState } = await session.submitMessage(
 				addressed,
 				message,


### PR DESCRIPTION
## What this fixes

Each AI's chat panel now grows token-by-token as the SSE stream from `/v1/chat/completions` delivers content, replacing the prior buffer-then-replay path where the round coordinator awaited all three streams to completion before any text appeared, then ran a synthetic word-pacing animation from the buffered transcripts.

The architectural cause (per the diagnose comment on #102): `round-coordinator.ts` serially awaited `provider.streamRound(...)` for red → green → blue, `BrowserLLMProvider.streamRound` discarded per-delta timing by buffering into `textParts[]` until the stream completed, and `routes/game.ts` only ran the encoder after all three streams resolved. Even with perfect wire delivery, no panel could paint mid-round.

The fix threads an `onAiDelta(aiId, text)` callback all the way down: `routes/game.ts` → `GameSession.submitMessage` (6th arg) → `runRound` (9th arg) → `BrowserLLMProvider.streamRound` (3rd arg) → wraps `parseSSEStream`'s existing `onDelta`. The callback fires synchronously inside the SSE parser, so each delta `appendToTranscript`s the addressed AI's panel before the next chunk is read. A per-round `liveAis: Set<AiId>` tracks which AIs streamed live; the encoder loop's `case "token"` skips the append for those AIs (already painted) but still `await pace()`s to preserve the synthetic-pacing path's timing shape, and `case "ai_start"` skips re-emitting the persona prefix. The synthetic-pacing fallback is preserved unchanged for `MockRoundLLMProvider`-driven jsdom tests and locked-out AIs (no `onDelta` invocation → empty `liveAis` → existing path runs).

Touched files:
- `src/spa/game/round-llm-provider.ts` — added optional `onDelta` to the `streamRound` interface; `MockRoundLLMProvider` accepts but ignores it.
- `src/spa/game/browser-llm-provider.ts` — wraps `streamCompletion`'s `onDelta` to fan out per-delta to the caller in addition to buffering.
- `src/spa/game/round-coordinator.ts` — added `onAiDelta` parameter, passed per-AI to `streamRound`.
- `src/spa/game/game-session.ts` — added `onAiDelta` parameter, propagated to `runRound`.
- `src/spa/routes/game.ts` — `liveAis` set + `onAiDelta` callback; persona prefix emitted live; encoder gates token + ai_start branches on liveness; placeholder stripped on first live delta.
- `e2e/diagnose-streaming.spec.ts` — ported from the diagnose branch as the regression test (real `ReadableStream` fetch override at 200 ms intervals; asserts ≥ 1 panel growth event between `firstFetch` and `lastFetchDone`).
- `e2e/token-pacing.spec.ts` — assertions adapted: under `route.fulfill` (single-chunk SSE), live `onAiDelta` fires synchronously for every word at the start of the response, so the prior monotonic-growth assertion no longer reflects the live path; replaced with "snap0 has content + final content correct + final ≥ snap0".
- 3 new vitest suites covering `BrowserLLMProvider.onDelta` plumbing, `runRound` per-AI delta routing, and `GameSession.submitMessage` propagation.

## QA steps for the human

1. `pnpm dev` then load `http://localhost:8787/?think=0` (or the standard URL) with a real OpenRouter key. Address a message to one AI. Confirm each AI's panel grows visibly while that AI is streaming, and confirm the `thinking…` placeholder disappears at first byte rather than after the round resolves.
2. Optional: load with `?debug=1` and confirm the action log still records its usual entries.
3. Optional: trigger a chat-lockout (exhaust budget) and confirm the in-character lockout placeholder still appears for the locked AI.

## Automated coverage

- `pnpm typecheck` clean.
- `pnpm test` — 563/563 pass.
- `pnpm test:e2e e2e/diagnose-streaming.spec.ts` — passes (`liveGrowthEvents=6`, confirms real wire-paced concurrent streaming).
- `pnpm test:e2e e2e/token-pacing.spec.ts e2e/persistence-reload.spec.ts e2e/addressed-and-parallel.spec.ts e2e/smoke.spec.ts` — all pass.
- 3 e2e specs (`chat-lockout`, `endgame-current-behaviour`, `think-disabled`) fail identically on `main` at parent commit `f209203`; this branch does not modify those specs and is not the cause.

Closes #102

---
_Generated by [Claude Code](https://claude.ai/code/session_019v29jFbVZPs4LcwNFRcz4T)_