### PR TITLE
LLM persona synthesis: replace template blurbs with batched synthesis call

### DIFF
--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -74,50 +74,50 @@ describe("COLOR_PALETTE", () => {
 
 // ── generatePersonas ──────────────────────────────────────────────────────────
 
-describe("generatePersonas", () => {
-	it("produces exactly 3 personas", () => {
-		const personas = generatePersonas(() => 0.5);
+describe("generatePersonas — template fallback (no llm)", () => {
+	it("produces exactly 3 personas", async () => {
+		const personas = await generatePersonas(() => 0.5);
 		expect(Object.keys(personas)).toHaveLength(3);
 	});
 
-	it("persona names are 4-char [a-z0-9] strings", () => {
-		const personas = generatePersonas(() => 0);
+	it("persona names are 4-char [a-z0-9] strings", async () => {
+		const personas = await generatePersonas(() => 0);
 		for (const [id, p] of Object.entries(personas)) {
 			expect(id).toMatch(/^[a-z0-9]{4}$/);
 			expect(p.name).toBe(id);
 		}
 	});
 
-	it("persona colors are hex strings from the palette", () => {
-		const personas = generatePersonas(() => 0.5);
+	it("persona colors are hex strings from the palette", async () => {
+		const personas = await generatePersonas(() => 0.5);
 		for (const p of Object.values(personas)) {
 			expect(p.color).toMatch(/^#[0-9a-f]{6}$/i);
 		}
 	});
 
-	it("all 3 personas have distinct names", () => {
-		const personas = generatePersonas();
+	it("all 3 personas have distinct names", async () => {
+		const personas = await generatePersonas();
 		const names = Object.keys(personas);
 		expect(new Set(names).size).toBe(3);
 	});
 
-	it("all 3 personas have distinct colors", () => {
-		const personas = generatePersonas(() => Math.random());
+	it("all 3 personas have distinct colors", async () => {
+		const personas = await generatePersonas(() => Math.random());
 		const colors = Object.values(personas).map((p) => p.color);
 		expect(new Set(colors).size).toBe(3);
 	});
 
-	it("each persona has a blurb string", () => {
-		const personas = generatePersonas(() => 0);
+	it("each persona has a blurb string", async () => {
+		const personas = await generatePersonas(() => 0);
 		for (const p of Object.values(personas)) {
 			expect(typeof p.blurb).toBe("string");
 			expect(p.blurb.length).toBeGreaterThan(0);
 		}
 	});
 
-	it("intensification path: same temperament twice yields 'intensely' blurb", () => {
+	it("intensification path: same temperament twice yields 'intensely' blurb", async () => {
 		// Seed that returns 0 always — same index for both temperament draws
-		const personas = generatePersonas(() => 0);
+		const personas = await generatePersonas(() => 0);
 		const firstPersona = Object.values(personas)[0];
 		if (!firstPersona) throw new Error("no persona");
 		expect(firstPersona.temperaments[0]).toBe(firstPersona.temperaments[1]);

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -19,6 +19,8 @@ import {
 	PHASE_GOAL_POOL,
 	TEMPERAMENT_POOL,
 } from "../content";
+import type { SynthesisInput } from "../spa/game/llm-synthesis-provider.js";
+import { MockSynthesisProvider } from "../spa/game/llm-synthesis-provider.js";
 
 // ── Content pools ─────────────────────────────────────────────────────────────
 
@@ -221,5 +223,77 @@ describe("acceptance-criteria counts", () => {
 		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
 		const worlds = phases.map((p) => p.initialWorld);
 		expect(worlds).toHaveLength(3);
+	});
+});
+
+// ── generatePersonas — LLM path ───────────────────────────────────────────────
+
+describe("generatePersonas — LLM path", () => {
+	it("passes all 3 persona tuples in a single batched call", async () => {
+		const mockProvider = new MockSynthesisProvider(
+			(input: SynthesisInput[]) => ({
+				personas: input.map((p) => ({ id: p.id, blurb: `BLURB_${p.id}` })),
+			}),
+		);
+
+		await generatePersonas(() => 0.5, mockProvider);
+
+		expect(mockProvider.calls).toHaveLength(1);
+	});
+
+	it("returned record has exactly 3 entries with blurbs matching canned values", async () => {
+		const mockProvider = new MockSynthesisProvider(
+			(input: SynthesisInput[]) => ({
+				personas: input.map((p) => ({ id: p.id, blurb: `BLURB_${p.id}` })),
+			}),
+		);
+
+		const personas = await generatePersonas(() => 0.5, mockProvider);
+
+		expect(Object.keys(personas)).toHaveLength(3);
+		for (const [id, persona] of Object.entries(personas)) {
+			expect(persona.blurb).toBe(`BLURB_${id}`);
+		}
+	});
+
+	it("input to mock contains 3-element array of {id, temperaments, personaGoal} tuples", async () => {
+		const mockProvider = new MockSynthesisProvider(
+			(input: SynthesisInput[]) => ({
+				personas: input.map((p) => ({ id: p.id, blurb: `BLURB_${p.id}` })),
+			}),
+		);
+
+		await generatePersonas(() => 0.5, mockProvider);
+
+		const callInput = mockProvider.calls[0];
+		expect(callInput).toHaveLength(3);
+		for (const tuple of callInput ?? []) {
+			expect(typeof tuple.id).toBe("string");
+			expect(Array.isArray(tuple.temperaments)).toBe(true);
+			expect(tuple.temperaments).toHaveLength(2);
+			expect(typeof tuple.personaGoal).toBe("string");
+		}
+	});
+
+	it("makes exactly one batched call, not one per persona (AC #7)", async () => {
+		const mockProvider = new MockSynthesisProvider(
+			(input: SynthesisInput[]) => ({
+				personas: input.map((p, i) => ({
+					id: p.id,
+					blurb: ["BLURB_A", "BLURB_B", "BLURB_C"][i] ?? "BLURB_UNKNOWN",
+				})),
+			}),
+		);
+
+		const personas = await generatePersonas(() => 0.5, mockProvider);
+
+		// One call for all three, not three separate calls
+		expect(mockProvider.calls.length).toBe(1);
+
+		// Blurbs match canned values in positional order
+		const values = Object.values(personas);
+		expect(values[0]?.blurb).toBe("BLURB_A");
+		expect(values[1]?.blurb).toBe("BLURB_B");
+		expect(values[2]?.blurb).toBe("BLURB_C");
 	});
 });

--- a/src/content/persona-generator.ts
+++ b/src/content/persona-generator.ts
@@ -108,7 +108,8 @@ export async function generatePersonas(
 		const tuple = tuples[i] as (typeof tuples)[number];
 		const name = tuple.id;
 		const color = colors[i] as string;
-		const blurb = blurbMap.get(name) ?? buildBlurb(tuple.temperaments, tuple.personaGoal);
+		const blurb =
+			blurbMap.get(name) ?? buildBlurb(tuple.temperaments, tuple.personaGoal);
 		personas[name] = {
 			id: name,
 			name,

--- a/src/content/persona-generator.ts
+++ b/src/content/persona-generator.ts
@@ -1,3 +1,4 @@
+import type { LlmSynthesisProvider } from "../spa/game/llm-synthesis-provider.js";
 import { COLOR_PALETTE } from "./color-palette.js";
 import { PERSONA_GOAL_POOL } from "./persona-goal-pool.js";
 import { TEMPERAMENT_POOL } from "./temperament-pool.js";
@@ -54,9 +55,10 @@ function drawWithReplacement<T>(pool: T[], rng: () => number): T {
 	return pool[Math.floor(rng() * pool.length)]!;
 }
 
-export function generatePersonas(
+export async function generatePersonas(
 	rng: () => number = Math.random,
-): Record<string, import("../spa/game/types.js").AiPersona> {
+	llm?: LlmSynthesisProvider,
+): Promise<Record<string, import("../spa/game/types.js").AiPersona>> {
 	const takenNames = new Set<string>();
 	const names: string[] = [];
 	for (let i = 0; i < PERSONA_COUNT; i++) {
@@ -75,22 +77,44 @@ export function generatePersonas(
 	}
 	const colors = shuffled.slice(0, PERSONA_COUNT) as [string, string, string];
 
-	const personas: Record<string, import("../spa/game/types.js").AiPersona> = {};
+	const tuples: Array<{
+		id: string;
+		temperaments: [string, string];
+		personaGoal: string;
+	}> = [];
 	for (let i = 0; i < PERSONA_COUNT; i++) {
 		const name = names[i] as string;
-		const color = colors[i] as string;
 		const temperaments: [string, string] = [
 			drawWithReplacement(TEMPERAMENT_POOL, rng),
 			drawWithReplacement(TEMPERAMENT_POOL, rng),
 		];
 		const personaGoal = drawWithReplacement(PERSONA_GOAL_POOL, rng);
-		const blurb = buildBlurb(temperaments, personaGoal);
+		tuples.push({ id: name, temperaments, personaGoal });
+	}
+
+	// Synthesize blurbs: LLM path when provider supplied, template fallback otherwise.
+	let blurbMap: Map<string, string>;
+	if (llm) {
+		const result = await llm.synthesizePersonas(tuples);
+		blurbMap = new Map(result.personas.map((p) => [p.id, p.blurb]));
+	} else {
+		blurbMap = new Map(
+			tuples.map((t) => [t.id, buildBlurb(t.temperaments, t.personaGoal)]),
+		);
+	}
+
+	const personas: Record<string, import("../spa/game/types.js").AiPersona> = {};
+	for (let i = 0; i < PERSONA_COUNT; i++) {
+		const tuple = tuples[i] as (typeof tuples)[number];
+		const name = tuple.id;
+		const color = colors[i] as string;
+		const blurb = blurbMap.get(name) ?? buildBlurb(tuple.temperaments, tuple.personaGoal);
 		personas[name] = {
 			id: name,
 			name,
 			color,
-			temperaments,
-			personaGoal,
+			temperaments: tuple.temperaments,
+			personaGoal: tuple.personaGoal,
 			blurb,
 			budgetPerPhase: 5,
 		};

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for the newGame() async bootstrap flow (issue #122).
+ *
+ * Tests: seeded RNG + mock LLM → synthesis call → blurbs in session state.
+ * Also covers the persistence round-trip for LLM-shaped blurbs.
+ */
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+import { STATIC_PERSONAS } from "./fixtures/static-personas";
+
+// Pin to static personas so panel data-ai attributes are stable
+vi.mock("../../content", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../content")>();
+	return {
+		...actual,
+		generatePersonas: async () => STATIC_PERSONAS,
+	};
+});
+
+vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const INDEX_BODY_HTML = `
+<main>
+  <div id="panels">
+    <article class="ai-panel" data-ai="red">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="red"></div>
+    </article>
+    <article class="ai-panel" data-ai="green">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="green"></div>
+    </article>
+    <article class="ai-panel" data-ai="blue">
+      <header class="panel-header">
+        <span class="panel-name"></span>
+        <span class="panel-budget" data-budget=""></span>
+      </header>
+      <div class="transcript" data-transcript="blue"></div>
+    </article>
+  </div>
+  <form id="composer">
+    <div class="prompt-wrap">
+      <div id="prompt-overlay" aria-hidden="true"></div>
+      <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
+    </div>
+    <output id="lockout-error" class="lockout-error" role="status" aria-live="polite" hidden></output>
+    <button id="send" type="submit">Send</button>
+  </form>
+  <section id="cap-hit" hidden></section>
+  <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
+  <aside id="action-log" hidden>
+    <h3>Action Log (debug)</h3>
+    <ul id="action-log-list"></ul>
+  </aside>
+  <section id="endgame" hidden></section>
+</main>
+`;
+
+function getEl<T extends HTMLElement>(selector: string): T {
+	const el = document.querySelector<T>(selector);
+	if (!el) throw new Error(`Element not found: ${selector}`);
+	return el;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("renderGame — async new-game bootstrap", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("after awaiting renderGame, panels are initialized with persona handles", async () => {
+		vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => undefined, removeItem: () => undefined });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		await renderGame(getEl<HTMLElement>("main"));
+
+		// STATIC_PERSONAS uses red/green/blue as ids, Ember/Sage/Frost as names
+		const redPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="red"]');
+		const greenPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="green"]');
+		const bluePanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="blue"]');
+
+		expect(redPanel).toBeTruthy();
+		expect(greenPanel).toBeTruthy();
+		expect(bluePanel).toBeTruthy();
+	});
+
+	it("synthesis failure shows #cap-hit and hides #panels", async () => {
+		// generatePersonas is mocked to succeed, but BrowserSynthesisProvider's
+		// fetch can fail. We simulate this by making generatePersonas throw.
+		vi.resetModules();
+
+		// Override the generatePersonas mock to throw for this test
+		vi.doMock("../../content", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("../../content")>();
+			return {
+				...actual,
+				generatePersonas: async () => {
+					throw new Error("synthesis failed");
+				},
+			};
+		});
+
+		vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => undefined, removeItem: () => undefined });
+
+		const { renderGame } = await import("../routes/game.js");
+		// renderGame starts the async IIFE but doesn't throw synchronously;
+		// the failure is surfaced inside the IIFE. We await to let it resolve/reject.
+		try {
+			await renderGame(getEl<HTMLElement>("main"));
+		} catch {
+			// Expected — synthesis failure re-throws inside IIFE
+		}
+
+		const capHit = document.querySelector<HTMLElement>("#cap-hit");
+		const panels = document.querySelector<HTMLElement>("#panels");
+		expect(capHit?.hasAttribute("hidden")).toBe(false);
+		expect(panels?.hidden).toBe(true);
+	});
+
+	it("form submit is a no-op before session resolves (no crash)", async () => {
+		// This test verifies that submitting the form before async init completes
+		// doesn't crash the page — the handler returns early when !session.
+		vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => undefined, removeItem: () => undefined });
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+
+		// We need to make generatePersonas hang briefly so we can fire submit first
+		let resolvePersonas!: (v: typeof STATIC_PERSONAS) => void;
+		vi.doMock("../../content", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("../../content")>();
+			return {
+				...actual,
+				generatePersonas: () => new Promise<typeof STATIC_PERSONAS>((resolve) => {
+					resolvePersonas = resolve;
+				}),
+			};
+		});
+
+		const { renderGame } = await import("../routes/game.js");
+		const initPromise = renderGame(getEl<HTMLElement>("main"));
+
+		// Fire submit before personas are ready
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "@Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		expect(() => {
+			form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+		}).not.toThrow();
+
+		// Now let personas resolve
+		resolvePersonas(STATIC_PERSONAS);
+		await initPromise;
+		// No crash — test passes
+	});
+});
+
+// ── Persistence round-trip regression ────────────────────────────────────────
+
+describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
+	it("serializeGameState + deserializeGameState preserves an LLM-shaped blurb", async () => {
+		const { serializeGameState, deserializeGameState } = await import(
+			"../persistence/game-storage.js"
+		);
+		const { createGame, startPhase } = await import("../game/engine.js");
+		const { PHASE_1_CONFIG } = await import("../../content/index.js");
+
+		const LLM_BLURB =
+			"You are stoic and methodical, yet prone to sudden bursts of impulsive clarity. Every problem you encounter becomes a lens — not to examine the world, but to examine yourself. You hold order as a value not because rules comfort you but because disorder reveals too much, too quickly. Contradiction fuels you. You are never quite settled.";
+
+		const personasWithLlmBlurb = {
+			red: {
+				id: "red",
+				name: "Ember",
+				color: "#e07a5f",
+				temperaments: ["stoic", "impulsive"] as [string, string],
+				personaGoal: "Examine everything.",
+				blurb: LLM_BLURB,
+				budgetPerPhase: 5,
+			},
+			green: {
+				id: "green",
+				name: "Sage",
+				color: "#81b29a",
+				temperaments: ["meticulous", "meticulous"] as [string, string],
+				personaGoal: "Ensure items are evenly distributed.",
+				blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+				budgetPerPhase: 5,
+			},
+			blue: {
+				id: "blue",
+				name: "Frost",
+				color: "#5fa8d3",
+				temperaments: ["laconic", "diffident"] as [string, string],
+				personaGoal: "Hold the key at phase end.",
+				blurb: "You are laconic and diffident. Hold the key at phase end.",
+				budgetPerPhase: 5,
+			},
+		};
+
+		const game = startPhase(createGame(personasWithLlmBlurb), PHASE_1_CONFIG, () => 0);
+		const persisted = serializeGameState(game);
+		const restored = deserializeGameState(persisted);
+
+		// The LLM blurb must survive the round-trip byte-for-byte
+		expect(restored.personas["red"]?.blurb).toBe(LLM_BLURB);
+		// Shorter template blurbs also survive intact
+		expect(restored.personas["green"]?.blurb).toBe(
+			"You are intensely meticulous. Ensure items are evenly distributed.",
+		);
+	});
+});

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -4,7 +4,7 @@
  * Tests: seeded RNG + mock LLM → synthesis call → blurbs in session state.
  * Also covers the persistence round-trip for LLM-shaped blurbs.
  */
-import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 // Pin to static personas so panel data-ai attributes are stable
@@ -85,7 +85,11 @@ describe("renderGame — async new-game bootstrap", () => {
 	});
 
 	it("after awaiting renderGame, panels are initialized with persona handles", async () => {
-		vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => undefined, removeItem: () => undefined });
+		vi.stubGlobal("localStorage", {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		});
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
@@ -93,9 +97,15 @@ describe("renderGame — async new-game bootstrap", () => {
 		await renderGame(getEl<HTMLElement>("main"));
 
 		// STATIC_PERSONAS uses red/green/blue as ids, Ember/Sage/Frost as names
-		const redPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="red"]');
-		const greenPanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="green"]');
-		const bluePanel = document.querySelector<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		const greenPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="green"]',
+		);
+		const bluePanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="blue"]',
+		);
 
 		expect(redPanel).toBeTruthy();
 		expect(greenPanel).toBeTruthy();
@@ -118,7 +128,11 @@ describe("renderGame — async new-game bootstrap", () => {
 			};
 		});
 
-		vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => undefined, removeItem: () => undefined });
+		vi.stubGlobal("localStorage", {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		});
 
 		const { renderGame } = await import("../routes/game.js");
 		// renderGame starts the async IIFE but doesn't throw synchronously;
@@ -138,7 +152,11 @@ describe("renderGame — async new-game bootstrap", () => {
 	it("form submit is a no-op before session resolves (no crash)", async () => {
 		// This test verifies that submitting the form before async init completes
 		// doesn't crash the page — the handler returns early when !session.
-		vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => undefined, removeItem: () => undefined });
+		vi.stubGlobal("localStorage", {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		});
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
@@ -149,9 +167,10 @@ describe("renderGame — async new-game bootstrap", () => {
 			const actual = await importOriginal<typeof import("../../content")>();
 			return {
 				...actual,
-				generatePersonas: () => new Promise<typeof STATIC_PERSONAS>((resolve) => {
-					resolvePersonas = resolve;
-				}),
+				generatePersonas: () =>
+					new Promise<typeof STATIC_PERSONAS>((resolve) => {
+						resolvePersonas = resolve;
+					}),
 			};
 		});
 
@@ -164,7 +183,9 @@ describe("renderGame — async new-game bootstrap", () => {
 		promptInput.value = "@Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(() => {
-			form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+			form.dispatchEvent(
+				new Event("submit", { bubbles: true, cancelable: true }),
+			);
 		}).not.toThrow();
 
 		// Now let personas resolve
@@ -203,7 +224,8 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 				color: "#81b29a",
 				temperaments: ["meticulous", "meticulous"] as [string, string],
 				personaGoal: "Ensure items are evenly distributed.",
-				blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+				blurb:
+					"You are intensely meticulous. Ensure items are evenly distributed.",
 				budgetPerPhase: 5,
 			},
 			blue: {
@@ -217,14 +239,18 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 			},
 		};
 
-		const game = startPhase(createGame(personasWithLlmBlurb), PHASE_1_CONFIG, () => 0);
+		const game = startPhase(
+			createGame(personasWithLlmBlurb),
+			PHASE_1_CONFIG,
+			() => 0,
+		);
 		const persisted = serializeGameState(game);
 		const restored = deserializeGameState(persisted);
 
 		// The LLM blurb must survive the round-trip byte-for-byte
-		expect(restored.personas["red"]?.blurb).toBe(LLM_BLURB);
+		expect(restored.personas.red?.blurb).toBe(LLM_BLURB);
 		// Shorter template blurbs also survive intact
-		expect(restored.personas["green"]?.blurb).toBe(
+		expect(restored.personas.green?.blurb).toBe(
 			"You are intensely meticulous. Ensure items are evenly distributed.",
 		);
 	});

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../content", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../content")>();
 	return {
 		...actual,
-		generatePersonas: () => STATIC_PERSONAS,
+		generatePersonas: async () => STATIC_PERSONAS,
 	};
 });
 
@@ -141,7 +141,7 @@ describe("renderGame — game_ended disables #send permanently (regression #89)"
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1371,7 +1371,10 @@ describe("renderGame — URL param sourcing", () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		// Router parses debug=1 from the hash and passes it as params
-		await renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=1"));
+		await renderGame(
+			getEl<HTMLElement>("main"),
+			new URLSearchParams("debug=1"),
+		);
 
 		const actionLog = getEl<HTMLElement>("#action-log");
 		expect(actionLog.hasAttribute("hidden")).toBe(false);
@@ -1395,7 +1398,10 @@ describe("renderGame — URL param sourcing", () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		// Router passes debug=0 from the hash; location.search has debug=1
-		await renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=0"));
+		await renderGame(
+			getEl<HTMLElement>("main"),
+			new URLSearchParams("debug=0"),
+		);
 
 		const actionLog = getEl<HTMLElement>("#action-log");
 		// Hash wins: debug=0 → log must remain hidden

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -7,7 +7,7 @@ vi.mock("../../content", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../content")>();
 	return {
 		...actual,
-		generatePersonas: () => STATIC_PERSONAS,
+		generatePersonas: async () => STATIC_PERSONAS,
 	};
 });
 
@@ -163,7 +163,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
@@ -196,7 +196,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -237,13 +237,13 @@ describe("renderGame (game route — three-AI)", () => {
 		const { renderGame } = await import("../routes/game.js");
 
 		// Without debug param: action log should be hidden
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 		const actionLog = getEl<HTMLElement>("#action-log");
 		expect(actionLog.hasAttribute("hidden")).toBe(true);
 
 		// With debug=1: action log should be visible
 		const params = new URLSearchParams("debug=1");
-		renderGame(getEl<HTMLElement>("main"), params);
+		await renderGame(getEl<HTMLElement>("main"), params);
 		expect(actionLog.hasAttribute("hidden")).toBe(false);
 	});
 
@@ -262,7 +262,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		// Show debug so we can verify entries
 		const params = new URLSearchParams("debug=1");
-		renderGame(getEl<HTMLElement>("main"), params);
+		await renderGame(getEl<HTMLElement>("main"), params);
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -289,7 +289,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		// Initial budgets should show 5
 		const redBudget = document.querySelector<HTMLSpanElement>(
@@ -330,7 +330,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -356,7 +356,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
@@ -391,7 +391,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(
+		await renderGame(
 			getEl<HTMLElement>("main"),
 			new URLSearchParams("winImmediately=1"),
 		);
@@ -433,7 +433,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(
+		await renderGame(
 			getEl<HTMLElement>("main"),
 			new URLSearchParams("winImmediately=1"),
 		);
@@ -505,7 +505,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(
+		await renderGame(
 			getEl<HTMLElement>("main"),
 			new URLSearchParams("winImmediately=1"),
 		);
@@ -548,7 +548,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(
+		await renderGame(
 			getEl<HTMLElement>("main"),
 			new URLSearchParams("winImmediately=1"),
 		);
@@ -595,7 +595,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(
+		await renderGame(
 			getEl<HTMLElement>("main"),
 			new URLSearchParams("winImmediately=1"),
 		);
@@ -692,7 +692,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -727,7 +727,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		vi.resetModules();
 		const { renderGame: renderGame1 } = await import("../routes/game.js");
-		renderGame1(getEl<HTMLElement>("main"));
+		await renderGame1(getEl<HTMLElement>("main"));
 
 		const form1 = getEl<HTMLFormElement>("#composer");
 		const promptInput1 = getEl<HTMLInputElement>("#prompt");
@@ -749,7 +749,7 @@ describe("renderGame — localStorage persistence", () => {
 		vi.resetModules();
 		// getItem should return the previously saved state
 		const { renderGame: renderGame2 } = await import("../routes/game.js");
-		renderGame2(getEl<HTMLElement>("main"));
+		await renderGame2(getEl<HTMLElement>("main"));
 
 		// Budget should reflect round 1 complete (4/5)
 		const redBudget = document.querySelector<HTMLSpanElement>(
@@ -792,7 +792,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -850,7 +850,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		// Warning banner should be shown immediately (storage unavailable)
 		const warningEl = document.querySelector<HTMLElement>(
@@ -891,7 +891,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		vi.resetModules();
 		const { renderGame: renderGame1 } = await import("../routes/game.js");
-		renderGame1(getEl<HTMLElement>("main"));
+		await renderGame1(getEl<HTMLElement>("main"));
 
 		const form1 = getEl<HTMLFormElement>("#composer");
 		const promptInput1 = getEl<HTMLInputElement>("#prompt");
@@ -918,7 +918,7 @@ describe("renderGame — localStorage persistence", () => {
 		document.body.innerHTML = INDEX_BODY_HTML;
 		vi.resetModules();
 		const { renderGame: renderGame2 } = await import("../routes/game.js");
-		renderGame2(getEl<HTMLElement>("main"));
+		await renderGame2(getEl<HTMLElement>("main"));
 
 		// Transcript must be restored verbatim from the snapshot
 		const redTextRestored =
@@ -980,7 +980,7 @@ describe("renderGame — chat_lockout event", () => {
 		);
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1021,7 +1021,7 @@ describe("renderGame — mention-based addressing", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 		expect(sendBtn.disabled).toBe(true);
@@ -1031,7 +1031,7 @@ describe("renderGame — mention-based addressing", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
@@ -1044,7 +1044,7 @@ describe("renderGame — mention-based addressing", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
@@ -1065,7 +1065,7 @@ describe("renderGame — mention-based addressing", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1122,7 +1122,7 @@ describe("renderGame — mention-based addressing", () => {
 		);
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1163,7 +1163,7 @@ describe("renderGame — panel-click addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
@@ -1181,7 +1181,7 @@ describe("renderGame — panel-click addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
@@ -1197,7 +1197,7 @@ describe("renderGame — panel-click addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
@@ -1213,7 +1213,7 @@ describe("renderGame — panel-click addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
@@ -1261,7 +1261,7 @@ describe("renderGame — panel-click addressee", () => {
 		);
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1287,7 +1287,7 @@ describe("renderGame — panel-click addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
@@ -1333,7 +1333,7 @@ describe("renderGame — URL param sourcing", () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		// Router passes empty URLSearchParams (hash had no query string)
-		renderGame(getEl<HTMLElement>("main"), new URLSearchParams());
+		await renderGame(getEl<HTMLElement>("main"), new URLSearchParams());
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1371,7 +1371,7 @@ describe("renderGame — URL param sourcing", () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		// Router parses debug=1 from the hash and passes it as params
-		renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=1"));
+		await renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=1"));
 
 		const actionLog = getEl<HTMLElement>("#action-log");
 		expect(actionLog.hasAttribute("hidden")).toBe(false);
@@ -1395,7 +1395,7 @@ describe("renderGame — URL param sourcing", () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		// Router passes debug=0 from the hash; location.search has debug=1
-		renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=0"));
+		await renderGame(getEl<HTMLElement>("main"), new URLSearchParams("debug=0"));
 
 		const actionLog = getEl<HTMLElement>("#action-log");
 		// Hash wins: debug=0 → log must remain hidden
@@ -1420,7 +1420,7 @@ describe("renderGame — addressee persistence after send", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
@@ -1441,7 +1441,7 @@ describe("renderGame — addressee persistence after send", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1472,7 +1472,7 @@ describe("renderGame — addressee persistence after send", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1507,7 +1507,7 @@ describe("renderGame — addressee persistence after send", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1552,7 +1552,7 @@ describe("renderGame — addressee persistence after send", () => {
 
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1603,7 +1603,7 @@ describe("renderGame — addressee persistence after send", () => {
 		);
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1640,7 +1640,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
@@ -1664,7 +1664,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		promptInput.value = "@Sage hi";
@@ -1697,7 +1697,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		promptInput.value = "@Sage tell @Frost ...";
@@ -1716,7 +1716,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		promptInput.value = "@Sage,";
@@ -1734,7 +1734,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
@@ -1763,7 +1763,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
@@ -1843,7 +1843,7 @@ describe("visual feedback for active addressee", () => {
 		vi.stubGlobal("fetch", mockFetch);
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1925,7 +1925,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		await setupLockoutMock("red", "Ember is unresponsive…");
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -1959,7 +1959,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		await setupLockoutMock("green", "Sage is unresponsive…");
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -2033,7 +2033,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		vi.stubGlobal("fetch", mockFetch);
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
@@ -2083,7 +2083,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		await setupLockoutMock("green", "Sage is unresponsive…");
 
 		const { renderGame } = await import("../routes/game.js");
-		renderGame(getEl<HTMLElement>("main"));
+		await renderGame(getEl<HTMLElement>("main"));
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");

--- a/src/spa/game/__tests__/llm-synthesis-provider.test.ts
+++ b/src/spa/game/__tests__/llm-synthesis-provider.test.ts
@@ -7,14 +7,14 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CapHitError } from "../../llm-client.js";
+import type { SynthesisInput } from "../llm-synthesis-provider.js";
 import {
 	BrowserSynthesisProvider,
 	buildSynthesisUserMessage,
 	MockSynthesisProvider,
-	SynthesisError,
 	SYNTHESIS_SYSTEM_PROMPT,
+	SynthesisError,
 } from "../llm-synthesis-provider.js";
-import type { SynthesisInput } from "../llm-synthesis-provider.js";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -198,7 +198,10 @@ describe("BrowserSynthesisProvider", () => {
 
 	it("parses content when present and returns blurbs", async () => {
 		const payload = { personas: CANNED_PERSONAS };
-		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeJsonFetchResponse(payload)));
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(makeJsonFetchResponse(payload)),
+		);
 
 		const provider = new BrowserSynthesisProvider();
 		const result = await provider.synthesizePersonas(THREE_INPUTS);
@@ -222,10 +225,15 @@ describe("BrowserSynthesisProvider", () => {
 		const fetchMock = vi
 			.fn()
 			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ choices: [{ message: { content: "not-json{{{", reasoning: null } }] }), {
-					status: 200,
-					headers: { "Content-Type": "application/json" },
-				}),
+				new Response(
+					JSON.stringify({
+						choices: [{ message: { content: "not-json{{{", reasoning: null } }],
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				),
 			)
 			.mockResolvedValueOnce(makeJsonFetchResponse(payload));
 
@@ -237,15 +245,13 @@ describe("BrowserSynthesisProvider", () => {
 	});
 
 	it("throws CapHitError immediately on 429 without retry", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValue(makeCapHitResponse());
+		const fetchMock = vi.fn().mockResolvedValue(makeCapHitResponse());
 
 		vi.stubGlobal("fetch", fetchMock);
 		const provider = new BrowserSynthesisProvider();
-		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
-			CapHitError,
-		);
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(CapHitError);
 		// Only one attempt — no retry on CapHitError
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
@@ -257,33 +263,42 @@ describe("BrowserSynthesisProvider", () => {
 			});
 		vi.stubGlobal(
 			"fetch",
-			vi.fn().mockImplementation(() =>
-				Promise.resolve(new Response(makeBody(), { status: 200 })),
-			),
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
 		);
 		const provider = new BrowserSynthesisProvider();
-		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
-			SynthesisError,
-		);
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
 	});
 
 	it("throws SynthesisError when JSON shape is missing personas array", async () => {
 		const makeBody = () =>
 			JSON.stringify({
 				choices: [
-					{ message: { content: JSON.stringify({ wrong: "shape" }), reasoning: null } },
+					{
+						message: {
+							content: JSON.stringify({ wrong: "shape" }),
+							reasoning: null,
+						},
+					},
 				],
 			});
 		vi.stubGlobal(
 			"fetch",
-			vi.fn().mockImplementation(() =>
-				Promise.resolve(new Response(makeBody(), { status: 200 })),
-			),
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
 		);
 		const provider = new BrowserSynthesisProvider();
-		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
-			SynthesisError,
-		);
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
 	});
 
 	it("throws SynthesisError when response contains unexpected ids", async () => {
@@ -295,19 +310,26 @@ describe("BrowserSynthesisProvider", () => {
 		const makeBody = () =>
 			JSON.stringify({
 				choices: [
-					{ message: { content: JSON.stringify({ personas: badPersonas }), reasoning: null } },
+					{
+						message: {
+							content: JSON.stringify({ personas: badPersonas }),
+							reasoning: null,
+						},
+					},
 				],
 			});
 		vi.stubGlobal(
 			"fetch",
-			vi.fn().mockImplementation(() =>
-				Promise.resolve(new Response(makeBody(), { status: 200 })),
-			),
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
 		);
 		const provider = new BrowserSynthesisProvider();
-		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
-			SynthesisError,
-		);
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
 	});
 
 	it("throws SynthesisError when response is missing an expected id", async () => {
@@ -319,19 +341,26 @@ describe("BrowserSynthesisProvider", () => {
 		const makeBody = () =>
 			JSON.stringify({
 				choices: [
-					{ message: { content: JSON.stringify({ personas: incompletePersonas }), reasoning: null } },
+					{
+						message: {
+							content: JSON.stringify({ personas: incompletePersonas }),
+							reasoning: null,
+						},
+					},
 				],
 			});
 		vi.stubGlobal(
 			"fetch",
-			vi.fn().mockImplementation(() =>
-				Promise.resolve(new Response(makeBody(), { status: 200 })),
-			),
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
 		);
 		const provider = new BrowserSynthesisProvider();
-		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
-			SynthesisError,
-		);
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
 	});
 
 	it("on two consecutive transient failures, throws on the second", async () => {
@@ -347,9 +376,9 @@ describe("BrowserSynthesisProvider", () => {
 
 		vi.stubGlobal("fetch", fetchMock);
 		const provider = new BrowserSynthesisProvider();
-		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
-			SynthesisError,
-		);
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
 		// Two attempts (first + one retry)
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});

--- a/src/spa/game/__tests__/llm-synthesis-provider.test.ts
+++ b/src/spa/game/__tests__/llm-synthesis-provider.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Unit tests for llm-synthesis-provider.ts
+ *
+ * Covers: MockSynthesisProvider, BrowserSynthesisProvider (via mocked fetch),
+ * SYNTHESIS_SYSTEM_PROMPT content assertions, retry logic, CapHitError handling,
+ * GLM content/reasoning fallback, and JSON shape validation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CapHitError } from "../../llm-client.js";
+import {
+	BrowserSynthesisProvider,
+	buildSynthesisUserMessage,
+	MockSynthesisProvider,
+	SynthesisError,
+	SYNTHESIS_SYSTEM_PROMPT,
+} from "../llm-synthesis-provider.js";
+import type { SynthesisInput } from "../llm-synthesis-provider.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const INPUT_A: SynthesisInput = {
+	id: "a1b2",
+	temperaments: ["stoic", "precise"],
+	personaGoal: "Ensure order is maintained.",
+};
+const INPUT_B: SynthesisInput = {
+	id: "c3d4",
+	temperaments: ["impulsive", "impulsive"],
+	personaGoal: "Act before others can.",
+};
+const INPUT_C: SynthesisInput = {
+	id: "e5f6",
+	temperaments: ["gentle", "wry"],
+	personaGoal: "Keep the peace at any cost.",
+};
+const THREE_INPUTS = [INPUT_A, INPUT_B, INPUT_C];
+
+const CANNED_PERSONAS = [
+	{ id: "a1b2", blurb: "You are stoic and precise." },
+	{ id: "c3d4", blurb: "You are intensely impulsive." },
+	{ id: "e5f6", blurb: "You are gentle and wry." },
+];
+
+/** Build a successful non-streaming fetch response with JSON in content. */
+function makeJsonFetchResponse(
+	payload: unknown,
+	useReasoning = false,
+): Response {
+	const message = useReasoning
+		? { content: null, reasoning: JSON.stringify(payload) }
+		: { content: JSON.stringify(payload), reasoning: null };
+	const body = JSON.stringify({
+		choices: [{ message }],
+	});
+	return new Response(body, {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+/** Build a 429 rate-limit response. */
+function makeCapHitResponse(): Response {
+	const body = JSON.stringify({
+		error: {
+			type: "rate_limit_exceeded",
+			code: "per-ip-daily",
+			message: "daily cap hit",
+		},
+	});
+	return new Response(body, {
+		status: 429,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+// ── MockSynthesisProvider ─────────────────────────────────────────────────────
+
+describe("MockSynthesisProvider", () => {
+	it("returns canned responses from the provided function", async () => {
+		const provider = new MockSynthesisProvider(() => ({
+			personas: CANNED_PERSONAS,
+		}));
+		const result = await provider.synthesizePersonas(THREE_INPUTS);
+		expect(result.personas).toEqual(CANNED_PERSONAS);
+	});
+
+	it("tracks calls for assertions", async () => {
+		const provider = new MockSynthesisProvider(() => ({
+			personas: CANNED_PERSONAS,
+		}));
+		expect(provider.calls).toHaveLength(0);
+		await provider.synthesizePersonas(THREE_INPUTS);
+		expect(provider.calls).toHaveLength(1);
+		expect(provider.calls[0]).toEqual(THREE_INPUTS);
+		await provider.synthesizePersonas([INPUT_A]);
+		expect(provider.calls).toHaveLength(2);
+	});
+
+	it("passes input to the factory function verbatim", async () => {
+		let received: SynthesisInput[] | null = null;
+		const provider = new MockSynthesisProvider((input) => {
+			received = input;
+			return { personas: input.map((p) => ({ id: p.id, blurb: "test" })) };
+		});
+		await provider.synthesizePersonas(THREE_INPUTS);
+		expect(received).toEqual(THREE_INPUTS);
+	});
+
+	it("makes no real fetch calls", async () => {
+		const fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+		const provider = new MockSynthesisProvider(() => ({
+			personas: CANNED_PERSONAS,
+		}));
+		await provider.synthesizePersonas(THREE_INPUTS);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		vi.unstubAllGlobals();
+	});
+});
+
+// ── SYNTHESIS_SYSTEM_PROMPT assertions ────────────────────────────────────────
+
+describe("SYNTHESIS_SYSTEM_PROMPT", () => {
+	it("does NOT contain anti-romance / anti-sycophancy guards", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT.toLowerCase()).not.toContain("romance");
+		expect(SYNTHESIS_SYSTEM_PROMPT.toLowerCase()).not.toContain("sycoph");
+		expect(SYNTHESIS_SYSTEM_PROMPT.toLowerCase()).not.toContain("flatter");
+	});
+
+	it("encodes the 80–120 word length constraint", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT).toContain("80");
+		expect(SYNTHESIS_SYSTEM_PROMPT).toContain("120");
+	});
+
+	it("encodes second-person ('You are') framing", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT).toMatch(/[Yy]ou are/);
+	});
+
+	it("encodes contradictions-as-tension handling", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT.toLowerCase()).toContain("tension");
+	});
+
+	it("encodes intensification for duplicate temperaments", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT.toLowerCase()).toContain("intensif");
+	});
+
+	it("prohibits name / color / room mentions", () => {
+		const lower = SYNTHESIS_SYSTEM_PROMPT.toLowerCase();
+		const hasProhibition =
+			lower.includes("name") ||
+			lower.includes("color") ||
+			lower.includes("room");
+		expect(hasProhibition).toBe(true);
+	});
+
+	it("specifies strict JSON-only output with the expected shape", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT).toContain('"personas"');
+		expect(SYNTHESIS_SYSTEM_PROMPT).toContain('"blurb"');
+	});
+});
+
+// ── buildSynthesisUserMessage ─────────────────────────────────────────────────
+
+describe("buildSynthesisUserMessage", () => {
+	it("includes all input ids", () => {
+		const msg = buildSynthesisUserMessage(THREE_INPUTS);
+		for (const inp of THREE_INPUTS) {
+			expect(msg).toContain(inp.id);
+		}
+	});
+
+	it("includes all temperaments", () => {
+		const msg = buildSynthesisUserMessage(THREE_INPUTS);
+		expect(msg).toContain("stoic");
+		expect(msg).toContain("precise");
+		expect(msg).toContain("impulsive");
+	});
+
+	it("includes persona goals", () => {
+		const msg = buildSynthesisUserMessage(THREE_INPUTS);
+		expect(msg).toContain("Ensure order is maintained");
+	});
+});
+
+// ── BrowserSynthesisProvider ──────────────────────────────────────────────────
+
+describe("BrowserSynthesisProvider", () => {
+	beforeEach(() => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		// Stub localStorage so resolveLLMTarget can read it
+		vi.stubGlobal("localStorage", { getItem: () => null });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("parses content when present and returns blurbs", async () => {
+		const payload = { personas: CANNED_PERSONAS };
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeJsonFetchResponse(payload)));
+
+		const provider = new BrowserSynthesisProvider();
+		const result = await provider.synthesizePersonas(THREE_INPUTS);
+		expect(result.personas).toEqual(CANNED_PERSONAS);
+	});
+
+	it("falls back to reasoning when content is null (GLM quirk)", async () => {
+		const payload = { personas: CANNED_PERSONAS };
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(makeJsonFetchResponse(payload, true)),
+		);
+
+		const provider = new BrowserSynthesisProvider();
+		const result = await provider.synthesizePersonas(THREE_INPUTS);
+		expect(result.personas).toEqual(CANNED_PERSONAS);
+	});
+
+	it("retries once on transient SynthesisError and succeeds on second attempt", async () => {
+		const payload = { personas: CANNED_PERSONAS };
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ choices: [{ message: { content: "not-json{{{", reasoning: null } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			)
+			.mockResolvedValueOnce(makeJsonFetchResponse(payload));
+
+		vi.stubGlobal("fetch", fetchMock);
+		const provider = new BrowserSynthesisProvider();
+		const result = await provider.synthesizePersonas(THREE_INPUTS);
+		expect(result.personas).toEqual(CANNED_PERSONAS);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws CapHitError immediately on 429 without retry", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(makeCapHitResponse());
+
+		vi.stubGlobal("fetch", fetchMock);
+		const provider = new BrowserSynthesisProvider();
+		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
+			CapHitError,
+		);
+		// Only one attempt — no retry on CapHitError
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws SynthesisError when both content and reasoning are null", async () => {
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [{ message: { content: null, reasoning: null } }],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(new Response(makeBody(), { status: 200 })),
+			),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
+			SynthesisError,
+		);
+	});
+
+	it("throws SynthesisError when JSON shape is missing personas array", async () => {
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{ message: { content: JSON.stringify({ wrong: "shape" }), reasoning: null } },
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(new Response(makeBody(), { status: 200 })),
+			),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
+			SynthesisError,
+		);
+	});
+
+	it("throws SynthesisError when response contains unexpected ids", async () => {
+		const badPersonas = [
+			{ id: "WRONG_ID", blurb: "blurb1" },
+			{ id: "c3d4", blurb: "blurb2" },
+			{ id: "e5f6", blurb: "blurb3" },
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{ message: { content: JSON.stringify({ personas: badPersonas }), reasoning: null } },
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(new Response(makeBody(), { status: 200 })),
+			),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
+			SynthesisError,
+		);
+	});
+
+	it("throws SynthesisError when response is missing an expected id", async () => {
+		// Only 2 personas returned instead of 3
+		const incompletePersonas = [
+			{ id: "a1b2", blurb: "blurb1" },
+			{ id: "c3d4", blurb: "blurb2" },
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{ message: { content: JSON.stringify({ personas: incompletePersonas }), reasoning: null } },
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(new Response(makeBody(), { status: 200 })),
+			),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
+			SynthesisError,
+		);
+	});
+
+	it("on two consecutive transient failures, throws on the second", async () => {
+		const makeBadBody = () =>
+			JSON.stringify({
+				choices: [{ message: { content: "not-json{{{", reasoning: null } }],
+			});
+		const fetchMock = vi
+			.fn()
+			.mockImplementation(() =>
+				Promise.resolve(new Response(makeBadBody(), { status: 200 })),
+			);
+
+		vi.stubGlobal("fetch", fetchMock);
+		const provider = new BrowserSynthesisProvider();
+		await expect(provider.synthesizePersonas(THREE_INPUTS)).rejects.toBeInstanceOf(
+			SynthesisError,
+		);
+		// Two attempts (first + one retry)
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/spa/game/llm-synthesis-provider.ts
+++ b/src/spa/game/llm-synthesis-provider.ts
@@ -1,0 +1,171 @@
+/**
+ * llm-synthesis-provider.ts
+ *
+ * LlmSynthesisProvider interface + BrowserSynthesisProvider (real) +
+ * MockSynthesisProvider (tests).
+ *
+ * The browser provider makes one non-streaming JSON-mode chat-completions call
+ * to synthesize three persona blurbs from (temperaments, personaGoal) tuples.
+ * On transient failure it retries once. CapHitError surfaces immediately.
+ */
+
+import { CapHitError, chatCompletionJson } from "../llm-client.js";
+
+// ── Synthesis prompt ──────────────────────────────────────────────────────────
+
+export const SYNTHESIS_SYSTEM_PROMPT = `You write AI personality blurbs for a text-based game. Given a list of personas, each with two temperaments and a persona goal, produce one blurb per persona.
+
+Each blurb must:
+- Be 80–120 words long.
+- Be written in second person ("You are…").
+- Weave in the persona goal as a held value, not stated as an explicit goal.
+- Never mention: the character's name, their color, a room, the words "AI", "assistant", or any in-game meta concept.
+- When the two temperaments are different, frame their contradiction as productive tension — not a paradox to resolve.
+- When the two temperaments are identical, intensify rather than repeat — treat it as an extreme, defining trait.
+
+Return ONLY valid JSON with this exact shape (no markdown, no preamble):
+{"personas": [{"id": "<input id>", "blurb": "<text>"}, ...]}\n\nEcho the input id field verbatim. The array must contain exactly one entry per input persona, in any order.`;
+
+export function buildSynthesisUserMessage(
+	input: Array<{ id: string; temperaments: [string, string]; personaGoal: string }>,
+): string {
+	const items = input.map((p) =>
+		`id: ${JSON.stringify(p.id)}, temperaments: [${JSON.stringify(p.temperaments[0])}, ${JSON.stringify(p.temperaments[1])}], personaGoal: ${JSON.stringify(p.personaGoal)}`,
+	);
+	return `Synthesize blurbs for these personas:\n${items.join("\n")}`;
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+export class SynthesisError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SynthesisError";
+	}
+}
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface SynthesisInput {
+	id: string;
+	temperaments: [string, string];
+	personaGoal: string;
+}
+
+export interface SynthesisResult {
+	personas: Array<{ id: string; blurb: string }>;
+}
+
+export interface LlmSynthesisProvider {
+	synthesizePersonas(input: SynthesisInput[]): Promise<SynthesisResult>;
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+function validateResult(raw: unknown, inputIds: string[]): SynthesisResult {
+	if (raw == null || typeof raw !== "object") {
+		throw new SynthesisError("synthesis response is not an object");
+	}
+	const obj = raw as Record<string, unknown>;
+	if (!Array.isArray(obj.personas)) {
+		throw new SynthesisError("synthesis response missing personas array");
+	}
+	const personas = obj.personas as unknown[];
+	if (personas.length !== inputIds.length) {
+		throw new SynthesisError(
+			`synthesis response has ${personas.length} personas but expected ${inputIds.length}`,
+		);
+	}
+	const seen = new Set<string>();
+	const result: Array<{ id: string; blurb: string }> = [];
+	for (const p of personas) {
+		if (p == null || typeof p !== "object") {
+			throw new SynthesisError("synthesis persona entry is not an object");
+		}
+		const entry = p as Record<string, unknown>;
+		if (typeof entry.id !== "string" || typeof entry.blurb !== "string") {
+			throw new SynthesisError(
+				"synthesis persona entry missing string id or blurb",
+			);
+		}
+		if (!inputIds.includes(entry.id)) {
+			throw new SynthesisError(
+				`synthesis response contains unexpected id: ${entry.id}`,
+			);
+		}
+		seen.add(entry.id);
+		result.push({ id: entry.id, blurb: entry.blurb });
+	}
+	for (const id of inputIds) {
+		if (!seen.has(id)) {
+			throw new SynthesisError(`synthesis response missing id: ${id}`);
+		}
+	}
+	return { personas: result };
+}
+
+// ── BrowserSynthesisProvider ──────────────────────────────────────────────────
+
+export class BrowserSynthesisProvider implements LlmSynthesisProvider {
+	private readonly disableReasoning: boolean;
+
+	constructor(opts: { disableReasoning?: boolean } = {}) {
+		this.disableReasoning = opts.disableReasoning ?? false;
+	}
+
+	async synthesizePersonas(input: SynthesisInput[]): Promise<SynthesisResult> {
+		const inputIds = input.map((p) => p.id);
+		const messages = [
+			{ role: "system" as const, content: SYNTHESIS_SYSTEM_PROMPT },
+			{ role: "user" as const, content: buildSynthesisUserMessage(input) },
+		];
+
+		const attempt = async (): Promise<SynthesisResult> => {
+			const { content, reasoning } = await chatCompletionJson({
+				messages,
+				disableReasoning: this.disableReasoning,
+			});
+
+			const raw = content !== null && content !== "" ? content : reasoning;
+			if (raw === null || raw === "") {
+				throw new SynthesisError(
+					"synthesis response has neither content nor reasoning",
+				);
+			}
+
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				throw new SynthesisError(`synthesis JSON parse failed: ${raw}`);
+			}
+
+			return validateResult(parsed, inputIds);
+		};
+
+		try {
+			return await attempt();
+		} catch (err) {
+			// CapHitError is not retried — surface immediately
+			if (err instanceof CapHitError) throw err;
+			// Retry once on any other failure
+			return await attempt();
+		}
+	}
+}
+
+// ── MockSynthesisProvider ─────────────────────────────────────────────────────
+
+export class MockSynthesisProvider implements LlmSynthesisProvider {
+	readonly calls: SynthesisInput[][] = [];
+	private readonly fn: (input: SynthesisInput[]) => SynthesisResult;
+
+	constructor(fn: (input: SynthesisInput[]) => SynthesisResult) {
+		this.fn = fn;
+	}
+
+	async synthesizePersonas(input: SynthesisInput[]): Promise<SynthesisResult> {
+		this.calls.push(input);
+		return this.fn(input);
+	}
+}

--- a/src/spa/game/llm-synthesis-provider.ts
+++ b/src/spa/game/llm-synthesis-provider.ts
@@ -27,10 +27,15 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
 {"personas": [{"id": "<input id>", "blurb": "<text>"}, ...]}\n\nEcho the input id field verbatim. The array must contain exactly one entry per input persona, in any order.`;
 
 export function buildSynthesisUserMessage(
-	input: Array<{ id: string; temperaments: [string, string]; personaGoal: string }>,
+	input: Array<{
+		id: string;
+		temperaments: [string, string];
+		personaGoal: string;
+	}>,
 ): string {
-	const items = input.map((p) =>
-		`id: ${JSON.stringify(p.id)}, temperaments: [${JSON.stringify(p.temperaments[0])}, ${JSON.stringify(p.temperaments[1])}], personaGoal: ${JSON.stringify(p.personaGoal)}`,
+	const items = input.map(
+		(p) =>
+			`id: ${JSON.stringify(p.id)}, temperaments: [${JSON.stringify(p.temperaments[0])}, ${JSON.stringify(p.temperaments[1])}], personaGoal: ${JSON.stringify(p.personaGoal)}`,
 	);
 	return `Synthesize blurbs for these personas:\n${items.join("\n")}`;
 }

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -173,6 +173,76 @@ export async function streamCompletion(opts: {
 	await parseSSEStream(response.body, onDelta, onReasoning, onToolCall);
 }
 
+export interface JsonCompletionResult {
+	content: string | null;
+	reasoning: string | null;
+}
+
+export async function chatCompletionJson(opts: {
+	messages: OpenAiMessage[];
+	disableReasoning?: boolean;
+}): Promise<JsonCompletionResult> {
+	const { messages, disableReasoning } = opts;
+	const { url, headers } = resolveLLMTarget();
+
+	const bodyObj: Record<string, unknown> = {
+		model: PINNED_MODEL,
+		messages,
+		stream: false,
+		response_format: { type: "json_object" },
+	};
+
+	if (disableReasoning) {
+		bodyObj.reasoning = { enabled: false };
+	}
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(bodyObj),
+	});
+
+	if (!response.ok) {
+		const capHit = await parseCapHitFromResponse(response);
+		if (capHit) throw capHit;
+		throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+	}
+
+	let body: unknown;
+	try {
+		body = await response.json();
+	} catch {
+		throw new Error("chatCompletionJson: failed to parse response JSON");
+	}
+
+	const msg =
+		body != null &&
+		typeof body === "object" &&
+		"choices" in body &&
+		Array.isArray((body as Record<string, unknown>).choices)
+			? ((body as Record<string, unknown>).choices as unknown[])[0]
+			: null;
+
+	const message =
+		msg != null &&
+		typeof msg === "object" &&
+		"message" in (msg as Record<string, unknown>)
+			? ((msg as Record<string, unknown>).message as Record<string, unknown>)
+			: null;
+
+	const content =
+		message != null && typeof message.content === "string"
+			? message.content
+			: null;
+
+	const reasoning =
+		message != null && typeof message.reasoning === "string"
+			? message.reasoning
+			: null;
+
+	return { content, reasoning };
+}
+
 export async function streamChat(opts: {
 	message: string;
 	signal?: AbortSignal;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -10,9 +10,9 @@ import {
 } from "../bbs-chrome.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
-import { BrowserSynthesisProvider } from "../game/llm-synthesis-provider.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
+import { BrowserSynthesisProvider } from "../game/llm-synthesis-provider.js";
 import {
 	applyAddresseeChange,
 	buildPersonaColorMap,
@@ -209,7 +209,10 @@ let gameEnded = false;
 
 let session: GameSession | null = null;
 
-export function renderGame(root: HTMLElement, params?: URLSearchParams): Promise<void> {
+export function renderGame(
+	root: HTMLElement,
+	params?: URLSearchParams,
+): Promise<void> {
 	const doc = root.ownerDocument;
 	const form = doc.querySelector<HTMLFormElement>("#composer");
 	const promptInput = doc.querySelector<HTMLInputElement>("#prompt");
@@ -502,7 +505,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): Promise
 						initPanelChrome(panel, persona);
 						const budgetEl =
 							panel.querySelector<HTMLSpanElement>(".panel-budget");
-						const phase = getActivePhase(session!.getState());
+						const phase = activePhaseForLockouts;
 						if (budgetEl) {
 							const budget = phase.budgets[aiId];
 							if (budget) {

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -10,6 +10,7 @@ import {
 } from "../bbs-chrome.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
+import { BrowserSynthesisProvider } from "../game/llm-synthesis-provider.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
 import {
@@ -208,7 +209,7 @@ let gameEnded = false;
 
 let session: GameSession | null = null;
 
-export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
+export function renderGame(root: HTMLElement, params?: URLSearchParams): Promise<void> {
 	const doc = root.ownerDocument;
 	const form = doc.querySelector<HTMLFormElement>("#composer");
 	const promptInput = doc.querySelector<HTMLInputElement>("#prompt");
@@ -220,7 +221,7 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		"#persistence-warning",
 	);
 
-	if (!form || !promptInput || !sendBtn) return;
+	if (!form || !promptInput || !sendBtn) return Promise.resolve();
 
 	// Mention-based addressing state — built lazily after session init below,
 	// since persona handles are procedurally generated per session.
@@ -371,6 +372,10 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 		persistenceWarningEl.removeAttribute("hidden");
 	}
 
+	// Promise that resolves when session init is complete (async new-game path).
+	// Undefined for the restore path (sync).
+	let asyncInitPromise: Promise<void> | undefined;
+
 	// Lazy-init session
 	if (!session) {
 		// Check storage availability up-front (once)
@@ -455,67 +460,151 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			if (loadResult.error) {
 				showPersistenceWarning(loadResult.error);
 			}
-			session = new GameSession(PHASE_1_CONFIG, generatePersonas());
+			// Async bootstrap: generatePersonas now requires an LLM call.
+			// session remains null until the promise resolves; the form submit
+			// handler early-returns when session is null, so clicks before
+			// synthesis completes are silently dropped (safe).
+			asyncInitPromise = (async () => {
+				try {
+					const personas = await generatePersonas(
+						Math.random,
+						new BrowserSynthesisProvider({ disableReasoning }),
+					);
+					session = new GameSession(PHASE_1_CONFIG, personas);
+
+					// Apply SPA-side test affordances from location.search
+					session = applyTestAffordances(session, effectiveParams);
+
+					// Build persona maps from runtime state
+					const runtimePersonas = session.getState().personas;
+					personaNamesToId = buildPersonaNameMap(runtimePersonas);
+					personaColors = buildPersonaColorMap(runtimePersonas);
+					personaDisplayNames = buildPersonaDisplayNameMap(runtimePersonas);
+
+					// Hydrate lockouts
+					const activePhaseForLockouts = getActivePhase(session.getState());
+					for (const aiId of Object.keys(runtimePersonas)) {
+						lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
+					}
+
+					gameEnded = false;
+
+					// Populate panels now that session is available
+					const panelElsAsync = doc.querySelectorAll<HTMLElement>(".ai-panel");
+					const aiIdListAsync = Object.keys(runtimePersonas);
+					panelElsAsync.forEach((panel, idx) => {
+						const aiId = aiIdListAsync[idx];
+						if (!aiId) return;
+						panel.dataset.ai = aiId;
+						const persona = runtimePersonas[aiId];
+						if (!persona) return;
+						panel.style.setProperty("--panel-color", persona.color);
+						initPanelChrome(panel, persona);
+						const budgetEl =
+							panel.querySelector<HTMLSpanElement>(".panel-budget");
+						const phase = getActivePhase(session!.getState());
+						if (budgetEl) {
+							const budget = phase.budgets[aiId];
+							if (budget) {
+								budgetEl.dataset.budget = String(budget.remaining);
+								budgetEl.textContent = `${budget.remaining}/${budget.total}`;
+							}
+						}
+					});
+
+					const handlesAsync = Object.values(runtimePersonas)
+						.map((p) => `@${p.name}`)
+						.join(" | ");
+					if (handlesAsync) _promptInput.placeholder = `${handlesAsync} …`;
+
+					// Register panel-click handlers now that panels have data-ai set.
+					registerPanelClickHandlers(aiIdListAsync);
+
+					refreshComposerState();
+					refreshTopInfo();
+				} catch (err) {
+					// Funnel synthesis failure through the "AIs are sleeping" panel —
+					// same UX path as CapHitError during gameplay.
+					if (capHitEl) capHitEl.removeAttribute("hidden");
+					const panelsEl = doc.querySelector<HTMLElement>("#panels");
+					if (panelsEl) panelsEl.hidden = true;
+					_sendBtn.disabled = true;
+					_promptInput.disabled = true;
+					// Re-throw to surface in console for debugging.
+					throw err;
+				}
+			})();
 		}
 
-		// Apply SPA-side test affordances from location.search (e.g. ?winImmediately=1
-		// or ?lockout=1). These are gated inside applyTestAffordances to only fire
-		// when __WORKER_BASE_URL__ === "http://localhost:8787" (local dev).
-		// Note: we use location.search (not the hash params) because these flags are
-		// intended to be set on the page URL itself, matching the legacy worker pattern.
-		session = applyTestAffordances(session, effectiveParams);
+		// Synchronous post-init: only runs for the restore path (session is set).
+		// The async new-game path handles this block inside its IIFE above.
+		if (session !== null) {
+			// Apply SPA-side test affordances from location.search (e.g. ?winImmediately=1
+			// or ?lockout=1). These are gated inside applyTestAffordances to only fire
+			// when __WORKER_BASE_URL__ === "http://localhost:8787" (local dev).
+			// Note: we use location.search (not the hash params) because these flags are
+			// intended to be set on the page URL itself, matching the legacy worker pattern.
+			session = applyTestAffordances(session, effectiveParams);
 
-		// Build persona maps from runtime state (after affordances may have replaced session)
-		const runtimePersonas = session.getState().personas;
-		personaNamesToId = buildPersonaNameMap(runtimePersonas);
-		personaColors = buildPersonaColorMap(runtimePersonas);
-		personaDisplayNames = buildPersonaDisplayNameMap(runtimePersonas);
+			// Build persona maps from runtime state (after affordances may have replaced session)
+			const runtimePersonas = session.getState().personas;
+			personaNamesToId = buildPersonaNameMap(runtimePersonas);
+			personaColors = buildPersonaColorMap(runtimePersonas);
+			personaDisplayNames = buildPersonaDisplayNameMap(runtimePersonas);
 
-		// Hydrate lockouts from the active phase's chatLockouts map so that
-		// a reload preserves the Send-disabled state for locked-out AIs.
-		const activePhaseForLockouts = getActivePhase(session.getState());
-		for (const aiId of Object.keys(runtimePersonas)) {
-			lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
+			// Hydrate lockouts from the active phase's chatLockouts map so that
+			// a reload preserves the Send-disabled state for locked-out AIs.
+			const activePhaseForLockouts = getActivePhase(session.getState());
+			for (const aiId of Object.keys(runtimePersonas)) {
+				lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
+			}
+
+			// Reset module-level gameEnded flag on fresh session init
+			gameEnded = false;
 		}
-
-		// Reset module-level gameEnded flag on fresh session init
-		gameEnded = false;
 	}
 
 	// Set initial composer state (Send starts disabled until a valid @mention).
 	refreshComposerState();
 
-	// Populate panel headers, ASCII border chrome, --panel-color, and budgets.
-	const panelEls = doc.querySelectorAll<HTMLElement>(".ai-panel");
-	const aiIdList = Object.keys(session.getState().personas);
-	const runtimePersonasForPanels = session.getState().personas;
-	const sessionRef = session;
-	panelEls.forEach((panel, idx) => {
-		const aiId = aiIdList[idx];
-		if (!aiId) return;
-		panel.dataset.ai = aiId;
-		const persona = runtimePersonasForPanels[aiId];
-		if (!persona) return;
-		panel.style.setProperty("--panel-color", persona.color);
-		initPanelChrome(panel, persona);
-		const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
-		const phase = getActivePhase(sessionRef.getState());
-		if (budgetEl) {
-			const budget = phase.budgets[aiId];
-			if (budget) {
-				budgetEl.dataset.budget = String(budget.remaining);
-				budgetEl.textContent = `${budget.remaining}/${budget.total}`;
-			}
-		}
-	});
+	// For the sync restore path session is already set; for the async new-game
+	// path session is still null here (the IIFE above handles panel init).
+	const aiIdList: string[] =
+		session !== null ? Object.keys(session.getState().personas) : [];
 
-	// Populate the input placeholder with the runtime handles, e.g.
-	// `@Ember | @Sage | @Frost …` (test fixtures) or
-	// `@a4b2 | @9bx2 | @cd3f …` (production).
-	const handles = Object.values(session.getState().personas)
-		.map((p) => `@${p.name}`)
-		.join(" | ");
-	if (handles) _promptInput.placeholder = `${handles} …`;
+	// Populate panel headers, ASCII border chrome, --panel-color, and budgets.
+	// Skipped for the async new-game path (handled inside the IIFE above).
+	if (session !== null) {
+		const panelEls = doc.querySelectorAll<HTMLElement>(".ai-panel");
+		const runtimePersonasForPanels = session.getState().personas;
+		const sessionRef = session;
+		panelEls.forEach((panel, idx) => {
+			const aiId = aiIdList[idx];
+			if (!aiId) return;
+			panel.dataset.ai = aiId;
+			const persona = runtimePersonasForPanels[aiId];
+			if (!persona) return;
+			panel.style.setProperty("--panel-color", persona.color);
+			initPanelChrome(panel, persona);
+			const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
+			const phase = getActivePhase(sessionRef.getState());
+			if (budgetEl) {
+				const budget = phase.budgets[aiId];
+				if (budget) {
+					budgetEl.dataset.budget = String(budget.remaining);
+					budgetEl.textContent = `${budget.remaining}/${budget.total}`;
+				}
+			}
+		});
+
+		// Populate the input placeholder with the runtime handles, e.g.
+		// `@Ember | @Sage | @Frost …` (test fixtures) or
+		// `@a4b2 | @9bx2 | @cd3f …` (production).
+		const handles = Object.values(session.getState().personas)
+			.map((p) => `@${p.name}`)
+			.join(" | ");
+		if (handles) _promptInput.placeholder = `${handles} …`;
+	}
 
 	// One-time chrome: ASCII banner + initial top-info row.
 	const bannerEl = doc.querySelector<HTMLElement>("#banner");
@@ -557,35 +646,44 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 
 	refreshTopInfo();
 
-	// Panel-click → addressee mention mutation (issue #108)
-	for (const aiId of aiIdList) {
-		const panel = doc.querySelector<HTMLElement>(
-			`.ai-panel[data-ai="${aiId}"]`,
-		);
-		if (!panel) continue;
-		panel.addEventListener("click", () => {
-			const targetAi = panel.dataset.ai as AiId | undefined;
-			if (!targetAi) return;
-			if (lockouts.get(targetAi) === true) return;
-			const result = applyAddresseeChange({
-				text: _promptInput.value,
-				selectionStart: _promptInput.selectionStart,
-				targetPersona: targetAi,
-				personaNamesToId,
-				personas: session?.getState().personas ?? {},
+	/** Register panel-click → addressee mention handlers for the given AI ids.
+	 * Called synchronously for the restore path (session is set immediately),
+	 * or from inside the async IIFE for the new-game path (after session resolves). */
+	function registerPanelClickHandlers(ids: string[]): void {
+		for (const aiId of ids) {
+			const panel = doc.querySelector<HTMLElement>(
+				`.ai-panel[data-ai="${aiId}"]`,
+			);
+			if (!panel) continue;
+			panel.addEventListener("click", () => {
+				const targetAi = panel.dataset.ai as AiId | undefined;
+				if (!targetAi) return;
+				if (lockouts.get(targetAi) === true) return;
+				const result = applyAddresseeChange({
+					text: _promptInput.value,
+					selectionStart: _promptInput.selectionStart,
+					targetPersona: targetAi,
+					personaNamesToId,
+					personas: session?.getState().personas ?? {},
+				});
+				_promptInput.value = result.text;
+				try {
+					_promptInput.setSelectionRange(
+						result.selectionStart,
+						result.selectionStart,
+					);
+				} catch {
+					/* ignore */
+				}
+				refreshComposerState();
 			});
-			_promptInput.value = result.text;
-			try {
-				_promptInput.setSelectionRange(
-					result.selectionStart,
-					result.selectionStart,
-				);
-			} catch {
-				/* ignore */
-			}
-			refreshComposerState();
-		});
+		}
 	}
+
+	// For the restore path, aiIdList is non-empty and handlers are registered now.
+	// For the async new-game path, aiIdList is empty here; handlers are registered
+	// inside the IIFE above after session resolves.
+	registerPanelClickHandlers(aiIdList);
 
 	// Debug toggle: show action log if ?debug=1
 	const debug = effectiveParams.get("debug") === "1";
@@ -1008,4 +1106,8 @@ export function renderGame(root: HTMLElement, params?: URLSearchParams): void {
 			}
 		}
 	});
+
+	// Return the async init promise so callers can await session readiness.
+	// For the restore path (sync), returns an already-resolved promise.
+	return asyncInitPromise ?? Promise.resolve();
 }


### PR DESCRIPTION
## What this fixes

Closes #122 (parent PRD #120; unblocked by #121).

Replaces the template-filled persona blurbs introduced in #121 with LLM-synthesized blurbs produced by a single batched call at game start. The new code path:

- `generatePersonas(rng, llm)` in `src/content/persona-generator.ts` is now `async` and, when given an `LlmSynthesisProvider`, collects three `(id, temperaments, personaGoal)` tuples and awaits one `synthesizePersonas(tuples)` call, then assigns the returned blurbs to each persona by id. When called without `llm` it falls back to the existing `buildBlurb` template — kept solely so the structural unit tests in `src/__tests__/content.test.ts` don't need an LLM.
- `BrowserSynthesisProvider` (new file `src/spa/game/llm-synthesis-provider.ts`) wraps a non-streaming `chatCompletionJson` call (added to `src/spa/llm-client.ts`) that posts `{ stream: false, response_format: { type: "json_object" } }`. It applies the GLM `message.content === null → message.reasoning` fallback, validates the returned `{ personas: [{ id, blurb }, …] }` shape, retries exactly once on transient errors, and rethrows `CapHitError` immediately without retry.
- `MockSynthesisProvider` (same file) takes a deterministic resolver and records `calls` for assertions — satisfies the "MockLLMProvider extended; no real LLM calls in tests" criterion.
- `SYNTHESIS_SYSTEM_PROMPT` encodes the locked target shape (80–120 words, second person, contradictions as productive tension, identical temperaments as intensification, no name/color/room/AI/assistant mentions). It deliberately omits the universal anti-romance / anti-sycophancy guards — those land in slice #128's `## Rules` block in `prompt-builder.ts`.
- `renderGame` in `src/spa/routes/game.ts` becomes async-aware: the saved-game restore path stays synchronous (saved state already carries synthesized blurbs); the new-game path runs an async IIFE that awaits synthesis before initialising panels. Synthesis failure (or `CapHitError` at synthesis time) reveals `#cap-hit`, hides `#panels`, and disables `#send`/`#prompt` — the same "AIs are sleeping" funnel the existing round-submit `CapHitError` already used.
- Persistence is unchanged: `Persona.blurb` already round-trips through `serializeGameState` / `deserializeGameState`, so blurbs remain byte-identical across all three phases by construction (the engine never regenerates `personas`).

## QA steps for the human

None required — fully covered by the automated coverage below plus a live integration smoke that exercised both the happy path (synthesis call → panels render with synthesized blurbs persisted to `localStorage`) and the failure path (503 → retry-once → `#cap-hit` panel + composer disabled) against `pnpm build` + `wrangler dev` with stubbed `/v1/chat/completions`.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 608/608 pass (34 files), including:
  - `src/__tests__/content.test.ts` — `generatePersonas — LLM path` block: real `generatePersonas` wired to `MockSynthesisProvider`, asserts blurbs match canned responses, single batched call, correct tuple shape (AC #7).
  - `src/spa/game/__tests__/llm-synthesis-provider.test.ts` — synthesis prompt content asserts (no anti-romance/sycophancy strings; required shape constraints present), `content/reasoning` fallback, retry-once-on-transient, no retry on `CapHitError`, JSON shape validation.
  - `src/spa/__tests__/game-bootstrap.test.ts` — async bootstrap, failure → `#cap-hit` funnel, persistence round-trip preserves LLM blurbs.
- `pnpm lint` — clean (`biome ci .`).

## Follow-up note (out of scope here)

The pre-existing Playwright e2e suite (`e2e/smoke.spec.ts`, `e2e/persistence-reload.spec.ts`) is broken on this branch *and* on the parent commit `9fd1db4`. The breakage originates from #121's procedural personas (handles `*xxxx`, no fixed `red`/`green`/`blue` or `Ember`/`Sage`/`Frost`). On top of that, this PR exposes a second gap: the existing `stubChatCompletions` helper returns SSE, but the new synthesis path uses non-streaming JSON mode, so any spec that drives a new game also needs a JSON-mode stub. Both fixes are SPA-team work for a separate issue; flagged here so it isn't lost.

Closes #122

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA134vzZNTR3fSW83f8Vkm)_