### PR TITLE
fix(#115): merge location.search with hash params for SPA dev flags

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -972,3 +972,102 @@ describe("renderGame — chat_lockout event", () => {
 		expect(redOption?.disabled).toBe(true);
 	});
 });
+
+describe("renderGame — URL param sourcing", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("search-only: ?winImmediately=1 in location.search (router passes empty params) triggers phase_advanced on first submit", async () => {
+		// Router always passes a non-null URLSearchParams, but it may be empty
+		// when the flag is in location.search rather than the hash query string.
+		vi.stubGlobal("location", {
+			search: "?winImmediately=1",
+			origin: "http://localhost:8787",
+			hash: "",
+		});
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		// Router passes empty URLSearchParams (hash had no query string)
+		renderGame(getEl<HTMLElement>("main"), new URLSearchParams());
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "go";
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Phase banner should be visible — winImmediately fired from location.search
+		const phaseBanner = getEl<HTMLElement>("#phase-banner");
+		expect(phaseBanner.hasAttribute("hidden")).toBe(false);
+		expect(phaseBanner.textContent).toContain("Phase 2");
+	});
+
+	it("hash-only: debug=1 in hash params (no location.search) shows action log", async () => {
+		vi.stubGlobal("location", {
+			search: "",
+			origin: "http://localhost:8787",
+			hash: "#/?debug=1",
+		});
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		// Router parses debug=1 from the hash and passes it as params
+		renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=1"));
+
+		const actionLog = getEl<HTMLElement>("#action-log");
+		expect(actionLog.hasAttribute("hidden")).toBe(false);
+	});
+
+	it("conflict: location.search has debug=1 but hash params have debug=0 → hash wins, log is hidden", async () => {
+		vi.stubGlobal("location", {
+			search: "?debug=1",
+			origin: "http://localhost:8787",
+			hash: "#/?debug=0",
+		});
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		// Router passes debug=0 from the hash; location.search has debug=1
+		renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=0"));
+
+		const actionLog = getEl<HTMLElement>("#action-log");
+		// Hash wins: debug=0 → log must remain hidden
+		expect(actionLog.hasAttribute("hidden")).toBe(true);
+	});
+});

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -156,7 +156,15 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 
 	// Dev-only: ?think=0 disables the model's thinking step (OpenRouter
 	// reasoning.enabled=false). Gated to wrangler-dev host (see isDevHost).
-	const effectiveParams = params ?? new URLSearchParams(location.search);
+	//
+	// Merge hash-query-string params (from the router) with location.search
+	// params so flags like ?think=0, ?lockout=1, ?winImmediately=1 work whether
+	// they appear in the search string (e.g. "/?lockout=1") or after the hash
+	// (e.g. "/#/?lockout=1"). Hash params win on conflict.
+	const effectiveParams = new URLSearchParams(location.search);
+	if (params) {
+		for (const [k, v] of params) effectiveParams.set(k, v);
+	}
 	const disableReasoning = isDevHost() && effectiveParams.get("think") === "0";
 
 	/** Show the persistence warning banner once (idempotent). */
@@ -253,7 +261,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 	}
 
 	// Debug toggle: show action log if ?debug=1
-	const debug = params?.get("debug") === "1";
+	const debug = effectiveParams.get("debug") === "1";
 	if (actionLogEl) {
 		if (debug) {
 			actionLogEl.removeAttribute("hidden");


### PR DESCRIPTION
## What this fixes

The SPA renderer was dropping any URL flag that lived in `location.search` (e.g. `/?think=0`, `/?lockout=1`, `/?winImmediately=1`, `/?debug=1`). The router parses params from `location.hash` only and always passes a `URLSearchParams` (often empty) to the renderer; the existing `params ?? new URLSearchParams(location.search)` fallback never triggered, so search-string flags silently no-op'd.

The fix merges both sources at the renderer boundary in `src/spa/routes/game.ts` — start from `location.search` and overlay router-passed hash params (hash wins on conflict). The `?debug=1` toggle is consolidated to read from the same merged source.

## QA steps for the human

- [ ] Run `pnpm test:e2e think-disabled` locally — both tests should pass.
- [ ] Smoke also confirmed `chat-lockout.spec.ts` and `addressed-and-parallel.spec.ts` now pass — this fix likely also resolves #114. Worth re-running the full e2e suite (`pnpm test:e2e`) once and seeing what's left.
- [ ] Hash-form flags (e.g. `/#/?debug=1`) still work — covered by unit test.

## Automated coverage

- `pnpm typecheck` ✓
- `pnpm test` ✓ (471 tests, 29 files; includes 3 new tests in `src/spa/__tests__/game.test.ts` covering search-only / hash-only / conflict)
- `pnpm lint` ✓
- `pnpm exec playwright test e2e/think-disabled.spec.ts` ✓
- `pnpm exec playwright test e2e/chat-lockout.spec.ts e2e/addressed-and-parallel.spec.ts` ✓

Closes #115
May also close #114 (chat-lockout) — smoke shows the spec now passes with this fix alone; verify on full suite run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfXpe2Nzn2pM6PPkHmSLhg)_