### PR TITLE
Persistent addressee after a successful send

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1121,6 +1121,9 @@ describe("renderGame — mention-based addressing", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
+		// After a successful send with green locked, the persisted prefix is written.
+		expect(promptInput.value).toBe("@Sage ");
+
 		// Now typing @Sage should leave Send disabled (green is locked)
 		promptInput.value = "@Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
@@ -1228,5 +1231,225 @@ describe("renderGame — URL param sourcing", () => {
 		const actionLog = getEl<HTMLElement>("#action-log");
 		// Hash wins: debug=0 → log must remain hidden
 		expect(actionLog.hasAttribute("hidden")).toBe(true);
+	});
+});
+
+describe("renderGame — addressee persistence after send", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("first-load: input empty and Send disabled (#107 preserved)", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		expect(promptInput.value).toBe("");
+		expect(sendBtn.disabled).toBe(true);
+	});
+
+	it("after a successful send: input contains '@Sage ' and Send is disabled", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.selectionStart).toBe(6);
+		expect(promptInput.selectionEnd).toBe(6);
+		expect(sendBtn.disabled).toBe(true);
+	});
+
+	it("typing body text after a successful send re-enables Send", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Send disabled after first send (only prefix remains)
+		expect(sendBtn.disabled).toBe(true);
+
+		// Typing body text after the persisted prefix re-enables Send
+		promptInput.value = "@Sage how are you";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(sendBtn.disabled).toBe(false);
+	});
+
+	it("two-message conversation: same addressee persists across turns, both in transcript", async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeAiSseStream(PASS_ACTION),
+		});
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// First turn
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Prefix persists after first send
+		expect(promptInput.value).toBe("@Sage ");
+
+		// Second turn: extend the persisted prefix
+		promptInput.value = "@Sage how are you";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Prefix persists again after second send
+		expect(promptInput.value).toBe("@Sage ");
+
+		// Both messages should be in the green transcript
+		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
+		expect(greenTranscript.textContent).toContain("[you] @Sage hello");
+		expect(greenTranscript.textContent).toContain("[you] @Sage how are you");
+	});
+
+	it("canonical-name normalization: @sage (lowercase) → '@Sage ' after send", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		promptInput.value = "@sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Should use canonical name from PERSONAS (Sage, not sage)
+		expect(promptInput.value).toBe("@Sage ");
+	});
+
+	it("locked-AI at round-completion: mention prefix persists but Send stays disabled", async () => {
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+
+		// Inject chatLockoutTriggered for green so the SPA sets green locked.
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutTriggered: {
+							aiId: "green" as const,
+							message: "Sage is unresponsive…",
+						},
+					},
+				};
+			},
+		);
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Prefix persists even when green is locked
+		expect(promptInput.value).toBe("@Sage ");
+		// Send must be disabled: green is locked and no body text
+		expect(sendBtn.disabled).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -46,14 +46,14 @@ describe("deriveComposerState", () => {
 		).toEqual({ addressee: null, sendEnabled: false });
 	});
 
-	it('"@Sage" no lockouts → { addressee: "green", sendEnabled: true }', () => {
+	it('"@Sage" no lockouts → { addressee: "green", sendEnabled: false } (no body)', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({ addressee: "green", sendEnabled: false });
 	});
 
 	it('"@Sage hi" no lockouts → { addressee: "green", sendEnabled: true }', () => {
@@ -96,14 +96,14 @@ describe("deriveComposerState", () => {
 		).toEqual({ addressee: null, sendEnabled: false });
 	});
 
-	it('"@Sage," no lockouts → { addressee: "green", sendEnabled: true }', () => {
+	it('"@Sage," no lockouts → { addressee: "green", sendEnabled: false } (no body after comma-stripped mention)', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage,",
 				lockouts: noLockouts(),
 				personaNamesToId,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({ addressee: "green", sendEnabled: false });
 	});
 
 	it('"@Frost @Sage" no lockouts → { addressee: "blue", sendEnabled: true }', () => {
@@ -124,5 +124,56 @@ describe("deriveComposerState", () => {
 				personaNamesToId,
 			}),
 		).toEqual({ addressee: "blue", sendEnabled: false });
+	});
+
+	// Body-after-mention rule: persisted prefix cases
+	it('"@Sage " (trailing space only) → { addressee: "green", sendEnabled: false }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage ",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: false });
+	});
+
+	it('"@Sage  " (two trailing spaces) → { addressee: "green", sendEnabled: false }', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage  ",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: false });
+	});
+
+	it('"hi @Sage" → { addressee: "green", sendEnabled: true } (body before mention)', () => {
+		expect(
+			deriveComposerState({
+				text: "hi @Sage",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: true });
+	});
+
+	it('"hi @Sage there" → { addressee: "green", sendEnabled: true } (body on both sides)', () => {
+		expect(
+			deriveComposerState({
+				text: "hi @Sage there",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: true });
+	});
+
+	it('"@sage hi" (lowercase mention) → { addressee: "green", sendEnabled: true }', () => {
+		expect(
+			deriveComposerState({
+				text: "@sage hi",
+				lockouts: noLockouts(),
+				personaNamesToId,
+			}),
+		).toEqual({ addressee: "green", sendEnabled: true });
 	});
 });

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildPersonaNameMap, parseFirstMention } from "../mention-parser.js";
+import {
+	buildPersonaNameMap,
+	findFirstMention,
+	parseFirstMention,
+} from "../mention-parser.js";
 import type { AiId } from "../types.js";
 
 // Build a minimal name→id map for the three canonical personas.
