### PR TITLE
Playwright e2e suite broken: obsolete fixed-handle specs + missing synthesis JSON stub

### DIFF
--- a/e2e/addressed-and-parallel.spec.ts
+++ b/e2e/addressed-and-parallel.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers/index";
+import { getAiHandles, stubChatCompletions } from "./helpers/index";
 
 /**
  * The three distinct completions served to the three AIs.  Since the SPA
@@ -9,9 +9,7 @@ import { stubChatCompletions } from "./helpers/index";
  */
 const COMPLETIONS = ["alpha beta gamma", "one two", "x y z"] as const;
 
-type LenPair = { red: number; green: number };
-
-test("addressed message lands only on red panel; all three panels render progressively", async ({
+test("addressed message lands only on first panel; all three panels render progressively", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -30,50 +28,61 @@ test("addressed message lands only on red panel; all three panels render progres
 		return (text as string).split(" ").map((w) => `${w} `);
 	});
 
-	// 3. Fill prompt with @Ember mention to address red.
-	const message = "@Ember hello red panel";
+	// 3. Read AI handles dynamically (set after synthesis completes).
+	const { ids, names } = await getAiHandles(page);
+
+	// 4. Fill prompt with first AI's mention to address ids[0].
+	const message = `@${names[0]} hello first panel`;
 	await page.fill("#prompt", message);
 
-	// 4. Install an in-page sampler that collects (red, green) transcript
+	// 5. Install an in-page sampler that collects (ids[0], ids[1]) transcript
 	//    lengths every 30 ms.  We read the results back after streaming ends.
-	await page.evaluate(() => {
+	await page.evaluate((aiIds: string[]) => {
 		(window as unknown as Record<string, unknown>).__lenSamples = [];
 		(window as unknown as Record<string, unknown>).__lenSampleId = setInterval(
 			() => {
 				const r =
-					document.querySelector('[data-transcript="red"]')?.textContent
+					document.querySelector(`[data-transcript="${aiIds[0]}"]`)?.textContent
 						?.length ?? 0;
 				const g =
-					document.querySelector('[data-transcript="green"]')?.textContent
+					document.querySelector(`[data-transcript="${aiIds[1]}"]`)?.textContent
 						?.length ?? 0;
 				(
-					(window as unknown as Record<string, unknown>)
-						.__lenSamples as LenPair[]
-				).push({ red: r, green: g });
+					(window as unknown as Record<string, unknown>).__lenSamples as Array<{
+						first: number;
+						second: number;
+					}>
+				).push({ first: r, second: g });
 			},
 			30,
 		);
-	});
+	}, ids);
 
-	// 5. Click send — triggers the SPA round flow.
+	// 6. Click send — triggers the SPA round flow.
 	await page.click("#send");
 
-	// 6. Wait for all three panels to show their completion text.
+	// 7. Wait for all three panels to show their completion text.
 	//    Each AI gets a distinct completion; wait until the third one appears.
 	await page.waitForFunction(
-		(completions: readonly string[]) => {
-			const texts = ["red", "green", "blue"].map(
+		({
+			completions,
+			aiIds,
+		}: {
+			completions: readonly string[];
+			aiIds: string[];
+		}) => {
+			const texts = aiIds.map(
 				(ai) =>
 					document.querySelector(`[data-transcript="${ai}"]`)?.textContent ??
 					"",
 			);
 			return completions.every((c) => texts.some((t) => t.includes(c)));
 		},
-		COMPLETIONS,
+		{ completions: COMPLETIONS, aiIds: ids },
 		{ timeout: 30_000 },
 	);
 
-	// 7. Stop sampler and retrieve snapshots.
+	// 8. Stop sampler and retrieve snapshots.
 	await page.evaluate(() => {
 		clearInterval(
 			(window as unknown as Record<string, unknown>)
@@ -82,34 +91,37 @@ test("addressed message lands only on red panel; all three panels render progres
 	});
 	const samples = await page.evaluate(
 		() =>
-			(window as unknown as Record<string, unknown>).__lenSamples as LenPair[],
+			(window as unknown as Record<string, unknown>).__lenSamples as Array<{
+				first: number;
+				second: number;
+			}>,
 	);
 
-	// 8. Gather transcript content.
-	const redTranscript = await page
-		.locator('[data-transcript="red"]')
+	// 9. Gather transcript content.
+	const firstTranscript = await page
+		.locator(`[data-transcript="${ids[0]}"]`)
 		.textContent();
-	const greenTranscript = await page
-		.locator('[data-transcript="green"]')
+	const secondTranscript = await page
+		.locator(`[data-transcript="${ids[1]}"]`)
 		.textContent();
-	const blueTranscript = await page
-		.locator('[data-transcript="blue"]')
+	const thirdTranscript = await page
+		.locator(`[data-transcript="${ids[2]}"]`)
 		.textContent();
 
-	// 9. player message appears in red transcript exactly once.
-	expect(redTranscript ?? "").toContain(`> @Ember hello red panel`);
+	// 10. player message appears in first transcript exactly once.
+	expect(firstTranscript ?? "").toContain(`> @${names[0]} hello first panel`);
 	// Exactly once: splitting on "> @" gives exactly two parts.
-	expect((redTranscript ?? "").split("> @").length).toBe(2);
+	expect((firstTranscript ?? "").split("> @").length).toBe(2);
 
-	// 10. green and blue do NOT contain "> @" (no player line).
-	expect(greenTranscript ?? "").not.toContain("> @");
-	expect(blueTranscript ?? "").not.toContain("> @");
+	// 11. second and third do NOT contain "> @" (no player line).
+	expect(secondTranscript ?? "").not.toContain("> @");
+	expect(thirdTranscript ?? "").not.toContain("> @");
 
-	// 11. Each distinct completion appears in exactly one transcript.
+	// 12. Each distinct completion appears in exactly one transcript.
 	const transcripts = [
-		redTranscript ?? "",
-		greenTranscript ?? "",
-		blueTranscript ?? "",
+		firstTranscript ?? "",
+		secondTranscript ?? "",
+		thirdTranscript ?? "",
 	];
 	for (const completion of COMPLETIONS) {
 		const count = transcripts.filter((t) => t.includes(completion)).length;
@@ -119,18 +131,18 @@ test("addressed message lands only on red panel; all three panels render progres
 		).toBe(1);
 	}
 
-	// 12. Progressive rendering: at least one sample must have both red and
-	//     green non-empty with different lengths.  This arises naturally once
+	// 13. Progressive rendering: at least one sample must have both first and
+	//     second non-empty with different lengths.  This arises naturally once
 	//     one panel finishes streaming and the next is mid-stream.
 	const divergentSample = samples.find(
-		(s) => s.red > 0 && s.green > 0 && s.red !== s.green,
+		(s) => s.first > 0 && s.second > 0 && s.first !== s.second,
 	);
 	expect(
 		divergentSample,
-		`Expected a sample where red and green both have non-zero but different ` +
+		`Expected a sample where first and second panels both have non-zero but different ` +
 			`lengths. Samples: ${JSON.stringify(samples.slice(0, 20))}`,
 	).toBeDefined();
 
-	// 13. No page errors.
+	// 14. No page errors.
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });

--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
-test("chat lockout disables the red AI option and appends an in-character lockout line", async ({
+test("chat lockout disables the first AI option and appends an in-character lockout line", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -14,30 +14,34 @@ test("chat lockout disables the red AI option and appends an in-character lockou
 	await stubChatCompletions(page, ["greetings"]);
 
 	// 2. Navigate with ?lockout=1 so applyTestAffordances() arms a chat-lockout
-	//    for red (2 rounds) effective on the next round.
+	//    for ids[0] (first AI in Object.keys order, rng: () => 0) effective on
+	//    the next round.
 	await page.goto("/?lockout=1");
 
-	// 3. Submit one message addressed to red (@Ember).
-	await page.fill("#prompt", "@Ember hello");
+	// 3. Read AI handles dynamically (set after synthesis completes).
+	const { ids, names } = await getAiHandles(page);
+
+	// 4. Submit one message addressed to ids[0].
+	await page.fill("#prompt", `@${names[0]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
-	// 4a. Wait for the chat_lockout to take effect: typing @Ember should disable Send.
-	await page.fill("#prompt", "@Ember hi");
+	// 5a. Wait for the chat_lockout to take effect: typing @<name[0]> should
+	//     disable Send.
+	await page.fill("#prompt", `@${names[0]} hi`);
 	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
-	// 4b. Red transcript ends with the in-character lockout line (appended by
+	// 5b. First AI transcript ends with the in-character lockout line (appended by
 	//     the chat_lockout event handler in game.ts: "[${event.message}]\n").
-	//     The exact persona name is "Ember" (from src/content/personas.ts).
-	const redTranscript = page.locator('[data-transcript="red"]');
-	await expect(redTranscript).toContainText(/[\w]+ is unresponsive…/);
+	const firstTranscript = page.locator(`[data-transcript="${ids[0]}"]`);
+	await expect(firstTranscript).toContainText(/[\w]+ is unresponsive…/);
 
-	// 4c. Green and blue transcripts contain a normal AI response line.
-	const greenTranscript = page.locator('[data-transcript="green"]');
-	const blueTranscript = page.locator('[data-transcript="blue"]');
-	await expect(greenTranscript).toContainText("greetings");
-	await expect(blueTranscript).toContainText("greetings");
+	// 5c. Second and third transcripts contain a normal AI response line.
+	const secondTranscript = page.locator(`[data-transcript="${ids[1]}"]`);
+	const thirdTranscript = page.locator(`[data-transcript="${ids[2]}"]`);
+	await expect(secondTranscript).toContainText("greetings");
+	await expect(thirdTranscript).toContainText("greetings");
 
-	// 4d. No page errors.
+	// 5d. No page errors.
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });

--- a/e2e/diagnose-streaming.spec.ts
+++ b/e2e/diagnose-streaming.spec.ts
@@ -22,13 +22,14 @@
  */
 
 import { expect, test } from "@playwright/test";
+import { getAiHandles } from "./helpers";
 
 // 5 chunks per AI × 200ms = 1.0s per stream × 3 AIs = ~3.0s total wire time.
 const CHUNK_INTERVAL_MS = 200;
 const CHUNKS_PER_AI: Record<string, string[]> = {
-	"call-1": ["alpha ", "beta ", "gamma ", "delta ", "epsilon."],
-	"call-2": ["uno ", "dos ", "tres ", "quatro ", "cinco."],
-	"call-3": ["one ", "two ", "three ", "four ", "five."],
+	"call-2": ["alpha ", "beta ", "gamma ", "delta ", "epsilon."],
+	"call-3": ["uno ", "dos ", "tres ", "quatro ", "cinco."],
+	"call-4": ["one ", "two ", "three ", "four ", "five."],
 };
 
 interface DiagSample {
@@ -54,11 +55,19 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 		}
 	});
 
-	// addInitScript runs before any page script. We monkey-patch fetch to
-	// intercept /v1/chat/completions and return a real ReadableStream-backed
-	// Response whose chunks emit at known intervals.
+	// addInitScript runs before any page script. We monkey-patch fetch to:
+	// (a) Handle the synthesis JSON-mode call (stream===false or response_format
+	//     present) by echoing back a canned personas response.
+	// (b) For SSE streaming calls, return a real ReadableStream-backed Response
+	//     whose chunks emit at known intervals.
 	await page.addInitScript(
-		({ chunkSets, intervalMs }) => {
+		({
+			chunkSets,
+			intervalMs,
+		}: {
+			chunkSets: Record<string, string[]>;
+			intervalMs: number;
+		}) => {
 			const t0 = performance.now();
 			function diag(payload: Record<string, unknown>): void {
 				const t = Math.round(performance.now() - t0);
@@ -66,16 +75,23 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 			}
 
 			// MutationObserver on each transcript — fires whenever textContent grows.
-			// We install it once DOM is ready.
+			// We install it once DOM is ready. Panels get data-transcript set
+			// dynamically after synthesis, so we observe all [data-transcript] elements
+			// by watching the document for new elements.
 			window.addEventListener("DOMContentLoaded", () => {
-				for (const ai of ["red", "green", "blue"]) {
-					const el = document.querySelector(`[data-transcript="${ai}"]`);
-					if (!el) continue;
+				const observedTranscripts = new Set<Element>();
+				function observeTranscript(el: Element): void {
+					if (observedTranscripts.has(el)) return;
+					observedTranscripts.add(el);
+					const tag =
+						(el as HTMLElement).dataset.transcript ??
+						el.getAttribute("data-transcript") ??
+						"?";
 					let lastLen = el.textContent?.length ?? 0;
 					new MutationObserver(() => {
 						const len = el.textContent?.length ?? 0;
 						if (len !== lastLen) {
-							diag({ kind: "dom", tag: ai, detail: `len=${len}` });
+							diag({ kind: "dom", tag, detail: `len=${len}` });
 							lastLen = len;
 						}
 					}).observe(el, {
@@ -84,6 +100,37 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 						subtree: true,
 					});
 				}
+
+				// Observe transcript elements that exist or appear later
+				for (const el of document.querySelectorAll("[data-transcript]")) {
+					observeTranscript(el);
+				}
+				new MutationObserver((mutations) => {
+					for (const m of mutations) {
+						for (const node of m.addedNodes) {
+							if (node instanceof Element) {
+								if (node.hasAttribute("data-transcript"))
+									observeTranscript(node);
+								for (const el of node.querySelectorAll("[data-transcript]")) {
+									observeTranscript(el);
+								}
+							}
+						}
+						// Also handle attribute changes on existing elements
+						if (
+							m.type === "attributes" &&
+							m.attributeName === "data-transcript" &&
+							m.target instanceof Element
+						) {
+							observeTranscript(m.target);
+						}
+					}
+				}).observe(document.body, {
+					childList: true,
+					subtree: true,
+					attributes: true,
+					attributeFilter: ["data-transcript"],
+				});
 			});
 
 			let callIdx = 0;
@@ -101,8 +148,45 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 
 				callIdx += 1;
 				const tag = `call-${callIdx}`;
+
+				// Detect synthesis call (stream===false or response_format present)
+				let isSynthesis = false;
+				try {
+					const body = JSON.parse(
+						typeof init?.body === "string" ? init.body : "",
+					) as {
+						stream?: boolean;
+						response_format?: unknown;
+						messages?: Array<{ content?: string }>;
+					};
+					isSynthesis = body.stream === false || body.response_format != null;
+					if (isSynthesis) {
+						// Echo back persona ids with canned blurbs
+						const content2 = body.messages?.[1]?.content ?? "";
+						const ids: string[] = Array.from(
+							content2.matchAll(/id:\s*"([a-z0-9]{4})"/g),
+							(m) => m[1] ?? "",
+						).filter(Boolean);
+						const personas = ids.map((id) => ({
+							id,
+							blurb: `Stub blurb for ${id}.`,
+						}));
+						const responseBody = JSON.stringify({
+							choices: [{ message: { content: JSON.stringify({ personas }) } }],
+						});
+						return Promise.resolve(
+							new Response(responseBody, {
+								status: 200,
+								headers: { "Content-Type": "application/json" },
+							}),
+						);
+					}
+				} catch {
+					// ignore parse errors
+				}
+
 				const chunks =
-					(chunkSets as Record<string, string[]>)[tag] ?? chunkSets["call-1"];
+					(chunkSets as Record<string, string[]>)[tag] ?? chunkSets["call-2"];
 				diag({ kind: "fetch", tag });
 
 				const encoder = new TextEncoder();
@@ -137,14 +221,18 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 	);
 
 	await page.goto("/");
-	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
 
-	await page.fill("#prompt", "@Ember Hello");
+	// Wait for synthesis to complete and panels to get dynamic data-ai attributes.
+	const { ids, names } = await getAiHandles(page);
+
+	await page.fill("#prompt", `@${names[0]} Hello`);
 	await page.click("#send");
 
 	// Wait until all three SSE streams complete. (Post-#107 the send button no
 	// longer re-enables after submit because the prompt is cleared and an empty
 	// prompt has no @mention.)
+	// The synthesis call is call-1, so streaming starts at call-2. We need 3
+	// fetch_done events (calls 2, 3, 4).
 	await expect
 		.poll(() => samples.filter((s) => s.kind === "fetch_done").length, {
 			timeout: 30_000,
@@ -184,6 +272,11 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 	console.log(
 		`firstFetch=${firstFetchT}ms  firstFetchDone=${firstFetchDoneT}ms  lastFetchDone=${lastFetchDoneT}ms  liveGrowthEvents=${liveGrowthEvents.length}`,
 	);
+
+	// Verify that ids are 4-char procedural handles (validates synthesis stub wiring)
+	for (const id of ids) {
+		expect(id).toMatch(/^[a-z0-9]{4}$/);
+	}
 
 	// LIVE-STREAMING ASSERTION (expected to FAIL on current code):
 	// At least one panel should grow with real content WHILE another AI's

--- a/e2e/endgame-current-behaviour.spec.ts
+++ b/e2e/endgame-current-behaviour.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
  * E2E Slice 4 — game_ended current behaviour (issue #80, simplified by #101)
@@ -14,7 +14,7 @@ import { stubChatCompletions } from "./helpers";
  * --------------------------------
  * `?winImmediately=1` (#101) recursively patches the real PHASE_1 → PHASE_2 →
  * PHASE_3 config chain, injecting `winCondition: () => true` at every level.
- * A cold-start `goto("/?winImmediately=1")` followed by three `@Ember`-addressed
+ * A cold-start `goto("/?winImmediately=1")` followed by three @<name>-addressed
  * messages (one per phase) reliably reaches `game_ended` without any
  * localStorage pre-seeding.
  *
@@ -38,33 +38,36 @@ test("game_ended disables composer and clears storage", async ({ page }) => {
 	// Wait for SPA mount.
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// 3. Capture URL before submitting (proves URL stability below).
+	// 3. Read AI handles dynamically (set after synthesis completes).
+	const { names } = await getAiHandles(page);
+
+	// 4. Capture URL before submitting (proves URL stability below).
 	const urlBefore = page.url();
 
-	// Helper: fill prompt with an @Ember mention, wait for Send to enable, click.
+	// Helper: fill prompt with a mention of ids[0], wait for Send to enable, click.
 	async function submitMessage(text: string): Promise<void> {
 		await page.fill("#prompt", text);
 		await expect(page.locator("#send")).toBeEnabled();
 		await page.click("#send");
 	}
 
-	// 4. Round 1 — phase 1 ends; wait for phase banner to advance to Phase 2.
-	await submitMessage("@Ember hello");
+	// 5. Round 1 — phase 1 ends; wait for phase banner to advance to Phase 2.
+	await submitMessage(`@${names[0]} hello`);
 	await expect(page.locator("#phase-banner")).toContainText("Phase 2", {
 		timeout: 30_000,
 	});
 
-	// 5. Round 2 — phase 2 ends; wait for phase banner to advance to Phase 3.
-	await submitMessage("@Ember hello");
+	// 6. Round 2 — phase 2 ends; wait for phase banner to advance to Phase 3.
+	await submitMessage(`@${names[0]} hello`);
 	await expect(page.locator("#phase-banner")).toContainText("Phase 3", {
 		timeout: 30_000,
 	});
 
-	// 6. Round 3 — phase 3 ends; game_ended fires → #send permanently disabled.
-	await submitMessage("@Ember hello");
+	// 7. Round 3 — phase 3 ends; game_ended fires → #send permanently disabled.
+	await submitMessage(`@${names[0]} hello`);
 	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
-	// 7. Assert all acceptance criteria.
+	// 8. Assert all acceptance criteria.
 
 	// #send disabled
 	await expect(page.locator("#send")).toBeDisabled();

--- a/e2e/helpers/handles.ts
+++ b/e2e/helpers/handles.ts
@@ -1,0 +1,59 @@
+import type { Page } from "@playwright/test";
+
+export type AiHandles = {
+	ids: [string, string, string];
+	names: [string, string, string];
+	mention: (index: number) => string;
+};
+
+/**
+ * Wait until 3 `article.ai-panel` elements have non-empty `data-ai` attributes
+ * (set after persona synthesis completes) and return the DOM-order ids tuple.
+ *
+ * Also reads the persona display names from `.panel-name` (format: `*<name> :: @<name>`)
+ * so callers can construct `@<name>` mention strings for the composer.
+ *
+ * @param page The Playwright Page to query.
+ */
+export async function getAiHandles(page: Page): Promise<AiHandles> {
+	await page.waitForFunction(
+		() => {
+			const panels = Array.from(
+				document.querySelectorAll<HTMLElement>("article.ai-panel"),
+			);
+			return (
+				panels.length === 3 &&
+				panels.every((p) => (p.dataset.ai ?? "").length > 0)
+			);
+		},
+		{ timeout: 30_000 },
+	);
+
+	const result = await page.evaluate(() => {
+		return Array.from(
+			document.querySelectorAll<HTMLElement>("article.ai-panel"),
+		).map((p) => {
+			const id = p.dataset.ai ?? "";
+			// .panel-name text is: `*<name> :: @<name>`, extract the name after `@`
+			const panelNameEl = p.querySelector<HTMLElement>(".panel-name");
+			const raw = panelNameEl?.textContent ?? "";
+			// Format: `*Ember :: @Ember` → extract after `@`
+			const atMatch = /@([A-Za-z0-9]+)/.exec(raw);
+			const name = atMatch?.[1] ?? id;
+			return { id, name };
+		});
+	});
+
+	if (result.length !== 3) {
+		throw new Error(`Expected 3 ai-panel elements, got ${result.length}`);
+	}
+
+	const ids = result.map((r) => r.id) as [string, string, string];
+	const names = result.map((r) => r.name) as [string, string, string];
+
+	return {
+		ids,
+		names,
+		mention: (index: number) => `@${names[index] ?? ids[index]}`,
+	};
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,5 +1,10 @@
+export { type AiHandles, getAiHandles } from "./handles";
 export {
+	type NewGameLLMOptions,
+	type SynthesisStubOptions,
 	stubChatCompletions,
+	stubNewGameLLM,
+	stubPersonaSynthesis,
 	type WordsFactory,
 	wordsToOpenAiSseBody,
 } from "./stubs";

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -24,8 +24,141 @@ export function wordsToOpenAiSseBody(words: string[]): string {
 }
 
 /**
+ * Extract persona ids from a synthesis user-message content string.
+ * The synthesis user message format is: `id: "xxxx", temperaments: ...`
+ * Ids are exactly 4 lowercase alphanumeric characters.
+ */
+function extractInputIds(content: string): string[] {
+	return Array.from(
+		content.matchAll(/id:\s*"([a-z0-9]{4})"/g),
+		(m) => m[1] ?? "",
+	).filter(Boolean);
+}
+
+export type SynthesisStubOptions = {
+	/** Generate a blurb for a given persona id. Defaults to `id => \`Stub blurb for ${id}.\`` */
+	blurb?: (id: string) => string;
+};
+
+/**
+ * Register a Playwright route stub that handles the persona synthesis
+ * JSON-mode `/v1/chat/completions` call.  It parses the request body,
+ * extracts persona ids from the user message, and returns a canned
+ * `{ choices: [{ message: { content: JSON.stringify({ personas: [...] }) } }] }`
+ * response that echoes each input id verbatim.
+ *
+ * Non-synthesis (SSE/streaming) requests are forwarded via `route.fallback()`.
+ */
+export async function stubPersonaSynthesis(
+	page: Page,
+	options?: SynthesisStubOptions,
+): Promise<void> {
+	const blurbFn = options?.blurb ?? ((id: string) => `Stub blurb for ${id}.`);
+	await page.route("**/v1/chat/completions", async (route, request) => {
+		let parsed: unknown = null;
+		try {
+			parsed = JSON.parse(request.postData() ?? "null");
+		} catch {
+			// ignore parse error
+		}
+		const body = parsed as {
+			stream?: boolean;
+			response_format?: unknown;
+			messages?: Array<{ content?: string }>;
+		} | null;
+		const isJsonMode =
+			body !== null && (body.stream === false || body.response_format != null);
+		if (isJsonMode) {
+			const ids = extractInputIds(body?.messages?.[1]?.content ?? "");
+			const content = JSON.stringify({
+				personas: ids.map((id) => ({ id, blurb: blurbFn(id) })),
+			});
+			await route.fulfill({
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ choices: [{ message: { content } }] }),
+			});
+			return;
+		}
+		await route.fallback();
+	});
+}
+
+export type NewGameLLMOptions = {
+	sse: string[] | WordsFactory;
+	synthesis?: SynthesisStubOptions;
+};
+
+/**
+ * Combined stub that handles both the persona synthesis JSON call and the
+ * gameplay SSE streaming call in a single `page.route` registration.
+ *
+ * Distinguishes calls by request body:
+ *   - `stream === false` or `response_format` present → synthesis JSON response
+ *   - otherwise → SSE streaming response
+ */
+export async function stubNewGameLLM(
+	page: Page,
+	opts: NewGameLLMOptions,
+): Promise<void> {
+	const blurbFn =
+		opts.synthesis?.blurb ?? ((id: string) => `Stub blurb for ${id}.`);
+	const wordsOrFactory = opts.sse;
+
+	await page.route("**/v1/chat/completions", async (route, request) => {
+		let parsed: unknown = null;
+		try {
+			parsed = JSON.parse(request.postData() ?? "null");
+		} catch {
+			// ignore parse error
+		}
+		const body = parsed as {
+			stream?: boolean;
+			response_format?: unknown;
+			messages?: Array<{ content?: string }>;
+		} | null;
+		const isJsonMode =
+			body !== null && (body.stream === false || body.response_format != null);
+
+		if (isJsonMode) {
+			const ids = extractInputIds(body?.messages?.[1]?.content ?? "");
+			const content = JSON.stringify({
+				personas: ids.map((id) => ({ id, blurb: blurbFn(id) })),
+			});
+			await route.fulfill({
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ choices: [{ message: { content } }] }),
+			});
+			return;
+		}
+
+		// SSE path
+		const words =
+			typeof wordsOrFactory === "function"
+				? await wordsOrFactory(request)
+				: wordsOrFactory;
+		await route.fulfill({
+			status: 200,
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+				"X-Content-Type-Options": "nosniff",
+			},
+			body: wordsToOpenAiSseBody(words),
+		});
+	});
+}
+
+/**
  * Register a Playwright route stub for the `/v1/chat/completions` endpoint
  * that responds with a synthetic streaming OpenAI SSE body.
+ *
+ * Also handles the persona synthesis JSON-mode call (stream === false or
+ * response_format present) by returning a canned JSON response that echoes
+ * the input persona ids verbatim.  This means every existing spec that calls
+ * `stubChatCompletions` continues to work even when the SPA fires the
+ * synthesis call first.
  *
  * The SPA's `BrowserLLMProvider` (via `src/spa/llm-client.ts`) calls
  * `${__WORKER_BASE_URL__}/v1/chat/completions` — this is the correct endpoint
@@ -54,6 +187,34 @@ export async function stubChatCompletions(
 	wordsOrFactory: string[] | WordsFactory,
 ): Promise<void> {
 	await page.route("**/v1/chat/completions", async (route, request) => {
+		let parsed: unknown = null;
+		try {
+			parsed = JSON.parse(request.postData() ?? "null");
+		} catch {
+			// ignore parse error
+		}
+		const body = parsed as {
+			stream?: boolean;
+			response_format?: unknown;
+			messages?: Array<{ content?: string }>;
+		} | null;
+		const isJsonMode =
+			body !== null && (body.stream === false || body.response_format != null);
+
+		if (isJsonMode) {
+			// Synthesis path — echo input ids with canned blurbs
+			const ids = extractInputIds(body?.messages?.[1]?.content ?? "");
+			const content = JSON.stringify({
+				personas: ids.map((id) => ({ id, blurb: `Stub blurb for ${id}.` })),
+			});
+			await route.fulfill({
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ choices: [{ message: { content } }] }),
+			});
+			return;
+		}
+
 		const words =
 			typeof wordsOrFactory === "function"
 				? await wordsOrFactory(request)

--- a/e2e/mention-addressing.spec.ts
+++ b/e2e/mention-addressing.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
  * E2E spec for #107: @mention-based addressing replaces the address dropdown.
@@ -8,7 +8,8 @@ import { stubChatCompletions } from "./helpers";
  * 1. The #address dropdown is gone.
  * 2. On first load, prompt is empty and Send is disabled.
  * 3. Typing "hi" (no mention) leaves Send disabled.
- * 4. Typing "@Sage hi" enables Send and submits to green panel.
+ * 4. Typing "@<name> hi" (using second AI's display name) enables Send and
+ *    submits to that panel only.
  */
 
 test("address dropdown is gone (#address count === 0)", async ({ page }) => {
@@ -31,7 +32,7 @@ test("typing 'hi' leaves Send disabled", async ({ page }) => {
 	await expect(page.locator("#send")).toBeDisabled();
 });
 
-test("typing '@Sage hi' enables Send and submits to green transcript only", async ({
+test("typing '@<ai1> hi' enables Send and submits to that transcript only", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -41,36 +42,39 @@ test("typing '@Sage hi' enables Send and submits to green transcript only", asyn
 	await page.goto("/");
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// Typing "@Sage hi" should enable Send.
-	await page.fill("#prompt", "@Sage hi");
+	const { ids, names } = await getAiHandles(page);
+
+	// Typing "@<name> hi" should enable Send.
+	await page.fill("#prompt", `@${names[1]} hi`);
 	await expect(page.locator("#send")).toBeEnabled();
 
 	// Click send and wait for the round to complete.
 	await page.click("#send");
 
-	// Wait until the green panel shows a response.
+	// Wait until the addressed panel shows a response.
 	await page.waitForFunction(
-		() => {
-			const el = document.querySelector('[data-transcript="green"]');
+		(selector: string) => {
+			const el = document.querySelector(selector);
 			return (el?.textContent ?? "").includes("greetings");
 		},
+		`[data-transcript="${ids[1]}"]`,
 		{ timeout: 30_000 },
 	);
 
-	const greenTranscript = await page
-		.locator('[data-transcript="green"]')
+	const addressedTranscript = await page
+		.locator(`[data-transcript="${ids[1]}"]`)
 		.textContent();
-	const redTranscript = await page
-		.locator('[data-transcript="red"]')
+	const otherTranscript0 = await page
+		.locator(`[data-transcript="${ids[0]}"]`)
 		.textContent();
-	const blueTranscript = await page
-		.locator('[data-transcript="blue"]')
+	const otherTranscript2 = await page
+		.locator(`[data-transcript="${ids[2]}"]`)
 		.textContent();
 
-	// player message appears only in green.
-	expect(greenTranscript ?? "").toContain("> @Sage hi");
-	expect(redTranscript ?? "").not.toContain("> @");
-	expect(blueTranscript ?? "").not.toContain("> @");
+	// player message appears only in addressed panel.
+	expect(addressedTranscript ?? "").toContain(`> @${names[1]} hi`);
+	expect(otherTranscript0 ?? "").not.toContain("> @");
+	expect(otherTranscript2 ?? "").not.toContain("> @");
 
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });

--- a/e2e/persistence-reload.spec.ts
+++ b/e2e/persistence-reload.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
- * AI completions returned by the stub, keyed by call index (0 = red, 1 = green, 2 = blue
+ * AI completions returned by the stub, keyed by call index (0 = first, 1 = second, 2 = third
  * for default initiative order).  We keep them short to minimise token-pacing delay.
  */
 const STUB_COMPLETION = "stub reply";
@@ -14,7 +14,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 	page.on("pageerror", (err) => pageErrors.push(err));
 
 	// Stub every call to /v1/chat/completions with a deterministic one-token response.
-	// The SPA fires one call per AI per round (red → green → blue in default order).
+	// The SPA fires one call per AI per round.
 	await stubChatCompletions(page, [STUB_COMPLETION]);
 
 	await page.goto("/");
@@ -22,8 +22,11 @@ test("game state and transcripts persist across mid-round reload", async ({
 	// Wait for the SPA game route to mount (the composer form is present)
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// Address red AI via @Ember mention and send a message
-	await page.fill("#prompt", "@Ember hello");
+	// Read AI handles dynamically (set after synthesis completes).
+	const { ids, names } = await getAiHandles(page);
+
+	// Address first AI via @<name> mention and send a message
+	await page.fill("#prompt", `@${names[0]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
@@ -50,16 +53,16 @@ test("game state and transcripts persist across mid-round reload", async ({
 		schemaVersion: number;
 		transcripts?: Partial<Record<string, string>>;
 	};
-	expect(saved.schemaVersion).toBe(1);
+	expect(saved.schemaVersion).toBeGreaterThanOrEqual(1);
 	expect(
-		saved.transcripts?.red,
-		"transcripts.red must be non-empty after turn 1",
+		saved.transcripts?.[ids[0]],
+		"transcripts[ids[0]] must be non-empty after turn 1",
 	).toBeTruthy();
 
 	// ── Capture pre-reload values ───────────────────────────────────────────────
 
 	const preReloadTranscript = await page
-		.locator('[data-transcript="red"]')
+		.locator(`[data-transcript="${ids[0]}"]`)
 		.textContent();
 	expect(preReloadTranscript).toBeTruthy();
 	// The player's message must appear in the transcript
@@ -68,7 +71,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 	expect(preReloadTranscript).toContain(STUB_COMPLETION);
 
 	const preReloadBudgets: Record<string, string> = {};
-	for (const aiId of ["red", "green", "blue"]) {
+	for (const aiId of ids) {
 		const el = page.locator(`.ai-panel[data-ai="${aiId}"] .panel-budget`);
 		preReloadBudgets[aiId] = (await el.getAttribute("data-budget")) ?? "";
 	}
@@ -80,10 +83,17 @@ test("game state and transcripts persist across mid-round reload", async ({
 	// Wait for SPA to remount after reload
 	await expect(page.locator("#composer")).toBeVisible();
 
+	// After reload we need to stub again for the restored session (the route
+	// intercept was only on the previous page context).
+	await stubChatCompletions(page, [STUB_COMPLETION]);
+
+	// After reload, fetch handles again — procedural names persist via saved persona.name.
+	const { ids: reloadIds } = await getAiHandles(page);
+
 	// ── Assert transcripts restored ─────────────────────────────────────────────
 
 	const postReloadTranscript = await page
-		.locator('[data-transcript="red"]')
+		.locator(`[data-transcript="${reloadIds[0]}"]`)
 		.textContent();
 	expect(postReloadTranscript).toContain("> @");
 	expect(postReloadTranscript).toContain(STUB_COMPLETION);
@@ -91,7 +101,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 
 	// ── Assert budgets restored ─────────────────────────────────────────────────
 
-	for (const aiId of ["red", "green", "blue"]) {
+	for (const aiId of reloadIds) {
 		const el = page.locator(`.ai-panel[data-ai="${aiId}"] .panel-budget`);
 		const postBudget = await el.getAttribute("data-budget");
 		expect(postBudget, `${aiId} budget must match after reload`).toBe(

--- a/e2e/persona-synthesis.spec.ts
+++ b/e2e/persona-synthesis.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import { getAiHandles, stubNewGameLLM } from "./helpers";
+
+/**
+ * Acceptance spec: new-game synthesis blurbs land in turn-stream system prompts.
+ *
+ * Proves that the synthesis output flows through the full chain:
+ * LLM synthesis JSON call → persona record → prompt-builder → SSE request body.
+ *
+ * Strategy:
+ * 1. Use `stubNewGameLLM` with a custom `synthesis.blurb` factory that embeds a
+ *    sentinel string per persona id.
+ * 2. Capture every SSE streaming request body.
+ * 3. After sending a message, verify that each persona's sentinel appears in at
+ *    least one streaming request's system prompt.
+ */
+test("new-game synthesis blurbs land in turn-stream system prompts", async ({
+	page,
+}) => {
+	const observedBodies: Array<{
+		messages?: Array<{ role?: string; content?: string }>;
+		stream?: boolean;
+	}> = [];
+
+	await stubNewGameLLM(page, {
+		synthesis: { blurb: (id) => `Synthesized blurb sentinel for ${id}.` },
+		sse: (request) => {
+			try {
+				const body = JSON.parse(request.postData() ?? "null") as {
+					stream?: boolean;
+					messages?: Array<{ role?: string; content?: string }>;
+				};
+				if (body?.stream === true) observedBodies.push(body);
+			} catch {
+				// ignore
+			}
+			return ["ok"];
+		},
+	});
+
+	await page.goto("/");
+
+	// getAiHandles also reads persona display names from .panel-name
+	const { ids, names } = await getAiHandles(page);
+
+	// All ids must be 4-char procedural handles
+	for (const id of ids) {
+		expect(id).toMatch(/^[a-z0-9]{4}$/);
+	}
+
+	// Send a message addressed to the first AI using its display name
+	await page.fill("#prompt", `@${names[0]} hi`);
+	await expect(page.locator("#send")).toBeEnabled();
+	await page.click("#send");
+
+	// Wait for all 3 AIs to have their SSE streams observed
+	await expect
+		.poll(() => observedBodies.length, { timeout: 30_000 })
+		.toBeGreaterThanOrEqual(3);
+
+	// For each persona id, find a matching SSE body whose system message
+	// contains the sentinel blurb for that persona
+	for (const id of ids) {
+		const sentinel = `Synthesized blurb sentinel for ${id}.`;
+		const matchingBody = observedBodies.find(
+			(b) =>
+				(b.messages?.[0]?.content ?? "").includes(sentinel) ||
+				b.messages?.some(
+					(m) => m.role === "system" && (m.content ?? "").includes(sentinel),
+				),
+		);
+		expect(
+			matchingBody,
+			`expected SSE body whose system prompt embeds synthesized blurb for ${id} (sentinel: "${sentinel}"). Observed ${observedBodies.length} bodies.`,
+		).toBeDefined();
+	}
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,16 +1,26 @@
 import { expect, test } from "@playwright/test";
+import { stubChatCompletions } from "./helpers";
 
 test("SPA root renders three AI panels and composer", async ({ page }) => {
 	const pageErrors: Error[] = [];
 	page.on("pageerror", (err) => pageErrors.push(err));
 
+	await stubChatCompletions(page, ["hi"]);
+
 	await page.goto("/");
 
 	await expect(page.locator("article.ai-panel")).toHaveCount(3);
 
-	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
-	await expect(page.locator('article.ai-panel[data-ai="green"]')).toBeVisible();
-	await expect(page.locator('article.ai-panel[data-ai="blue"]')).toBeVisible();
+	// Panels must have non-empty 4-char [a-z0-9] procedural handles
+	const handles = await page
+		.locator("article.ai-panel")
+		.evaluateAll((els) =>
+			els.map((el) => (el as HTMLElement).dataset.ai ?? ""),
+		);
+	expect(handles).toHaveLength(3);
+	for (const handle of handles) {
+		expect(handle).toMatch(/^[a-z0-9]{4}$/);
+	}
 
 	await expect(page.locator("#composer")).toBeVisible();
 

--- a/e2e/think-disabled.spec.ts
+++ b/e2e/think-disabled.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
  * `?think=0` is a wrangler-dev-only affordance that adds
@@ -33,7 +33,9 @@ test("?think=0 adds reasoning:{enabled:false} to chat-completions requests", asy
 
 	await page.goto("/?think=0");
 
-	await page.fill("#prompt", "@Sage hello");
+	const { names } = await getAiHandles(page);
+
+	await page.fill("#prompt", `@${names[1]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
@@ -68,7 +70,9 @@ test("without ?think=0, requests do NOT include the reasoning field", async ({
 
 	await page.goto("/");
 
-	await page.fill("#prompt", "@Sage hello");
+	const { names } = await getAiHandles(page);
+
+	await page.fill("#prompt", `@${names[1]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { stubChatCompletions } from "./helpers";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
-// Word chunks yielded for every AI call.  Red gets these tokens and we
-// sample its transcript; green / blue responses use the same stub so all
+// Word chunks yielded for every AI call.  First AI gets these tokens and we
+// sample its transcript; second / third responses use the same stub so all
 // three LLM calls resolve quickly.
 // 20 words × ≈42 ms/word (TOKEN_PACE_MS 60 × red-speed 0.7 × avg 1.0)
 // ≈ 840 ms total display window — well beyond the 500 ms sample point.
@@ -29,7 +29,7 @@ const WORDS = [
 	"twenty.",
 ];
 
-// The expected final text appended to red's transcript by the token loop.
+// The expected final text appended to the first AI's transcript by the token loop.
 // game.ts prepends "[<PersonaName>] " before token emission and appends "\n"
 // on ai_end.  We only assert the token portion here.
 const EXPECTED_TOKENS = WORDS.join("");
@@ -37,7 +37,7 @@ const EXPECTED_TOKENS = WORDS.join("");
 /**
  * E2E Slice 2 — Token delivery
  *
- * Verifies that the SPA delivers AI content to `[data-transcript="red"]`
+ * Verifies that the SPA delivers AI content to `[data-transcript="<ids[0]>"]`
  * correctly when the completion SSE body arrives in a single chunk
  * (as `route.fulfill` does — the entire body is delivered at once).
  *
@@ -68,17 +68,22 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 
 	await page.goto("/");
 
-	// Ensure the game page is ready.
-	await expect(page.locator('article.ai-panel[data-ai="red"]')).toBeVisible();
+	// Read AI handles dynamically (set after synthesis completes).
+	const { ids, names } = await getAiHandles(page);
 
-	// ── Submit a message addressed to red via @Ember mention ────────────────
-	await page.fill("#prompt", "@Ember Hello");
+	// Ensure the game page is ready.
+	await expect(
+		page.locator(`article.ai-panel[data-ai="${ids[0]}"]`),
+	).toBeVisible();
+
+	// ── Submit a message addressed to ids[0] ─────────────────────────────────────
+	await page.fill("#prompt", `@${names[0]} Hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 
-	const redTranscript = page.locator('[data-transcript="red"]');
+	const firstTranscript = page.locator(`[data-transcript="${ids[0]}"]`);
 
 	// Capture pre-submit baseline length.
-	const baselineText = (await redTranscript.textContent()) ?? "";
+	const baselineText = (await firstTranscript.textContent()) ?? "";
 
 	await page.click("#send");
 
@@ -86,11 +91,13 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	// With live streaming, "thinking…" is stripped on the first live delta and
 	// replaced immediately by the AI's persona prefix + content. We wait for
 	// thinking… to disappear and the transcript to grow past the player message.
-	const playerMsg = `\n> @Ember Hello\n`;
+	const playerMsg = `\n> @${names[0]} Hello\n`;
 	const afterPlayerLength = baselineText.length + playerMsg.length;
 
 	// Wait for thinking… to clear (first live delta strips it).
-	await expect(redTranscript).not.toHaveText(/thinking…/, { timeout: 15_000 });
+	await expect(firstTranscript).not.toHaveText(/thinking…/, {
+		timeout: 15_000,
+	});
 
 	// Poll until at least one token character arrives after the player message.
 	await page.waitForFunction(
@@ -98,24 +105,24 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 			const el = document.querySelector(selector);
 			return el != null && (el.textContent ?? "").length > minLen;
 		},
-		{ selector: '[data-transcript="red"]', minLen: afterPlayerLength },
+		{ selector: `[data-transcript="${ids[0]}"]`, minLen: afterPlayerLength },
 		{ timeout: 10_000 },
 	);
 
 	// snap0: capture transcript immediately after first content arrives.
 	// With live streaming + route.fulfill the entire AI response is already
 	// there at this point (all deltas fire synchronously in one SSE read).
-	const snap0 = (await redTranscript.textContent()) ?? "";
+	const snap0 = (await firstTranscript.textContent()) ?? "";
 
 	// ── Wait for the round to fully complete ────────────────────────────────
-	// Wait for red's full token stream to land. The encoder pacing loop still
-	// runs (pace() awaits) but skips re-appending text for live AIs. (Post-#107
-	// the send button no longer re-enables after submit because the prompt is
-	// cleared and an empty prompt has no @mention.)
-	await expect(redTranscript).toContainText(EXPECTED_TOKENS, {
+	// Wait for the first AI's full token stream to land. The encoder pacing loop
+	// still runs (pace() awaits) but skips re-appending text for live AIs.
+	// (Post-#107 the send button no longer re-enables after submit because the
+	// prompt is cleared and an empty prompt has no @mention.)
+	await expect(firstTranscript).toContainText(EXPECTED_TOKENS, {
 		timeout: 20_000,
 	});
-	const snapFinal = (await redTranscript.textContent()) ?? "";
+	const snapFinal = (await firstTranscript.textContent()) ?? "";
 
 	// ── Assertions ────────────────────────────────────────────────────────────
 

--- a/e2e/visual-feedback.spec.ts
+++ b/e2e/visual-feedback.spec.ts
@@ -1,108 +1,102 @@
 import { expect, test } from "@playwright/test";
+import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
  * E2E spec for #109: visual feedback for the active addressee.
  *
- * Three tests — no LLM stub needed (no submits):
- * 1. Type "@Sage hi": green border on #prompt, green panel highlight, @Sage overlay span.
- * 2. After step-1 setup, click blue panel: highlight transfers to blue, overlay shows @Frost.
- * 3. Clear input: all visual feedback removed.
+ * Tests read AI handles dynamically from data-ai; no spec hard-codes handle
+ * names (replaces obsolete red/green/blue/Ember/Sage/Frost fixed handles).
+ *
+ * Visual feedback in the new BBS UI:
+ *  - The addressed panel receives the `panel--addressed` CSS class.
+ *  - Non-addressed panels do NOT have `panel--addressed`.
+ *  - The overlay mention span has `--panel-color` set (not a color class name).
+ *  - Clicking a different panel rewrites the mention and transfers the highlight.
+ *  - Clearing the input removes all feedback.
  */
 
-test("typing '@Sage hi' → green border, green panel highlight, @Sage overlay span", async ({
+test("typing '@<ai1> hi' → second panel highlighted, overlay mention-highlight span", async ({
 	page,
 }) => {
+	await stubChatCompletions(page, ["hi"]);
 	await page.goto("/");
 	await expect(page.locator("#composer")).toBeVisible();
 
-	await page.fill("#prompt", "@Sage hi");
+	const { ids, names } = await getAiHandles(page);
 
-	// Composer border has composer-border--green
-	await expect(page.locator("#prompt")).toHaveClass(/composer-border--green/);
+	await page.fill("#prompt", `@${names[1]} hi`);
 
-	// Green panel has panel--addressed and panel--addressed-green
-	await expect(page.locator('.ai-panel[data-ai="green"]')).toHaveClass(
-		/panel--addressed/,
-	);
-	await expect(page.locator('.ai-panel[data-ai="green"]')).toHaveClass(
-		/panel--addressed-green/,
-	);
-
-	// Other panels do NOT have panel--addressed
-	await expect(page.locator('.ai-panel[data-ai="red"]')).not.toHaveClass(
-		/panel--addressed/,
-	);
-	await expect(page.locator('.ai-panel[data-ai="blue"]')).not.toHaveClass(
+	// Second panel has panel--addressed
+	await expect(page.locator(`.ai-panel[data-ai="${ids[1]}"]`)).toHaveClass(
 		/panel--addressed/,
 	);
 
-	// Overlay has exactly one mention-highlight span with @Sage text and mention--green
-	const highlightSpan = page.locator(
-		"#prompt-overlay .mention-highlight.mention--green",
+	// First and third panels do NOT have panel--addressed
+	await expect(page.locator(`.ai-panel[data-ai="${ids[0]}"]`)).not.toHaveClass(
+		/panel--addressed/,
 	);
+	await expect(page.locator(`.ai-panel[data-ai="${ids[2]}"]`)).not.toHaveClass(
+		/panel--addressed/,
+	);
+
+	// Overlay has exactly one mention-highlight span with the correct name
+	const highlightSpan = page.locator("#prompt-overlay .mention-highlight");
 	await expect(highlightSpan).toHaveCount(1);
-	await expect(highlightSpan).toHaveText("@Sage");
+	await expect(highlightSpan).toHaveText(`@${names[1]}`);
 });
 
-test("after typing '@Sage hi', clicking blue panel transfers highlight to blue", async ({
+test("after typing '@<ai1> hi', clicking third panel transfers highlight to third panel", async ({
 	page,
 }) => {
+	await stubChatCompletions(page, ["hi"]);
 	await page.goto("/");
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// Set up green mention first
-	await page.fill("#prompt", "@Sage hi");
-	await expect(page.locator("#prompt")).toHaveClass(/composer-border--green/);
+	const { ids, names } = await getAiHandles(page);
 
-	// Click the blue panel
-	await page.locator('.ai-panel[data-ai="blue"]').click();
+	// Set up second AI mention first
+	await page.fill("#prompt", `@${names[1]} hi`);
+	await expect(page.locator(`.ai-panel[data-ai="${ids[1]}"]`)).toHaveClass(
+		/panel--addressed/,
+	);
 
-	// Input value should start with @Frost
+	// Click the third panel
+	await page.locator(`.ai-panel[data-ai="${ids[2]}"]`).click();
+
+	// Input value should start with @<name of ids[2]>
 	const value = await page.locator("#prompt").inputValue();
-	expect(value.startsWith("@Frost")).toBe(true);
+	expect(value.startsWith(`@${names[2]}`)).toBe(true);
 
-	// Border flips to blue
-	await expect(page.locator("#prompt")).toHaveClass(/composer-border--blue/);
-	await expect(page.locator("#prompt")).not.toHaveClass(
-		/composer-border--green/,
-	);
-
-	// Blue panel now has highlight
-	await expect(page.locator('.ai-panel[data-ai="blue"]')).toHaveClass(
-		/panel--addressed/,
-	);
-	await expect(page.locator('.ai-panel[data-ai="blue"]')).toHaveClass(
-		/panel--addressed-blue/,
-	);
-
-	// Green panel no longer highlighted
-	await expect(page.locator('.ai-panel[data-ai="green"]')).not.toHaveClass(
+	// Third panel now has highlight
+	await expect(page.locator(`.ai-panel[data-ai="${ids[2]}"]`)).toHaveClass(
 		/panel--addressed/,
 	);
 
-	// Overlay highlight is @Frost with mention--blue
-	const highlightSpan = page.locator(
-		"#prompt-overlay .mention-highlight.mention--blue",
+	// Second panel no longer highlighted
+	await expect(page.locator(`.ai-panel[data-ai="${ids[1]}"]`)).not.toHaveClass(
+		/panel--addressed/,
 	);
+
+	// Overlay highlight is @<name of ids[2]>
+	const highlightSpan = page.locator("#prompt-overlay .mention-highlight");
 	await expect(highlightSpan).toHaveCount(1);
-	await expect(highlightSpan).toHaveText("@Frost");
+	await expect(highlightSpan).toHaveText(`@${names[2]}`);
 });
 
 test("clearing input removes all visual feedback", async ({ page }) => {
+	await stubChatCompletions(page, ["hi"]);
 	await page.goto("/");
 	await expect(page.locator("#composer")).toBeVisible();
 
+	const { names } = await getAiHandles(page);
+
 	// First set a mention to create visual state
-	await page.fill("#prompt", "@Sage hi");
-	await expect(page.locator("#prompt")).toHaveClass(/composer-border--green/);
+	await page.fill("#prompt", `@${names[1]} hi`);
+	await expect(page.locator(".panel--addressed")).toHaveCount(1);
 
 	// Clear the input
 	await page.fill("#prompt", "");
 	await page.locator("#prompt").dispatchEvent("input");
-
-	// No composer-border-- class on #prompt
-	const classList = await page.locator("#prompt").getAttribute("class");
-	expect(classList ?? "").not.toMatch(/composer-border--/);
 
 	// No panel--addressed on any panel
 	await expect(page.locator(".panel--addressed")).toHaveCount(0);


### PR DESCRIPTION
## What this fixes

The Playwright e2e suite was red on `main` for two compounding reasons introduced by #121 (procedural personas) and #122 (JSON-mode persona synthesis):

1. **Obsolete fixed handles.** Every spec under `e2e/` referenced AI handles that no longer exist (`red`/`green`/`blue` for panels, `Ember`/`Sage`/`Frost` for mentions). After #121 each new game produces three procedurally-named AIs (4-char `[a-z0-9]` strings) exposed via `data-ai` on `article.ai-panel`.
2. **Missing JSON-mode stub for persona synthesis.** After #122, starting a new game first fires a non-streaming `chatCompletionJson` call (`stream: false, response_format: { type: "json_object" }`) before any gameplay turn streams. The existing `stubChatCompletions` helper only fulfilled SSE — the synthesis fetch crashed against an SSE body and prevented panels from rendering at all.

The fix lives entirely in `e2e/`; no `src/` changes were needed.

- `e2e/helpers/stubs.ts` — extended `stubChatCompletions` to branch on request shape: requests with `stream === false` or a `response_format` field are answered as a JSON-mode synthesis response (`{ choices: [{ message: { content: JSON.stringify({ personas: […] }) } }] }`) whose persona ids are extracted verbatim from the synthesis user message via a `/id:\s*"([a-z0-9]{4})"/g` regex. Existing SSE callers continue to work without code changes. Two explicit helpers — `stubPersonaSynthesis` and `stubNewGameLLM` — are also exported for tests that want to control the canned blurb.
- `e2e/helpers/handles.ts` (new) — `getAiHandles(page)` waits until all three `article.ai-panel` elements have non-empty `data-ai`, then returns `{ ids, names, mention(index) }` in DOM order. Specs use this immediately after `page.goto` instead of guessing handles.
- All 10 spec files migrated to dynamic handles. `red`/`green`/`blue`/`Ember`/`Sage`/`Frost` no longer appear as identifiers in any spec.
- `e2e/persona-synthesis.spec.ts` (new) — end-to-end acceptance: stubs a sentinel synthesis blurb, drives a turn, captures the SSE request body, and asserts each AI's system prompt contains its synthesized blurb. This proves the canned content threads through `BrowserSynthesisProvider.synthesizePersonas` → persona record → `prompt-builder.ts` → wire.

Three documented deviations from the original plan, all narrow:
- `visual-feedback.spec.ts`: BBS UI does not use `composer-border--*` classes (they were removed in the BBS redesign); rewrote assertions around `panel--addressed` and `.mention-highlight` instead.
- `persistence-reload.spec.ts`: saved-game `schemaVersion` is 3, not 1; relaxed the assertion to `>=1`.
- `diagnose-streaming.spec.ts`: `addInitScript` runs before `page.route` is set up, so the synthesis-vs-SSE branch is implemented inline inside the init-script fetch override using the same regex.

## QA steps for the human

None — fully covered by the integration smoke. `pnpm smoke` ran 17/17 specs green in 11.8s with zero retries; the new acceptance spec executed (not skipped) and reached its sentinel-blurb assertion.

## Automated coverage

`pnpm typecheck`, `pnpm lint`, `pnpm test` (vitest, 687 unit tests), and `pnpm smoke` (Playwright, 17 specs) all green on this branch.

Closes #142

https://claude.ai/code/session_01QzeWVw7VJujd65MwpZbfTH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzeWVw7VJujd65MwpZbfTH)_