### PR TITLE
Visual feedback for the active addressee (mention, border, panel highlight)

### DIFF
--- a/e2e/visual-feedback.spec.ts
+++ b/e2e/visual-feedback.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #109 — Visual feedback for the active addressee.
+ *
+ * Tests that typing a @mention or clicking a panel applies the correct
+ * CSS classes and overlay content.  No LLM stubs needed (no submit fired).
+ */
+
+test("typing @Sage hi → composer-border--green; green panel highlighted; overlay has @Sage span", async ({
+	page,
+}) => {
+	await page.goto("/");
+
+	const prompt = page.locator("#prompt");
+	await prompt.fill("@Sage hi");
+	// Dispatch an input event so the listener fires.
+	await prompt.dispatchEvent("input");
+
+	// Composer border
+	await expect(prompt).toHaveClass(/composer-border--green/);
+
+	// Green panel highlighted
+	const greenPanel = page.locator('.ai-panel[data-ai="green"]');
+	await expect(greenPanel).toHaveClass(/panel--addressed/);
+	await expect(greenPanel).toHaveClass(/panel--addressed-green/);
+
+	// Other panels not highlighted
+	await expect(page.locator('.ai-panel[data-ai="red"]')).not.toHaveClass(
+		/panel--addressed\b/,
+	);
+	await expect(page.locator('.ai-panel[data-ai="blue"]')).not.toHaveClass(
+		/panel--addressed\b/,
+	);
+
+	// Overlay highlight span
+	const span = page.locator("#prompt-overlay .mention-highlight");
+	await expect(span).toHaveCount(1);
+	await expect(span).toHaveText("@Sage");
+	await expect(span).toHaveClass(/mention--green/);
+});
+
+test("clicking blue panel when input has '@Sage hi' rewrites to @Frost and switches highlight to blue", async ({
+	page,
+}) => {
+	await page.goto("/");
+
+	const prompt = page.locator("#prompt");
+	await prompt.fill("@Sage hi");
+	await prompt.dispatchEvent("input");
+
+	// Click blue panel to rewrite mention.
+	await page.locator('.ai-panel[data-ai="blue"]').click();
+
+	// Input value starts with @Frost
+	const value = await prompt.inputValue();
+	expect(value.startsWith("@Frost")).toBe(true);
+
+	// Border flipped to blue
+	await expect(prompt).toHaveClass(/composer-border--blue/);
+	await expect(prompt).not.toHaveClass(/composer-border--green/);
+
+	// Blue panel highlighted
+	const bluePanel = page.locator('.ai-panel[data-ai="blue"]');
+	await expect(bluePanel).toHaveClass(/panel--addressed/);
+	await expect(bluePanel).toHaveClass(/panel--addressed-blue/);
+
+	// Green panel no longer highlighted
+	await expect(page.locator('.ai-panel[data-ai="green"]')).not.toHaveClass(
+		/panel--addressed\b/,
+	);
+
+	// Overlay highlight span is @Frost
+	const span = page.locator("#prompt-overlay .mention-highlight");
+	await expect(span).toHaveCount(1);
+	await expect(span).toHaveText("@Frost");
+	await expect(span).toHaveClass(/mention--blue/);
+});
+
+test("clearing input removes all visual classes and overlay highlights", async ({
+	page,
+}) => {
+	await page.goto("/");
+
+	const prompt = page.locator("#prompt");
+	await prompt.fill("@Sage hi");
+	await prompt.dispatchEvent("input");
+
+	// Confirm highlights are active
+	await expect(prompt).toHaveClass(/composer-border--green/);
+
+	// Clear input
+	await prompt.fill("");
+	await prompt.dispatchEvent("input");
+
+	// No composer-border classes
+	await expect(prompt).not.toHaveClass(/composer-border--/);
+
+	// No panel--addressed on any panel
+	for (const ai of ["red", "green", "blue"]) {
+		await expect(page.locator(`.ai-panel[data-ai="${ai}"]`)).not.toHaveClass(
+			/panel--addressed\b/,
+		);
+	}
+
+	// No overlay highlight spans
+	await expect(
+		page.locator("#prompt-overlay .mention-highlight"),
+	).toHaveCount(0);
+});

--- a/e2e/visual-feedback.spec.ts
+++ b/e2e/visual-feedback.spec.ts
@@ -104,7 +104,7 @@ test("clearing input removes all visual classes and overlay highlights", async (
 	}
 
 	// No overlay highlight spans
-	await expect(
-		page.locator("#prompt-overlay .mention-highlight"),
-	).toHaveCount(0);
+	await expect(page.locator("#prompt-overlay .mention-highlight")).toHaveCount(
+		0,
+	);
 });

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1257,11 +1257,15 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 
 		// No composer-border--* class
-		expect([...prompt.classList].some((c) => c.startsWith("composer-border--"))).toBe(false);
+		expect(
+			[...prompt.classList].some((c) => c.startsWith("composer-border--")),
+		).toBe(false);
 
 		// No panel--addressed on any panel
 		for (const ai of ["red", "green", "blue"]) {
-			const panel = document.querySelector<HTMLElement>(`.ai-panel[data-ai="${ai}"]`);
+			const panel = document.querySelector<HTMLElement>(
+				`.ai-panel[data-ai="${ai}"]`,
+			);
 			expect(panel?.classList.contains("panel--addressed")).toBe(false);
 		}
 
@@ -1287,9 +1291,15 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 		expect(prompt.classList.contains("composer-border--blue")).toBe(false);
 
 		// Panel highlights
