### PR TITLE
Visual feedback for the active addressee (mention, border, panel highlight)

### DIFF
--- a/e2e/visual-feedback.spec.ts
+++ b/e2e/visual-feedback.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E spec for #109: visual feedback for the active addressee.
+ *
+ * Three tests — no LLM stub needed (no submits):
+ * 1. Type "@Sage hi": green border on #prompt, green panel highlight, @Sage overlay span.
+ * 2. After step-1 setup, click blue panel: highlight transfers to blue, overlay shows @Frost.
+ * 3. Clear input: all visual feedback removed.
+ */
+
+test("typing '@Sage hi' → green border, green panel highlight, @Sage overlay span", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+
+	await page.fill("#prompt", "@Sage hi");
+
+	// Composer border has composer-border--green
+	await expect(page.locator("#prompt")).toHaveClass(/composer-border--green/);
+
+	// Green panel has panel--addressed and panel--addressed-green
+	await expect(page.locator('.ai-panel[data-ai="green"]')).toHaveClass(
+		/panel--addressed/,
+	);
+	await expect(page.locator('.ai-panel[data-ai="green"]')).toHaveClass(
+		/panel--addressed-green/,
+	);
+
+	// Other panels do NOT have panel--addressed
+	await expect(page.locator('.ai-panel[data-ai="red"]')).not.toHaveClass(
+		/panel--addressed/,
+	);
+	await expect(page.locator('.ai-panel[data-ai="blue"]')).not.toHaveClass(
+		/panel--addressed/,
+	);
+
+	// Overlay has exactly one mention-highlight span with @Sage text and mention--green
+	const highlightSpan = page.locator(
+		"#prompt-overlay .mention-highlight.mention--green",
+	);
+	await expect(highlightSpan).toHaveCount(1);
+	await expect(highlightSpan).toHaveText("@Sage");
+});
+
+test("after typing '@Sage hi', clicking blue panel transfers highlight to blue", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// Set up green mention first
+	await page.fill("#prompt", "@Sage hi");
+	await expect(page.locator("#prompt")).toHaveClass(/composer-border--green/);
+
+	// Click the blue panel
+	await page.locator('.ai-panel[data-ai="blue"]').click();
+
+	// Input value should start with @Frost
+	const value = await page.locator("#prompt").inputValue();
+	expect(value.startsWith("@Frost")).toBe(true);
+
+	// Border flips to blue
+	await expect(page.locator("#prompt")).toHaveClass(/composer-border--blue/);
+	await expect(page.locator("#prompt")).not.toHaveClass(
+		/composer-border--green/,
+	);
+
+	// Blue panel now has highlight
+	await expect(page.locator('.ai-panel[data-ai="blue"]')).toHaveClass(
+		/panel--addressed/,
+	);
+	await expect(page.locator('.ai-panel[data-ai="blue"]')).toHaveClass(
+		/panel--addressed-blue/,
+	);
+
+	// Green panel no longer highlighted
+	await expect(page.locator('.ai-panel[data-ai="green"]')).not.toHaveClass(
+		/panel--addressed/,
+	);
+
+	// Overlay highlight is @Frost with mention--blue
+	const highlightSpan = page.locator(
+		"#prompt-overlay .mention-highlight.mention--blue",
+	);
+	await expect(highlightSpan).toHaveCount(1);
+	await expect(highlightSpan).toHaveText("@Frost");
+});
+
+test("clearing input removes all visual feedback", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// First set a mention to create visual state
+	await page.fill("#prompt", "@Sage hi");
+	await expect(page.locator("#prompt")).toHaveClass(/composer-border--green/);
+
+	// Clear the input
+	await page.fill("#prompt", "");
+	await page.locator("#prompt").dispatchEvent("input");
+
+	// No composer-border-- class on #prompt
+	const classList = await page.locator("#prompt").getAttribute("class");
+	expect(classList ?? "").not.toMatch(/composer-border--/);
+
+	// No panel--addressed on any panel
+	await expect(page.locator(".panel--addressed")).toHaveCount(0);
+
+	// No .mention-highlight in overlay
+	await expect(page.locator("#prompt-overlay .mention-highlight")).toHaveCount(
+		0,
+	);
+});

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -28,7 +28,10 @@ const INDEX_BODY_HTML = `
     </article>
   </div>
   <form id="composer">
-    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+    <div class="prompt-wrap">
+      <div id="prompt-overlay" aria-hidden="true"></div>
+      <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+    </div>
     <button id="send" type="submit">Send</button>
   </form>
   <section id="cap-hit" hidden></section>
@@ -1605,5 +1608,266 @@ describe("renderGame — addressee persistence after send", () => {
 		expect(promptInput.value).toBe("@Sage ");
 		// Send must be disabled: green is locked and no body text
 		expect(sendBtn.disabled).toBe(true);
+	});
+});
+
+describe("visual feedback for active addressee", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("empty input → neutral state: no composer-border-*, no panel--addressed, no mention-highlight", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// Trigger input event with empty value
+		promptInput.value = "";
+		promptInput.dispatchEvent(new Event("input"));
+
+		// No composer-border-- class
+		const hasAnyBorder = [...promptInput.classList].some((c) =>
+			c.startsWith("composer-border--"),
+		);
+		expect(hasAnyBorder).toBe(false);
+
+		// No panel--addressed
+		const addressedPanels = document.querySelectorAll(".panel--addressed");
+		expect(addressedPanels.length).toBe(0);
+
+		// No mention-highlight in overlay
+		const overlay = document.querySelector<HTMLElement>("#prompt-overlay");
+		expect(overlay?.querySelector(".mention-highlight")).toBeNull();
+	});
+
+	it("typing '@Sage hi' → green border, green panel highlight, @Sage span in overlay", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+
+		// Composer border is green
+		expect(promptInput.classList.contains("composer-border--green")).toBe(true);
+
+		// Green panel has highlight classes
+		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
+		expect(greenPanel.classList.contains("panel--addressed")).toBe(true);
+		expect(greenPanel.classList.contains("panel--addressed-green")).toBe(true);
+
+		// Red and blue panels do NOT have highlight
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		expect(redPanel.classList.contains("panel--addressed")).toBe(false);
+		expect(bluePanel.classList.contains("panel--addressed")).toBe(false);
+
+		// Overlay has exactly one mention-highlight span with @Sage text and mention--green
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		const spans = overlay.querySelectorAll(".mention-highlight");
+		expect(spans.length).toBe(1);
+		expect(spans[0]?.textContent).toBe("@Sage");
+		expect(spans[0]?.classList.contains("mention--green")).toBe(true);
+	});
+
+	it("multi-mention '@Sage tell @Frost ...' → exactly one mention-highlight for @Sage only", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "@Sage tell @Frost ...";
+		promptInput.dispatchEvent(new Event("input"));
+
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		const spans = overlay.querySelectorAll(".mention-highlight");
+		expect(spans.length).toBe(1);
+		expect(spans[0]?.textContent).toBe("@Sage");
+		expect(spans[0]?.classList.contains("mention--green")).toBe(true);
+	});
+
+	it("trailing punctuation '@Sage,' → overlay mention-highlight has textContent '@Sage' (comma is plain text)", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "@Sage,";
+		promptInput.dispatchEvent(new Event("input"));
+
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		const span = overlay.querySelector(".mention-highlight");
+		expect(span?.textContent).toBe("@Sage");
+
+		// Comma should be outside the span (in a text node)
+		expect(overlay.textContent).toBe("@Sage,");
+	});
+
+	it("clearing input → all visual feedback removed", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// First set a mention
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(promptInput.classList.contains("composer-border--green")).toBe(true);
+
+		// Now clear
+		promptInput.value = "";
+		promptInput.dispatchEvent(new Event("input"));
+
+		// All composer-border-- classes removed
+		const hasAnyBorder = [...promptInput.classList].some((c) =>
+			c.startsWith("composer-border--"),
+		);
+		expect(hasAnyBorder).toBe(false);
+
+		// No panel--addressed
+		const addressedPanels = document.querySelectorAll(".panel--addressed");
+		expect(addressedPanels.length).toBe(0);
+
+		// No mention-highlight in overlay
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		expect(overlay.querySelector(".mention-highlight")).toBeNull();
+	});
+
+	it("panel-click transfers highlight: type @Sage hi then click blue panel → blue border, blue panel, @Frost span", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// Type @Sage hi
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(promptInput.classList.contains("composer-border--green")).toBe(true);
+
+		// Click blue panel
+		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		bluePanel.click();
+
+		// Input value should start with @Frost
+		expect(promptInput.value.startsWith("@Frost")).toBe(true);
+
+		// Blue border
+		expect(promptInput.classList.contains("composer-border--blue")).toBe(true);
+		expect(promptInput.classList.contains("composer-border--green")).toBe(
+			false,
+		);
+
+		// Blue panel has highlight
+		expect(bluePanel.classList.contains("panel--addressed")).toBe(true);
+		expect(bluePanel.classList.contains("panel--addressed-blue")).toBe(true);
+
+		// Green panel no longer highlighted
+		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
+		expect(greenPanel.classList.contains("panel--addressed")).toBe(false);
+
+		// Overlay highlight is @Frost with mention--blue
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		const span = overlay.querySelector(".mention-highlight");
+		expect(span?.textContent).toBe("@Frost");
+		expect(span?.classList.contains("mention--blue")).toBe(true);
+	});
+
+	it("locked addressee still gets visual feedback (typing path)", async () => {
+		vi.stubGlobal("fetch", {});
+		vi.stubGlobal("localStorage", { getItem: () => null });
+
+		vi.resetModules();
+
+		// Import GameSession before renderGame so the spy is in place
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutTriggered: {
+							aiId: "green" as const,
+							message: "Sage is unresponsive…",
+						},
+					},
+				};
+			},
+		);
+
+		// Provide a mock fetch for the session submit
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: (() => {
+				const encoder = new TextEncoder();
+				const sseData = `data: ${JSON.stringify({ choices: [{ delta: { content: '{"action":"pass"}' } }] })}\n\ndata: [DONE]\n\n`;
+				return new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode(sseData));
+						controller.close();
+					},
+				});
+			})(),
+		});
+		vi.stubGlobal("fetch", mockFetch);
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		// Submit one round to lock green
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Now type @Sage hi (green is locked)
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+
+		// Send disabled (green locked)
+		expect(sendBtn.disabled).toBe(true);
+
+		// Visual feedback still shows green
+		expect(promptInput.classList.contains("composer-border--green")).toBe(true);
+		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
+		expect(greenPanel.classList.contains("panel--addressed")).toBe(true);
+
+		// Overlay still shows the mention highlight
+		const overlay = getEl<HTMLElement>("#prompt-overlay");
+		const span = overlay.querySelector(".mention-highlight");
+		expect(span?.textContent).toBe("@Sage");
+		expect(span?.classList.contains("mention--green")).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { PERSONAS } from "../../../content/personas.js";
 import { deriveComposerState } from "../composer-reducer.js";
-import { buildPersonaNameMap } from "../mention-parser.js";
+import {
+	buildPersonaColorMap,
+	buildPersonaNameMap,
+} from "../mention-parser.js";
 import type { AiId } from "../types.js";
 
 // Re-use the real PERSONAS so the map is canonical.
 const personaNamesToId = buildPersonaNameMap(PERSONAS);
+const personaColors = buildPersonaColorMap(PERSONAS);
 
 function noLockouts(): ReadonlyMap<AiId, boolean> {
 	return new Map<AiId, boolean>([
@@ -26,54 +30,155 @@ function lockouts(locked: AiId): ReadonlyMap<AiId, boolean> {
 }
 
 describe("deriveComposerState", () => {
-	it("empty text → { addressee: null, sendEnabled: false }", () => {
+	it("empty text → all-null visual fields", () => {
 		expect(
 			deriveComposerState({
 				text: "",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: null, sendEnabled: false });
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		});
 	});
 
-	it('"hi" → { addressee: null, sendEnabled: false }', () => {
+	it('"hi" → all-null visual fields', () => {
 		expect(
 			deriveComposerState({
 				text: "hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: null, sendEnabled: false });
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		});
 	});
 
-	it('"@Sage" no lockouts → { addressee: "green", sendEnabled: false } (no body)', () => {
+	it('"@Sage" no lockouts → sendEnabled: false (no body), visual fields populated', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: false });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Sage hi" no lockouts → { addressee: "green", sendEnabled: true }', () => {
+	it('"@Sage hi" no lockouts → sendEnabled: true, visual fields populated', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Sage hi" green locked → { addressee: "green", sendEnabled: false }', () => {
+	it('"@Sage hi" green locked → sendEnabled: false BUT visual fields still populated', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: false });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
+	});
+
+	it('"@Sage," → mentionHighlight.end = 5 (nameEnd, NOT 6 — trailing punct excluded from highlight)', () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage,",
+				lockouts: noLockouts(),
+				personaNamesToId,
+				personaColors,
+			}),
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
+	});
+
+	it('"@Sage tell @Frost ..." → only first mention highlighted (covers @Sage)', () => {
+		const result = deriveComposerState({
+			text: "@Sage tell @Frost ...",
+			lockouts: noLockouts(),
+			personaNamesToId,
+			personaColors,
+		});
+		expect(result.addressee).toBe("green");
+		expect(result.mentionHighlight).toEqual({
+			start: 0,
+			end: 5,
+			color: "green",
+		});
+	});
+
+	it('"hi @Sage" → mentionHighlight.start = 3, end = 8', () => {
+		expect(
+			deriveComposerState({
+				text: "hi @Sage",
+				lockouts: noLockouts(),
+				personaNamesToId,
+				personaColors,
+			}),
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 3, end: 8, color: "green" },
+		});
+	});
+
+	it('"@Frost @Sage" blue-locked → addressee blue, sendEnabled false, visual fields all blue, range covers @Frost', () => {
+		expect(
+			deriveComposerState({
+				text: "@Frost @Sage",
+				lockouts: lockouts("blue"),
+				personaNamesToId,
+				personaColors,
+			}),
+		).toEqual({
+			addressee: "blue",
+			sendEnabled: false,
+			borderColor: "blue",
+			panelHighlight: "blue",
+			mentionHighlight: { start: 0, end: 6, color: "blue" },
+		});
 	});
 
 	it('"@Ember hi" green locked → { addressee: "red", sendEnabled: true }', () => {
@@ -82,98 +187,117 @@ describe("deriveComposerState", () => {
 				text: "@Ember hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "red", sendEnabled: true });
+		).toEqual({
+			addressee: "red",
+			sendEnabled: true,
+			borderColor: "red",
+			panelHighlight: "red",
+			mentionHighlight: { start: 0, end: 6, color: "red" },
+		});
 	});
 
-	it('"@Nonpersona hi" no lockouts → { addressee: null, sendEnabled: false }', () => {
+	it('"@Nonpersona hi" no lockouts → all-null visual fields', () => {
 		expect(
 			deriveComposerState({
 				text: "@Nonpersona hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: null, sendEnabled: false });
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+		});
 	});
 
-	it('"@Sage," no lockouts → { addressee: "green", sendEnabled: false } (no body after comma-stripped mention)', () => {
-		expect(
-			deriveComposerState({
-				text: "@Sage,",
-				lockouts: noLockouts(),
-				personaNamesToId,
-			}),
-		).toEqual({ addressee: "green", sendEnabled: false });
-	});
-
-	it('"@Frost @Sage" no lockouts → { addressee: "blue", sendEnabled: true }', () => {
+	it('"@Frost @Sage" no lockouts → addressee blue, sendEnabled true (body = @Sage)', () => {
 		expect(
 			deriveComposerState({
 				text: "@Frost @Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "blue", sendEnabled: true });
-	});
-
-	it('"@Frost @Sage" blue locked → { addressee: "blue", sendEnabled: false } (no fallthrough)', () => {
-		expect(
-			deriveComposerState({
-				text: "@Frost @Sage",
-				lockouts: lockouts("blue"),
-				personaNamesToId,
-			}),
-		).toEqual({ addressee: "blue", sendEnabled: false });
+		).toEqual({
+			addressee: "blue",
+			sendEnabled: true,
+			borderColor: "blue",
+			panelHighlight: "blue",
+			mentionHighlight: { start: 0, end: 6, color: "blue" },
+		});
 	});
 
 	// Body-after-mention rule: persisted prefix cases
-	it('"@Sage " (trailing space only) → { addressee: "green", sendEnabled: false }', () => {
+	it('"@Sage " (trailing space only) → sendEnabled: false', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage ",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: false });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"@Sage  " (two trailing spaces) → { addressee: "green", sendEnabled: false }', () => {
+	it('"@Sage  " (two trailing spaces) → sendEnabled: false', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage  ",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: false });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 
-	it('"hi @Sage" → { addressee: "green", sendEnabled: true } (body before mention)', () => {
-		expect(
-			deriveComposerState({
-				text: "hi @Sage",
-				lockouts: noLockouts(),
-				personaNamesToId,
-			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
-	});
-
-	it('"hi @Sage there" → { addressee: "green", sendEnabled: true } (body on both sides)', () => {
+	it('"hi @Sage there" → sendEnabled: true (body on both sides)', () => {
 		expect(
 			deriveComposerState({
 				text: "hi @Sage there",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 3, end: 8, color: "green" },
+		});
 	});
 
-	it('"@sage hi" (lowercase mention) → { addressee: "green", sendEnabled: true }', () => {
+	it('"@sage hi" (lowercase mention) → sendEnabled: true', () => {
 		expect(
 			deriveComposerState({
 				text: "@sage hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
+				personaColors,
 			}),
-		).toEqual({ addressee: "green", sendEnabled: true });
+		).toEqual({
+			addressee: "green",
+			sendEnabled: true,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+		});
 	});
 });

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	applyAddresseeChange,
+	buildPersonaColorMap,
 	buildPersonaNameMap,
 	findFirstMention,
 	parseFirstMention,
@@ -40,50 +41,65 @@ describe("parseFirstMention", () => {
 });
 
 describe("findFirstMention", () => {
-	it('"@Sage" → { aiId: "green", start: 0, end: 5 }', () => {
+	it('"@Sage" → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
 		expect(findFirstMention("@Sage", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
+			nameEnd: 5,
 			end: 5,
 		});
 	});
 
-	it('"@Sage hi" → { aiId: "green", start: 0, end: 5 }', () => {
+	it('"@Sage hi" → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
 		expect(findFirstMention("@Sage hi", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
+			nameEnd: 5,
 			end: 5,
 		});
 	});
 
-	it('"hi @Sage" → { aiId: "green", start: 3, end: 8 }', () => {
+	it('"hi @Sage" → { aiId: "green", start: 3, nameEnd: 8, end: 8 }', () => {
 		expect(findFirstMention("hi @Sage", nameMap)).toEqual({
 			aiId: "green",
 			start: 3,
+			nameEnd: 8,
 			end: 8,
 		});
 	});
 
-	it('"@sage" (lowercase) → { aiId: "green", start: 0, end: 5 }', () => {
+	it('"@sage" (lowercase) → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
 		expect(findFirstMention("@sage", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
+			nameEnd: 5,
 			end: 5,
 		});
 	});
 
-	it('"@Sage," → end includes the comma (end: 6)', () => {
+	it('"@Sage," → nameEnd: 5 (excludes comma), end: 6 (includes comma)', () => {
 		expect(findFirstMention("@Sage,", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
+			nameEnd: 5,
 			end: 6,
 		});
 	});
 
-	it('"@Frost @Sage" → first match is Frost (blue)', () => {
+	it('"hi @Sage." → nameEnd: 8 (excludes period), end: 9 (includes period)', () => {
+		expect(findFirstMention("hi @Sage.", nameMap)).toEqual({
+			aiId: "green",
+			start: 3,
+			nameEnd: 8,
+			end: 9,
+		});
+	});
+
+	it('"@Frost @Sage" → first match is Frost (blue), nameEnd: 6, end: 6', () => {
 		expect(findFirstMention("@Frost @Sage", nameMap)).toEqual({
 			aiId: "blue",
 			start: 0,
+			nameEnd: 6,
 			end: 6,
 		});
 	});
@@ -109,6 +125,37 @@ describe("buildPersonaNameMap", () => {
 		expect(map.get("sage")).toBe("green");
 		expect(map.get("frost")).toBe("blue");
 		expect(map.size).toBe(3);
+	});
+});
+
+describe("buildPersonaColorMap", () => {
+	it("maps each AiId to the persona's color value (not the id key)", () => {
+		// Use distinct color values that differ from the AiId keys
+		// so a wrong implementation that returns the key is immediately caught.
+		const personas = {
+			red: { color: "crimson" },
+			green: { color: "lime" },
+			blue: { color: "cyan" },
+		} as Record<AiId, { color: string }>;
+		const map = buildPersonaColorMap(personas);
+		expect(map.get("red")).toBe("crimson");
+		expect(map.get("green")).toBe("lime");
+		expect(map.get("blue")).toBe("cyan");
+		expect(map.size).toBe(3);
+	});
+
+	it("returns the color string from the persona record, not the AiId key", () => {
+		// If implementation mistakenly returns the key instead of persona.color,
+		// these assertions will fail.
+		const personas = {
+			red: { color: "tomato" },
+			green: { color: "forest" },
+			blue: { color: "ocean" },
+		} as Record<AiId, { color: string }>;
+		const map = buildPersonaColorMap(personas);
+		expect(map.get("red")).not.toBe("red");
+		expect(map.get("green")).not.toBe("green");
+		expect(map.get("blue")).not.toBe("blue");
 	});
 });
 

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -5,31 +5,65 @@ export interface ComposerInput {
 	text: string;
 	lockouts: ReadonlyMap<AiId, boolean>;
 	personaNamesToId: ReadonlyMap<string, AiId>;
+	personaColors: ReadonlyMap<AiId, string>;
 }
 
 export interface ComposerState {
 	addressee: AiId | null;
 	sendEnabled: boolean;
+	/** Border color string for the composer input, or null when no addressee. */
+	borderColor: string | null;
+	/** AiId whose panel should carry the highlight class, or null. */
+	panelHighlight: AiId | null;
+	/** Highlight range for the first @mention in the overlay, or null. */
+	mentionHighlight: { start: number; end: number; color: string } | null;
 }
 
+const NULL_VISUAL: Pick<
+	ComposerState,
+	"borderColor" | "panelHighlight" | "mentionHighlight"
+> = {
+	borderColor: null,
+	panelHighlight: null,
+	mentionHighlight: null,
+};
+
 /**
- * Derives the composer state (addressee + send button enabled) from the
- * current prompt text, the chat-lockout map, and the persona name→id map.
+ * Derives the composer state (addressee + send button enabled + visual cues)
+ * from the current prompt text, the chat-lockout map, and the persona maps.
  *
  * - `addressee` is the first valid @mention in the text.
  * - `sendEnabled` is true only when `addressee` is non-null AND the
  *   addressed AI is not chat-locked AND there is non-empty body text
  *   outside the mention token.
+ * - `borderColor`, `panelHighlight`, `mentionHighlight` are populated whenever
+ *   an addressee is identified — even when `sendEnabled` is false (locked
+ *   addressees still get visual feedback).
  */
 export function deriveComposerState(input: ComposerInput): ComposerState {
-	const { text, lockouts, personaNamesToId } = input;
+	const { text, lockouts, personaNamesToId, personaColors } = input;
 	const match = findFirstMention(text, personaNamesToId);
-	if (match === null) return { addressee: null, sendEnabled: false };
+	if (match === null)
+		return { addressee: null, sendEnabled: false, ...NULL_VISUAL };
 
-	const { aiId: addressee, start, end } = match;
+	const { aiId: addressee, start, nameEnd, end } = match;
 	// Body is everything except the @Name token itself.
 	const bodyAfterMention = (text.slice(0, start) + text.slice(end)).trim();
 	const sendEnabled =
 		lockouts.get(addressee) !== true && bodyAfterMention.length > 0;
-	return { addressee, sendEnabled };
+
+	// Visual cues are populated regardless of sendEnabled.
+	const color = personaColors.get(addressee) ?? null;
+	const borderColor = color;
+	const panelHighlight = addressee;
+	const mentionHighlight =
+		color != null ? { start, end: nameEnd, color } : null;
+
+	return {
+		addressee,
+		sendEnabled,
+		borderColor,
+		panelHighlight,
+		mentionHighlight,
+	};
 }

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -9,6 +9,8 @@ export interface MentionMatch {
 	aiId: AiId;
 	/** Index of the `@` character in `text`. */
 	start: number;
+	/** End of `@Name` (excludes any trailing punctuation). Use this for the highlight range. */
+	nameEnd: number;
 	/** One past the last consumed character: end of name, or end of a single trailing punctuation char if one immediately follows. */
 	end: number;
 }
@@ -38,14 +40,15 @@ export function findFirstMention(
 			// The `@` is at match.index + (full-match-length - raw.length - 1).
 			const fullMatch = match[0];
 			const start = (match.index ?? 0) + fullMatch.length - raw.length - 1;
-			let end = start + 1 + raw.length; // 1 for '@'
+			const nameEnd = start + 1 + raw.length; // 1 for '@', excludes trailing punct
+			let end = nameEnd;
 			// Consume a single trailing punctuation character immediately after the
 			// name so that "@Sage," treats the comma as part of the token and the
 			// body-after-mention computation does not surface bare punctuation.
 			if (/[.,!?;:]/.test(text[end] ?? "")) {
 				end += 1;
 			}
-			return { aiId: id, start, end };
+			return { aiId: id, start, nameEnd, end };
 		}
 	}
 	return null;
@@ -160,6 +163,24 @@ export function buildPersonaNameMap(
 		{ name: string },
 	][]) {
 		map.set(persona.name.toLowerCase(), id);
+	}
+	return map;
+}
+
+/**
+ * Builds an AiId → color string map from a personas record.
+ * Color values are sourced from the persona's `color` field (not the AiId key),
+ * so a future palette swap only requires persona-record updates, not JS changes.
+ */
+export function buildPersonaColorMap(
+	personas: Record<AiId, { color: string }>,
+): Map<AiId, string> {
+	const map = new Map<AiId, string>();
+	for (const [id, persona] of Object.entries(personas) as [
+		AiId,
+		{ color: string },
+	][]) {
+		map.set(id, persona.color);
 	}
 	return map;
 }

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -36,7 +36,10 @@
 		    </article>
 		  </div>
 		  <form id="composer">
-		    <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+		    <div class="prompt-wrap">
+		      <div id="prompt-overlay" aria-hidden="true"></div>
+		      <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+		    </div>
 		    <button id="send" type="submit">Send</button>
 		  </form>
 		  <section id="cap-hit" hidden>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -6,6 +6,7 @@ import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
 import {
 	applyAddresseeChange,
+	buildPersonaColorMap,
 	buildPersonaNameMap,
 } from "../game/mention-parser.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
@@ -160,6 +161,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 
 	// Mention-based addressing state
 	const personaNamesToId = buildPersonaNameMap(PERSONAS);
+	const personaColors = buildPersonaColorMap(PERSONAS);
 	const lockouts: Map<AiId, boolean> = new Map([
 		["red", false],
 		["green", false],
@@ -171,16 +173,75 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 	const _promptInput = promptInput;
 	const _sendBtn = sendBtn;
 
+	// Overlay for mention highlight rendering.
+	const overlay = doc.querySelector<HTMLElement>("#prompt-overlay");
+
+	/** Remove any class on `el` that starts with `prefix`, then add `${prefix}${value}` if non-null. */
+	function setColorClass(
+		el: HTMLElement,
+		prefix: string,
+		value: string | null,
+	): void {
+		for (const cls of [...el.classList]) {
+			if (cls.startsWith(prefix)) el.classList.remove(cls);
+		}
+		if (value != null) el.classList.add(`${prefix}${value}`);
+	}
+
+	/** Rebuild the overlay's DOM to reflect the current text and highlight range. */
+	function rebuildOverlay(
+		ov: HTMLElement | null,
+		text: string,
+		highlight: { start: number; end: number; color: string } | null,
+	): void {
+		if (!ov) return;
+		// Remove all children.
+		while (ov.firstChild) ov.removeChild(ov.firstChild);
+		if (!highlight) {
+			ov.appendChild(doc.createTextNode(text));
+			return;
+		}
+		const { start, end, color } = highlight;
+		if (start > 0) {
+			ov.appendChild(doc.createTextNode(text.slice(0, start)));
+		}
+		const span = doc.createElement("span");
+		span.className = `mention-highlight mention--${color}`;
+		span.appendChild(doc.createTextNode(text.slice(start, end)));
+		ov.appendChild(span);
+		if (end < text.length) {
+			ov.appendChild(doc.createTextNode(text.slice(end)));
+		}
+	}
+
 	function refreshComposerState(): void {
-		const { sendEnabled } = deriveComposerState({
+		const state = deriveComposerState({
 			text: _promptInput.value,
 			lockouts,
 			personaNamesToId,
+			personaColors,
 		});
-		_sendBtn.disabled = !sendEnabled || roundInFlight;
+		_sendBtn.disabled = !state.sendEnabled || roundInFlight;
+		setColorClass(_promptInput, "composer-border--", state.borderColor);
+		for (const aiId of AI_ORDER) {
+			const panel = doc.querySelector<HTMLElement>(
+				`.ai-panel[data-ai="${aiId}"]`,
+			);
+			if (!panel) continue;
+			const isAddressed = state.panelHighlight === aiId;
+			panel.classList.toggle("panel--addressed", isAddressed);
+			const color = personaColors.get(aiId);
+			if (color)
+				panel.classList.toggle(`panel--addressed-${color}`, isAddressed);
+		}
+		rebuildOverlay(overlay, _promptInput.value, state.mentionHighlight);
+		if (overlay) overlay.scrollLeft = _promptInput.scrollLeft;
 	}
 
 	promptInput.addEventListener("input", refreshComposerState);
+	promptInput.addEventListener("scroll", () => {
+		if (overlay) overlay.scrollLeft = _promptInput.scrollLeft;
+	});
 
 	// Dev-only: ?think=0 disables the model's thinking step (OpenRouter
 	// reasoning.enabled=false). Gated to wrangler-dev host (see isDevHost).
@@ -386,6 +447,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			text: promptInput.value,
 			lockouts,
 			personaNamesToId,
+			personaColors,
 		});
 		if (!sendEnabled || !addressee) return;
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -26,12 +26,79 @@ main {
 	gap: 0.5rem;
 }
 
-#prompt {
+.prompt-wrap {
+	position: relative;
 	flex: 1;
+	display: block;
+}
+
+#prompt-overlay {
+	position: absolute;
+	inset: 0;
+	padding: 0.5rem 0.75rem;
+	font: inherit;
+	font-size: 1rem;
+	pointer-events: none;
+	white-space: pre;
+	overflow: hidden;
+	color: #222;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	background: transparent;
+}
+
+#prompt {
+	position: relative;
+	z-index: 1;
+	color: transparent;
+	caret-color: #222;
+	background: transparent;
+	width: 100%;
 	padding: 0.5rem 0.75rem;
 	font-size: 1rem;
 	border: 1px solid #ccc;
 	border-radius: 4px;
+}
+
+#prompt.composer-border--red {
+	border-color: #b83232;
+}
+#prompt.composer-border--green {
+	border-color: #2e7a3e;
+}
+#prompt.composer-border--blue {
+	border-color: #2458a0;
+}
+
+.ai-panel.panel--addressed {
+	box-shadow: 0 0 0 2px var(--addressed-color, #888);
+}
+.ai-panel.panel--addressed.panel--addressed-red {
+	--addressed-color: #b83232;
+}
+.ai-panel.panel--addressed.panel--addressed-green {
+	--addressed-color: #2e7a3e;
+}
+.ai-panel.panel--addressed.panel--addressed-blue {
+	--addressed-color: #2458a0;
+}
+
+.mention-highlight {
+	font-weight: bold;
+	padding: 0 1px;
+	border-radius: 2px;
+}
+.mention-highlight.mention--red {
+	color: #b83232;
+	background: rgba(184, 50, 50, 0.1);
+}
+.mention-highlight.mention--green {
+	color: #2e7a3e;
+	background: rgba(46, 122, 62, 0.1);
+}
+.mention-highlight.mention--blue {
+	color: #2458a0;
+	background: rgba(36, 88, 160, 0.1);
 }
 
 #send {


### PR DESCRIPTION
## What this fixes

Adds the three coupled visual cues from #109 — a colored highlight on the leading `@mention` in the composer input, a composer border tinted to the addressed AI's color, and a ring on the addressed AI's panel — and keeps them in sync as the addressee changes.

This is a re-implementation of #134 (closed) layered cleanly on top of PRs #132 (`#110`) and #133 (`#108`), which landed in the same files while #134 was open.

