### PR TITLE
Tracer: typed @mention replaces address dropdown

### DIFF
--- a/e2e/addressed-and-parallel.spec.ts
+++ b/e2e/addressed-and-parallel.spec.ts
@@ -30,9 +30,8 @@ test("addressed message lands only on red panel; all three panels render progres
 		return (text as string).split(" ").map((w) => `${w} `);
 	});
 
-	// 3. Address red, fill prompt.
-	const message = "hello red panel";
-	await page.selectOption("#address", "red");
+	// 3. Fill prompt with @Ember mention to address red.
+	const message = "@Ember hello red panel";
 	await page.fill("#prompt", message);
 
 	// 4. Install an in-page sampler that collects (red, green) transcript
@@ -98,7 +97,7 @@ test("addressed message lands only on red panel; all three panels render progres
 		.textContent();
 
 	// 9. [you] message appears in red transcript exactly once.
-	expect(redTranscript ?? "").toContain(`[you] ${message}`);
+	expect(redTranscript ?? "").toContain(`[you] @Ember hello red panel`);
 	// Exactly once: splitting on "[you]" gives exactly two parts.
 	expect((redTranscript ?? "").split("[you]").length).toBe(2);
 

--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -17,15 +17,14 @@ test("chat lockout disables the red AI option and appends an in-character lockou
 	//    for red (2 rounds) effective on the next round.
 	await page.goto("/?lockout=1");
 
-	// 3. Submit one message.
-	await page.fill("#prompt", "hello");
+	// 3. Submit one message addressed to red (@Ember).
+	await page.fill("#prompt", "@Ember hello");
+	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
-	// 4a. Wait for the red option to become disabled (chat_lockout event
-	//     processed by the SPA's round-coordinator render loop).
-	await expect(page.locator('#address option[value="red"]')).toBeDisabled({
-		timeout: 30_000,
-	});
+	// 4a. Wait for the chat_lockout to take effect: typing @Ember should disable Send.
+	await page.fill("#prompt", "@Ember hi");
+	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
 	// 4b. Red transcript ends with the in-character lockout line (appended by
 	//     the chat_lockout event handler in game.ts: "[${event.message}]\n").

--- a/e2e/diagnose-streaming.spec.ts
+++ b/e2e/diagnose-streaming.spec.ts
@@ -139,8 +139,7 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 	await page.goto("/");
 	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
 
-	await page.selectOption("#address", "red");
-	await page.fill("#prompt", "Hello");
+	await page.fill("#prompt", "@Ember Hello");
 	await page.click("#send");
 
 	// Wait until the round fully completes (send re-enables) plus a small grace.

--- a/e2e/endgame-current-behaviour.spec.ts
+++ b/e2e/endgame-current-behaviour.spec.ts
@@ -107,11 +107,11 @@ test("game_ended disables composer and clears storage", async ({ page }) => {
 	// 4. Capture URL before submitting (proves URL stability below).
 	const urlBefore = page.url();
 
-	// 5. Submit one message addressed to red. Because winCondition always
+	// 5. Submit one message addressed to red (@Ember). Because winCondition always
 	//    returns true and phase 3 has no nextPhaseConfig, advancePhase sets
 	//    isComplete=true → game_ended event → composer disabled.
-	await page.selectOption("#address", "red");
-	await page.fill("#prompt", "hello");
+	await page.fill("#prompt", "@Ember hello");
+	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
 	// 6. Wait for game_ended handler to fire: #send must become disabled.

--- a/e2e/mention-addressing.spec.ts
+++ b/e2e/mention-addressing.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+import { stubChatCompletions } from "./helpers";
+
+/**
+ * E2E spec for #107: @mention-based addressing replaces the address dropdown.
+ *
+ * Verifies:
+ * 1. The #address dropdown is gone.
+ * 2. On first load, prompt is empty and Send is disabled.
+ * 3. Typing "hi" (no mention) leaves Send disabled.
+ * 4. Typing "@Sage hi" enables Send and submits to green panel.
+ */
+
+test("address dropdown is gone (#address count === 0)", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+	await expect(page.locator("#address")).toHaveCount(0);
+});
+
+test("on first load, prompt empty and Send disabled", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+	await expect(page.locator("#prompt")).toHaveValue("");
+	await expect(page.locator("#send")).toBeDisabled();
+});
+
+test("typing 'hi' leaves Send disabled", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+	await page.fill("#prompt", "hi");
+	await expect(page.locator("#send")).toBeDisabled();
+});
+
+test("typing '@Sage hi' enables Send and submits to green transcript only", async ({
+	page,
+}) => {
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	await stubChatCompletions(page, ["greetings"]);
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// Typing "@Sage hi" should enable Send.
+	await page.fill("#prompt", "@Sage hi");
+	await expect(page.locator("#send")).toBeEnabled();
+
+	// Click send and wait for the round to complete.
+	await page.click("#send");
+
+	// Wait until the green panel shows a response.
+	await page.waitForFunction(
+		() => {
+			const el = document.querySelector('[data-transcript="green"]');
+			return (el?.textContent ?? "").includes("greetings");
+		},
+		{ timeout: 30_000 },
+	);
+
+	const greenTranscript = await page
+		.locator('[data-transcript="green"]')
+		.textContent();
+	const redTranscript = await page
+		.locator('[data-transcript="red"]')
+		.textContent();
+	const blueTranscript = await page
+		.locator('[data-transcript="blue"]')
+		.textContent();
+
+	// [you] message appears only in green.
+	expect(greenTranscript ?? "").toContain("[you] @Sage hi");
+	expect(redTranscript ?? "").not.toContain("[you]");
+	expect(blueTranscript ?? "").not.toContain("[you]");
+
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+});

--- a/e2e/persistence-reload.spec.ts
+++ b/e2e/persistence-reload.spec.ts
@@ -22,9 +22,9 @@ test("game state and transcripts persist across mid-round reload", async ({
 	// Wait for the SPA game route to mount (the composer form is present)
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// Address red AI and send a message
-	await page.selectOption("#address", "red");
-	await page.fill("#prompt", "hello");
+	// Address red AI via @Ember mention and send a message
+	await page.fill("#prompt", "@Ember hello");
+	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
 	// Wait for the send button to re-enable (round completed)

--- a/e2e/think-disabled.spec.ts
+++ b/e2e/think-disabled.spec.ts
@@ -33,7 +33,8 @@ test("?think=0 adds reasoning:{enabled:false} to chat-completions requests", asy
 
 	await page.goto("/?think=0");
 
-	await page.fill("#prompt", "hello");
+	await page.fill("#prompt", "@Sage hello");
+	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
 	// Wait for at least one chat-completions request to land.
@@ -67,7 +68,8 @@ test("without ?think=0, requests do NOT include the reasoning field", async ({
 
 	await page.goto("/");
 
-	await page.fill("#prompt", "hello");
+	await page.fill("#prompt", "@Sage hello");
+	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
 	await expect.poll(() => observedBodies.length).toBeGreaterThan(0);

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -71,9 +71,9 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	// Ensure the game page is ready.
 	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
 
-	// ── Submit a message addressed to red ────────────────────────────────────
-	await page.selectOption("#address", "red");
-	await page.fill("#prompt", "Hello");
+	// ── Submit a message addressed to red via @Ember mention ────────────────
+	await page.fill("#prompt", "@Ember Hello");
+	await expect(page.locator("#send")).toBeEnabled();
 
 	const redTranscript = page.locator('[data-transcript="red"]');
 
@@ -86,7 +86,7 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	// With live streaming, "thinking…" is stripped on the first live delta and
 	// replaced immediately by the AI's persona prefix + content. We wait for
 	// thinking… to disappear and the transcript to grow past the player message.
-	const playerMsg = `\n[you] Hello\n`;
+	const playerMsg = `\n[you] @Ember Hello\n`;
 	const afterPlayerLength = baselineText.length + playerMsg.length;
 
 	// Wait for thinking… to clear (first live delta strips it).

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -89,11 +89,6 @@ const INDEX_BODY_HTML = `
     </article>
   </div>
   <form id="composer">
-    <select id="address" aria-label="Address AI">
-      <option value="red">Ember (red)</option>
-      <option value="green">Sage (green)</option>
-      <option value="blue">Frost (blue)</option>
-    </select>
     <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
     <button id="send" type="submit">Send</button>
   </form>
@@ -138,7 +133,8 @@ describe("renderGame — game_ended disables #send permanently (regression #89)"
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "finish the game";
+		promptInput.value = "@Sage finish the game";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -28,11 +28,6 @@ const INDEX_BODY_HTML = `
     </article>
   </div>
   <form id="composer">
-    <select id="address" aria-label="Address AI">
-      <option value="red">Ember (red)</option>
-      <option value="green">Sage (green)</option>
-      <option value="blue">Frost (blue)</option>
-    </select>
     <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
     <button id="send" type="submit">Send</button>
   </form>
@@ -157,7 +152,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
-		promptInput.value = "hello world";
+		promptInput.value = "@Sage hello world";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -189,7 +185,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "hi";
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -254,7 +251,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "test";
+		promptInput.value = "@Sage test";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -292,7 +290,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "test";
+		promptInput.value = "@Sage test";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -320,7 +319,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "test";
+		promptInput.value = "@Sage test";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -345,11 +345,9 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
-		// Address the green panel
-		const addressSelect = getEl<HTMLSelectElement>("#address");
-		addressSelect.value = "green";
-
-		promptInput.value = "hello";
+		// Address the green panel via @Sage mention
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -385,7 +383,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "go";
+		promptInput.value = "@Sage go";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -428,21 +427,24 @@ describe("renderGame (game route — three-AI)", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// Submit 1: phase 1 → phase 2 (phase_advanced)
-		promptInput.value = "one";
+		promptInput.value = "@Sage one";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Submit 2: phase 2 → phase 3 (phase_advanced)
-		promptInput.value = "two";
+		promptInput.value = "@Sage two";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Submit 3: phase 3 → game_ended
-		promptInput.value = "three";
+		promptInput.value = "@Sage three";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -496,8 +498,9 @@ describe("renderGame (game route — three-AI)", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		for (const msg of ["one", "two", "three"]) {
+		for (const msg of ["@Sage one", "@Sage two", "@Sage three"]) {
 			promptInput.value = msg;
+			promptInput.dispatchEvent(new Event("input"));
 			form.dispatchEvent(
 				new Event("submit", { bubbles: true, cancelable: true }),
 			);
@@ -538,8 +541,9 @@ describe("renderGame (game route — three-AI)", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		for (const msg of ["one", "two", "three"]) {
+		for (const msg of ["@Sage one", "@Sage two", "@Sage three"]) {
 			promptInput.value = msg;
+			promptInput.dispatchEvent(new Event("input"));
 			form.dispatchEvent(
 				new Event("submit", { bubbles: true, cancelable: true }),
 			);
@@ -584,8 +588,9 @@ describe("renderGame (game route — three-AI)", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		for (const msg of ["one", "two", "three"]) {
+		for (const msg of ["@Sage one", "@Sage two", "@Sage three"]) {
 			promptInput.value = msg;
+			promptInput.dispatchEvent(new Event("input"));
 			form.dispatchEvent(
 				new Event("submit", { bubbles: true, cancelable: true }),
 			);
@@ -676,7 +681,8 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "test";
+		promptInput.value = "@Sage test";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -710,7 +716,8 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form1 = getEl<HTMLFormElement>("#composer");
 		const promptInput1 = getEl<HTMLInputElement>("#prompt");
-		promptInput1.value = "hello";
+		promptInput1.value = "@Sage hello";
+		promptInput1.dispatchEvent(new Event("input"));
 		form1.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -774,14 +781,20 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "test";
+		promptInput.value = "@Sage test";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		// Send button should be re-enabled (round completed)
+		// Send button should be in a known state after round (round completed,
+		// prompt was cleared so Send is disabled until a new @mention is typed).
 		const sendBtn = getEl<HTMLButtonElement>("#send");
+		// roundInFlight is false (round finished), so disabled reflects empty prompt.
+		// Typing a valid mention re-enables it.
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
 		expect(sendBtn.disabled).toBe(false);
 
 		// Warning banner should be visible
@@ -834,7 +847,8 @@ describe("renderGame — localStorage persistence", () => {
 		// Game should still function (submit works)
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "test";
+		promptInput.value = "@Sage test";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -866,7 +880,8 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form1 = getEl<HTMLFormElement>("#composer");
 		const promptInput1 = getEl<HTMLInputElement>("#prompt");
-		promptInput1.value = "test";
+		promptInput1.value = "@Sage test";
+		promptInput1.dispatchEvent(new Event("input"));
 		form1.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -954,7 +969,8 @@ describe("renderGame — chat_lockout event", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "hello";
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
@@ -965,10 +981,149 @@ describe("renderGame — chat_lockout event", () => {
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
 		expect(redTranscript.textContent).toContain("[Ember is unresponsive…]");
 
-		// The address selector option for red should be disabled.
-		const redOption = document.querySelector<HTMLOptionElement>(
-			'#address option[value="red"]',
+		// After the chat_lockout fires for red, typing @Ember should leave Send disabled.
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		promptInput.value = "@Ember hi";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(sendBtn.disabled).toBe(true);
+	});
+});
+
+describe("renderGame — mention-based addressing", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("empty input on initial load leaves Send disabled", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		expect(sendBtn.disabled).toBe(true);
+	});
+
+	it("typing 'hi' (no mention) leaves Send disabled", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		promptInput.value = "hi";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(sendBtn.disabled).toBe(true);
+	});
+
+	it("typing '@Sage hi' enables Send", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(sendBtn.disabled).toBe(false);
+	});
+
+	it("submit with '@Sage hi' routes [you] message to green panel", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
 		);
-		expect(redOption?.disabled).toBe(true);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
+		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
+		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
+
+		expect(greenTranscript.textContent).toContain("[you] @Sage hi");
+		expect(redTranscript.textContent).not.toContain("[you]");
+		expect(blueTranscript.textContent).not.toContain("[you]");
+	});
+
+	it("@Sage while green locked leaves Send disabled", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+
+		// Import GameSession first so the spy is in place before renderGame
+		// creates a session from the same module registry.
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				// Inject a chatLockoutTriggered for green so the SPA sets green locked.
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutTriggered: {
+							aiId: "green" as const,
+							message: "Sage is unresponsive…",
+						},
+					},
+				};
+			},
+		);
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		// Submit first round to trigger the lockout
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Now typing @Sage should leave Send disabled (green is locked)
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(sendBtn.disabled).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { PERSONAS } from "../../../content/personas.js";
+import { deriveComposerState } from "../composer-reducer.js";
+import { buildPersonaNameMap } from "../mention-parser.js";
+import type { AiId } from "../types.js";
+
+// Re-use the real PERSONAS so the map is canonical.
+const personaNamesToId = buildPersonaNameMap(PERSONAS);
+
+function noLockouts(): ReadonlyMap<AiId, boolean> {
+	return new Map<AiId, boolean>([
+		["red", false],
+		["green", false],
+		["blue", false],
+	]);
+}
+
+function lockouts(locked: AiId): ReadonlyMap<AiId, boolean> {
+	const m = new Map<AiId, boolean>([
+		["red", false],
+		["green", false],
+		["blue", false],
+	]);
+	m.set(locked, true);
+	return m;
+}
+
+describe("deriveComposerState", () => {
+	it("empty text → { addressee: null, sendEnabled: false }", () => {
+		expect(
+			deriveComposerState({
+				text: "",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: null, sendEnabled: false });
+	});
+
+	it('"hi" → { addressee: null, sendEnabled: false }', () => {
+		expect(
+			deriveComposerState({
+				text: "hi",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: null, sendEnabled: false });
+	});
+
+	it('"@Sage" no lockouts → { addressee: "green", sendEnabled: true }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: true });
+	});
+
+	it('"@Sage hi" no lockouts → { addressee: "green", sendEnabled: true }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage hi",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: true });
+	});
+
+	it('"@Sage hi" green locked → { addressee: "green", sendEnabled: false }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage hi",
+				lockouts: lockouts("green"),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: false });
+	});
+
+	it('"@Ember hi" green locked → { addressee: "red", sendEnabled: true }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Ember hi",
+				lockouts: lockouts("green"),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "red", sendEnabled: true });
+	});
+
+	it('"@Nonpersona hi" no lockouts → { addressee: null, sendEnabled: false }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Nonpersona hi",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: null, sendEnabled: false });
+	});
+
+	it('"@Sage," no lockouts → { addressee: "green", sendEnabled: true }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage,",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: true });
+	});
+
+	it('"@Frost @Sage" no lockouts → { addressee: "blue", sendEnabled: true }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Frost @Sage",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "blue", sendEnabled: true });
+	});
+
+	it('"@Frost @Sage" blue locked → { addressee: "blue", sendEnabled: false } (no fallthrough)', () => {
+		expect(
+			deriveComposerState({
+				text: "@Frost @Sage",
+				lockouts: lockouts("blue"),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "blue", sendEnabled: false });
+	});
+});

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -29,7 +29,7 @@ describe("parseFirstMention", () => {
 		["@", null],
 		["@Ember", "red"],
 		["@Frost", "blue"],
-	])('parseFirstMention(%j) → %j', (text, expected) => {
+	])("parseFirstMention(%j) → %j", (text, expected) => {
 		expect(parseFirstMention(text, nameMap)).toBe(expected);
 	});
 });

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildPersonaNameMap, parseFirstMention } from "../mention-parser.js";
+import type { AiId } from "../types.js";
+
+// Build a minimal name→id map for the three canonical personas.
+const nameMap = new Map<string, AiId>([
+	["ember", "red"],
+	["sage", "green"],
+	["frost", "blue"],
+]);
+
+describe("parseFirstMention", () => {
+	it.each<[string, AiId | null]>([
+		["@Sage", "green"],
+		["@Sage hi", "green"],
+		["hi @Sage", "green"],
+		["hello @Sage how are you", "green"],
+		["@sage", "green"],
+		["@SAGE", "green"],
+		["@SaGe", "green"],
+		["@Sage,", "green"],
+		["@Sage.", "green"],
+		["@Sage @Frost", "green"],
+		["@Frost @Sage", "blue"],
+		["", null],
+		["hello world", null],
+		["email me at user@host", null],
+		["@Nonpersona hi", null],
+		["@", null],
+		["@Ember", "red"],
+		["@Frost", "blue"],
+	])('parseFirstMention(%j) → %j', (text, expected) => {
+		expect(parseFirstMention(text, nameMap)).toBe(expected);
+	});
+});
+
+describe("buildPersonaNameMap", () => {
+	it("builds a map with lowercased keys pointing to AiId values", () => {
+		const personas = {
+			red: { name: "Ember" },
+			green: { name: "Sage" },
+			blue: { name: "Frost" },
+		} as Record<AiId, { name: string }>;
+		const map = buildPersonaNameMap(personas);
+		expect(map.get("ember")).toBe("red");
+		expect(map.get("sage")).toBe("green");
+		expect(map.get("frost")).toBe("blue");
+		expect(map.size).toBe(3);
+	});
+});

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -23,7 +23,6 @@ export interface ComposerState {
 export function deriveComposerState(input: ComposerInput): ComposerState {
 	const { text, lockouts, personaNamesToId } = input;
 	const addressee = parseFirstMention(text, personaNamesToId);
-	const sendEnabled =
-		addressee !== null && lockouts.get(addressee) !== true;
+	const sendEnabled = addressee !== null && lockouts.get(addressee) !== true;
 	return { addressee, sendEnabled };
 }

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -1,0 +1,29 @@
+import { parseFirstMention } from "./mention-parser.js";
+import type { AiId } from "./types.js";
+
+export interface ComposerInput {
+	text: string;
+	lockouts: ReadonlyMap<AiId, boolean>;
+	personaNamesToId: ReadonlyMap<string, AiId>;
+}
+
+export interface ComposerState {
+	addressee: AiId | null;
+	sendEnabled: boolean;
+}
+
+/**
+ * Derives the composer state (addressee + send button enabled) from the
+ * current prompt text, the chat-lockout map, and the persona name→id map.
+ *
+ * - `addressee` is the first valid @mention in the text.
+ * - `sendEnabled` is true only when `addressee` is non-null AND the
+ *   addressed AI is not chat-locked.
+ */
+export function deriveComposerState(input: ComposerInput): ComposerState {
+	const { text, lockouts, personaNamesToId } = input;
+	const addressee = parseFirstMention(text, personaNamesToId);
+	const sendEnabled =
+		addressee !== null && lockouts.get(addressee) !== true;
+	return { addressee, sendEnabled };
+}

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -17,8 +17,7 @@ export function parseFirstMention(
 	personaNamesToId: ReadonlyMap<string, AiId>,
 ): AiId | null {
 	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
-	let match: RegExpExecArray | null;
-	while ((match = re.exec(text)) !== null) {
+	for (const match of text.matchAll(re)) {
 		const raw = match[1];
 		if (!raw) continue;
 		// Strip a single trailing punctuation character if present.

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -1,0 +1,46 @@
+import type { AiId } from "./types.js";
+
+/**
+ * Parses the first valid @mention from `text` that maps to a known persona.
+ *
+ * Rules:
+ * - "@Name" must be preceded by start-of-string or whitespace.
+ * - "@Name" terminates at end-of-string, whitespace, or a single trailing
+ *   punctuation character (the punctuation is not part of the name).
+ * - Case-insensitive.
+ * - First mention wins.
+ * - "@Nonpersona" or "@" alone returns null.
+ * - "user@host" style does NOT match (no preceding whitespace).
+ */
+export function parseFirstMention(
+	text: string,
+	personaNamesToId: ReadonlyMap<string, AiId>,
+): AiId | null {
+	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(text)) !== null) {
+		const raw = match[1];
+		if (!raw) continue;
+		// Strip a single trailing punctuation character if present.
+		const name = /[.,!?;:]$/.test(raw) ? raw.slice(0, -1) : raw;
+		const id = personaNamesToId.get(name.toLowerCase());
+		if (id !== undefined) return id;
+	}
+	return null;
+}
+
+/**
+ * Builds a lowercased name → AiId map from a personas record.
+ */
+export function buildPersonaNameMap(
+	personas: Record<AiId, { name: string }>,
+): Map<string, AiId> {
+	const map = new Map<string, AiId>();
+	for (const [id, persona] of Object.entries(personas) as [
+		AiId,
+		{ name: string },
+	][]) {
+		map.set(persona.name.toLowerCase(), id);
+	}
+	return map;
+}

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -36,11 +36,6 @@
 		    </article>
 		  </div>
 		  <form id="composer">
-		    <select id="address" aria-label="Address AI">
-		      <option value="red">Ember (red)</option>
-		      <option value="green">Sage (green)</option>
-		      <option value="blue">Frost (blue)</option>
-		    </select>
 		    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
 		    <button id="send" type="submit">Send</button>
 		  </form>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1,8 +1,10 @@
 import { PERSONAS, PHASE_1_CONFIG } from "../../content";
 import { serializeGameSave } from "../../save-serializer.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
+import { deriveComposerState } from "../game/composer-reducer.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
+import { buildPersonaNameMap } from "../game/mention-parser.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
 import type { AiId, PhaseConfig } from "../game/types";
 import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";
@@ -144,7 +146,6 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 	const form = doc.querySelector<HTMLFormElement>("#composer");
 	const promptInput = doc.querySelector<HTMLInputElement>("#prompt");
 	const sendBtn = doc.querySelector<HTMLButtonElement>("#send");
-	const addressSelect = doc.querySelector<HTMLSelectElement>("#address");
 	const capHitEl = doc.querySelector<HTMLElement>("#cap-hit");
 	const actionLogEl = doc.querySelector<HTMLElement>("#action-log");
 	const actionLogList = doc.querySelector<HTMLUListElement>("#action-log-list");
@@ -152,7 +153,31 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		"#persistence-warning",
 	);
 
-	if (!form || !promptInput || !sendBtn || !addressSelect) return;
+	if (!form || !promptInput || !sendBtn) return;
+
+	// Mention-based addressing state
+	const personaNamesToId = buildPersonaNameMap(PERSONAS);
+	const lockouts: Map<AiId, boolean> = new Map([
+		["red", false],
+		["green", false],
+		["blue", false],
+	]);
+	let roundInFlight = false;
+
+	// promptInput and sendBtn are guaranteed non-null (checked above).
+	const _promptInput = promptInput;
+	const _sendBtn = sendBtn;
+
+	function refreshComposerState(): void {
+		const { sendEnabled } = deriveComposerState({
+			text: _promptInput.value,
+			lockouts,
+			personaNamesToId,
+		});
+		_sendBtn.disabled = !sendEnabled || roundInFlight;
+	}
+
+	promptInput.addEventListener("input", refreshComposerState);
 
 	// Dev-only: ?think=0 disables the model's thinking step (OpenRouter
 	// reasoning.enabled=false). Gated to wrangler-dev host (see isDevHost).
@@ -230,9 +255,19 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		// intended to be set on the page URL itself, matching the legacy worker pattern.
 		session = applyTestAffordances(session, effectiveParams);
 
+		// Hydrate lockouts from the active phase's chatLockouts map so that
+		// a reload preserves the Send-disabled state for locked-out AIs.
+		const activePhaseForLockouts = getActivePhase(session.getState());
+		for (const aiId of AI_ORDER) {
+			lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
+		}
+
 		// Reset module-level gameEnded flag on fresh session init
 		gameEnded = false;
 	}
+
+	// Set initial composer state (Send starts disabled until a valid @mention).
+	refreshComposerState();
 
 	// Populate panel headers from PERSONAS so renames don't require HTML edits
 	for (const aiId of AI_ORDER) {
@@ -296,21 +331,29 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		budgetEl.textContent = `${remaining}/${total}`;
 	}
 
-	// Helper: update chat lockout status in dropdown
+	// Helper: update chat lockout status in the lockouts map
 	function setChatLockout(aiId: AiId, locked: boolean): void {
-		const option = addressSelect?.querySelector<HTMLOptionElement>(
-			`option[value="${aiId}"]`,
-		);
-		if (option) option.disabled = locked;
+		lockouts.set(aiId, locked);
+		refreshComposerState();
 	}
 
 	form.addEventListener("submit", async (evt) => {
 		evt.preventDefault();
-		const message = promptInput.value.trim();
-		if (!message || !session) return;
+		if (!session) return;
 
-		const addressed = addressSelect.value as AiId;
+		const { sendEnabled, addressee } = deriveComposerState({
+			text: promptInput.value,
+			lockouts,
+			personaNamesToId,
+		});
+		if (!sendEnabled || !addressee) return;
+
+		const message = promptInput.value.trim();
+		if (!message) return;
+
+		const addressed = addressee;
 		promptInput.value = "";
+		roundInFlight = true;
 		sendBtn.disabled = true;
 
 		// Append player's message to the addressed panel
@@ -467,12 +510,10 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 									budgetEl.dataset.budget = String(b.remaining);
 									budgetEl.textContent = `${b.remaining}/${b.total}`;
 								}
-								// Re-enable chat-locked options that were carried over
-								const option = addressSelect?.querySelector<HTMLOptionElement>(
-									`option[value="${aid}"]`,
-								);
-								if (option) option.disabled = false;
+								// Re-enable chat-locked AIs that were carried over
+								lockouts.set(aid, false);
 							}
+							refreshComposerState();
 						}
 						// Append phase separator to each transcript
 						for (const aid of AI_ORDER) {
@@ -604,7 +645,8 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			}
 		} finally {
 			stripPlaceholder();
-			if (!roundGameEnded) sendBtn.disabled = false;
+			roundInFlight = false;
+			if (!roundGameEnded) refreshComposerState();
 		}
 	});
 }


