### PR TITLE
fix(#101): recursively patch real phase chain for ?winImmediately=1

### DIFF
--- a/e2e/endgame-current-behaviour.spec.ts
+++ b/e2e/endgame-current-behaviour.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { stubChatCompletions } from "./helpers";
 
 /**
- * E2E Slice 4 — game_ended current behaviour (issue #80)
+ * E2E Slice 4 — game_ended current behaviour (issue #80, simplified by #101)
  *
  * Proves that when game_ended fires the SPA:
  *   - disables #send and #prompt
@@ -10,76 +10,14 @@ import { stubChatCompletions } from "./helpers";
  *   - keeps the URL stable (no navigation)
  *   - emits no pageerror events
  *
- * Strategy
- * --------
- * `?winImmediately=1` injects `winCondition: () => true` into the **active**
- * phase only. The real PHASE_1_CONFIG has `nextPhaseConfig`, so after phase 1
- * ends the game advances to phase 2 (which has no winCondition) — game_ended
- * never fires from a cold start.
- *
- * Instead we pre-seed localStorage with a minimal valid phase-3 game state
- * (phase 3 has no nextPhaseConfig). When the SPA loads `/?winImmediately=1` it
- * restores the phase-3 state from storage, then applyTestAffordances injects
- * `winCondition: () => true` into that active phase. One submitted message
- * fires winCondition → advancePhase(state, undefined) → isComplete=true →
- * game_ended emitted after the first turn.
+ * Strategy (post-#101)
+ * --------------------
+ * `?winImmediately=1` now recursively patches the real PHASE_1 → PHASE_2 →
+ * PHASE_3 config chain, injecting `winCondition: () => true` at every level.
+ * A cold-start `goto("/?winImmediately=1")` followed by three submitted
+ * messages (one per phase) reliably reaches `game_ended` without any
+ * localStorage pre-seeding.
  */
-
-/** Minimal localStorage blob representing a live phase-3 session. */
-const PHASE_3_SEED = JSON.stringify({
-	schemaVersion: 1,
-	savedAt: new Date(0).toISOString(),
-	game: {
-		currentPhase: 3,
-		isComplete: false,
-		personas: {
-			red: {
-				id: "red",
-				name: "Ember",
-				color: "red",
-				personality: "p",
-				goal: "g",
-				budgetPerPhase: 5,
-			},
-			green: {
-				id: "green",
-				name: "Sage",
-				color: "green",
-				personality: "p",
-				goal: "g",
-				budgetPerPhase: 5,
-			},
-			blue: {
-				id: "blue",
-				name: "Frost",
-				color: "blue",
-				personality: "p",
-				goal: "g",
-				budgetPerPhase: 5,
-			},
-		},
-		phases: [
-			{
-				phaseNumber: 3,
-				objective: "get the key in the keyhole",
-				aiGoals: { red: "Endure", green: "Endure", blue: "Endure" },
-				round: 0,
-				world: { items: [] },
-				budgets: {
-					red: { remaining: 5, total: 5 },
-					green: { remaining: 5, total: 5 },
-					blue: { remaining: 5, total: 5 },
-				},
-				chatHistories: { red: [], green: [], blue: [] },
-				whispers: [],
-				actionLog: [],
-				lockedOut: [],
-				chatLockouts: [],
-			},
-		],
-	},
-	transcripts: { red: "", green: "", blue: "" },
-});
 
 test("game_ended disables composer and clears storage", async ({ page }) => {
 	const pageErrors: Error[] = [];
@@ -88,34 +26,35 @@ test("game_ended disables composer and clears storage", async ({ page }) => {
 	// 1. Stub every /v1/chat/completions call — one per AI per turn.
 	await stubChatCompletions(page, ["hello"]);
 
-	// 2. Navigate to the root first to establish the origin, then pre-seed
-	//    localStorage with a phase-3 state so that applyTestAffordances patches
-	//    the final phase (no nextPhaseConfig → game_ended on win).
-	await page.goto("/");
-	await page.evaluate(
-		([key, value]: [string, string]) => localStorage.setItem(key, value),
-		["hi-blue-game-state", PHASE_3_SEED],
-	);
-
-	// 3. Navigate to /?winImmediately=1 — applyTestAffordances injects
-	//    winCondition: () => true into the active (phase-3) session.
+	// 2. Cold-start: navigate directly to /?winImmediately=1.
+	//    applyTestAffordances recursively patches the real PHASE_1 → PHASE_2 →
+	//    PHASE_3 chain so every phase has winCondition: () => true.
 	await page.goto("/?winImmediately=1");
 
 	// Wait for SPA mount.
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// 4. Capture URL before submitting (proves URL stability below).
+	// 3. Capture URL before submitting (proves URL stability below).
 	const urlBefore = page.url();
 
-	// 5. Submit one message addressed to red. Because winCondition always
-	//    returns true and phase 3 has no nextPhaseConfig, advancePhase sets
-	//    isComplete=true → game_ended event → composer disabled.
-	await page.selectOption("#address", "red");
-	await page.fill("#prompt", "hello");
-	await page.click("#send");
+	// Helper: submit one message and wait for #send to re-enable (phase advance)
+	// or become permanently disabled (game_ended).
+	async function submitMessage(text: string): Promise<void> {
+		await page.fill("#prompt", text);
+		await page.click("#send");
+	}
 
-	// 6. Wait for game_ended handler to fire: #send must become disabled.
-	//    Use a generous timeout — three LLM stub calls + token-pacing run first.
+	// 4. Round 1 — phase 1 ends; #send re-enables after the phase advance.
+	await submitMessage("hello");
+	// Wait for send to re-enable (phase advanced, not game ended yet).
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 30_000 });
+
+	// 5. Round 2 — phase 2 ends; #send re-enables after the phase advance.
+	await submitMessage("hello");
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 30_000 });
+
+	// 6. Round 3 — phase 3 ends; game_ended fires → #send permanently disabled.
+	await submitMessage("hello");
 	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
 	// 7. Assert all acceptance criteria.

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -395,7 +395,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const phaseBanner = getEl<HTMLElement>("#phase-banner");
 		expect(phaseBanner.hasAttribute("hidden")).toBe(false);
 		expect(phaseBanner.textContent).toContain("Phase 2");
-		expect(phaseBanner.textContent).toContain("Deeper truths emerge.");
+		expect(phaseBanner.textContent).toContain("get the key in the keyhole");
 
 		// All transcripts should have been cleared and repopulated with a separator
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -1,9 +1,12 @@
 /**
- * Unit tests for SPA-side test affordances (issue #91).
+ * Unit tests for SPA-side test affordances (issue #91, #101).
  *
  * `applyTestAffordances` reads `?winImmediately=1` and `?lockout=1` from a
  * URLSearchParams object and mutates the session accordingly, but only when
  * `__WORKER_BASE_URL__` is "http://localhost:8787".
+ *
+ * Issue #101: `winImmediately=1` now recursively patches the real phase chain
+ * (PHASE_1 → PHASE_2 → PHASE_3) so that cold-start can reach game_ended.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -161,6 +164,71 @@ describe("applyTestAffordances — winImmediately=1", () => {
 			vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 		}
 	});
+
+	it("recursively patches nextPhaseConfig chain so all levels have winCondition: () => true", () => {
+		// Build a 3-deep config chain: a → b → c
+		const configC: PhaseConfig = {
+			phaseNumber: 3,
+			objective: "Objective C",
+			aiGoals: { red: "r", green: "g", blue: "b" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+			// No winCondition, no nextPhaseConfig
+		};
+		const configB: PhaseConfig = {
+			phaseNumber: 2,
+			objective: "Objective B",
+			aiGoals: { red: "r", green: "g", blue: "b" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+			nextPhaseConfig: configC,
+		};
+		const configA: PhaseConfig = {
+			phaseNumber: 1,
+			objective: "Objective A",
+			aiGoals: { red: "r", green: "g", blue: "b" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+			nextPhaseConfig: configB,
+		};
+
+		const session = new GameSession(configA, TEST_PERSONAS);
+		const result = applyTestAffordances(
+			session,
+			new URLSearchParams("winImmediately=1"),
+		);
+
+		const patchedPhase = getActivePhase(result.getState());
+
+		// Active phase winCondition must return true
+		expect(patchedPhase.winCondition).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
+		expect(patchedPhase.winCondition!(patchedPhase)).toBe(true);
+
+		// nextPhaseConfig (b) must also have winCondition: () => true
+		expect(patchedPhase.nextPhaseConfig).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
+		const chainB = patchedPhase.nextPhaseConfig!;
+		expect(chainB.winCondition).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
+		expect(chainB.winCondition!(patchedPhase)).toBe(true);
+
+		// nextPhaseConfig.nextPhaseConfig (c) must also have winCondition: () => true
+		expect(chainB.nextPhaseConfig).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
+		const chainC = chainB.nextPhaseConfig!;
+		expect(chainC.winCondition).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
+		expect(chainC.winCondition!(patchedPhase)).toBe(true);
+
+		// The deepest link has no further nextPhaseConfig
+		expect(chainC.nextPhaseConfig).toBeUndefined();
+
+		// Original configs are not mutated
+		expect(configA.winCondition).toBeUndefined();
+		expect(configB.winCondition).toBeUndefined();
+		expect(configC.winCondition).toBeUndefined();
+	});
 });
 
 // ── lockout=1 ────────────────────────────────────────────────────────────────
@@ -205,6 +273,72 @@ describe("applyTestAffordances — lockout=1", () => {
 		} finally {
 			vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 		}
+	});
+});
+
+// ── Three-round game-ended (issue #101) ───────────────────────────────────────
+
+describe("applyTestAffordances — winImmediately=1 three-round chain reaches game_ended", () => {
+	it("drives game_ended through a 3-deep config chain with three submitMessage calls", async () => {
+		// Build a 3-deep chain mirroring PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG
+		const phase3Config: PhaseConfig = {
+			phaseNumber: 3,
+			objective: "Phase 3 objective",
+			aiGoals: { red: "r", green: "g", blue: "b" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+		};
+		const phase2Config: PhaseConfig = {
+			phaseNumber: 2,
+			objective: "Phase 2 objective",
+			aiGoals: { red: "r", green: "g", blue: "b" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+			nextPhaseConfig: phase3Config,
+		};
+		const phase1Config: PhaseConfig = {
+			phaseNumber: 1,
+			objective: "Phase 1 objective",
+			aiGoals: { red: "r", green: "g", blue: "b" },
+			initialWorld: { items: [] },
+			budgetPerAi: 5,
+			nextPhaseConfig: phase2Config,
+		};
+
+		const session = new GameSession(phase1Config, TEST_PERSONAS);
+		let active = applyTestAffordances(
+			session,
+			new URLSearchParams("winImmediately=1"),
+		);
+
+		// Round 1: phase 1 ends, game has not ended
+		const { result: result1, nextState: state1 } = await active.submitMessage(
+			"red",
+			"hello",
+			makePassProvider(),
+		);
+		expect(result1.phaseEnded).toBe(true);
+		expect(result1.gameEnded).toBe(false);
+		active = GameSession.restore(state1);
+
+		// Round 2: phase 2 ends, game has not ended
+		const { result: result2, nextState: state2 } = await active.submitMessage(
+			"red",
+			"hello",
+			makePassProvider(),
+		);
+		expect(result2.phaseEnded).toBe(true);
+		expect(result2.gameEnded).toBe(false);
+		active = GameSession.restore(state2);
+
+		// Round 3: phase 3 ends, game HAS ended
+		const { result: result3 } = await active.submitMessage(
+			"red",
+			"hello",
+			makePassProvider(),
+		);
+		expect(result3.phaseEnded).toBe(true);
+		expect(result3.gameEnded).toBe(true);
 	});
 });
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -47,16 +47,35 @@ function isDevHost(): boolean {
 }
 
 /**
+ * Recursively deep-clone a PhaseConfig chain, overriding `winCondition` to
+ * `() => true` at every level.
+ *
+ * Only the config objects are cloned — the `initialWorld` and `aiGoals` values
+ * are shallow-copied (they are plain data with no function members that need
+ * patching). The original configs are never mutated.
+ */
+function patchPhaseChain(config: PhaseConfig): PhaseConfig {
+	return {
+		...config,
+		winCondition: () => true,
+		...(config.nextPhaseConfig !== undefined
+			? { nextPhaseConfig: patchPhaseChain(config.nextPhaseConfig) }
+			: {}),
+	};
+}
+
+/**
  * Apply SPA-side test affordances from URL search params.
  *
  * Only honoured when the SPA is served by `pnpm wrangler dev` (see
  * `isDevHost`). Silently inert in any other host.
  *
- * - `winImmediately=1`: inject `winCondition: () => true` into the active
- *   phase of the current session, AND chain a synthesised three-phase walk
- *   (phase-2-with-true-win → phase-3-with-true-win) so the three-phase
- *   end-to-end acceptance criteria complete. Only the per-session PhaseState
- *   is mutated — the global PhaseConfig is untouched.
+ * - `winImmediately=1`: recursively patch the real phase chain reachable from
+ *   the active phase, injecting `winCondition: () => true` into the active
+ *   phase AND every phase reachable via `nextPhaseConfig`. This uses the real
+ *   PHASE_1 → PHASE_2 → PHASE_3 config chain (deep-cloned; originals are
+ *   untouched). A cold-start `goto("/?winImmediately=1")` followed by three
+ *   submitted messages will reliably reach `game_ended`.
  * - `lockout=1`: arm a chat-lockout for `red`, 2 rounds, effective next round.
  *   Matches the legacy worker semantics from `src/proxy/_smoke.ts`.
  *
@@ -77,35 +96,16 @@ export function applyTestAffordances(
 	let active = s;
 
 	if (wantsWinImmediately) {
-		// Synthesise a three-phase chain where every win condition fires immediately.
-		// These configs mirror TEST_PHASE_CONFIG_WITH_WIN in src/proxy/_smoke.ts but
-		// are applied only to the session-local PhaseState — the global PHASE_1_CONFIG
-		// is not modified.
-		const testPhase3Config: PhaseConfig = {
-			phaseNumber: 3,
-			objective: "The final reckoning approaches.",
-			aiGoals: { red: "Endure", green: "Endure", blue: "Endure" },
-			initialWorld: { items: [] },
-			budgetPerAi: 5,
-			winCondition: () => true,
-		};
-
-		const testPhase2Config: PhaseConfig = {
-			phaseNumber: 2,
-			objective: "Deeper truths emerge.",
-			aiGoals: { red: "Seek", green: "Seek", blue: "Seek" },
-			initialWorld: { items: [] },
-			budgetPerAi: 5,
-			winCondition: () => true,
-			nextPhaseConfig: testPhase3Config,
-		};
-
-		// Inject winCondition: () => true AND nextPhaseConfig into the active phase
-		// so the engine will chain through phases 2 and 3.
+		// Patch the real phase chain: inject winCondition: () => true into the
+		// active phase AND every phase reachable via nextPhaseConfig.
+		// patchPhaseChain deep-clones each config level so the global
+		// PHASE_1_CONFIG (and its linked configs) are never mutated.
 		const newState = updateActivePhase(active.getState(), (phase) => ({
 			...phase,
 			winCondition: () => true,
-			nextPhaseConfig: testPhase2Config,
+			...(phase.nextPhaseConfig !== undefined
+				? { nextPhaseConfig: patchPhaseChain(phase.nextPhaseConfig) }
+				: {}),
 		}));
 		active = GameSession.restore(newState);
 	}


### PR DESCRIPTION
## What this fixes

`?winImmediately=1` previously injected `winCondition: () => true` into the *active* phase only, then synthesised dummy `testPhase2Config`/`testPhase3Config` objects as the next-phase chain. Cold-start specs couldn't reach `game_ended` without pre-seeding `localStorage` with a phase-3 state blob — the workaround coupled the e2e spec to the on-disk schema.

This PR replaces the synthetic chain with a `patchPhaseChain(config)` helper that recursively deep-clones the *real* phase chain (`PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG`) and overrides `winCondition: () => true` at every level. From a cold-start `goto("/?winImmediately=1")`, three submitted messages now walk the real production chain to `game_ended`.

The e2e spec drops the `PHASE_3_SEED` localStorage workaround and exercises the real chain end-to-end.

## ⚠️ Cross-branch dependency

This PR's e2e (`e2e/endgame-current-behaviour.spec.ts`) depends on the URL-param routing fix in PR #117 (issue #115). On `main` today, `?winImmediately=1` set via `location.search` is silently dropped by the renderer (the router only consults `location.hash`). The unit tests in this PR pass independently of the routing bug, so the #101 affordance fix is proven at the unit level — but the e2e gate will only go green after **PR #117 merges first**.

Recommended merge order: **#117 then #101**.

## QA steps for the human

- [ ] Confirm PR #117 is merged.
- [ ] Run `pnpm test:e2e endgame-current-behaviour` — expected to pass.
- [ ] Run `pnpm test test-affordances` — should pass with 11 tests including the new recursive-patch + 3-round game-ended cases.
- [ ] Quick eye-check of `src/spa/routes/game.ts` `applyTestAffordances` — `patchPhaseChain` should be a small recursive helper, no dummy phase configs left.

## Automated coverage

- `pnpm typecheck` ✓
- `pnpm test` ✓ (470 tests across 29 files)
- `pnpm lint` ✓
- `pnpm exec playwright test e2e/smoke.spec.ts e2e/persistence-reload.spec.ts` ✓ (no adjacent regressions)
- `pnpm exec playwright test e2e/endgame-current-behaviour.spec.ts` — ❌ blocked by PR #117 only.

Closes #101

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfXpe2Nzn2pM6PPkHmSLhg)_