The composer-reducer (`src/spa/game/composer-reducer.ts`) gains three derived fields: `borderColor: string | null`, `panelHighlight: AiId | null`, `mentionHighlight: { start, end, color } | null`. Upstream's `MentionMatch.end` deliberately consumes a single trailing punctuation character (used by the body-after-mention `sendEnabled` check). The mention-highlight needs the range *without* trailing punctuation, so `MentionMatch` gains a sibling `nameEnd` field — the reducer uses `match.nameEnd` for the highlight range, leaving `match.end` for upstream's body check.

The DOM controller (`src/spa/routes/game.ts`) consumes the new fields in `refreshComposerState`. Since the `<input id="prompt">` cannot natively style a substring, it's wrapped in `<div class="prompt-wrap">` with a sibling `<div id="prompt-overlay" aria-hidden="true">` that mirrors the input's font/padding and is layered behind a transparent-text input (caret stays visible via `caret-color`). The overlay is rebuilt on every input event from text-nodes plus a single `<span class="mention-highlight mention--{color}">` for the first mention range — `textContent` / `createElement` only, no `innerHTML` (no XSS surface). Upstream's panel-click handler already calls `refreshComposerState()`, so the highlight transfers automatically when a panel-click rewrites the leading mention via `applyAddresseeChange` — no new panel-click logic needed.

