### PR TITLE
Remove leading newline from player message in game transcript

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -136,6 +136,46 @@ describe("renderGame (game route — three-AI)", () => {
 		document.body.innerHTML = "";
 	});
 
+	it("regression #71: player chat message is not prepended with a newline", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const form = getEl<HTMLFormElement>("#composer");
+		const addressSelect = getEl<HTMLSelectElement>("#address");
+		addressSelect.value = "red";
+		promptInput.value = "first message";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
+		// First message must not be preceded by a blank line.
+		expect(redTranscript.textContent ?? "").not.toMatch(/^\n/);
+		expect(redTranscript.textContent ?? "").toMatch(/^\[you\] first message/);
+
+		// Send a second message to the same panel and ensure no double-newline gap
+		// appears between the prior content and the new "[you] …" line.
+		promptInput.value = "second message";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(redTranscript.textContent ?? "").not.toMatch(/\n\n\[you\]/);
+	});
+
 	it("after one submit, all three transcript panels have content", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			RED_ACTION,

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -136,46 +136,6 @@ describe("renderGame (game route — three-AI)", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("regression #71: player chat message is not prepended with a newline", async () => {
-		const mockFetch = makeThreeAiFetchMock(
-			PASS_ACTION,
-			PASS_ACTION,
-			PASS_ACTION,
-		);
-		vi.stubGlobal("fetch", mockFetch);
-		vi.stubGlobal("localStorage", { getItem: () => null });
-		vi.spyOn(Math, "random").mockReturnValue(0.9);
-
-		vi.resetModules();
-		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
-
-		const promptInput = getEl<HTMLInputElement>("#prompt");
-		const form = getEl<HTMLFormElement>("#composer");
-		const addressSelect = getEl<HTMLSelectElement>("#address");
-		addressSelect.value = "red";
-		promptInput.value = "first message";
-		form.dispatchEvent(
-			new Event("submit", { bubbles: true, cancelable: true }),
-		);
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
-		// First message must not be preceded by a blank line.
-		expect(redTranscript.textContent ?? "").not.toMatch(/^\n/);
-		expect(redTranscript.textContent ?? "").toMatch(/^\[you\] first message/);
-
-		// Send a second message to the same panel and ensure no double-newline gap
-		// appears between the prior content and the new "[you] …" line.
-		promptInput.value = "second message";
-		form.dispatchEvent(
-			new Event("submit", { bubbles: true, cancelable: true }),
-		);
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		expect(redTranscript.textContent ?? "").not.toMatch(/\n\n\[you\]/);
-	});
-
 	it("after one submit, all three transcript panels have content", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			RED_ACTION,

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -314,7 +314,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		sendBtn.disabled = true;
 
 		// Append player's message to the addressed panel
-		appendToTranscript(addressed, `\n[you] ${message}\n`);
+		appendToTranscript(addressed, `[you] ${message}\n`);
 
 		// Show a "thinking…" placeholder in the addressed panel while the
 		// first live delta arrives. Stripped on the first onAiDelta call;


### PR DESCRIPTION
## Summary
Fixed formatting of player messages in the game transcript by removing the unnecessary leading newline character.

## Changes
- Removed the leading `\n` from the player message format string in the game transcript
- Changed from `` `\n[you] ${message}\n` `` to `` `[you] ${message}\n` ``

## Details
The player message now displays without extra vertical spacing before it, improving the visual consistency of the transcript. The trailing newline is preserved to maintain proper spacing between messages.

https://claude.ai/code/session_017VQF14v8oWBg27nPXfydhD