@@ -31,6 +35,64 @@ describe("parseFirstMention", () => {
 		["@Frost", "blue"],
 	])("parseFirstMention(%j) → %j", (text, expected) => {
 		expect(parseFirstMention(text, nameMap)).toBe(expected);
+	});
+});
+
+describe("findFirstMention", () => {
+	it('"@Sage" → { aiId: "green", start: 0, end: 5 }', () => {
+		expect(findFirstMention("@Sage", nameMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it('"@Sage hi" → { aiId: "green", start: 0, end: 5 }', () => {
+		expect(findFirstMention("@Sage hi", nameMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it('"hi @Sage" → { aiId: "green", start: 3, end: 8 }', () => {
+		expect(findFirstMention("hi @Sage", nameMap)).toEqual({
+			aiId: "green",
+			start: 3,
+			end: 8,
+		});
+	});
+
+	it('"@sage" (lowercase) → { aiId: "green", start: 0, end: 5 }', () => {
+		expect(findFirstMention("@sage", nameMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it('"@Sage," → end includes the comma (end: 6)', () => {
+		expect(findFirstMention("@Sage,", nameMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 6,
+		});
+	});
+
+	it('"@Frost @Sage" → first match is Frost (blue)', () => {
+		expect(findFirstMention("@Frost @Sage", nameMap)).toEqual({
+			aiId: "blue",
+			start: 0,
+			end: 6,
+		});
+	});
+
+	it('"hello world" → null', () => {
+		expect(findFirstMention("hello world", nameMap)).toBeNull();
+	});
+
+	it('"@Nonpersona" → null', () => {
+		expect(findFirstMention("@Nonpersona", nameMap)).toBeNull();
 	});
 });
 

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -1,4 +1,4 @@
-import { parseFirstMention } from "./mention-parser.js";
+import { findFirstMention } from "./mention-parser.js";
 import type { AiId } from "./types.js";
 
 export interface ComposerInput {
@@ -18,11 +18,18 @@ export interface ComposerState {
  *
  * - `addressee` is the first valid @mention in the text.
  * - `sendEnabled` is true only when `addressee` is non-null AND the
- *   addressed AI is not chat-locked.
+ *   addressed AI is not chat-locked AND there is non-empty body text
+ *   outside the mention token.
  */
 export function deriveComposerState(input: ComposerInput): ComposerState {
 	const { text, lockouts, personaNamesToId } = input;
-	const addressee = parseFirstMention(text, personaNamesToId);
-	const sendEnabled = addressee !== null && lockouts.get(addressee) !== true;
+	const match = findFirstMention(text, personaNamesToId);
+	if (match === null) return { addressee: null, sendEnabled: false };
+
+	const { aiId: addressee, start, end } = match;
+	// Body is everything except the @Name token itself.
+	const bodyAfterMention = (text.slice(0, start) + text.slice(end)).trim();
+	const sendEnabled =
+		lockouts.get(addressee) !== true && bodyAfterMention.length > 0;
 	return { addressee, sendEnabled };
 }

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -1,6 +1,57 @@
 import type { AiId } from "./types.js";
 
 /**
+ * Result of a successful mention parse — includes the AiId and the character
+ * offsets of the `@Name` token (excluding any leading whitespace captured by
+ * the regex but including the `@`).
+ */
+export interface MentionMatch {
+	aiId: AiId;
+	/** Index of the `@` character in `text`. */
+	start: number;
+	/** One past the last consumed character: end of name, or end of a single trailing punctuation char if one immediately follows. */
+	end: number;
+}
+
+/**
+ * Like `parseFirstMention` but also returns the position of the `@Name`
+ * token so callers can compute what text surrounds the mention.
+ *
+ * Rules (same as `parseFirstMention`):
+ * - "@Name" must be preceded by start-of-string or whitespace.
+ * - A single trailing punctuation character immediately after the name is
+ *   consumed into the token (included in `end`) so it is excluded from the
+ *   body-after-mention computation.
+ * - Case-insensitive, first mention wins.
+ */
+export function findFirstMention(
+	text: string,
+	personaNamesToId: ReadonlyMap<string, AiId>,
+): MentionMatch | null {
+	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
+	for (const match of text.matchAll(re)) {
+		const raw = match[1];
+		if (!raw) continue;
+		const id = personaNamesToId.get(raw.toLowerCase());
+		if (id !== undefined) {
+			// match.index is the start of the full match (may include a leading space).
+			// The `@` is at match.index + (full-match-length - raw.length - 1).
+			const fullMatch = match[0];
+			const start = (match.index ?? 0) + fullMatch.length - raw.length - 1;
+			let end = start + 1 + raw.length; // 1 for '@'
+			// Consume a single trailing punctuation character immediately after the
+			// name so that "@Sage," treats the comma as part of the token and the
+			// body-after-mention computation does not surface bare punctuation.
+			if (/[.,!?;:]/.test(text[end] ?? "")) {
+				end += 1;
+			}
+			return { aiId: id, start, end };
+		}
+	}
+	return null;
+}
+
+/**
  * Parses the first valid @mention from `text` that maps to a known persona.
  *
  * Rules:
@@ -16,16 +67,7 @@ export function parseFirstMention(
 	text: string,
 	personaNamesToId: ReadonlyMap<string, AiId>,
 ): AiId | null {
-	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
-	for (const match of text.matchAll(re)) {
-		const raw = match[1];
-		if (!raw) continue;
-		// Strip a single trailing punctuation character if present.
-		const name = /[.,!?;:]$/.test(raw) ? raw.slice(0, -1) : raw;
-		const id = personaNamesToId.get(name.toLowerCase());
-		if (id !== undefined) return id;
-	}
-	return null;
+	return findFirstMention(text, personaNamesToId)?.aiId ?? null;
 }
 
 /**

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -360,7 +360,6 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		if (!message) return;
 
 		const addressed = addressee;
-		promptInput.value = "";
 		roundInFlight = true;
 		sendBtn.disabled = true;
 
@@ -645,6 +644,19 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 				if (!saveResult.ok) {
 					showPersistenceWarning(saveResult.reason);
 				}
+			}
+
+			// Persist the addressee prefix so threaded conversations don't require
+			// re-picking the mention each turn. Body is cleared; cursor lands at end.
+			// Only written on success (not in catch) and not on round-game-ended.
+			if (!roundGameEnded) {
+				const persistedPrefix = `@${PERSONAS[addressed].name} `;
+				promptInput.value = persistedPrefix;
+				promptInput.setSelectionRange(
+					persistedPrefix.length,
+					persistedPrefix.length,
+				);
+				promptInput.focus();
 			}
 		} catch (err) {
 			stripPlaceholder();


### PR DESCRIPTION
## What this fixes

After a successful round, the composer now keeps the leading `@<addressee> ` of the just-sent addressee while clearing the body, so threaded conversations don't require re-picking the addressee every turn. Cold-start behaviour from #107 is preserved (empty input, no addressee, Send disabled).

The change has three pieces:

- **`src/spa/game/mention-parser.ts`** — adds `findFirstMention(text, personaNamesToId)` returning `{ aiId, start, end }` (or `null`). `parseFirstMention` is now a thin wrapper that delegates to it, so all existing callers and tests are unchanged. The `end` offset consumes a single trailing punctuation char so the body-after-mention computation gives an empty body for `"@Sage,"`.
- **`src/spa/game/composer-reducer.ts`** — `deriveComposerState` now uses `findFirstMention` to derive the body-after-mention substring (`text.slice(0, start) + text.slice(end)`, trimmed) and gates `sendEnabled` on that being non-empty. The reducer remains the single source of truth for Send-enabled state, so the post-send `"@Sage "` value naturally yields `sendEnabled = false` without any route special-casing. Locked-AI gating still dominates.
- **`src/spa/routes/game.ts`** — removes the synchronous `promptInput.value = ""` at submit-time. After the encoder render loop and the persistence write, in the success branch only (guarded by `!roundGameEnded`), writes `\`@${PERSONAS[addressed].name} \`` back to the input, calls `setSelectionRange(len, len)`, and `focus()`. The catch branch (`CapHitError` etc.) is unchanged — on error the input keeps the user's typed text. Canonical capitalization comes from `PERSONAS[id].name`, so `@sage hello` becomes `@Sage ` afterward — forward-compatible with PRD #120's `*xxxx` handle migration.

## QA steps for the human

None — fully covered by the integration smoke (Playwright) and the new jsdom integration tests.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 526/526 (31 files): new reducer cases for body-after-mention, new `findFirstMention` describe block in `mention-parser.test.ts`, new 6-test `renderGame — addressee persistence after send` describe block in `game.test.ts` covering all six acceptance criteria including the locked-AI persistence and canonical-name normalization
- `pnpm test:e2e` — 13/13 specs green; live two-turn flow exercised via temporary spec confirmed `@Sage ` persists with cursor at position 6, body-typing re-enables Send, and the cap-hit error path retains the user's original input

Closes #110

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4t6BTPk9bFn3PHF4Ga66)_