### PR DESCRIPTION
Closes #107 (parent PRD #65).

## What this fixes

The composer no longer needs the separate `<select id="address">` dropdown to pick which AI a message is going to. The player addresses an AI by typing `@Ember`, `@Sage`, or `@Frost` in the message body — case-insensitively, anywhere in the text, with the first valid mention winning.

Two pure modules introduce the rule, isolated from the DOM:

- `src/spa/game/mention-parser.ts` — `parseFirstMention(text, personaNamesToId)` returns the canonical `AiId` of the first `@Persona` token (or `null`). Uses `(?:^|\s)@([A-Za-z][A-Za-z0-9]*)` so `email me @user` (no preceding whitespace) and `@nonpersona` don't match, while `@Sage,` and `@Sage.` parse cleanly. `buildPersonaNameMap(PERSONAS)` derives the lowercased name → AiId lookup so the rule has a single source of truth.
- `src/spa/game/composer-reducer.ts` — `deriveComposerState({ text, lockouts, personaNamesToId })` returns `{ addressee, sendEnabled }`. Send is on iff a mention is present AND that addressee isn't currently chat-locked.

`src/spa/routes/game.ts` is rewired around those: a route-local `lockouts: Map<AiId, boolean>` (hydrated from `getActivePhase(state).chatLockouts` on init so reload preserves disabled state), an `input` listener that calls `refreshComposerState()` to drive `sendBtn.disabled`, a `roundInFlight` guard so Send can't re-enable mid-round, and `setChatLockout(aiId, locked)` mutating the map + refreshing instead of toggling `<option>.disabled`. The `<select>` and its label are gone from `src/spa/index.html`; nothing reads `addressSelect.value` anymore.