-		const greenPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="green"]');
-		const redPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="red"]');
-		const bluePanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const greenPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="green"]',
+		);
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		const bluePanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="blue"]',
+		);
 		expect(greenPanel?.classList.contains("panel--addressed")).toBe(true);
 		expect(greenPanel?.classList.contains("panel--addressed-green")).toBe(true);
 		expect(redPanel?.classList.contains("panel--addressed")).toBe(false);
@@ -1336,16 +1346,24 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 		prompt.dispatchEvent(new Event("input"));
 
 		// No composer-border--* class
-		expect([...prompt.classList].some((c) => c.startsWith("composer-border--"))).toBe(false);
+		expect(
+			[...prompt.classList].some((c) => c.startsWith("composer-border--")),
+		).toBe(false);
 
 		for (const ai of ["red", "green", "blue"]) {
-			const panel = document.querySelector<HTMLElement>(`.ai-panel[data-ai="${ai}"]`);
+			const panel = document.querySelector<HTMLElement>(
+				`.ai-panel[data-ai="${ai}"]`,
+			);
 			expect(panel?.classList.contains("panel--addressed")).toBe(false);
 		}
 	});
 
 	it("locked addressee still shows visual highlight", async () => {
-		const mockFetch = makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION);
+		const mockFetch = makeThreeAiFetchMock(
+			PASS_ACTION,
+			PASS_ACTION,
+			PASS_ACTION,
+		);
 		vi.stubGlobal("fetch", mockFetch);
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -1364,7 +1382,10 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 					...real,
 					result: {
 						...real.result,
-						chatLockoutTriggered: { aiId: "green" as const, message: "Sage is unresponsive…" },
+						chatLockoutTriggered: {
+							aiId: "green" as const,
+							message: "Sage is unresponsive…",
+						},
 					},
 				};
 			},
@@ -1380,7 +1401,9 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 		// Trigger lockout
 		prompt.value = "@Sage hello";
 		prompt.dispatchEvent(new Event("input"));
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Now type @Sage again — send disabled but visual highlight still active
@@ -1390,7 +1413,9 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 		expect(sendBtn.disabled).toBe(true);
 		const prompt2 = getEl<HTMLInputElement>("#prompt");
 		expect(prompt2.classList.contains("composer-border--green")).toBe(true);
-		const greenPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="green"]');
+		const greenPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="green"]',
+		);
 		expect(greenPanel?.classList.contains("panel--addressed")).toBe(true);
 	});
 
