### PR TITLE
Lockout: muted panels and inline error message

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1887,7 +1887,10 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 	});
 
 	/** Helper: inject a chatLockoutTriggered for a given aiId via submitMessage spy. */
-	async function setupLockoutMock(aiId: "red" | "green" | "blue", message: string) {
+	async function setupLockoutMock(
+		aiId: "red" | "green" | "blue",
+		message: string,
+	) {
 		const { GameSession } = await import("../game/game-session.js");
 		const originalSubmit = GameSession.prototype.submitMessage;
 		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
@@ -1925,7 +1928,9 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 
 		promptInput.value = "@Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
@@ -1959,7 +1964,9 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		// Submit to trigger the lockout
 		promptInput.value = "@Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Type @Sage hi while green is locked
@@ -2030,7 +2037,9 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		// Round 1: lock green
 		promptInput.value = "@Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Verify green is locked
@@ -2040,7 +2049,9 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		// Round 2 via @Ember: resolve green lockout
 		promptInput.value = "@Ember hi";
 		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Green panel should no longer be locked
@@ -2076,7 +2087,9 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		// Trigger lockout
 		promptInput.value = "@Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Clear input (empty text)

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -32,6 +32,7 @@ const INDEX_BODY_HTML = `
       <div id="prompt-overlay" aria-hidden="true"></div>
       <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
     </div>
+    <output id="lockout-error" class="lockout-error" role="status" aria-live="polite" hidden></output>
     <button id="send" type="submit">Send</button>
   </form>
   <section id="cap-hit" hidden></section>
@@ -1869,5 +1870,225 @@ describe("visual feedback for active addressee", () => {
 		const span = overlay.querySelector(".mention-highlight");
 		expect(span?.textContent).toBe("@Sage");
 		expect(span?.classList.contains("mention--green")).toBe(true);
+	});
+});
+
+describe("renderGame — chat lockout visual affordances (panel muting + inline error)", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	/** Helper: inject a chatLockoutTriggered for a given aiId via submitMessage spy. */
+	async function setupLockoutMock(aiId: "red" | "green" | "blue", message: string) {
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutTriggered: { aiId, message },
+					},
+				};
+			},
+		);
+	}
+
+	it("chat_lockout fires → locked panel gains panel--locked and aria-disabled=true", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION),
+		);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		await setupLockoutMock("red", "Ember is unresponsive…");
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
+		expect(redPanel.classList.contains("panel--locked")).toBe(true);
+		expect(redPanel.getAttribute("aria-disabled")).toBe("true");
+
+		// Green and blue panels should NOT be locked
+		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
+		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		expect(greenPanel.classList.contains("panel--locked")).toBe(false);
+		expect(bluePanel.classList.contains("panel--locked")).toBe(false);
+	});
+
+	it("type @Sage while green locked → Send disabled, #lockout-error visible with text containing 'Sage'", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION),
+		);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		await setupLockoutMock("green", "Sage is unresponsive…");
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+
+		// Submit to trigger the lockout
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Type @Sage hi while green is locked
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+
+		expect(sendBtn.disabled).toBe(true);
+
+		const lockoutError = getEl<HTMLOutputElement>("#lockout-error");
+		expect(lockoutError.hasAttribute("hidden")).toBe(false);
+		expect(lockoutError.textContent).toContain("Sage");
+	});
+
+	it("chat_lockout_resolved mid-draft → muting clears, #lockout-error hidden, Send re-enables when @Sage re-typed", async () => {
+		// First round: inject lockout for green
+		// Second round: inject lockout_resolved for green via mock
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		const { GameSession } = await import("../game/game-session.js");
+		const originalSubmit = GameSession.prototype.submitMessage;
+		let callCount = 0;
+		vi.spyOn(GameSession.prototype, "submitMessage").mockImplementation(
+			async function (
+				this: InstanceType<typeof GameSession>,
+				...args: Parameters<InstanceType<typeof GameSession>["submitMessage"]>
+			) {
+				const real = await originalSubmit.apply(this, args);
+				callCount++;
+				if (callCount === 1) {
+					// First call: lock green
+					return {
+						...real,
+						result: {
+							...real.result,
+							chatLockoutTriggered: {
+								aiId: "green" as const,
+								message: "Sage is unresponsive…",
+							},
+						},
+					};
+				}
+				// Second call: resolve green lockout
+				return {
+					...real,
+					result: {
+						...real.result,
+						chatLockoutsResolved: ["green" as const],
+					},
+				};
+			},
+		);
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeAiSseStream(PASS_ACTION),
+		});
+		vi.stubGlobal("fetch", mockFetch);
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// Round 1: lock green
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Verify green is locked
+		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
+		expect(greenPanel.classList.contains("panel--locked")).toBe(true);
+
+		// Round 2 via @Ember: resolve green lockout
+		promptInput.value = "@Ember hi";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Green panel should no longer be locked
+		expect(greenPanel.classList.contains("panel--locked")).toBe(false);
+
+		// Type @Sage again: should now enable Send and hide error
+		promptInput.value = "@Sage hi";
+		promptInput.dispatchEvent(new Event("input"));
+
+		const sendBtn = getEl<HTMLButtonElement>("#send");
+		expect(sendBtn.disabled).toBe(false);
+
+		const lockoutError = getEl<HTMLOutputElement>("#lockout-error");
+		expect(lockoutError.hasAttribute("hidden")).toBe(true);
+	});
+
+	it("empty input + green locked → green panel muted but #lockout-error stays hidden", async () => {
+		vi.stubGlobal(
+			"fetch",
+			makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION),
+		);
+		vi.stubGlobal("localStorage", { getItem: () => null });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		await setupLockoutMock("green", "Sage is unresponsive…");
+
+		const { renderGame } = await import("../routes/game.js");
+		renderGame(getEl<HTMLElement>("main"));
+
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+
+		// Trigger lockout
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Clear input (empty text)
+		promptInput.value = "";
+		promptInput.dispatchEvent(new Event("input"));
+
+		// Green panel is muted (locked)
+		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
+		expect(greenPanel.classList.contains("panel--locked")).toBe(true);
+
+		// Error element is hidden (no addressee)
+		const lockoutError = getEl<HTMLOutputElement>("#lockout-error");
+		expect(lockoutError.hasAttribute("hidden")).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -3,6 +3,7 @@ import { PERSONAS } from "../../../content/personas.js";
 import { deriveComposerState } from "../composer-reducer.js";
 import {
 	buildPersonaColorMap,
+	buildPersonaDisplayNameMap,
 	buildPersonaNameMap,
 } from "../mention-parser.js";
 import type { AiId } from "../types.js";
@@ -10,6 +11,7 @@ import type { AiId } from "../types.js";
 // Re-use the real PERSONAS so the map is canonical.
 const personaNamesToId = buildPersonaNameMap(PERSONAS);
 const personaColors = buildPersonaColorMap(PERSONAS);
+const personaDisplayNames = buildPersonaDisplayNameMap(PERSONAS);
 
 function noLockouts(): ReadonlyMap<AiId, boolean> {
 	return new Map<AiId, boolean>([
@@ -29,6 +31,16 @@ function lockouts(locked: AiId): ReadonlyMap<AiId, boolean> {
 	return m;
 }
 
+function multiLockouts(locked: AiId[]): ReadonlyMap<AiId, boolean> {
+	const m = new Map<AiId, boolean>([
+		["red", false],
+		["green", false],
+		["blue", false],
+	]);
+	for (const id of locked) m.set(id, true);
+	return m;
+}
+
 describe("deriveComposerState", () => {
 	it("empty text → all-null visual fields", () => {
 		expect(
@@ -37,6 +49,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: null,
@@ -44,6 +57,8 @@ describe("deriveComposerState", () => {
 			borderColor: null,
 			panelHighlight: null,
 			mentionHighlight: null,
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -54,6 +69,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: null,
@@ -61,6 +77,8 @@ describe("deriveComposerState", () => {
 			borderColor: null,
 			panelHighlight: null,
 			mentionHighlight: null,
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -71,6 +89,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -78,6 +97,8 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -88,6 +109,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -95,16 +117,19 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
-	it('"@Sage hi" green locked → sendEnabled: false BUT visual fields still populated', () => {
+	it('"@Sage hi" green locked → sendEnabled: false, lockoutError set, lockedPanels has green', () => {
 		expect(
 			deriveComposerState({
 				text: "@Sage hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -112,6 +137,8 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: "Sage isn't reading right now",
+			lockedPanels: new Set(["green"]),
 		});
 	});
 
@@ -122,6 +149,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -129,6 +157,8 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -138,6 +168,7 @@ describe("deriveComposerState", () => {
 			lockouts: noLockouts(),
 			personaNamesToId,
 			personaColors,
+			personaDisplayNames,
 		});
 		expect(result.addressee).toBe("green");
 		expect(result.mentionHighlight).toEqual({
@@ -154,6 +185,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -161,16 +193,19 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 3, end: 8, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
-	it('"@Frost @Sage" blue-locked → addressee blue, sendEnabled false, visual fields all blue, range covers @Frost', () => {
+	it('"@Frost @Sage" blue-locked → addressee blue, sendEnabled false, lockoutError set for Frost', () => {
 		expect(
 			deriveComposerState({
 				text: "@Frost @Sage",
 				lockouts: lockouts("blue"),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "blue",
@@ -178,16 +213,19 @@ describe("deriveComposerState", () => {
 			borderColor: "blue",
 			panelHighlight: "blue",
 			mentionHighlight: { start: 0, end: 6, color: "blue" },
+			lockoutError: "Frost isn't reading right now",
+			lockedPanels: new Set(["blue"]),
 		});
 	});
 
-	it('"@Ember hi" green locked → { addressee: "red", sendEnabled: true }', () => {
+	it('"@Ember hi" green locked → { addressee: "red", sendEnabled: true, lockoutError: null }', () => {
 		expect(
 			deriveComposerState({
 				text: "@Ember hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "red",
@@ -195,6 +233,8 @@ describe("deriveComposerState", () => {
 			borderColor: "red",
 			panelHighlight: "red",
 			mentionHighlight: { start: 0, end: 6, color: "red" },
+			lockoutError: null,
+			lockedPanels: new Set(["green"]),
 		});
 	});
 
@@ -205,6 +245,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: null,
@@ -212,6 +253,8 @@ describe("deriveComposerState", () => {
 			borderColor: null,
 			panelHighlight: null,
 			mentionHighlight: null,
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -222,6 +265,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "blue",
@@ -229,6 +273,8 @@ describe("deriveComposerState", () => {
 			borderColor: "blue",
 			panelHighlight: "blue",
 			mentionHighlight: { start: 0, end: 6, color: "blue" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -240,6 +286,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -247,6 +294,8 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -257,6 +306,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -264,6 +314,8 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -274,6 +326,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -281,6 +334,8 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 3, end: 8, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
 		});
 	});
 
@@ -291,6 +346,7 @@ describe("deriveComposerState", () => {
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
+				personaDisplayNames,
 			}),
 		).toEqual({
 			addressee: "green",
@@ -298,6 +354,89 @@ describe("deriveComposerState", () => {
 			borderColor: "green",
 			panelHighlight: "green",
 			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: null,
+			lockedPanels: new Set(),
+		});
+	});
+
+	// New lockout-specific tests
+	it("empty text + green locked → lockoutError: null, lockedPanels has green", () => {
+		expect(
+			deriveComposerState({
+				text: "",
+				lockouts: lockouts("green"),
+				personaNamesToId,
+				personaColors,
+				personaDisplayNames,
+			}),
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+			lockoutError: null,
+			lockedPanels: new Set(["green"]),
+		});
+	});
+
+	it('"@Nonpersona hi" + green locked → lockoutError: null, lockedPanels has green', () => {
+		expect(
+			deriveComposerState({
+				text: "@Nonpersona hi",
+				lockouts: lockouts("green"),
+				personaNamesToId,
+				personaColors,
+				personaDisplayNames,
+			}),
+		).toEqual({
+			addressee: null,
+			sendEnabled: false,
+			borderColor: null,
+			panelHighlight: null,
+			mentionHighlight: null,
+			lockoutError: null,
+			lockedPanels: new Set(["green"]),
+		});
+	});
+
+	it("multiple locks red+green, @Sage hi → lockoutError for Sage, lockedPanels has both", () => {
+		expect(
+			deriveComposerState({
+				text: "@Sage hi",
+				lockouts: multiLockouts(["red", "green"]),
+				personaNamesToId,
+				personaColors,
+				personaDisplayNames,
+			}),
+		).toEqual({
+			addressee: "green",
+			sendEnabled: false,
+			borderColor: "green",
+			panelHighlight: "green",
+			mentionHighlight: { start: 0, end: 5, color: "green" },
+			lockoutError: "Sage isn't reading right now",
+			lockedPanels: new Set(["red", "green"]),
+		});
+	});
+
+	it('"@Frost @Sage" + blue locked → lockoutError for Frost, lockedPanels has blue', () => {
+		expect(
+			deriveComposerState({
+				text: "@Frost @Sage",
+				lockouts: lockouts("blue"),
+				personaNamesToId,
+				personaColors,
+				personaDisplayNames,
+			}),
+		).toEqual({
+			addressee: "blue",
+			sendEnabled: false,
+			borderColor: "blue",
+			panelHighlight: "blue",
+			mentionHighlight: { start: 0, end: 6, color: "blue" },
+			lockoutError: "Frost isn't reading right now",
+			lockedPanels: new Set(["blue"]),
 		});
 	});
 });

--- a/src/spa/game/__tests__/persona-display.test.ts
+++ b/src/spa/game/__tests__/persona-display.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { displayName, lockoutErrorText } from "../persona-display.js";
+
+describe("displayName", () => {
+	it("returns the persona name", () => {
+		expect(displayName({ name: "Sage" })).toBe("Sage");
+	});
+
+	it("returns Ember for red persona", () => {
+		expect(displayName({ name: "Ember" })).toBe("Ember");
+	});
+});
+
+describe("lockoutErrorText", () => {
+	it("contains the persona name", () => {
+		const text = lockoutErrorText({ name: "Sage" });
+		expect(text).toContain("Sage");
+	});
+
+	it("is non-empty", () => {
+		const text = lockoutErrorText({ name: "Frost" });
+		expect(text.length).toBeGreaterThan(0);
+	});
+
+	it("returns expected format for Sage", () => {
+		expect(lockoutErrorText({ name: "Sage" })).toBe(
+			"Sage isn't reading right now",
+		);
+	});
+});

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -50,8 +50,13 @@ const NULL_VISUAL: Pick<
  *   or null when there is no addressee or addressee is not locked.
  */
 export function deriveComposerState(input: ComposerInput): ComposerState {
-	const { text, lockouts, personaNamesToId, personaColors, personaDisplayNames } =
-		input;
+	const {
+		text,
+		lockouts,
+		personaNamesToId,
+		personaColors,
+		personaDisplayNames,
+	} = input;
 
 	// Derive lockedPanels from the lockouts map (entries where locked === true).
 	const lockedPanels: Set<AiId> = new Set();

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -1,4 +1,5 @@
 import { findFirstMention } from "./mention-parser.js";
+import { lockoutErrorText } from "./persona-display.js";
 import type { AiId } from "./types.js";
 
 export interface ComposerInput {
@@ -6,6 +7,7 @@ export interface ComposerInput {
 	lockouts: ReadonlyMap<AiId, boolean>;
 	personaNamesToId: ReadonlyMap<string, AiId>;
 	personaColors: ReadonlyMap<AiId, string>;
+	personaDisplayNames: ReadonlyMap<AiId, string>;
 }
 
 export interface ComposerState {
@@ -17,6 +19,10 @@ export interface ComposerState {
 	panelHighlight: AiId | null;
 	/** Highlight range for the first @mention in the overlay, or null. */
 	mentionHighlight: { start: number; end: number; color: string } | null;
+	/** Inline error message when the addressed AI is chat-locked, or null. */
+	lockoutError: string | null;
+	/** Set of AiIds currently chat-locked (panel muting). */
+	lockedPanels: ReadonlySet<AiId>;
 }
 
 const NULL_VISUAL: Pick<
@@ -39,18 +45,45 @@ const NULL_VISUAL: Pick<
  * - `borderColor`, `panelHighlight`, `mentionHighlight` are populated whenever
  *   an addressee is identified — even when `sendEnabled` is false (locked
  *   addressees still get visual feedback).
+ * - `lockedPanels` is a set of all currently chat-locked AiIds (for panel muting).
+ * - `lockoutError` is the inline error string when the addressed AI is locked,
+ *   or null when there is no addressee or addressee is not locked.
  */
 export function deriveComposerState(input: ComposerInput): ComposerState {
-	const { text, lockouts, personaNamesToId, personaColors } = input;
+	const { text, lockouts, personaNamesToId, personaColors, personaDisplayNames } =
+		input;
+
+	// Derive lockedPanels from the lockouts map (entries where locked === true).
+	const lockedPanels: Set<AiId> = new Set();
+	for (const [aiId, locked] of lockouts) {
+		if (locked) lockedPanels.add(aiId);
+	}
+
 	const match = findFirstMention(text, personaNamesToId);
-	if (match === null)
-		return { addressee: null, sendEnabled: false, ...NULL_VISUAL };
+	if (match === null) {
+		return {
+			addressee: null,
+			sendEnabled: false,
+			...NULL_VISUAL,
+			lockoutError: null,
+			lockedPanels,
+		};
+	}
 
 	const { aiId: addressee, start, nameEnd, end } = match;
 	// Body is everything except the @Name token itself.
 	const bodyAfterMention = (text.slice(0, start) + text.slice(end)).trim();
-	const sendEnabled =
-		lockouts.get(addressee) !== true && bodyAfterMention.length > 0;
+	const isAddresseeLocked = lockedPanels.has(addressee);
+	const sendEnabled = !isAddresseeLocked && bodyAfterMention.length > 0;
+
+	// Inline error: only set when addressee is locked.
+	let lockoutError: string | null = null;
+	if (isAddresseeLocked) {
+		const displayName = personaDisplayNames.get(addressee);
+		if (displayName !== undefined) {
+			lockoutError = lockoutErrorText({ name: displayName });
+		}
+	}
 
 	// Visual cues are populated regardless of sendEnabled.
 	const color = personaColors.get(addressee) ?? null;
@@ -65,5 +98,7 @@ export function deriveComposerState(input: ComposerInput): ComposerState {
 		borderColor,
 		panelHighlight,
 		mentionHighlight,
+		lockoutError,
+		lockedPanels,
 	};
 }

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -184,3 +184,21 @@ export function buildPersonaColorMap(
 	}
 	return map;
 }
+
+/**
+ * Builds an AiId → display name string map from a personas record.
+ * Used by the composer reducer to look up a persona's display name when
+ * generating inline lockout error text.
+ */
+export function buildPersonaDisplayNameMap(
+	personas: Record<AiId, { name: string }>,
+): Map<AiId, string> {
+	const map = new Map<AiId, string>();
+	for (const [id, persona] of Object.entries(personas) as [
+		AiId,
+		{ name: string },
+	][]) {
+		map.set(id, persona.name);
+	}
+	return map;
+}

--- a/src/spa/game/persona-display.ts
+++ b/src/spa/game/persona-display.ts
@@ -1,0 +1,19 @@
+/**
+ * Tiny display-name helpers for persona objects.
+ * Isolates access patterns so PRD #120 can extend display logic later.
+ */
+
+/**
+ * Returns the display name of a persona.
+ */
+export function displayName(persona: { name: string }): string {
+	return persona.name;
+}
+
+/**
+ * Returns the inline error text shown when a player tries to message
+ * a persona that is currently chat-locked.
+ */
+export function lockoutErrorText(persona: { name: string }): string {
+	return `${displayName(persona)} isn't reading right now`;
+}

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -40,6 +40,7 @@
 		      <div id="prompt-overlay" aria-hidden="true"></div>
 		      <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
 		    </div>
+		    <output id="lockout-error" class="lockout-error" role="status" aria-live="polite" hidden></output>
 		    <button id="send" type="submit">Send</button>
 		  </form>
 		  <section id="cap-hit" hidden>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -245,7 +245,8 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		}
 
 		// Inline lockout error element
