### PR TITLE
Panel-click sets or replaces the addressee mention

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1131,6 +1131,159 @@ describe("renderGame — mention-based addressing", () => {
 	});
 });
 
+describe("renderGame — panel-click addressee", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("empty input + click red panel → '@Ember ', Send enabled", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+
+		expect(promptInput.value).toBe("");
+		redPanel.click();
+
+		expect(promptInput.value).toBe("@Ember ");
+		expect(sendBtn.disabled).toBe(false);
+	});
+
+	it("'@Sage hi' in input + click red panel → '@Ember hi'", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		redPanel.click();
+
+		expect(promptInput.value).toBe("@Ember hi");
+	});
+
+	it("multi-mention '@Sage tell @Frost go' + click red → only first mention replaced", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+
+		promptInput.value = "@Sage tell @Frost go";
+		promptInput.dispatchEvent(new Event("input"));
+		redPanel.click();
+
+		expect(promptInput.value).toBe("@Ember tell @Frost go");
+	});
+
+	it("cursor is preserved after mention mutation (after the mention)", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+
+		promptInput.value = "@Sage hi";
+		// Simulate cursor at end (position 8)
+		promptInput.setSelectionRange(8, 8);
+		redPanel.click();
+
+		// "@Ember hi" length is 9; cursor was at 8 (after @Sage hi), delta = 1 → 9
+		expect(promptInput.selectionStart).toBe(9);
+	});
+
+	it("clicking a locked panel is a no-op (input unchanged)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION),
+		);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+
+		// Import GameSession first to set up the spy before renderGame
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				// Lock out red
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutTriggered: {
+							aiId: "red" as const,
+							message: "Ember is unresponsive…",
+						},
+					},
+				};
+			},
+		);
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// Trigger one round to lock out red
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Now click red panel — should be no-op because red is locked
+		promptInput.value = "";
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+		redPanel.click();
+
+		// Input should remain empty (red is locked out)
+		expect(promptInput.value).toBe("");
+	});
+
+	it("'@Nonpersona hi' + click blue → prepends '@Frost '", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+
+		promptInput.value = "@nonpersona hi";
+		promptInput.dispatchEvent(new Event("input"));
+		bluePanel.click();
+
+		expect(promptInput.value).toBe("@Frost @nonpersona hi");
+	});
+});
+
 describe("renderGame — URL param sourcing", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1144,7 +1144,7 @@ describe("renderGame — panel-click addressee", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("empty input + click red panel → '@Ember ', Send enabled", async () => {
+	it("empty input + click red panel → '@Ember ', Send stays disabled (no body)", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1158,7 +1158,8 @@ describe("renderGame — panel-click addressee", () => {
 		redPanel.click();
 
 		expect(promptInput.value).toBe("@Ember ");
-		expect(sendBtn.disabled).toBe(false);
+		// Per #110: addressee prefix alone is not enough to enable Send.
+		expect(sendBtn.disabled).toBe(true);
 	});
 
 	it("'@Sage hi' in input + click red panel → '@Ember hi'", async () => {

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	applyAddresseeChange,
 	buildPersonaNameMap,
 	findFirstMention,
 	parseFirstMention,
@@ -109,4 +110,48 @@ describe("buildPersonaNameMap", () => {
 		expect(map.get("frost")).toBe("blue");
 		expect(map.size).toBe(3);
 	});
+});
+
+const personasFixture = {
+	red: { name: "Ember" },
+	green: { name: "Sage" },
+	blue: { name: "Frost" },
+} as Record<AiId, { name: string }>;
+
+describe("applyAddresseeChange", () => {
+	it.each<
+		[
+			string,
+			number | null,
+			AiId,
+			string,
+			number,
+		]
+	>([
+		// [text, cursor, target, expectedText, expectedCursor]
+		["", 0, "red", "@Ember ", 7],
+		["hi", 2, "green", "@Sage hi", 8],
+		["@Sage hi", 8, "red", "@Ember hi", 9],
+		["@Sage hi", 0, "red", "@Ember hi", 0],
+		["@Sage hi", 3, "red", "@Ember hi", 6],
+		["@Sage tell @Frost ...", 21, "red", "@Ember tell @Frost ...", 22],
+		["@Sage,", 6, "red", "@Ember,", 7],
+		["hello @Sage how are you", 23, "blue", "hello @Frost how are you", 24],
+		["@nonpersona hi", 14, "red", "@Ember @nonpersona hi", 21],
+		["hi", null, "green", "@Sage hi", 6],
+		["hi", 0, "green", "@Sage hi", 6],
+	])(
+		"applyAddresseeChange(%j, cursor=%j, target=%j) → text=%j, cursor=%j",
+		(text, cursor, target, expectedText, expectedCursor) => {
+			const result = applyAddresseeChange({
+				text,
+				selectionStart: cursor,
+				targetPersona: target,
+				personaNamesToId: nameMap,
+				personas: personasFixture,
+			});
+			expect(result.text).toBe(expectedText);
+			expect(result.selectionStart).toBe(expectedCursor);
+		},
+	);
 });

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -119,15 +119,7 @@ const personasFixture = {
 } as Record<AiId, { name: string }>;
 
 describe("applyAddresseeChange", () => {
-	it.each<
-		[
-			string,
-			number | null,
-			AiId,
-			string,
-			number,
-		]
-	>([
+	it.each<[string, number | null, AiId, string, number]>([
 		// [text, cursor, target, expectedText, expectedCursor]
 		["", 0, "red", "@Ember ", 7],
 		["hi", 2, "green", "@Sage hi", 8],
@@ -140,18 +132,15 @@ describe("applyAddresseeChange", () => {
 		["@nonpersona hi", 14, "red", "@Ember @nonpersona hi", 21],
 		["hi", null, "green", "@Sage hi", 6],
 		["hi", 0, "green", "@Sage hi", 6],
-	])(
-		"applyAddresseeChange(%j, cursor=%j, target=%j) → text=%j, cursor=%j",
-		(text, cursor, target, expectedText, expectedCursor) => {
-			const result = applyAddresseeChange({
-				text,
-				selectionStart: cursor,
-				targetPersona: target,
-				personaNamesToId: nameMap,
-				personas: personasFixture,
-			});
-			expect(result.text).toBe(expectedText);
-			expect(result.selectionStart).toBe(expectedCursor);
-		},
-	);
+	])("applyAddresseeChange(%j, cursor=%j, target=%j) → text=%j, cursor=%j", (text, cursor, target, expectedText, expectedCursor) => {
+		const result = applyAddresseeChange({
+			text,
+			selectionStart: cursor,
+			targetPersona: target,
+			personaNamesToId: nameMap,
+			personas: personasFixture,
+		});
+		expect(result.text).toBe(expectedText);
+		expect(result.selectionStart).toBe(expectedCursor);
+	});
 });

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -71,6 +71,85 @@ export function parseFirstMention(
 }
 
 /**
+ * Applies an addressee change to the composer text by either rewriting an
+ * existing first mention in-place or prepending a new mention.
+ *
+ * Rules:
+ * a. If a valid first mention is found, rewrite it with the target persona's
+ *    name. Cursor delta is applied based on position relative to the mention.
+ * b. If no valid mention is found, prepend "@<name> " to the text.
+ *    Cursor shifts by the prefix length.
+ */
+export function applyAddresseeChange({
+	text,
+	selectionStart,
+	targetPersona,
+	personaNamesToId,
+	personas,
+}: {
+	text: string;
+	selectionStart: number | null;
+	targetPersona: AiId;
+	personaNamesToId: ReadonlyMap<string, AiId>;
+	personas: Record<AiId, { name: string }>;
+}): { text: string; selectionStart: number } {
+	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
+	let foundAtStart = -1;
+	let foundNameEnd = -1;
+
+	for (const match of text.matchAll(re)) {
+		const raw = match[1];
+		if (!raw) continue;
+		// Strip a single trailing punctuation character if present.
+		const name = /[.,!?;:]$/.test(raw) ? raw.slice(0, -1) : raw;
+		const id = personaNamesToId.get(name.toLowerCase());
+		if (id !== undefined) {
+			// matchIndex is the start of the full match (which may include a
+			// leading space). The @ is immediately after any leading whitespace.
+			const matchIndex = match.index ?? 0;
+			const atStart =
+				matchIndex + (match[0].startsWith("@") ? 0 : match[0].indexOf("@"));
+			// nameEnd is the index after the raw capture (before trailing punct).
+			const nameEnd = atStart + 1 + name.length;
+			foundAtStart = atStart;
+			foundNameEnd = nameEnd;
+			break;
+		}
+	}
+
+	if (foundAtStart !== -1) {
+		// Rewrite in place.
+		const newName = personas[targetPersona].name;
+		const atStart = foundAtStart;
+		const nameEnd = foundNameEnd;
+		const newText =
+			text.slice(0, atStart) + `@${newName}` + text.slice(nameEnd);
+		const delta = 1 + newName.length - (nameEnd - atStart);
+
+		let newCursor: number;
+		if (selectionStart === null) {
+			newCursor = newText.length;
+		} else if (selectionStart <= atStart) {
+			newCursor = selectionStart;
+		} else if (selectionStart >= nameEnd) {
+			newCursor = selectionStart + delta;
+		} else {
+			// Cursor inside the mention → move to end of new name.
+			newCursor = atStart + 1 + newName.length;
+		}
+
+		return { text: newText, selectionStart: newCursor };
+	} else {
+		// Prepend.
+		const newName = personas[targetPersona].name;
+		const prefix = `@${newName} `;
+		const newText = prefix + text;
+		const cursor = (selectionStart ?? 0) + prefix.length;
+		return { text: newText, selectionStart: cursor };
+	}
+}
+
+/**
  * Builds a lowercased name → AiId map from a personas record.
  */
 export function buildPersonaNameMap(

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -122,8 +122,7 @@ export function applyAddresseeChange({
 		const newName = personas[targetPersona].name;
 		const atStart = foundAtStart;
 		const nameEnd = foundNameEnd;
-		const newText =
-			text.slice(0, atStart) + `@${newName}` + text.slice(nameEnd);
+		const newText = `${text.slice(0, atStart)}@${newName}${text.slice(nameEnd)}`;
 		const delta = 1 + newName.length - (nameEnd - atStart);
 
 		let newCursor: number;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -300,7 +300,9 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 
 	// Panel-click → addressee mention mutation (issue #108)
 	for (const aiId of AI_ORDER) {
-		const panel = doc.querySelector<HTMLElement>(`.ai-panel[data-ai="${aiId}"]`);
+		const panel = doc.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
 		if (!panel) continue;
 		panel.addEventListener("click", () => {
 			const targetAi = panel.dataset.ai as AiId | undefined;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -4,7 +4,10 @@ import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
-import { buildPersonaNameMap } from "../game/mention-parser.js";
+import {
+	applyAddresseeChange,
+	buildPersonaNameMap,
+} from "../game/mention-parser.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
 import type { AiId, PhaseConfig } from "../game/types";
 import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";
@@ -293,6 +296,34 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			budgetEl.dataset.budget = String(budget.remaining);
 			budgetEl.textContent = `${budget.remaining}/${budget.total}`;
 		}
+	}
+
+	// Panel-click → addressee mention mutation (issue #108)
+	for (const aiId of AI_ORDER) {
+		const panel = doc.querySelector<HTMLElement>(`.ai-panel[data-ai="${aiId}"]`);
+		if (!panel) continue;
+		panel.addEventListener("click", () => {
+			const targetAi = panel.dataset.ai as AiId | undefined;
+			if (!targetAi) return;
+			if (lockouts.get(targetAi) === true) return;
+			const result = applyAddresseeChange({
+				text: _promptInput.value,
+				selectionStart: _promptInput.selectionStart,
+				targetPersona: targetAi,
+				personaNamesToId,
+				personas: PERSONAS,
+			});
+			_promptInput.value = result.text;
+			try {
+				_promptInput.setSelectionRange(
+					result.selectionStart,
+					result.selectionStart,
+				);
+			} catch {
+				/* ignore */
+			}
+			refreshComposerState();
+		});
 	}
 
 	// Debug toggle: show action log if ?debug=1


### PR DESCRIPTION
## What this fixes

Implements slice #108 of PRD #65: clicking an AI's panel now mutates the composer text so that AI becomes the addressee. The change adds a pure helper `applyAddresseeChange` in `src/spa/game/mention-parser.ts` that either rewrites the first existing `@Persona` mention in place or prepends `@<Name> ` if there is none, while preserving (or shifting) the cursor by the length delta. The DOM controller in `src/spa/routes/game.ts` (around the existing `AI_ORDER` panel-header loop) wires a `click` listener on each `.ai-panel[data-ai="<id>"]`, looks the target AI up from the existing `data-ai` attribute, no-ops when the panel's AI is in the existing `lockouts` map, calls the helper, writes the new value + selection back to `_promptInput`, and calls the existing `refreshComposerState()` so the Send button re-evaluates.

The helper is parameterised over `personaNamesToId` and `personas` (no hardcoded `Ember`/`Sage`/`Frost`), keeping the wiring forward-compatible with PRD #120's procedurally-generated handles per the adaptation note on the issue.

## QA steps for the human

None required — the change is fully covered by the integration smoke (6 jsdom click tests + 11 helper unit tests + the existing 4 `mention-addressing.spec.ts` Playwright specs all green). If you want a manual sanity pass, open `/` in `wrangler dev`, type `@Sage hi`, click the red panel, and confirm the input becomes `@Ember hi` with the cursor at offset 9.

## Automated coverage

`pnpm typecheck` + `pnpm test` (524 tests, 31 files) + `pnpm test:e2e` (13 Playwright specs) all green on `13e5e0e`. `pnpm lint` (`biome ci .`) clean.

Closes #108

---
_Generated by [Claude Code](https://claude.ai/code/session_01U84gcdTqgJ7imrBkbSFF6m)_