Forward-compat with PRD #120 (procedural personas drawn from a 10–12 color palette): the reducer never switches on `"red"|"green"|"blue"`. Color values flow through a new `personaColors: ReadonlyMap<AiId, string>` input (built via `buildPersonaColorMap(PERSONAS)`) and are treated as opaque strings; CSS classes use `composer-border--{value}` / `panel--addressed-{value}` / `mention--{value}` suffixes. When PRD #120 swaps the palette, the JS in the reducer + DOM controller requires zero changes — only CSS rules + persona-record updates.

## QA steps for the human

None — fully covered by the integration smoke (16/16 Playwright e2e tests passing, including the three new `e2e/visual-feedback.spec.ts` cases plus `mention-addressing`, `chat-lockout`, `addressed-and-parallel`, `persistence-reload`, `endgame-current-behaviour`, `token-pacing`, `think-disabled`, and the smoke spec — all of which exercise the new `.prompt-wrap`-wrapped composer).

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 554/554 Vitest passing (6 new jsdom integration tests + extended reducer/parser unit tests covering trailing-punct carve-out, multi-mention, locked-but-highlighted)
- `pnpm lint` (biome ci) — clean
- `pnpm test:e2e` — 16/16 Playwright tests passing

Closes #109

https://claude.ai/code/session_01Aoq5HErwwWLCgoboPLVeXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aoq5HErwwWLCgoboPLVeXk)_