-		const lockoutErrorEl = doc.querySelector<HTMLOutputElement>("#lockout-error");
+		const lockoutErrorEl =
+			doc.querySelector<HTMLOutputElement>("#lockout-error");
 		if (lockoutErrorEl) {
 			if (state.lockoutError) {
 				lockoutErrorEl.textContent = state.lockoutError;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -7,6 +7,7 @@ import { GameSession } from "../game/game-session.js";
 import {
 	applyAddresseeChange,
 	buildPersonaColorMap,
+	buildPersonaDisplayNameMap,
 	buildPersonaNameMap,
 } from "../game/mention-parser.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
@@ -162,6 +163,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 	// Mention-based addressing state
 	const personaNamesToId = buildPersonaNameMap(PERSONAS);
 	const personaColors = buildPersonaColorMap(PERSONAS);
+	const personaDisplayNames = buildPersonaDisplayNameMap(PERSONAS);
 	const lockouts: Map<AiId, boolean> = new Map([
 		["red", false],
 		["green", false],
@@ -220,9 +222,12 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			lockouts,
 			personaNamesToId,
 			personaColors,
+			personaDisplayNames,
 		});
 		_sendBtn.disabled = !state.sendEnabled || roundInFlight;
 		setColorClass(_promptInput, "composer-border--", state.borderColor);
+
+		// Panel muting (panel--locked) and addressing
 		for (const aiId of AI_ORDER) {
 			const panel = doc.querySelector<HTMLElement>(
 				`.ai-panel[data-ai="${aiId}"]`,
@@ -233,7 +238,24 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			const color = personaColors.get(aiId);
 			if (color)
 				panel.classList.toggle(`panel--addressed-${color}`, isAddressed);
+			// Lock muting
+			const isLocked = state.lockedPanels.has(aiId);
+			panel.classList.toggle("panel--locked", isLocked);
+			panel.setAttribute("aria-disabled", isLocked ? "true" : "false");
 		}
+
+		// Inline lockout error element
+		const lockoutErrorEl = doc.querySelector<HTMLOutputElement>("#lockout-error");
+		if (lockoutErrorEl) {
+			if (state.lockoutError) {
+				lockoutErrorEl.textContent = state.lockoutError;
+				lockoutErrorEl.removeAttribute("hidden");
+			} else {
+				lockoutErrorEl.textContent = "";
+				lockoutErrorEl.setAttribute("hidden", "");
+			}
+		}
+
 		rebuildOverlay(overlay, _promptInput.value, state.mentionHighlight);
 		if (overlay) overlay.scrollLeft = _promptInput.scrollLeft;
 	}
@@ -448,6 +470,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			lockouts,
 			personaNamesToId,
 			personaColors,
+			personaDisplayNames,
 		});
 		if (!sendEnabled || !addressee) return;
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -101,14 +101,6 @@ main {
 	background: rgba(36, 88, 160, 0.1);
 }
 
