### PR TITLE
Add commit SHA display to development builds

### DIFF
--- a/scripts/build-spa.mjs
+++ b/scripts/build-spa.mjs
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,7 +10,19 @@ const root = path.resolve(__dirname, "..");
 const WORKER_BASE_URL = process.env.WORKER_BASE_URL ?? "http://localhost:8787";
 const watchMode = process.argv.includes("--watch");
 
-console.log(`Building SPA with WORKER_BASE_URL=${WORKER_BASE_URL}`);
+const COMMIT_SHA = (() => {
+	try {
+		return execSync("git rev-parse --short HEAD", { cwd: root })
+			.toString()
+			.trim();
+	} catch {
+		return "unknown";
+	}
+})();
+
+console.log(
+	`Building SPA with WORKER_BASE_URL=${WORKER_BASE_URL} COMMIT_SHA=${COMMIT_SHA}`,
+);
 
 // Ensure dist/ and dist/assets/ exist
 await fs.mkdir(path.join(root, "dist", "assets"), { recursive: true });
@@ -42,6 +55,7 @@ const ctx = await esbuild.context({
 	loader: { ".css": "css" },
 	define: {
 		__WORKER_BASE_URL__: JSON.stringify(WORKER_BASE_URL),
+		__COMMIT_SHA__: JSON.stringify(COMMIT_SHA),
 	},
 	plugins: [copyHtmlPlugin],
 });

--- a/src/spa/byok-modal.ts
+++ b/src/spa/byok-modal.ts
@@ -131,6 +131,18 @@ function renderModalState(): void {
 
 	if (!modeLine || !keyInput || !statusEl) return;
 
+	const buildInfo = getEl("byok-build-info");
+	if (buildInfo) {
+		const isDev =
+			__WORKER_BASE_URL__ === "http://localhost:8787" &&
+			typeof location !== "undefined" &&
+			location.origin === __WORKER_BASE_URL__;
+		if (isDev) {
+			buildInfo.textContent = `Commit ${__COMMIT_SHA__}`;
+			buildInfo.hidden = false;
+		}
+	}
+
 	const key = readKey();
 	const meta = readMeta();
 

--- a/src/spa/env.d.ts
+++ b/src/spa/env.d.ts
@@ -1,4 +1,5 @@
 declare const __WORKER_BASE_URL__: string;
+declare const __COMMIT_SHA__: string;
 
 // Allow CSS side-effect imports processed by esbuild
 declare module "*.css" {

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -77,6 +77,7 @@ come back tomorrow — they wake at midnight UTC.</pre>
 		  <form method="dialog" id="byok-form">
 		    <h2 id="byok-title">OpenRouter API Key</h2>
 		    <p id="byok-mode-line"></p>
+		    <p id="byok-build-info" hidden></p>
 		    <label for="byok-key-input">API key</label>
 		    <input id="byok-key-input" type="password" autocomplete="off" spellcheck="false" />
 		    <p id="byok-status" role="status" aria-live="polite"></p>

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -76,8 +76,8 @@ come back tomorrow — they wake at midnight UTC.</pre>
 		<dialog id="byok-dialog" aria-labelledby="byok-title">
 		  <form method="dialog" id="byok-form">
 		    <h2 id="byok-title">OpenRouter API Key</h2>
+			<p id="byok-build-info" hidden></p>
 		    <p id="byok-mode-line"></p>
-		    <p id="byok-build-info" hidden></p>
 		    <label for="byok-key-input">API key</label>
 		    <input id="byok-key-input" type="password" autocomplete="off" spellcheck="false" />
 		    <p id="byok-status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
This PR adds the ability to display the current Git commit SHA in the BYOK modal during development builds, helping developers identify which version they're running.

## Key Changes
- **Build script enhancement**: Modified `scripts/build-spa.mjs` to capture the short Git commit SHA at build time using `git rev-parse --short HEAD`, with fallback to "unknown" if Git is unavailable
- **Environment variable injection**: Added `__COMMIT_SHA__` as a build-time constant that gets injected into the SPA via esbuild's `define` option
- **Type declarations**: Updated `src/spa/env.d.ts` to declare the `__COMMIT_SHA__` global constant
- **UI display**: Added a new `byok-build-info` element to the BYOK modal in `index.html` that displays the commit SHA
- **Conditional rendering**: Implemented logic in `byok-modal.ts` to only show the commit SHA when running in development mode (localhost with matching origin)

## Implementation Details
- The commit SHA is only displayed when both the worker base URL and current location origin match `http://localhost:8787`, ensuring it only appears during local development
- The Git command gracefully handles failures by returning "unknown" rather than breaking the build
- The build info element is hidden by default and only shown when development conditions are met

https://claude.ai/code/session_014wX59uVaHfvZhJTCXVyfAE