@@ -1408,7 +1433,9 @@ describe("renderGame — visual feedback for active addressee (issue #109)", () 
 		expect(prompt.classList.contains("composer-border--green")).toBe(true);
 
 		// Click blue panel
-		const bluePanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const bluePanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="blue"]',
+		);
 		bluePanel?.click();
 
 		// Input value should start with @Frost

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -28,7 +28,10 @@ const INDEX_BODY_HTML = `
     </article>
   </div>
   <form id="composer">
-    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+    <div class="prompt-wrap">
+      <div id="prompt-overlay" aria-hidden="true"></div>
+      <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+    </div>
     <button id="send" type="submit">Send</button>
   </form>
   <section id="cap-hit" hidden></section>
@@ -1228,5 +1231,201 @@ describe("renderGame — URL param sourcing", () => {
 		const actionLog = getEl<HTMLElement>("#action-log");
 		// Hash wins: debug=0 → log must remain hidden
 		expect(actionLog.hasAttribute("hidden")).toBe(true);
+	});
+});
+
+describe("renderGame — visual feedback for active addressee (issue #109)", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("empty input → no composer-border-- class; no panel--addressed; overlay empty", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const prompt = getEl<HTMLInputElement>("#prompt");
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+
+		// No composer-border--* class
+		expect([...prompt.classList].some((c) => c.startsWith("composer-border--"))).toBe(false);
+
+		// No panel--addressed on any panel
+		for (const ai of ["red", "green", "blue"]) {
+			const panel = document.querySelector<HTMLElement>(`.ai-panel[data-ai="${ai}"]`);
+			expect(panel?.classList.contains("panel--addressed")).toBe(false);
+		}
+
+		// Overlay has no highlight span
+		expect(overlay.querySelector(".mention-highlight")).toBeNull();
+	});
+
+	it("typing '@Sage hi' → composer-border--green; green panel highlighted; overlay has @Sage span", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const prompt = getEl<HTMLInputElement>("#prompt");
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+
+		prompt.value = "@Sage hi";
+		prompt.dispatchEvent(new Event("input"));
+
+		// Composer border
+		expect(prompt.classList.contains("composer-border--green")).toBe(true);
+		expect(prompt.classList.contains("composer-border--red")).toBe(false);
+		expect(prompt.classList.contains("composer-border--blue")).toBe(false);
+
+		// Panel highlights
+		const greenPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="green"]');
+		const redPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="red"]');
+		const bluePanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="blue"]');
+		expect(greenPanel?.classList.contains("panel--addressed")).toBe(true);
+		expect(greenPanel?.classList.contains("panel--addressed-green")).toBe(true);
+		expect(redPanel?.classList.contains("panel--addressed")).toBe(false);
+		expect(bluePanel?.classList.contains("panel--addressed")).toBe(false);
+
+		// Overlay mention highlight
+		const span = overlay.querySelector<HTMLElement>(".mention-highlight");
+		expect(span).not.toBeNull();
+		expect(span?.classList.contains("mention--green")).toBe(true);
+		expect(span?.textContent).toBe("@Sage");
+	});
+
+	it("multi-mention '@Sage tell @Frost ...' → only @Sage highlighted in overlay", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const prompt = getEl<HTMLInputElement>("#prompt");
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+
+		prompt.value = "@Sage tell @Frost ...";
+		prompt.dispatchEvent(new Event("input"));
+
+		const spans = overlay.querySelectorAll(".mention-highlight");
+		expect(spans).toHaveLength(1);
+		expect(spans[0]?.textContent).toBe("@Sage");
+	});
+
+	it("clearing input → all visual classes removed", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const prompt = getEl<HTMLInputElement>("#prompt");
+
+		// First set a valid mention
+		prompt.value = "@Sage hi";
+		prompt.dispatchEvent(new Event("input"));
+
+		// Then clear
+		prompt.value = "";
+		prompt.dispatchEvent(new Event("input"));
+
+		// No composer-border--* class
+		expect([...prompt.classList].some((c) => c.startsWith("composer-border--"))).toBe(false);
+
+		for (const ai of ["red", "green", "blue"]) {
+			const panel = document.querySelector<HTMLElement>(`.ai-panel[data-ai="${ai}"]`);
+			expect(panel?.classList.contains("panel--addressed")).toBe(false);
+		}
+	});
+
+	it("locked addressee still shows visual highlight", async () => {
+		const mockFetch = makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION);
+		vi.stubGlobal("fetch", mockFetch);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutTriggered: { aiId: "green" as const, message: "Sage is unresponsive…" },
+					},
+				};
+			},
+		);
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const prompt = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		// Trigger lockout
+		prompt.value = "@Sage hello";
+		prompt.dispatchEvent(new Event("input"));
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Now type @Sage again — send disabled but visual highlight still active
+		prompt.value = "@Sage hi";
+		prompt.dispatchEvent(new Event("input"));
+
+		expect(sendBtn.disabled).toBe(true);
+		const prompt2 = getEl<HTMLInputElement>("#prompt");
+		expect(prompt2.classList.contains("composer-border--green")).toBe(true);
+		const greenPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="green"]');
+		expect(greenPanel?.classList.contains("panel--addressed")).toBe(true);
+	});
+
+	it("panel-click rewrites mention and updates visual highlight", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const prompt = getEl<HTMLInputElement>("#prompt");
+
+		// Start with @Sage
+		prompt.value = "@Sage hi";
+		prompt.dispatchEvent(new Event("input"));
+		expect(prompt.classList.contains("composer-border--green")).toBe(true);
+
+		// Click blue panel
+		const bluePanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="blue"]');
+		bluePanel?.click();
+
+		// Input value should start with @Frost
+		expect(prompt.value.startsWith("@Frost")).toBe(true);
+
+		// Border should switch to blue
+		expect(prompt.classList.contains("composer-border--blue")).toBe(true);
+		expect(prompt.classList.contains("composer-border--green")).toBe(false);
+
+		// Blue panel highlighted
+		expect(bluePanel?.classList.contains("panel--addressed")).toBe(true);
+		expect(bluePanel?.classList.contains("panel--addressed-blue")).toBe(true);
+
+		// Overlay mention is @Frost
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		const span = overlay.querySelector<HTMLElement>(".mention-highlight");
+		expect(span?.textContent).toBe("@Frost");
+		expect(span?.classList.contains("mention--blue")).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { PERSONAS } from "../../../content/personas.js";
 import { deriveComposerState } from "../composer-reducer.js";
-import { buildPersonaColorMap, buildPersonaNameMap } from "../mention-parser.js";
+import {
+	buildPersonaColorMap,
+	buildPersonaNameMap,
+} from "../mention-parser.js";
 import type { AiId } from "../types.js";
 
 // Re-use the real PERSONAS so the map is canonical.
@@ -27,7 +30,7 @@ function lockouts(locked: AiId): ReadonlyMap<AiId, boolean> {
 }
 
 describe("deriveComposerState", () => {
-	it('empty text → all fields null/false', () => {
+	it("empty text → all fields null/false", () => {
 		expect(
 			deriveComposerState({
 				text: "",

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { PERSONAS } from "../../../content/personas.js";
 import { deriveComposerState } from "../composer-reducer.js";
-import { buildPersonaNameMap } from "../mention-parser.js";
+import { buildPersonaColorMap, buildPersonaNameMap } from "../mention-parser.js";
 import type { AiId } from "../types.js";
 
 // Re-use the real PERSONAS so the map is canonical.
 const personaNamesToId = buildPersonaNameMap(PERSONAS);
+const personaColors = buildPersonaColorMap(PERSONAS);
 
 function noLockouts(): ReadonlyMap<AiId, boolean> {
 	return new Map<AiId, boolean>([
@@ -26,103 +27,207 @@ function lockouts(locked: AiId): ReadonlyMap<AiId, boolean> {
 }
 
 describe("deriveComposerState", () => {
-	it("empty text → { addressee: null, sendEnabled: false }", () => {
+	it('empty text → all fields null/false', () => {
 		expect(
 			deriveComposerState({
 				text: "",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: null, sendEnabled: false });
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		});
 	});
 
-	it('"hi" → { addressee: null, sendEnabled: false }', () => {
+	it('"hi" → all fields null/false', () => {
 		expect(
 			deriveComposerState({
 				text: "hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: null, sendEnabled: false });
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		});
 	});
 
-	it('"@Sage" no lockouts → { addressee: "green", sendEnabled: true }', () => {
+	it('"@Sage" no lockouts → visual fields populated with green', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Sage hi" no lockouts → { addressee: "green", sendEnabled: true }', () => {
+	it('"@Sage hi" no lockouts → visual fields populated, range [0,5)', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Sage hi" green locked → { addressee: "green", sendEnabled: false }', () => {
+	it('"@Sage hi" green locked → sendEnabled false BUT visual fields still populated', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: false });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Ember hi" green locked → { addressee: "red", sendEnabled: true }', () => {
+	it('"@Ember hi" green locked → addressee red, visual fields red', () => {
 		expect(
 			deriveComposerState({
 				text: "@Ember hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "red", sendEnabled: true });
+		).toEqual({
+			addressee: "red",
+			sendEnabled: true,
+			borderColor: "red",
+			panelHighlight: "red",
+			mentionHighlight: { start: 0, end: 6, color: "red" },
+		});
 	});
 
-	it('"@Nonpersona hi" no lockouts → { addressee: null, sendEnabled: false }', () => {
+	it('"@Nonpersona hi" no lockouts → all fields null/false', () => {
 		expect(
 			deriveComposerState({
 				text: "@Nonpersona hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: null, sendEnabled: false });
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		});
 	});
 
-	it('"@Sage," no lockouts → { addressee: "green", sendEnabled: true }', () => {
+	it('"@Sage," no lockouts → trailing comma excluded from range', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage,",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Frost @Sage" no lockouts → { addressee: "blue", sendEnabled: true }', () => {
+	it('"@Sage tell @Frost ..." → only first mention fields used', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage tell @Frost ...",
+				lockouts: noLockouts(),
+				personaNamesToId,
+				personaColors,
+			}),
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
+	});
+
+	it('"hi @Sage how" → range [3, 8)', () => {
+		expect(
+			deriveComposerState({
+				text: "hi @Sage how",
+				lockouts: noLockouts(),
+				personaNamesToId,
+				personaColors,
+			}),
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 3, end: 8, color: "green" },
+		});
+	});
+
+	it('"@Frost @Sage" no lockouts → addressee blue, visual fields blue', () => {
 		expect(
 			deriveComposerState({
 				text: "@Frost @Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "blue", sendEnabled: true });
+		).toEqual({
+			addressee: "blue",
+			sendEnabled: true,
+			borderColor: "blue",
+			panelHighlight: "blue",
+			mentionHighlight: { start: 0, end: 6, color: "blue" },
+		});
 	});
 
-	it('"@Frost @Sage" blue locked → { addressee: "blue", sendEnabled: false } (no fallthrough)', () => {
+	it('"@Frost @Sage" blue locked → sendEnabled false, visual fields still blue', () => {
 		expect(
 			deriveComposerState({
 				text: "@Frost @Sage",
 				lockouts: lockouts("blue"),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "blue", sendEnabled: false });
+		).toEqual({
+			addressee: "blue",
+			sendEnabled: false,
+			borderColor: "blue",
+			panelHighlight: "blue",
+			mentionHighlight: { start: 0, end: 6, color: "blue" },
+		});
 	});
 });

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildPersonaNameMap, parseFirstMention } from "../mention-parser.js";
+import {
+	buildPersonaColorMap,
+	buildPersonaNameMap,
+	findFirstMention,
+	parseFirstMention,
+} from "../mention-parser.js";
 import type { AiId } from "../types.js";
 
 // Build a minimal name→id map for the three canonical personas.
@@ -45,6 +50,117 @@ describe("buildPersonaNameMap", () => {
 		expect(map.get("ember")).toBe("red");
 		expect(map.get("sage")).toBe("green");
 		expect(map.get("frost")).toBe("blue");
+		expect(map.size).toBe(3);
+	});
+});
+
+describe("findFirstMention", () => {
+	const colorMap = new Map<string, AiId>([
+		["ember", "red"],
+		["sage", "green"],
+		["frost", "blue"],
+	]);
+
+	it("returns null for empty string", () => {
+		expect(findFirstMention("", colorMap)).toBeNull();
+	});
+
+	it("returns null for text with no mention", () => {
+		expect(findFirstMention("hello world", colorMap)).toBeNull();
+	});
+
+	it("returns null for email-style user@host (no leading whitespace)", () => {
+		expect(findFirstMention("email me at user@host", colorMap)).toBeNull();
+	});
+
+	it("returns null for @Nonpersona", () => {
+		expect(findFirstMention("@Nonpersona hi", colorMap)).toBeNull();
+	});
+
+	it("@Sage → { aiId: 'green', start: 0, end: 5 }", () => {
+		expect(findFirstMention("@Sage", colorMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it("@Sage hi → range still [0, 5)", () => {
+		expect(findFirstMention("@Sage hi", colorMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it("hi @Sage how → range [3, 8)", () => {
+		expect(findFirstMention("hi @Sage how", colorMap)).toEqual({
+			aiId: "green",
+			start: 3,
+			end: 8,
+		});
+	});
+
+	it("@Sage, → range [0, 5) (trailing comma excluded)", () => {
+		expect(findFirstMention("@Sage,", colorMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it("@Sage @Frost → first mention wins (green, [0, 5))", () => {
+		expect(findFirstMention("@Sage @Frost", colorMap)).toEqual({
+			aiId: "green",
+			start: 0,
+			end: 5,
+		});
+	});
+
+	it("@Frost @Sage → first mention wins (blue, [0, 6))", () => {
+		expect(findFirstMention("@Frost @Sage", colorMap)).toEqual({
+			aiId: "blue",
+			start: 0,
+			end: 6,
+		});
+	});
+
+	it("hi @Sage how are you → correct range [3, 8)", () => {
+		expect(findFirstMention("hi @Sage how are you", colorMap)).toEqual({
+			aiId: "green",
+			start: 3,
+			end: 8,
+		});
+	});
+
+	it("@Ember → { aiId: 'red', start: 0, end: 6 }", () => {
+		expect(findFirstMention("@Ember", colorMap)).toEqual({
+			aiId: "red",
+			start: 0,
+			end: 6,
+		});
+	});
+
+	it("@Frost → { aiId: 'blue', start: 0, end: 6 }", () => {
+		expect(findFirstMention("@Frost", colorMap)).toEqual({
+			aiId: "blue",
+			start: 0,
+			end: 6,
+		});
+	});
+});
+
+describe("buildPersonaColorMap", () => {
+	it("builds a map from AiId to color string", () => {
+		const personas = {
+			red: { color: "red" },
+			green: { color: "green" },
+			blue: { color: "blue" },
+		} as Record<AiId, { color: string }>;
+		const map = buildPersonaColorMap(personas);
+		expect(map.get("red")).toBe("red");
+		expect(map.get("green")).toBe("green");
+		expect(map.get("blue")).toBe("blue");
 		expect(map.size).toBe(3);
 	});
 });

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -1,28 +1,75 @@
-import { parseFirstMention } from "./mention-parser.js";
+/**
+ * Derives the full composer state from the current prompt text, lock-out map,
+ * persona name→id map, and persona color map.
+ *
+ * New fields (issue #109 — visual feedback for active addressee):
+ * - borderColor: string | null — the color value from the persona record (e.g. "red"),
+ *   or null when no valid mention is present. Applied as composer-border--${value} class.
+ * - panelHighlight: AiId | null — the AiId of the panel to highlight, or null.
+ *   Applied as panel--addressed + panel--addressed-${color} classes.
+ * - mentionHighlight: { start, end, color } | null — the range of the @mention in the
+ *   input text and the color to use in the overlay. null when no valid mention.
+ *
+ * Color invariant: borderColor, panelHighlight, and mentionHighlight.color all derive
+ * from the same first mention. personaColors is the source of truth; JS never
+ * hard-codes color strings.
+ */
+import { findFirstMention } from "./mention-parser.js";
 import type { AiId } from "./types.js";
 
 export interface ComposerInput {
 	text: string;
 	lockouts: ReadonlyMap<AiId, boolean>;
 	personaNamesToId: ReadonlyMap<string, AiId>;
+	personaColors: ReadonlyMap<AiId, string>;
 }
 
 export interface ComposerState {
 	addressee: AiId | null;
 	sendEnabled: boolean;
+	/** Color string from the persona record (e.g. "red"), or null. */
+	borderColor: string | null;
+	/** AiId of the panel to highlight, or null. */
+	panelHighlight: AiId | null;
+	/** Range of the @mention to highlight in the overlay, or null. */
+	mentionHighlight: { start: number; end: number; color: string } | null;
 }
 
 /**
- * Derives the composer state (addressee + send button enabled) from the
- * current prompt text, the chat-lockout map, and the persona name→id map.
+ * Derives the composer state (addressee + send button + visual feedback) from
+ * the current prompt text, the chat-lockout map, the persona name→id map, and
+ * the persona color map.
  *
  * - `addressee` is the first valid @mention in the text.
  * - `sendEnabled` is true only when `addressee` is non-null AND the
  *   addressed AI is not chat-locked.
+ * - Visual fields (borderColor, panelHighlight, mentionHighlight) are set
+ *   whenever a valid mention is found, regardless of lock-out state.
  */
 export function deriveComposerState(input: ComposerInput): ComposerState {
-	const { text, lockouts, personaNamesToId } = input;
-	const addressee = parseFirstMention(text, personaNamesToId);
-	const sendEnabled = addressee !== null && lockouts.get(addressee) !== true;
-	return { addressee, sendEnabled };
+	const { text, lockouts, personaNamesToId, personaColors } = input;
+	const match = findFirstMention(text, personaNamesToId);
+
+	if (match === null) {
+		return {
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		};
+	}
+
+	const { aiId, start, end } = match;
+	const sendEnabled = lockouts.get(aiId) !== true;
+	const color = personaColors.get(aiId) ?? null;
+
+	return {
+		addressee: aiId,
+		sendEnabled,
+		borderColor: color,
+		panelHighlight: aiId,
+		mentionHighlight:
+			color !== null ? { start, end, color } : null,
+	};
 }

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -69,7 +69,6 @@ export function deriveComposerState(input: ComposerInput): ComposerState {
 		sendEnabled,
 		borderColor: color,
 		panelHighlight: aiId,
-		mentionHighlight:
-			color !== null ? { start, end, color } : null,
+		mentionHighlight: color !== null ? { start, end, color } : null,
 	};
 }

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -1,5 +1,48 @@
 import type { AiId } from "./types.js";
 
+/** Shape returned by findFirstMention — includes range info for the overlay. */
+export interface MentionMatch {
+	aiId: AiId;
+	/** Start index of "@Name" in the text (inclusive). */
+	start: number;
+	/** End index of "@Name" in the text (exclusive). Trailing punctuation excluded. */
+	end: number;
+}
+
+/**
+ * Finds the first valid @mention from `text` that maps to a known persona,
+ * returning both the resolved AiId and the character range [start, end).
+ *
+ * Rules:
+ * - "@Name" must be preceded by start-of-string or whitespace.
+ * - "@Name" terminates at end-of-string, whitespace, or a single trailing
+ *   punctuation character (the punctuation is not part of the range).
+ * - Case-insensitive.
+ * - First mention wins.
+ * - "@Nonpersona" or "@" alone returns null.
+ * - "user@host" style does NOT match (no preceding whitespace).
+ */
+export function findFirstMention(
+	text: string,
+	personaNamesToId: ReadonlyMap<string, AiId>,
+): MentionMatch | null {
+	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
+	for (const match of text.matchAll(re)) {
+		const raw = match[1];
+		if (!raw) continue;
+		// Strip a single trailing punctuation character if present.
+		const name = /[.,!?;:]$/.test(raw) ? raw.slice(0, -1) : raw;
+		const id = personaNamesToId.get(name.toLowerCase());
+		if (id !== undefined) {
+			// start is the index of "@" in the full text
+			const start = match.index! + match[0].indexOf("@");
+			const end = start + 1 + name.length;
+			return { aiId: id, start, end };
+		}
+	}
+	return null;
+}
+
 /**
  * Parses the first valid @mention from `text` that maps to a known persona.
  *
@@ -16,16 +59,7 @@ export function parseFirstMention(
 	text: string,
 	personaNamesToId: ReadonlyMap<string, AiId>,
 ): AiId | null {
-	const re = /(?:^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
-	for (const match of text.matchAll(re)) {
-		const raw = match[1];
-		if (!raw) continue;
-		// Strip a single trailing punctuation character if present.
-		const name = /[.,!?;:]$/.test(raw) ? raw.slice(0, -1) : raw;
-		const id = personaNamesToId.get(name.toLowerCase());
-		if (id !== undefined) return id;
-	}
-	return null;
+	return findFirstMention(text, personaNamesToId)?.aiId ?? null;
 }
 
 /**
@@ -40,6 +74,23 @@ export function buildPersonaNameMap(
 		{ name: string },
 	][]) {
 		map.set(persona.name.toLowerCase(), id);
+	}
+	return map;
+}
+
+/**
+ * Builds an AiId → color string map from a personas record.
+ * The color value is returned verbatim from the persona record.
+ */
+export function buildPersonaColorMap(
+	personas: Record<AiId, { color: string }>,
+): Map<AiId, string> {
+	const map = new Map<AiId, string>();
+	for (const [id, persona] of Object.entries(personas) as [
+		AiId,
+		{ color: string },
+	][]) {
+		map.set(id, persona.color);
 	}
 	return map;
 }

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -34,8 +34,9 @@ export function findFirstMention(
 		const name = /[.,!?;:]$/.test(raw) ? raw.slice(0, -1) : raw;
 		const id = personaNamesToId.get(name.toLowerCase());
 		if (id !== undefined) {
-			// start is the index of "@" in the full text
-			const start = match.index! + match[0].indexOf("@");
+			// matchAll always populates match.index for each result.
+			const matchIndex = match.index ?? 0;
+			const start = matchIndex + match[0].indexOf("@");
 			const end = start + 1 + name.length;
 			return { aiId: id, start, end };
 		}

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -36,7 +36,10 @@
 		    </article>
 		  </div>
 		  <form id="composer">
-		    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+		    <div class="prompt-wrap">
+		      <div id="prompt-overlay" aria-hidden="true"></div>
+		      <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+		    </div>
 		    <button id="send" type="submit">Send</button>
 		  </form>
 		  <section id="cap-hit" hidden>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -4,7 +4,7 @@ import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
-import { buildPersonaNameMap } from "../game/mention-parser.js";
+import { buildPersonaColorMap, buildPersonaNameMap } from "../game/mention-parser.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
 import type { AiId, PhaseConfig } from "../game/types";
 import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";
@@ -136,6 +136,28 @@ const PERSISTENCE_WARNING_MESSAGES: Record<string, string> = {
 	unknown: "Game progress could not be saved due to an unexpected error.",
 };
 
+/**
+ * Rewrites the leading @mention in the input value to `@name `.
+ *
+ * If `input.value` starts with `@<Token>` (optionally followed by a single
+ * space), that prefix is replaced with `@name `.  Otherwise `@name ` is
+ * prepended.  The caret is placed at end-of-text.
+ */
+export function rewriteLeadingMention(
+	input: HTMLInputElement,
+	name: string,
+): void {
+	const current = input.value;
+	const prefix = `@${name} `;
+	if (/^@[A-Za-z][A-Za-z0-9]*\s?/.test(current)) {
+		input.value = current.replace(/^@[A-Za-z][A-Za-z0-9]*\s?/, prefix);
+	} else {
+		input.value = prefix + current;
+	}
+	// Move caret to end.
+	input.selectionStart = input.selectionEnd = input.value.length;
+}
+
 /** Guards against duplicate game_ended events re-binding handlers. */
 let gameEnded = false;
 
@@ -157,6 +179,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 
 	// Mention-based addressing state
 	const personaNamesToId = buildPersonaNameMap(PERSONAS);
+	const personaColors = buildPersonaColorMap(PERSONAS);
 	const lockouts: Map<AiId, boolean> = new Map([
 		["red", false],
 		["green", false],
@@ -168,16 +191,82 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 	const _promptInput = promptInput;
 	const _sendBtn = sendBtn;
 
+	// Overlay element for mention highlight (may be absent in legacy test DOM).
+	const overlay = doc.querySelector<HTMLElement>("#prompt-overlay");
+
+	/** Helper: replace any class matching prefix+* with prefix+value (or just remove). */
+	function setColorClass(
+		el: Element,
+		prefix: string,
+		value: string | null,
+	): void {
+		for (const cls of [...el.classList]) {
+			if (cls.startsWith(prefix)) el.classList.remove(cls);
+		}
+		if (value !== null) el.classList.add(`${prefix}${value}`);
+	}
+
+	/** Rebuild the overlay's child nodes to highlight the mention range. */
+	function rebuildOverlay(
+		text: string,
+		highlight: { start: number; end: number; color: string } | null,
+	): void {
+		if (!overlay) return;
+		// Clear existing children.
+		while (overlay.firstChild) overlay.removeChild(overlay.firstChild);
+		if (highlight === null) {
+			overlay.appendChild(doc.createTextNode(text));
+		} else {
+			const { start, end, color } = highlight;
+			if (start > 0) {
+				overlay.appendChild(doc.createTextNode(text.slice(0, start)));
+			}
+			const span = doc.createElement("span");
+			span.className = `mention-highlight mention--${color}`;
+			span.textContent = text.slice(start, end);
+			overlay.appendChild(span);
+			if (end < text.length) {
+				overlay.appendChild(doc.createTextNode(text.slice(end)));
+			}
+		}
+		// Keep horizontal scroll in sync so long text doesn't desync.
+		overlay.scrollLeft = _promptInput.scrollLeft;
+	}
+
 	function refreshComposerState(): void {
-		const { sendEnabled } = deriveComposerState({
+		const state = deriveComposerState({
 			text: _promptInput.value,
 			lockouts,
 			personaNamesToId,
+			personaColors,
 		});
-		_sendBtn.disabled = !sendEnabled || roundInFlight;
+		_sendBtn.disabled = !state.sendEnabled || roundInFlight;
+
+		// Composer border.
+		setColorClass(_promptInput, "composer-border--", state.borderColor);
+
+		// Panel highlight.
+		for (const aiId of AI_ORDER) {
+			const panel = doc.querySelector<HTMLElement>(
+				`.ai-panel[data-ai="${aiId}"]`,
+			);
+			if (!panel) continue;
+			const isAddressed = state.panelHighlight === aiId;
+			panel.classList.toggle("panel--addressed", isAddressed);
+			const color = personaColors.get(aiId) ?? null;
+			// Always clear any previous addressed-color class, then set the new one.
+			setColorClass(panel, "panel--addressed-", isAddressed ? color : null);
+		}
+
+		// Mention overlay.
+		rebuildOverlay(_promptInput.value, state.mentionHighlight);
 	}
 
 	promptInput.addEventListener("input", refreshComposerState);
+	// Keep overlay in sync when the user scrolls a long input.
+	promptInput.addEventListener("scroll", () => {
+		if (overlay) overlay.scrollLeft = _promptInput.scrollLeft;
+	});
 
 	// Dev-only: ?think=0 disables the model's thinking step (OpenRouter
 	// reasoning.enabled=false). Gated to wrangler-dev host (see isDevHost).
@@ -295,6 +384,20 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		}
 	}
 
+	// Panel-click: rewrite leading @Mention in the composer.
+	for (const aiId of AI_ORDER) {
+		const panel = doc.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
+		if (!panel) continue;
+		const persona = PERSONAS[aiId];
+		panel.addEventListener("click", () => {
+			rewriteLeadingMention(_promptInput, persona.name);
+			_promptInput.dispatchEvent(new Event("input", { bubbles: true }));
+			_promptInput.focus();
+		});
+	}
+
 	// Debug toggle: show action log if ?debug=1
 	const debug = effectiveParams.get("debug") === "1";
 	if (actionLogEl) {
@@ -353,6 +456,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			text: promptInput.value,
 			lockouts,
 			personaNamesToId,
+			personaColors,
 		});
 		if (!sendEnabled || !addressee) return;
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -4,7 +4,10 @@ import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
-import { buildPersonaColorMap, buildPersonaNameMap } from "../game/mention-parser.js";
+import {
+	buildPersonaColorMap,
+	buildPersonaNameMap,
+} from "../game/mention-parser.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
 import type { AiId, PhaseConfig } from "../game/types";
 import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -63,21 +63,48 @@ main {
 }
 
 /* Composer border per addressee */
-#prompt.composer-border--red   { border-color: #b83232; }
-#prompt.composer-border--green { border-color: #2e7a3e; }
-#prompt.composer-border--blue  { border-color: #2458a0; }
+#prompt.composer-border--red {
+	border-color: #b83232;
+}
+#prompt.composer-border--green {
+	border-color: #2e7a3e;
+}
+#prompt.composer-border--blue {
+	border-color: #2458a0;
+}
 
 /* Panel highlight (ring/glow) */
-.ai-panel.panel--addressed { box-shadow: 0 0 0 2px var(--addressed-color, #888); }
-.ai-panel.panel--addressed.panel--addressed-red   { --addressed-color: #b83232; }
-.ai-panel.panel--addressed.panel--addressed-green { --addressed-color: #2e7a3e; }
-.ai-panel.panel--addressed.panel--addressed-blue  { --addressed-color: #2458a0; }
+.ai-panel.panel--addressed {
+	box-shadow: 0 0 0 2px var(--addressed-color, #888);
+}
+.ai-panel.panel--addressed.panel--addressed-red {
+	--addressed-color: #b83232;
+}
+.ai-panel.panel--addressed.panel--addressed-green {
+	--addressed-color: #2e7a3e;
+}
+.ai-panel.panel--addressed.panel--addressed-blue {
+	--addressed-color: #2458a0;
+}
 
 /* Mention overlay highlight spans */
-.mention-highlight { font-weight: bold; padding: 0 1px; border-radius: 2px; }
-.mention-highlight.mention--red   { color: #b83232; background: rgba(184,50,50,0.10); }
-.mention-highlight.mention--green { color: #2e7a3e; background: rgba(46,122,62,0.10); }
-.mention-highlight.mention--blue  { color: #2458a0; background: rgba(36,88,160,0.10); }
+.mention-highlight {
+	font-weight: bold;
+	padding: 0 1px;
+	border-radius: 2px;
+}
+.mention-highlight.mention--red {
+	color: #b83232;
+	background: rgba(184, 50, 50, 0.1);
+}
+.mention-highlight.mention--green {
+	color: #2e7a3e;
+	background: rgba(46, 122, 62, 0.1);
+}
+.mention-highlight.mention--blue {
+	color: #2458a0;
+	background: rgba(36, 88, 160, 0.1);
+}
 
 #send {
 	padding: 0.5rem 1rem;

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -26,13 +26,58 @@ main {
 	gap: 0.5rem;
 }
 
-#prompt {
+/* Wrapper that grows to fill the composer flex row. */
+.prompt-wrap {
+	position: relative;
 	flex: 1;
+	display: block;
+}
+
+/* Mirror overlay for mention highlighting. */
+#prompt-overlay {
+	position: absolute;
+	inset: 0;
+	padding: 0.5rem 0.75rem;
+	font: inherit;
+	font-size: 1rem;
+	pointer-events: none;
+	white-space: pre;
+	overflow: hidden;
+	color: #222;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	background: transparent;
+}
+
+#prompt {
+	width: 100%;
 	padding: 0.5rem 0.75rem;
 	font-size: 1rem;
 	border: 1px solid #ccc;
 	border-radius: 4px;
+	color: transparent;
+	caret-color: #222;
+	background: transparent;
+	position: relative;
+	z-index: 1;
 }
+
+/* Composer border per addressee */
+#prompt.composer-border--red   { border-color: #b83232; }
+#prompt.composer-border--green { border-color: #2e7a3e; }
+#prompt.composer-border--blue  { border-color: #2458a0; }
+
+/* Panel highlight (ring/glow) */
+.ai-panel.panel--addressed { box-shadow: 0 0 0 2px var(--addressed-color, #888); }
+.ai-panel.panel--addressed.panel--addressed-red   { --addressed-color: #b83232; }
+.ai-panel.panel--addressed.panel--addressed-green { --addressed-color: #2e7a3e; }
+.ai-panel.panel--addressed.panel--addressed-blue  { --addressed-color: #2458a0; }
+
+/* Mention overlay highlight spans */
+.mention-highlight { font-weight: bold; padding: 0 1px; border-radius: 2px; }
+.mention-highlight.mention--red   { color: #b83232; background: rgba(184,50,50,0.10); }
+.mention-highlight.mention--green { color: #2e7a3e; background: rgba(46,122,62,0.10); }
+.mention-highlight.mention--blue  { color: #2458a0; background: rgba(36,88,160,0.10); }
 
 #send {
 	padding: 0.5rem 1rem;


### PR DESCRIPTION
## What this fixes

Adds the three coupled visual cues from #109 — a colored highlight on the leading `@mention` in the composer input, a composer border tinted to the addressed AI's color, and a ring on the addressed AI's panel — and keeps them in sync as the addressee changes.

The composer-reducer (`src/spa/game/composer-reducer.ts`) is extended with three new derived fields: `borderColor: string | null`, `panelHighlight: AiId | null`, and `mentionHighlight: { start, end, color } | null`. A new `findFirstMention` helper in `src/spa/game/mention-parser.ts` returns the mention's character range (excluding any single trailing punctuation) alongside the resolved `AiId`. The DOM controller (`src/spa/routes/game.ts`) consumes those fields and applies CSS classes on every `input` event and after panel-clicks; CSS owns the actual rendering (`src/spa/styles.css`).

The `<input id="prompt">` cannot natively style a substring, so the input is wrapped in `<div class="prompt-wrap">` with a sibling `<div id="prompt-overlay" aria-hidden="true">` that mirrors the input's font/padding and is layered behind a transparent-text input (caret stays visible via `caret-color`). The overlay's content is rebuilt every input event from text-nodes plus a single `<span class="mention-highlight mention--{color}">` for the first mention range — `textContent`/`createElement` only, no `innerHTML` (no XSS surface).

Panel-click handlers call a new `rewriteLeadingMention(input, name)` helper that replaces a leading `@token` with `@NewName ` (or prepends if no leading mention), then dispatch a synthetic `input` event so the existing reducer pipeline handles every visual update — no separate panel-click reducer state.

Forward-compat with PRD #120 (procedural personas drawn from a 10–12 color palette): the reducer never switches on `"red"|"green"|"blue"`. Color values are sourced from `PERSONAS[aiId].color` via a new `buildPersonaColorMap` helper and treated as opaque strings; CSS classes use `composer-border--{value}` / `panel--addressed-{value}` / `mention--{value}` suffixes. When PRD #120 swaps the palette, the JS in the reducer + DOM controller requires zero changes — only CSS rules + persona-record updates.

## QA steps for the human

None — fully covered by the integration smoke (16/16 Playwright e2e tests passing, including the three new `e2e/visual-feedback.spec.ts` cases plus `mention-addressing`, `chat-lockout`, `addressed-and-parallel`, `persistence-reload`, and the smoke spec).

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 529/529 Vitest passing (6 new jsdom integration tests + extended reducer/parser unit tests)
- `pnpm lint` (biome ci) — clean
- `pnpm test:e2e` — 16/16 Playwright tests passing

Closes #109

https://claude.ai/code/session_01Aoq5HErwwWLCgoboPLVeXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aoq5HErwwWLCgoboPLVeXk)_