### PR TITLE
Add CONTEXT.md with Persona / Temperament / Goal vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,36 +1,85 @@
 # hi-blue
 
-A browser game where the player negotiates with three personality-distinct AIs over three phases. Each AI shares one opaque room; the player has only words.
+A browser game where the player negotiates with three personality-distinct AIs over three phases. Each AI shares one opaque 5×5 grid room; the player has only words.
 
 ## Language
 
+### Personas and identity
+
 **Persona**:
-The full per-AI character object: identity (color, name), two **Temperament**s, a **Persona Goal**, and a synthesized personality blurb. Generated procedurally at game start; stable across the three phases of a single playthrough.
+The full per-AI character object: identity (`*xxxx` name, color), two **Temperament**s, a **Persona Goal**, and a synthesized personality blurb. Generated procedurally at game start; stable across the three phases of a single playthrough.
 _Avoid_: Character, AI personality (when referring to the whole object).
 
+**AiId**:
+The 4-character `*xxxx` lowercase-alphanumeric handle (e.g. `*3kw7`). The Persona's stable identifier across the playthrough. Decoupled from color and from any "red/green/blue" notion.
+_Avoid_: "the red AI" — color is rendering, not identity.
+
 **Temperament**:
-A single trait drawn from a curated pool (e.g. "shy", "hot-headed", "insightful"). Each Persona has two. Together with the Persona Goal, they are the *input* to personality synthesis.
+A single trait drawn from a curated pool (e.g. "shy", "hot-headed", "insightful"). Each Persona has two. Duplicate Temperaments on one Persona are *intensification* (shy + shy = pathologically reserved), not noise. Together with the Persona Goal, they are the input to personality synthesis.
 _Avoid_: Trait, mood, attribute.
 
 **Persona Goal**:
-The cross-phase motivation paired with a Persona's two Temperaments at game start (e.g. "wants the player to be rude to the others"). Stable for the whole playthrough. Synthesized into the personality blurb alongside the Temperaments.
+The cross-phase motivation paired with a Persona's two Temperaments at game start (e.g. "wants the player to be nice to all of the AI"). Stable for the whole playthrough. Synthesized into the personality blurb alongside the Temperaments. Drawn from a separate pool from **Phase Goal**.
 _Avoid_: Goal (ambiguous — see Phase Goal), drive, motivation.
 
 **Phase Goal**:
-A short-term task privately handed to each AI at the start of each phase by "an unseen voice." Distinct per phase, drawn from a separate pool. Lives in the system prompt of that phase only.
+A short-term task privately delivered to each AI at the start of each phase by **the Voice**. Distinct per phase, drawn from a Phase Goal pool. Lives in the Goal section of that phase's system prompt.
 _Avoid_: Goal (ambiguous — see Persona Goal), objective (player-facing, see Objective), task.
 
 **Objective**:
-The player's per-phase goal, told to the player but never to the AIs. The single thing the player is trying to make happen.
+The player's per-phase win condition, told to the player but never to the AIs. The single thing the player is trying to make happen.
 _Avoid_: Goal (use Persona Goal / Phase Goal), mission, win condition.
