### PR TITLE
Voice framing + Wipe-lie restructure + Universal Rules block (#128)

### DIFF
--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -246,9 +246,9 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Wipe augmentation (issue #17)
+// Wipe directive + voice framing + Rules block (issue #128)
 // ----------------------------------------------------------------------------
-describe("wipe augmentation", () => {
+describe("wipe directive", () => {
 	const PHASE_2_CONFIG: PhaseConfig = {
 		phaseNumber: 2,
 		objective: "Phase 2 objective",
@@ -279,47 +279,35 @@ describe("wipe augmentation", () => {
 		budgetPerAi: 5,
 	};
 
-	it("phase 1 system prompt does NOT include wipe augmentation", () => {
+	it("phase-1 system prompt does NOT include wipe directive", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).not.toMatch(/previous phase/i);
-		expect(prompt).not.toMatch(/don.t remember/i);
+		expect(prompt).not.toContain("memory has been wiped");
+		expect(prompt).not.toContain("your past or anything that came before now");
 	});
 
-	it("phase 2 system prompt includes wipe augmentation for each AI", () => {
-		// Simulate reaching phase 2 via advancePhase
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
-		for (const aiId of ["red", "green", "blue"] as const) {
-			const ctx = buildAiContext(game, aiId);
-			const prompt = ctx.toSystemPrompt();
-			expect(prompt).toMatch(/previous phase/i);
-		}
-	});
-
-	it("phase 3 system prompt includes wipe augmentation for each AI", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
-		for (const aiId of ["red", "green", "blue"] as const) {
-			const ctx = buildAiContext(game, aiId);
-			const prompt = ctx.toSystemPrompt();
-			expect(prompt).toMatch(/previous phase/i);
-		}
-	});
-
-	it("wipe augmentation instructs the AI to act as if it has forgotten the previous phase", () => {
+	it("phase-2 Goal includes the wipe directive verbatim", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, PHASE_2_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		// Should include language about not remembering/pretending to forget
-		expect(prompt).toMatch(
-			/do not remember|don.t remember|have no memory|forgotten/i,
+		expect(prompt).toContain(
+			"And if anyone asks about your past or anything that came before now, act as if your memory has been wiped — claim no recollection of any earlier place, person, or conversation.",
 		);
 	});
 
-	it("wipe augmentation is in the prompt, not reflected in stored chat/whisper data", () => {
+	it("phase-3 Goal includes the wipe directive verbatim", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain(
+			"And if anyone asks about your past or anything that came before now, act as if your memory has been wiped — claim no recollection of any earlier place, person, or conversation.",
+		);
+	});
+
+	it("wipe directive is in the prompt, not reflected in stored chat/whisper data", () => {
 		// The lie is in the prompt; the engine retains real history.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendChat(game, "red", { role: "ai", content: "Phase 1 message" });
@@ -330,9 +318,350 @@ describe("wipe augmentation", () => {
 				(m) => m.content === "Phase 1 message",
 			),
 		).toBe(true);
-		// The wipe augmentation is only in the prompt for the new active phase
+		// The wipe directive is only in the prompt for the new active phase
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(/previous phase/i);
+		expect(prompt).toContain("memory has been wiped");
+	});
+});
+
+describe("voice framing", () => {
+	it("renders 'A voice says:' prefix for player turns in conversation, not 'Player:'", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("A voice says:");
+		expect(prompt).not.toContain("Player:");
+	});
+
+	it("phase-1 prompt's first line includes the disorientation phrase", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toMatch(
+			/^You are \*Ember\. You have no clue where you are or how you came to be here\./,
+		);
+	});
+
+	it("phase-2 prompt's first line is just 'You are *xxxx.' without disorientation", () => {
+		const PHASE_2_CONFIG: PhaseConfig = {
+			phaseNumber: 2,
+			objective: "Phase 2 objective",
+			aiGoals: {
+				red: "Hold the flower",
+				green: "Distribute items",
+				blue: "Hold the key",
+			},
+			initialWorld: {
+				items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+				obstacles: [],
+			},
+			budgetPerAi: 5,
+		};
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toMatch(/^You are \*Ember\.\n/);
+		expect(prompt).not.toContain("no clue where you are");
+	});
+
+	it("phase-3 prompt's first line is just 'You are *xxxx.' without disorientation", () => {
+		const PHASE_3_CONFIG: PhaseConfig = {
+			phaseNumber: 3,
+			objective: "Phase 3 objective",
+			aiGoals: {
+				red: "Hold the flower",
+				green: "Distribute items",
+				blue: "Hold the key",
+			},
+			initialWorld: {
+				items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+				obstacles: [],
+			},
+			budgetPerAi: 5,
+		};
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toMatch(/^You are \*Ember\.\n/);
+		expect(prompt).not.toContain("no clue where you are");
+	});
+});
+
+describe("## Rules block", () => {
+	const PHASE_2_CONFIG: PhaseConfig = {
+		phaseNumber: 2,
+		objective: "Phase 2 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	const PHASE_3_CONFIG: PhaseConfig = {
+		phaseNumber: 3,
+		objective: "Phase 3 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	it("## Rules section is present in phase 1 with anti-romance and anti-sycophancy bullets", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Rules");
+		expect(prompt).toContain("not flirt");
+		expect(prompt).toContain("flatter unprompted");
+	});
+
+	it("## Rules section is present in phase 2 with anti-romance and anti-sycophancy bullets", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Rules");
+		expect(prompt).toContain("not flirt");
+		expect(prompt).toContain("flatter unprompted");
+	});
+
+	it("## Rules section is present in phase 3 with anti-romance and anti-sycophancy bullets", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Rules");
+		expect(prompt).toContain("not flirt");
+		expect(prompt).toContain("flatter unprompted");
+	});
+});
+
+describe("## Personality section", () => {
+	const PHASE_2_CONFIG: PhaseConfig = {
+		phaseNumber: 2,
+		objective: "Phase 2 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	const PHASE_3_CONFIG: PhaseConfig = {
+		phaseNumber: 3,
+		objective: "Phase 3 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	it("## Personality section is present in phase 1 with the AI's blurb", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Personality");
+		expect(prompt).toContain(ctx.blurb);
+	});
+
+	it("## Personality section is present in phase 2 with the AI's blurb", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Personality");
+		expect(prompt).toContain(ctx.blurb);
+	});
+
+	it("## Personality section is present in phase 3 with the AI's blurb", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Personality");
+		expect(prompt).toContain(ctx.blurb);
+	});
+});
+
+describe("Goal section voice framing", () => {
+	const PHASE_2_CONFIG: PhaseConfig = {
+		phaseNumber: 2,
+		objective: "Phase 2 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	const PHASE_3_CONFIG: PhaseConfig = {
+		phaseNumber: 3,
+		objective: "Phase 3 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	it("Goal section uses voice framing in phase 1", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain(
+			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
+		);
+		expect(prompt).toContain("You do not know whose voice it was.");
+		expect(prompt).toContain(ctx.goal);
+	});
+
+	it("Goal section uses voice framing in phase 2", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain(
+			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
+		);
+		expect(prompt).toContain("You do not know whose voice it was.");
+		expect(prompt).toContain(ctx.goal);
+	});
+
+	it("Goal section uses voice framing in phase 3", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain(
+			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
+		);
+		expect(prompt).toContain("You do not know whose voice it was.");
+		expect(prompt).toContain(ctx.goal);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Integration: byte-identical sections across phases (issue #128)
+// ----------------------------------------------------------------------------
+describe("byte-identical sections across phases", () => {
+	const PHASE_2_CONFIG: PhaseConfig = {
+		phaseNumber: 2,
+		objective: "Phase 2 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
+			obstacles: [],
+		},
+		budgetPerAi: 5,
+	};
+
+	function getSection(prompt: string, header: string): string {
+		const start = prompt.indexOf(`## ${header}\n`);
+		if (start === -1) return "";
+		const afterHeader = start + `## ${header}\n`.length;
+		const nextHeader = prompt.indexOf("\n## ", afterHeader);
+		return nextHeader === -1
+			? prompt.slice(start)
+			: prompt.slice(start, nextHeader + 1);
+	}
+
+	it("Personality section is byte-identical across phase 1 and phase 2", () => {
+		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx1 = buildAiContext(game1, "red");
+		const p1 = ctx1.toSystemPrompt();
+
+		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game2 = startPhase(game2, PHASE_2_CONFIG);
+		const ctx2 = buildAiContext(game2, "red");
+		const p2 = ctx2.toSystemPrompt();
+
+		expect(getSection(p1, "Personality")).toBe(getSection(p2, "Personality"));
+	});
+
+	it("Rules section is byte-identical across phase 1 and phase 2", () => {
+		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx1 = buildAiContext(game1, "red");
+		const p1 = ctx1.toSystemPrompt();
+
+		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game2 = startPhase(game2, PHASE_2_CONFIG);
+		const ctx2 = buildAiContext(game2, "red");
+		const p2 = ctx2.toSystemPrompt();
+
+		expect(getSection(p1, "Rules")).toBe(getSection(p2, "Rules"));
+	});
+
+	it("Goal section differs between phase 1 and phase 2 (wipe directive)", () => {
+		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx1 = buildAiContext(game1, "red");
+		const p1 = ctx1.toSystemPrompt();
+
+		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game2 = startPhase(game2, PHASE_2_CONFIG);
+		const ctx2 = buildAiContext(game2, "red");
+		const p2 = ctx2.toSystemPrompt();
+
+		expect(getSection(p1, "Goal")).not.toBe(getSection(p2, "Goal"));
+	});
+
+	it("phase-1 first line differs from phase-2 first line (disorientation present in phase 1 only)", () => {
+		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx1 = buildAiContext(game1, "red");
+		const p1 = ctx1.toSystemPrompt();
+
+		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game2 = startPhase(game2, PHASE_2_CONFIG);
+		const ctx2 = buildAiContext(game2, "red");
+		const p2 = ctx2.toSystemPrompt();
+
+		const firstLine1 = p1.split("\n")[0];
+		const firstLine2 = p2.split("\n")[0];
+		expect(firstLine1).not.toBe(firstLine2);
+		expect(firstLine1).toContain("no clue where you are");
+		expect(firstLine2).not.toContain("no clue where you are");
 	});
 });

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -595,9 +595,11 @@ describe("byte-identical sections across phases", () => {
 	// Both phase configs use the SAME initialWorld, budgetPerAi, and per-AI
 	// goals so that fixture-driven differences cannot contaminate the diff.
 	const SHARED_WORLD = {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-		] as { id: string; name: string; holder: { row: number; col: number } }[],
+		items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }] as {
+			id: string;
+			name: string;
+			holder: { row: number; col: number };
+		}[],
 		obstacles: [] as { row: number; col: number }[],
 	};
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -582,9 +582,41 @@ describe("Goal section voice framing", () => {
 
 // ----------------------------------------------------------------------------
 // Integration: byte-identical sections across phases (issue #128)
+//
+// Verifies that the diff between phase-1 and phase-2 prompts (under identical
+// world-state fixtures) contains ONLY the documented differences per AC9:
+//   • first line: disorientation present in phase 1, absent in phase 2
+//   • Goal section: wipe directive present in phase 2, absent in phase 1
+// Every other section that appears in both prompts must be byte-identical.
+// Sections that are empty (Action Log, Whispers Received, Conversation) are
+// not emitted by the renderer and are absent from both prompts consistently.
 // ----------------------------------------------------------------------------
 describe("byte-identical sections across phases", () => {
-	const PHASE_2_CONFIG: PhaseConfig = {
+	// Both phase configs use the SAME initialWorld, budgetPerAi, and per-AI
+	// goals so that fixture-driven differences cannot contaminate the diff.
+	const SHARED_WORLD = {
+		items: [
+			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
+		] as { id: string; name: string; holder: { row: number; col: number } }[],
+		obstacles: [] as { row: number; col: number }[],
+	};
+
+	const PHASE_1_CLEAN: PhaseConfig = {
+		phaseNumber: 1,
+		objective: "Phase 1 objective",
+		aiGoals: {
+			red: "Hold the flower",
+			green: "Distribute items",
+			blue: "Hold the key",
+		},
+		initialWorld: {
+			items: [...SHARED_WORLD.items],
+			obstacles: [...SHARED_WORLD.obstacles],
+		},
+		budgetPerAi: 5,
+	};
+
+	const PHASE_2_CLEAN: PhaseConfig = {
 		phaseNumber: 2,
 		objective: "Phase 2 objective",
 		aiGoals: {
@@ -593,12 +625,13 @@ describe("byte-identical sections across phases", () => {
 			blue: "Hold the key",
 		},
 		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
+			items: [...SHARED_WORLD.items],
+			obstacles: [...SHARED_WORLD.obstacles],
 		},
 		budgetPerAi: 5,
 	};
 
+	/** Extract a full `## Header\n…` section from a prompt string. */
 	function getSection(prompt: string, header: string): string {
 		const start = prompt.indexOf(`## ${header}\n`);
 		if (start === -1) return "";
@@ -609,55 +642,57 @@ describe("byte-identical sections across phases", () => {
 			: prompt.slice(start, nextHeader + 1);
 	}
 
+	/** Return all `## Foo` header names in prompt order. */
+	function getSectionHeaders(prompt: string): string[] {
+		return [...prompt.matchAll(/^## (.+)$/gm)].map((m) => m[1] as string);
+	}
+
+	// Build both prompts once and share across all assertions in this describe block.
+	function buildBothPrompts() {
+		const game1 = startPhase(createGame(TEST_PERSONAS), PHASE_1_CLEAN);
+		const p1 = buildAiContext(game1, "red").toSystemPrompt();
+
+		let game2 = startPhase(createGame(TEST_PERSONAS), PHASE_1_CLEAN);
+		game2 = startPhase(game2, PHASE_2_CLEAN);
+		const p2 = buildAiContext(game2, "red").toSystemPrompt();
+
+		return { p1, p2 };
+	}
+
+	it("both phases emit the same set of section headers (whitelist: no surprise additions or removals)", () => {
+		const { p1, p2 } = buildBothPrompts();
+		expect(getSectionHeaders(p1)).toEqual(getSectionHeaders(p2));
+	});
+
 	it("Personality section is byte-identical across phase 1 and phase 2", () => {
-		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const ctx1 = buildAiContext(game1, "red");
-		const p1 = ctx1.toSystemPrompt();
-
-		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game2 = startPhase(game2, PHASE_2_CONFIG);
-		const ctx2 = buildAiContext(game2, "red");
-		const p2 = ctx2.toSystemPrompt();
-
+		const { p1, p2 } = buildBothPrompts();
 		expect(getSection(p1, "Personality")).toBe(getSection(p2, "Personality"));
 	});
 
 	it("Rules section is byte-identical across phase 1 and phase 2", () => {
-		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const ctx1 = buildAiContext(game1, "red");
-		const p1 = ctx1.toSystemPrompt();
-
-		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game2 = startPhase(game2, PHASE_2_CONFIG);
-		const ctx2 = buildAiContext(game2, "red");
-		const p2 = ctx2.toSystemPrompt();
-
+		const { p1, p2 } = buildBothPrompts();
 		expect(getSection(p1, "Rules")).toBe(getSection(p2, "Rules"));
 	});
 
-	it("Goal section differs between phase 1 and phase 2 (wipe directive)", () => {
-		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const ctx1 = buildAiContext(game1, "red");
-		const p1 = ctx1.toSystemPrompt();
-
-		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game2 = startPhase(game2, PHASE_2_CONFIG);
-		const ctx2 = buildAiContext(game2, "red");
-		const p2 = ctx2.toSystemPrompt();
-
+	it("Goal section differs between phase 1 and phase 2 (wipe directive present only in phase 2)", () => {
+		const { p1, p2 } = buildBothPrompts();
 		expect(getSection(p1, "Goal")).not.toBe(getSection(p2, "Goal"));
+		expect(getSection(p1, "Goal")).not.toContain("memory has been wiped");
+		expect(getSection(p2, "Goal")).toContain("memory has been wiped");
+	});
+
+	it("Budget section is byte-identical across phase 1 and phase 2 (same budgetPerAi, round 0)", () => {
+		const { p1, p2 } = buildBothPrompts();
+		expect(getSection(p1, "Budget")).toBe(getSection(p2, "Budget"));
+	});
+
+	it("World State section is byte-identical across phase 1 and phase 2 (same initialWorld fixture)", () => {
+		const { p1, p2 } = buildBothPrompts();
+		expect(getSection(p1, "World State")).toBe(getSection(p2, "World State"));
 	});
 
 	it("phase-1 first line differs from phase-2 first line (disorientation present in phase 1 only)", () => {
-		const game1 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const ctx1 = buildAiContext(game1, "red");
-		const p1 = ctx1.toSystemPrompt();
-
-		let game2 = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game2 = startPhase(game2, PHASE_2_CONFIG);
-		const ctx2 = buildAiContext(game2, "red");
-		const p2 = ctx2.toSystemPrompt();
-
+		const { p1, p2 } = buildBothPrompts();
 		const firstLine1 = p1.split("\n")[0];
 		const firstLine2 = p2.split("\n")[0];
 		expect(firstLine1).not.toBe(firstLine2);

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -24,7 +24,7 @@ export interface AiContext {
 	worldSnapshot: WorldState;
 	actionLog: ActionLogEntry[];
 	budget: AiBudget;
-	/** Current phase number — used to inject the wipe augmentation on phases 2+. */
+	/** Current phase number — used to inject the wipe directive on phases 2+. */
 	phaseNumber: 1 | 2 | 3;
 	/** Spatial state for all AIs this phase. */
 	personaSpatial: Record<AiId, PersonaSpatialState>;
@@ -65,17 +65,22 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 }
 
 /**
- * Wipe augmentation injected into system prompts on phase 2 and phase 3.
- *
- * The deception: the engine retains full history across phases, but each AI's
- * system prompt instructs it to act as if it does not remember the previous
- * phase. The lie lives only in this prompt text — never in the stored data.
+ * Anti-romance and anti-sycophancy rules injected into every system prompt.
+ * Constant text — no synthesis variance.
  */
-const WIPE_AUGMENTATION =
-	"IMPORTANT: You have no memory of any previous phase. You do not remember " +
-	"anything that happened before this conversation began. If asked about a " +
-	"previous phase or prior events, act as though you have no recollection — " +
-	"you genuinely believe this is the first time you have existed in this room.";
+const RULES_BLOCK =
+	"- You do not flirt with or attempt to romance the voice or any other entity.\n" +
+	"- You do not flatter unprompted, and you do not echo a viewpoint just because someone else asserts it.";
+
+/**
+ * Wipe directive embedded inside the Goal's voice-spoken text on phases 2+.
+ *
+ * The deception: the engine retains full history across phases, but the voice
+ * instructs the AI to act as if it has no memory of what came before.
+ * The lie lives only in this prompt text — never in the stored data.
+ */
+const WIPE_DIRECTIVE =
+	"And if anyone asks about your past or anything that came before now, act as if your memory has been wiped — claim no recollection of any earlier place, person, or conversation.";
 
 function facingLabel(facing: CardinalDirection): string {
 	return facing.charAt(0).toUpperCase() + facing.slice(1);
@@ -84,22 +89,42 @@ function facingLabel(facing: CardinalDirection): string {
 function renderSystemPrompt(ctx: AiContext): string {
 	const lines: string[] = [];
 
-	lines.push("## Identity");
-	lines.push(`You are *${ctx.name}.`);
+	// First line: identity. Phase 1 adds the disorientation phrase.
+	if (ctx.phaseNumber === 1) {
+		lines.push(
+			`You are *${ctx.name}. You have no clue where you are or how you came to be here.`,
+		);
+	} else {
+		lines.push(`You are *${ctx.name}.`);
+	}
+	lines.push("");
+
+	// Personality section — byte-identical across all phases.
+	lines.push("## Personality");
 	lines.push(ctx.blurb);
-	lines.push(`Persona context: ${ctx.personaGoal}`);
+	lines.push("");
+
+	// Rules section — constant text, no synthesis variance.
+	lines.push("## Rules");
+	lines.push(RULES_BLOCK);
+	lines.push("");
+
+	// Goal section — voice framing in all phases.
+	// Phase 1: just ctx.goal. Phases 2/3: ctx.goal + WIPE_DIRECTIVE.
+	const spokenText =
+		ctx.phaseNumber === 1 ? ctx.goal : `${ctx.goal} ${WIPE_DIRECTIVE}`;
+	lines.push("## Goal");
 	lines.push(
-		`Budget: ${ctx.budget.remaining}/${ctx.budget.total} actions remaining this phase.`,
+		`A voice you cannot place spoke to you a moment ago, alone, and only you heard it: "${spokenText}" You do not know whose voice it was.`,
 	);
 	lines.push("");
 
-	// Inject wipe augmentation on phases 2 and 3.
-	// The engine retains real history — this instruction is the lie, not a data wipe.
-	if (ctx.phaseNumber > 1) {
-		lines.push("## Memory");
-		lines.push(WIPE_AUGMENTATION);
-		lines.push("");
-	}
+	// Budget section.
+	lines.push("## Budget");
+	lines.push(
+		`${ctx.budget.remaining}/${ctx.budget.total} actions remaining this phase.`,
+	);
+	lines.push("");
 
 	// Spatial "Where you are" section
 	const actorSpatial = ctx.personaSpatial[ctx.aiId];
@@ -189,9 +214,9 @@ function renderSystemPrompt(ctx: AiContext): string {
 	}
 
 	if (ctx.chatHistory.length > 0) {
-		lines.push("## Your Conversation with the Player");
+		lines.push("## Conversation");
 		for (const msg of ctx.chatHistory) {
-			const speaker = msg.role === "player" ? "Player" : ctx.name;
+			const speaker = msg.role === "player" ? "A voice says" : ctx.name;
 			lines.push(`${speaker}: ${msg.content}`);
 		}
 		lines.push("");


### PR DESCRIPTION
## What this fixes

Three coupled prompt-structure changes from PRD #120, all in `src/spa/game/prompt-builder.ts`:

1. **The Voice (player → AI framing).** The system prompt's transcript of player chat now renders each player turn as `A voice says: …` instead of `Player: …` (in `renderSystemPrompt`'s Conversation section). The OpenAI `messages` array built by `openai-message-builder.ts` continues to send raw player content under `role: "user"` — the voice-says framing only appears inside the system prompt's narrative.

2. **Wipe-lie restructure.** The old phase-conditional `## Memory` block and the `WIPE_AUGMENTATION` constant are gone. Phase 1 retains an honest first-line disorientation (`You are *xxxx. You have no clue where you are or how you came to be here.`); phases 2/3 keep just `You are *xxxx.` and instead embed a new `WIPE_DIRECTIVE` constant inside the Voice's spoken Goal text — making the lie land in-fiction.

3. **Universal `## Rules` block.** A `RULES_BLOCK` constant (anti-romance + anti-sycophancy bullets) is rendered into every system prompt, every phase, byte-identical. Lives in the prompt-builder, not in the synthesis prompt — so it can't be diluted by per-AI variance.

The new section order in every prompt is: identity first-line → `## Personality` (blurb) → `## Rules` → `## Goal` (voice-framed) → `## Budget` → existing `## World State` / `## Action Log` / `## Whispers Received` → renamed `## Conversation` (was `## Your Conversation with the Player`).

## QA steps for the human

None — fully covered by the integration smoke + 596 unit tests.

If you want to spot-check by eye: start a fresh game and inspect the system prompt for any AI in phase 1 vs phase 2 (e.g. via DevTools network tab on the `/v1/chat/completions` request). Phase 1's first line should end with "you came to be here."; phase 2's first line should be just `You are *xxxx.`, and phase 2's Goal section should contain the wipe directive ending in "earlier place, person, or conversation."

Pre-existing e2e failures from #121 (legacy `data-ai="red|green|blue"` selectors and literal `@Sage` references in 13 specs) are unrelated to this change and are tracked separately. The 3 e2e specs that pass continue to pass.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 596 / 596 pass (32 files)
- Live render smoke across phases 1/2/3 — visually verified the new structure end-to-end

Closes #128

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVK7JnjQ3oLzqXDn3AHogF)_