-.ai-panel.panel--locked {
-	opacity: 0.45;
-	filter: grayscale(0.7);
-	pointer-events: none;
-}
-.ai-panel.panel--locked .panel-header {
-	opacity: 0.9;
-}
 .lockout-error {
 	color: #b83232;
 	font-size: 0.85rem;
@@ -165,6 +157,15 @@ main {
 
 .ai-panel[data-ai="blue"] .panel-header {
 	background: #2458a0;
+}
+
+.ai-panel.panel--locked {
+	opacity: 0.45;
+	filter: grayscale(0.7);
+	pointer-events: none;
+}
+.ai-panel.panel--locked .panel-header {
+	opacity: 0.9;
 }
 
 .panel-budget {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -101,6 +101,21 @@ main {
 	background: rgba(36, 88, 160, 0.1);
 }
 
+.ai-panel.panel--locked {
+	opacity: 0.45;
+	filter: grayscale(0.7);
+	pointer-events: none;
+}
+.ai-panel.panel--locked .panel-header {
+	opacity: 0.9;
+}
+.lockout-error {
+	color: #b83232;
+	font-size: 0.85rem;
+	align-self: center;
+	padding: 0 0.5rem;
+}
+
 #send {
 	padding: 0.5rem 1rem;
 	font-size: 1rem;


### PR DESCRIPTION
## What this fixes

Adds the player-facing visual side of chat lockout (#107 already enforced lockout at submit time and on panel-clicks; this slice makes it observable). Three pieces:

- **Reducer** (`src/spa/game/composer-reducer.ts`): `deriveComposerState` now produces `lockedPanels: ReadonlySet<AiId>` (built from the `lockouts` map regardless of input) and `lockoutError: string | null` (in-character text when the input's addressee is currently locked, otherwise `null`). A new `personaDisplayNames: ReadonlyMap<AiId, string>` input feeds the error text so it never hardcodes a persona name — forward-compatible with PRD #120.
- **UI wiring** (`src/spa/routes/game.ts`): `refreshComposerState()` now toggles `panel--locked` + `aria-disabled` per panel, and shows/hides `<output id="lockout-error">` based on the derived state. `setChatLockout()` already calls `refreshComposerState()`, so `chat_lockout` and `chat_lockout_resolved` events drive the muting and inline error reactively without further user input.
- **Helpers** (`src/spa/game/persona-display.ts`, NEW): `displayName(persona)` and `lockoutErrorText(persona)` — the single place wording lives, rendering `"<Name> isn't reading right now"`.

CSS adds `.ai-panel.panel--locked` (opacity 0.45 + grayscale 0.7 + `pointer-events: none`) and `.lockout-error` styling. The existing click handler still short-circuits on locked panels for defence-in-depth.

## QA steps for the human

None — fully covered by the integration smoke (jsdom integration tests for all three issue scenarios + Playwright `e2e/chat-lockout.spec.ts` passing 3/3 on `--repeat-each=3`).

## Automated coverage

`pnpm lint`, `pnpm typecheck`, `pnpm test` (567/567), `pnpm build`, `pnpm test:e2e e2e/chat-lockout.spec.ts` all pass.

Closes #111

https://claude.ai/code/session_01TTGro7yPJSY4Sm7qLaUqwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTGro7yPJSY4Sm7qLaUqwQ)_