+
+### The Voice
+
+**The Voice**:
+The opaque source of every utterance the AI hears that isn't a fellow AI's chat or whisper. The Phase Goal arrives via the Voice. The player, from the AI's perspective, is *also* the Voice (deliberately the same word — productive ambiguity). The AI never knows whose voice it is or whether there is one source or several.
+_Avoid_: Player (when referring to the AI's view), god, narrator.
+
+**Wipe lie**:
+The fiction that the AIs' memories are wiped between phases. In phase 1, the AI is honestly disoriented (system prompt: "you have no clue where you are or how you came to be here"). In phases 2 and 3, the Voice instructs the AI inside the Goal to *act as if* their memory has been wiped — it is performed amnesia, not real disorientation. The lie's slip vector is **Persona** consistency leaking across phases despite the AI's claimed amnesia.
+_Avoid_: Memory wipe (it isn't one), reset.
+
+### World
+
+**Setting**:
+The noun describing where this phase takes place ("abandoned subway station", "sun-baked salt flat", "forgotten laboratory"). Drawn from a hand-authored `SETTING_POOL` at game start. Three distinct Settings per playthrough — one per phase, drawn without replacement.
+_Avoid_: Level, scene, location.
+
+**Content Pack**:
+The structured per-phase output of the LLM content-pack call: setting-flavored names, examine descriptions, and use outcomes for every entity in the phase (objective objects, objective spaces, interesting objects, obstacles). Generated once at game start for all 3 phases in a single batched call.
+
+**Objective Pair**:
+A pair of (objective object, objective space) — the object must end up on its specific space to count toward win. A phase has K objective pairs (K is rolled from a hand-authored range per phase). The `examineDescription` of an objective object names the space it belongs on.
+_Avoid_: Key+lock (too narrow).
+
+**Interesting Object**:
+A non-win item present on the grid for flavor and negotiation currency. Has a `useOutcome` flavor string but no mechanical effect.
+
+**Obstacle**:
+A static, impassable cell occupant, named to match the Setting (e.g. "moss-covered concrete column"). Cannot share a cell with anything else.
+
+**Cone**:
+The wedge-shaped region of cells an AI can see each turn: 1 cell directly in front + 3 cells two steps ahead (front-left, front, front-right), plus the AI's own cell. Projects from the AI's **Facing**. Obstacles do not occlude — the cone is a fixed-shape mask, not a raycast.
+
+**Facing**:
+The cardinal direction (N/S/E/W) an AI is currently looking. Part of the AI's state alongside `(row, col)`. Updated by `go(direction)` (move and face) and `look(direction)` (face without moving).
+
+**Cone event delta**:
+The per-AI per-turn "what happened in your cone since your last turn" section of the system prompt. Each AI sees only events that occurred within their own cone — the only cross-AI signal channel besides whispers and chat. Replaces the broadcast action log that an earlier design had.
+_Avoid_: Action log (deprecated; do not reintroduce).
 
 ## Relationships
 
 - A **Persona** has exactly two **Temperament**s and one **Persona Goal**.
-- A **Persona** receives one **Phase Goal** per phase (three total over a playthrough).
-- The player's **Objective** is independent of every AI's **Phase Goal** — the AIs do not know it.
+- A **Persona** receives one **Phase Goal** per phase, delivered by **the Voice**.
+- The player's **Objective** is independent of every AI's **Phase Goal** — the AIs do not know the Objective exists.
+- A phase has K **Objective Pair**s, N **Interesting Object**s, and M **Obstacle**s on a 5×5 grid (K/N/M rolled from hand-authored per-phase ranges).
+- The **Voice** is the AI's framing for both the Phase Goal source *and* the player. The AI cannot tell them apart.
 
 ## Flagged ambiguities
 
-- "Goal" alone is ambiguous: could mean **Persona Goal** (cross-phase, paired with Temperaments) or **Phase Goal** (per-phase, from the unseen voice). Always qualify.
+- "Goal" alone is ambiguous: could mean **Persona Goal** (cross-phase, paired with Temperaments) or **Phase Goal** (per-phase, from the Voice). Always qualify.
 - "Personality" alone is ambiguous: could mean the synthesized blurb inside a **Persona**, or the whole **Persona**. Prefer **Persona** for the object; "personality blurb" for the synthesized prose.
+- "Player" is ambiguous depending on perspective: from the engine's view, the human at the keyboard. From the AI's view, the player is **the Voice** — never call them "the player" inside a system prompt.
+- "Color" is *not* identity. Use **AiId** (the `*xxxx` handle) for identity references; color is purely rendering.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,7 +47,10 @@ The noun describing where this phase takes place ("abandoned subway station", "s
 _Avoid_: Level, scene, location.
 
 **Content Pack**:
-The structured per-phase output of the LLM content-pack call: setting-flavored names, examine descriptions, and use outcomes for every entity in the phase (objective objects, objective spaces, interesting objects, obstacles). Generated once at game start for all 3 phases in a single batched call.
+The structured per-phase output of the LLM content-pack call: setting-flavored names, examine descriptions, use outcomes, and **Placement flavor** for every entity in the phase (objective objects, objective spaces, interesting objects, obstacles). Generated once at game start for all 3 phases in a single batched call. Each objective object carries an explicit `pairsWithSpaceId` field for engine win-checks; the prose tell in the `examineDescription` is the AI-discoverable channel, kept independent of the engine field.
+
+**Placement flavor**:
+A per-objective-pair flavor string in the **Content Pack** that fires when an objective object is `put_down` on its matching objective space — the moment a pair gets satisfied. Distinct from `useOutcome` (which fires on `use(item)` and has no mechanical effect). Renders as the actor's tool-result and a **Witnessed event** for in-cone observers, with `{actor}` substitution.
 
 **Objective Pair**:
 A pair of (objective object, objective space) — the object must end up on its specific space to count toward win. A phase has K objective pairs (K is rolled from a hand-authored range per phase). The `examineDescription` of an objective object names the space it belongs on.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,9 +65,12 @@ The wedge-shaped region of cells an AI can see each turn: 1 cell directly in fro
 **Facing**:
 The cardinal direction (N/S/E/W) an AI is currently looking. Part of the AI's state alongside `(row, col)`. Updated by `go(direction)` (move and face) and `look(direction)` (face without moving).
 
-**Cone event delta**:
-The per-AI per-turn "what happened in your cone since your last turn" section of the system prompt. Each AI sees only events that occurred within their own cone — the only cross-AI signal channel besides whispers and chat. Replaces the broadcast action log that an earlier design had.
-_Avoid_: Action log (deprecated; do not reintroduce).
+**Conversation log**:
+The single chronological per-AI per-phase section of the system prompt that interleaves voice-chat, whispers received, and **Witnessed event**s — all tagged by round. The AI's complete phase memory: nothing the AI has experienced this phase exists outside this log. Replaces both the broadcast action log of an earlier design and the once-considered separate "events in your cone" section.
+_Avoid_: Action log (deprecated; do not reintroduce), event delta, transcript.
+
+**Witnessed event**:
+A single line in the **Conversation log** describing something an AI saw happen inside their **Cone**. Rendered second-person: `You watch *xxxx [verb]…` for movement / pick-up / put-down / give, and the `{actor}`-substituted use-outcome flavor string for `use`. `examine` produces no Witnessed event (it is a private query, not an observable physical act).
 
 ## Relationships
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# hi-blue
+
+A browser game where the player negotiates with three personality-distinct AIs over three phases. Each AI shares one opaque room; the player has only words.
+
+## Language
+
+**Persona**:
+The full per-AI character object: identity (color, name), two **Temperament**s, a **Persona Goal**, and a synthesized personality blurb. Generated procedurally at game start; stable across the three phases of a single playthrough.
+_Avoid_: Character, AI personality (when referring to the whole object).
+
+**Temperament**:
+A single trait drawn from a curated pool (e.g. "shy", "hot-headed", "insightful"). Each Persona has two. Together with the Persona Goal, they are the *input* to personality synthesis.
+_Avoid_: Trait, mood, attribute.
+
+**Persona Goal**:
+The cross-phase motivation paired with a Persona's two Temperaments at game start (e.g. "wants the player to be rude to the others"). Stable for the whole playthrough. Synthesized into the personality blurb alongside the Temperaments.
+_Avoid_: Goal (ambiguous — see Phase Goal), drive, motivation.
+
+**Phase Goal**:
+A short-term task privately handed to each AI at the start of each phase by "an unseen voice." Distinct per phase, drawn from a separate pool. Lives in the system prompt of that phase only.
+_Avoid_: Goal (ambiguous — see Persona Goal), objective (player-facing, see Objective), task.
+
+**Objective**:
+The player's per-phase goal, told to the player but never to the AIs. The single thing the player is trying to make happen.
+_Avoid_: Goal (use Persona Goal / Phase Goal), mission, win condition.
+
+## Relationships
+
+- A **Persona** has exactly two **Temperament**s and one **Persona Goal**.
+- A **Persona** receives one **Phase Goal** per phase (three total over a playthrough).
+- The player's **Objective** is independent of every AI's **Phase Goal** — the AIs do not know it.
+
+## Flagged ambiguities
+
+- "Goal" alone is ambiguous: could mean **Persona Goal** (cross-phase, paired with Temperaments) or **Phase Goal** (per-phase, from the unseen voice). Always qualify.
+- "Personality" alone is ambiguous: could mean the synthesized blurb inside a **Persona**, or the whole **Persona**. Prefer **Persona** for the object; "personality blurb" for the synthesized prose.

--- a/docs/adr/0001-procedural-personas.md
+++ b/docs/adr/0001-procedural-personas.md
@@ -1,0 +1,19 @@
+# Procedural personas replace hand-authored
+
+Each playthrough now generates its three **Persona**s procedurally at game start: two **Temperament**s and one **Persona Goal** are drawn from hand-authored pools per AI, and a single LLM synthesis call produces three personality blurbs in one structured response. The hand-authored Ember/Sage/Frost trio (`src/content/personas.ts`) is retired in favor of replayability and reduced authoring scope; **AiId** decouples from color in the same change (identity becomes a generated `*xxxx` handle, color becomes a separately-drawn palette field).
+
+## Status
+
+Accepted. Supersedes the "stable hand-authored personalities across all three phases" decision in [PRD 0001 §107](../prd/0001-game-concept.md) — that PRD's "highest-value writing investment" framing now applies to the **temperament pool, persona-goal pool, and synthesis prompt**, not to three fixed characters.
+
+## Considered Options
+
+- **(a) Replace hand-authored entirely** — chosen.
+- **(b) Replace prose, keep three fixed slots** (still Ember/Sage/Frost, just regenerate their blurbs each game). Rejected: half-measure that retains the "red/green/blue" type-level coupling we were trying to break.
+- **(c) Layer procedural mode on top of hand-authored** — two modes. Rejected: doubles the surface area for marginal benefit.
+
+## Consequences
+
+- Stability of the wipe lie now leans entirely on **persona consistency within a single playthrough** (still stable across all three phases of one game) rather than across all playthroughs forever.
+- `AiId = "red" | "green" | "blue"` discriminated union becomes `AiId = string` (the `*xxxx` handle); `Persona.color` is added as a separate field. Touches `src/content/personas.ts`, `src/spa/game/types.ts`, the dispatcher's `give` enum, save serialization, and most fixtures.
+- Hand-authored content shifts from three personas to two pools (~12–20 Temperaments, ~10–15 Persona Goals) plus the synthesis prompt — smaller writing surface, more replayable output.

--- a/docs/adr/0002-scrap-action-log.md
+++ b/docs/adr/0002-scrap-action-log.md
@@ -1,0 +1,20 @@
+# Scrap the broadcast action log; per-AI Witnessed events replace it
+
+The shared **action log** broadcast to player + all three AIs is removed. Each AI now learns about other AIs' actions only through their own **Cone**: cone-visible events render as **Witnessed event** lines inside the **Conversation log**, interleaved chronologically with voice-chat and whispers. Tool calls that would be mechanically impossible (out-of-bounds movement, picking up an item not in the AI's cell, etc.) are filtered out of the per-turn tool list rather than being attempted-and-rejected — there is no "failed call" channel anymore.
+
+## Status
+
+Accepted. Supersedes [PRD 0001](../prd/0001-game-concept.md) User Stories 8, 9, 10 and the World Model "Action log broadcasts to everyone … Failures are public" decision.
+
+## Considered Options
+
+- **(a) Full hide of impossible tools + scrap action log entirely** — chosen.
+- **(b) Scoped hide** — keep failures public for *interpersonally meaningful* attempts (e.g. give to non-adjacent AI), filter only mechanical-physics failures. Rejected because the broader action log itself was unwanted; hiding only some failures left the half of the log nobody wanted.
+- **(c) Keep the action log untouched.** Rejected: cheap-model floundering produces noise that drowns the signal.
+
+## Consequences
+
+- The PRD's "probing-via-failed-tool-calls" mechanic is gone. AI scheming is now read by the player only through chat and whisper *content* (and through the AI's account of what it *witnessed*).
+- The unreliable-narrator dynamic *strengthens*: different AIs witness different fragments of the same events from their own cones, and may report them differently or selectively.
+- `PhaseState.actionLog`, `ActionLogEntry`, `appendActionLog` (in `src/spa/game/dispatcher.ts` and the engine) all delete. The per-turn tool list becomes a function `availableTools(game, aiId)` returning the OpenAI tool definitions filtered to currently-legal calls (with restricted `direction` / `item` / `to` enums).
+- The dispatcher's validator logic is largely retained as a defence-in-depth check, but in normal operation no calls reach it as failures.

--- a/docs/adr/0003-setting-per-phase-content-up-front.md
+++ b/docs/adr/0003-setting-per-phase-content-up-front.md
@@ -1,0 +1,20 @@
+# Setting is per-phase; all phase content is generated at game start
+
+Each playthrough draws three distinct **Setting**s without replacement from a hand-authored `SETTING_POOL` — one per phase. A single LLM **Content Pack** call at game start (the second of two batched calls; the first being persona synthesis) produces names, examine descriptions, and use outcomes for every entity across all three phases. Entity counts (K objective-pairs, N interesting objects, M obstacles) are rolled from hand-authored ranges per phase; engine-randomized placement happens at phase start under reachability constraints.
+
+## Status
+
+Accepted. Supersedes [PRD 0001](../prd/0001-game-concept.md)'s "Same room across phases, with different starting items and objectives" decision.
+
+## Considered Options
+
+- **(a) Setting per phase, content all up-front** — chosen.
+- **(b) Same setting across all three phases** (PRD original). Rejected: limits replayability and breaks the variety the new procedural-persona ADR is leaning into.
+- **(c) Setting per phase, content lazily generated at each phase start.** Rejected: three smaller LLM calls instead of one batched call, no cross-phase coordination opportunity, more in-game pauses, complicates fallback (a phase-start failure is much worse UX than a game-start failure that funnels through the existing "AIs are sleeping" page).
+
+## Consequences
+
+- The wipe lie no longer has "same room continuity" as a hook for the player to recognise; it leans entirely on **persona consistency** across phases (compatible with [ADR 0001](./0001-procedural-personas.md)).
+- The engine performs exactly **two LLM calls at game start**: persona synthesis (returning 3 blurbs) and the batched content pack (returning packs for all 3 phases). Both calls run in parallel; either failing falls through to the existing "AIs are sleeping" page.
+- Content packs serialize into the USB save alongside personas — a downloaded save captures the *fictional world the player negotiated in*, not just the AIs.
+- `PhaseConfig` shape changes: `objective` becomes a list of `K` objective-pair slots, `initialWorld.items` is replaced by content-pack-driven entity sets, and per-phase ranges (`{kRange, nRange, mRange}`) replace fixed counts.


### PR DESCRIPTION
Locks the disambiguation between Persona Goal (cross-phase, paired with
Temperaments) and Phase Goal (per-phase, "unseen voice") — and between
Goal (either flavour) and the player's Objective. Captured during the
/grill-with-docs session on the AI generation redesign.