## QA steps for the human

Automated coverage is strong on units + jsdom integration, but the **Playwright e2e suite was not exercised in this sandbox** (chromium binary unavailable, install URL blocked, `wrangler dev` requires Cloudflare login). Before merge, please run locally:

- [ ] `pnpm test:e2e` — must be green. The new `e2e/mention-addressing.spec.ts` covers: `#address` removed, first-load Send disabled, `hi` keeps Send disabled, `@Sage hi` enables Send and routes `[you]` to the green panel only. Existing specs (`addressed-and-parallel`, `chat-lockout`, `persistence-reload`, `diagnose-streaming`, `endgame-current-behaviour`, `smoke`, `think-disabled`, `token-pacing`) had their prompts mention-prefixed and `selectOption("#address", ...)` calls removed.
- [ ] Spot-check in a real browser: load the SPA, confirm Send starts disabled with no dropdown visible, type `@Sage hi`, hit Send, watch the round route to the green panel; trigger the `?lockout=1` affordance and confirm `@Ember hi` keeps Send disabled.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 502/502 vitest (including 18 `mention-parser` cases, 10 `composer-reducer` cases, and a new `renderGame — mention-based addressing` describe block in `src/spa/__tests__/game.test.ts` covering first-load disabled, no-mention disabled, mention enables, `@Sage hi` routes to green, and `@Sage` with green locked stays disabled)
- `pnpm lint` — clean
- `pnpm build` — green; `dist/index.html` confirms `id="address"` count is 0 and `#prompt`/`#send`/`#composer` are intact

## Out of scope (follow-up slices of #65)

- Visual highlight of the addressed AI's panel and of the leading `@mention` token
- Composer border colour reflecting the addressee
- Panel-click as an alternative to typing the mention (`applyAddresseeChange`)
- Inline in-character error message when Send is blocked by lockout (Send simply stays disabled here)
- Locked-panel muted/unclickable styling
- Post-send retention of `@Persona ` in the input

https://claude.ai/code/session_01X3r2w2hC3J9SPuYy2ENtKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3r2w2hC3J9SPuYy2ENtKJ)_