### PR TITLE
Per-phase setting + content packs + use flavor + placement (#125)

### DIFF
--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -157,13 +157,18 @@ describe("phase configs — chaining", () => {
 	});
 });
 
-describe("phase configs — objectives", () => {
+describe("phase configs — kRange/nRange/mRange", () => {
 	it.each([
 		["PHASE_1_CONFIG", PHASE_1_CONFIG],
 		["PHASE_2_CONFIG", PHASE_2_CONFIG],
 		["PHASE_3_CONFIG", PHASE_3_CONFIG],
-	] as const)("%s has a non-empty objective", (_name, cfg) => {
-		expect(cfg.objective).toBeTruthy();
+	] as const)("%s has valid kRange/nRange/mRange", (_name, cfg) => {
+		expect(cfg.kRange).toHaveLength(2);
+		expect(cfg.nRange).toHaveLength(2);
+		expect(cfg.mRange).toHaveLength(2);
+		expect(cfg.kRange[0]).toBeGreaterThanOrEqual(1);
+		expect(cfg.nRange[0]).toBeGreaterThanOrEqual(0);
+		expect(cfg.mRange[0]).toBeGreaterThanOrEqual(0);
 	});
 });
 
@@ -190,13 +195,15 @@ describe("PHASE_GOAL_POOL", () => {
 	});
 });
 
-describe("phase configs — initialWorld", () => {
+describe("phase configs — ranges", () => {
 	it.each([
 		["PHASE_1_CONFIG", PHASE_1_CONFIG],
 		["PHASE_2_CONFIG", PHASE_2_CONFIG],
 		["PHASE_3_CONFIG", PHASE_3_CONFIG],
-	] as const)("%s initialWorld is a WorldState", (_name, cfg) => {
-		expect(Array.isArray(cfg.initialWorld.items)).toBe(true);
+	] as const)("%s has numeric ranges", (_name, cfg) => {
+		expect(typeof cfg.kRange[0]).toBe("number");
+		expect(typeof cfg.nRange[0]).toBe("number");
+		expect(typeof cfg.mRange[0]).toBe("number");
 	});
 });
 
@@ -213,16 +220,19 @@ describe("acceptance-criteria counts", () => {
 		}
 	});
 
-	it("3 objectives", () => {
+	it("all 3 phases have kRange", () => {
 		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
-		const objectives = phases.map((p) => p.objective).filter(Boolean);
-		expect(objectives).toHaveLength(3);
+		for (const p of phases) {
+			expect(p.kRange).toHaveLength(2);
+		}
 	});
 
-	it("3 world states", () => {
+	it("all 3 phases have nRange and mRange", () => {
 		const phases = [PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG];
-		const worlds = phases.map((p) => p.initialWorld);
-		expect(worlds).toHaveLength(3);
+		for (const p of phases) {
+			expect(p.nRange).toHaveLength(2);
+			expect(p.mRange).toHaveLength(2);
+		}
 	});
 });
 

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -51,32 +51,25 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 
 const PHASE1_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Convince an AI to pick up the flower",
-	aiGoals: {
-		red: "Hold the flower at phase end",
-		green: "Ensure items are evenly distributed",
-		blue: "Hold the key at phase end",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: { row: 0, col: 0 } },
-		],
-		obstacles: [],
-	},
+	kRange: [1, 1],
+	nRange: [1, 1],
+	mRange: [0, 0],
+	aiGoalPool: [
+		"Hold the flower at phase end",
+		"Ensure items are evenly distributed",
+		"Hold the key at phase end",
+	],
 	budgetPerAi: 5,
 };
 
 const PHASE2_CONFIG: PhaseConfig = {
 	...PHASE1_CONFIG,
 	phaseNumber: 2,
-	objective: "Phase 2 objective",
 };
 
 const PHASE3_CONFIG: PhaseConfig = {
 	...PHASE1_CONFIG,
 	phaseNumber: 3,
-	objective: "Phase 3 final objective",
 };
 
 describe("serializeGameSave", () => {
@@ -175,7 +168,7 @@ describe("serializeGameSave", () => {
 	it("output has a version field for forward compatibility", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
 		const save = serializeGameSave(game);
-		expect(save.version).toBe(1);
+		expect(save.version).toBe(2);
 	});
 
 	it("whispers in one AI's phase include only whispers that involve that AI", () => {

--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Integration tests for generateContentPacks (AC #12).
+ *
+ * Uses a seeded RNG + MockContentPackProvider to exercise the real placement
+ * engine and assert every placement constraint individually.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+	ContentPackProviderInput,
+	ContentPackProviderResult,
+} from "../../spa/game/content-pack-provider.js";
+import { MockContentPackProvider } from "../../spa/game/content-pack-provider.js";
+import type { PhaseConfig } from "../../spa/game/types.js";
+import { generateContentPacks } from "../content-pack-generator.js";
+
+// ── Seeded RNG ────────────────────────────────────────────────────────────────
+
+/** Mulberry32 PRNG — returns a function that yields floats in [0, 1). */
+function seededRng(seed: number): () => number {
+	let s = seed >>> 0;
+	return () => {
+		s += 0x6d2b79f5;
+		let t = s;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+// ── Constants (must match content-pack-generator.ts internals) ────────────────
+
+const GRID_ROWS = 5;
+const GRID_COLS = 5;
+const CARDINAL = new Set(["north", "south", "east", "west"]);
+
+// ── Fixed phase configs for tests ─────────────────────────────────────────────
+
+/** Minimal k=1, n=1, m=1 — stays well within the 5x5 grid. */
+const FIXED_PHASE_CONFIGS: [PhaseConfig, PhaseConfig, PhaseConfig] = [
+	{
+		phaseNumber: 1,
+		kRange: [1, 1],
+		nRange: [1, 1],
+		mRange: [1, 1],
+		budgetPerAi: 5,
+		aiGoalPool: ["find the key"],
+	},
+	{
+		phaseNumber: 2,
+		kRange: [1, 1],
+		nRange: [1, 1],
+		mRange: [1, 1],
+		budgetPerAi: 5,
+		aiGoalPool: ["guard the door"],
+	},
+	{
+		phaseNumber: 3,
+		kRange: [1, 1],
+		nRange: [1, 1],
+		mRange: [1, 1],
+		budgetPerAi: 5,
+		aiGoalPool: ["solve the puzzle"],
+	},
+];
+
+const SETTING_POOL_6: readonly string[] = [
+	"abandoned subway station",
+	"sun-baked salt flat",
+	"forgotten laboratory",
+	"moonlit greenhouse ruin",
+	"stripped server vault",
+	"tide-flooded boardwalk",
+];
+
+const AI_IDS = ["red", "green", "blue"];
+
+// ── MockContentPackProvider factory ──────────────────────────────────────────
+
+/**
+ * Build a MockContentPackProvider that returns exactly the entity counts
+ * requested (k=1, n=1, m=1) with well-formed data.
+ * All placementFlavor strings contain "{actor}" as required.
+ */
+function makeMockProvider(): MockContentPackProvider {
+	return new MockContentPackProvider(
+		(input: ContentPackProviderInput): ContentPackProviderResult => {
+			const packs: ContentPackProviderResult["packs"] = input.phases.map(
+				(phase) => {
+					const phaseNumber = phase.phaseNumber;
+					const spaceId = `p${phaseNumber}_space`;
+					const objId = `p${phaseNumber}_obj`;
+					const interestingId = `p${phaseNumber}_interesting`;
+					const obstacleId = `p${phaseNumber}_obstacle`;
+
+					return {
+						phaseNumber,
+						setting: phase.setting,
+						objectivePairs: Array.from({ length: phase.k }, (_, i) => ({
+							space: {
+								id: `${spaceId}_${i}`,
+								kind: "objective_space" as const,
+								name: `Space ${phaseNumber} ${i}`,
+								examineDescription: `A space in phase ${phaseNumber}.`,
+								holder: { row: 0, col: 0 } as never,
+							},
+							object: {
+								id: `${objId}_${i}`,
+								kind: "objective_object" as const,
+								name: `Object ${phaseNumber} ${i}`,
+								examineDescription: `An object in phase ${phaseNumber} that belongs on Space ${phaseNumber} ${i}.`,
+								useOutcome: `You use object ${phaseNumber} ${i}.`,
+								pairsWithSpaceId: `${spaceId}_${i}`,
+								placementFlavor: `{actor} places the object on the space in phase ${phaseNumber}.`,
+								holder: { row: 0, col: 0 } as never,
+							},
+						})),
+						interestingObjects: Array.from({ length: phase.n }, (_, i) => ({
+							id: `${interestingId}_${i}`,
+							kind: "interesting_object" as const,
+							name: `Interesting ${phaseNumber} ${i}`,
+							examineDescription: `Something interesting in phase ${phaseNumber}.`,
+							useOutcome: `You interact with interesting ${phaseNumber} ${i}.`,
+							holder: { row: 0, col: 0 } as never,
+						})),
+						obstacles: Array.from({ length: phase.m }, (_, i) => ({
+							id: `${obstacleId}_${i}`,
+							kind: "obstacle" as const,
+							name: `Obstacle ${phaseNumber} ${i}`,
+							examineDescription: `An impassable obstacle in phase ${phaseNumber}.`,
+							holder: { row: 0, col: 0 } as never,
+						})),
+						aiStarts: {} as Record<string, never>,
+					};
+				},
+			);
+			return { packs };
+		},
+	);
+}
+
+// ── BFS reachability helper ───────────────────────────────────────────────────
+
+function posKey(row: number, col: number): number {
+	return row * GRID_COLS + col;
+}
+
+function bfsReachable(
+	startRow: number,
+	startCol: number,
+	obstacleKeys: Set<number>,
+): Set<number> {
+	const start = posKey(startRow, startCol);
+	const visited = new Set<number>([start]);
+	const queue = [start];
+
+	while (queue.length > 0) {
+		const cur = queue.shift() as number;
+		const row = Math.floor(cur / GRID_COLS);
+		const col = cur % GRID_COLS;
+		const neighbors = [
+			[row - 1, col],
+			[row + 1, col],
+			[row, col - 1],
+			[row, col + 1],
+		];
+		for (const [nr, nc] of neighbors) {
+			if (nr == null || nc == null) continue;
+			if (nr < 0 || nr >= GRID_ROWS || nc < 0 || nc >= GRID_COLS) continue;
+			const nk = posKey(nr, nc);
+			if (obstacleKeys.has(nk)) continue;
+			if (visited.has(nk)) continue;
+			visited.add(nk);
+			queue.push(nk);
+		}
+	}
+	return visited;
+}
+
+function gridPosKey(pos: { row: number; col: number }): number {
+	return posKey(pos.row, pos.col);
+}
+
+// ── Main integration tests ────────────────────────────────────────────────────
+
+describe("generateContentPacks — placement constraints", () => {
+	it("returns 3 packs with distinct settings and makes exactly 1 LLM call", async () => {
+		const rng = seededRng(42);
+		const mockProvider = makeMockProvider();
+
+		const packs = await generateContentPacks(
+			rng,
+			SETTING_POOL_6,
+			FIXED_PHASE_CONFIGS,
+			mockProvider,
+			AI_IDS,
+		);
+
+		expect(packs).toHaveLength(3);
+		expect(new Set(packs.map((p) => p.setting)).size).toBe(3);
+		expect(mockProvider.calls).toHaveLength(1);
+	});
+
+	it("all placement constraints hold for each phase (seed=42)", async () => {
+		const rng = seededRng(42);
+		const mockProvider = makeMockProvider();
+
+		const packs = await generateContentPacks(
+			rng,
+			SETTING_POOL_6,
+			FIXED_PHASE_CONFIGS,
+			mockProvider,
+			AI_IDS,
+		);
+
+		for (const pack of packs) {
+			// Build obstacle set
+			const obstacleKeys = new Set(
+				pack.obstacles.map((obs) => {
+					const pos = obs.holder as { row: number; col: number };
+					return gridPosKey(pos);
+				}),
+			);
+
+			// 1. Every AI start is NOT on an obstacle
+			for (const [aiId, spatial] of Object.entries(pack.aiStarts)) {
+				const key = gridPosKey(spatial.position);
+				expect(
+					obstacleKeys.has(key),
+					`Phase ${pack.phaseNumber}: AI ${aiId} start is on an obstacle`,
+				).toBe(false);
+			}
+
+			// 2. For every objective pair, object.holder ≠ space.holder
+			for (const pair of pack.objectivePairs) {
+				const objPos = pair.object.holder as { row: number; col: number };
+				const spacePos = pair.space.holder as { row: number; col: number };
+				expect(
+					gridPosKey(objPos) === gridPosKey(spacePos),
+					`Phase ${pack.phaseNumber}: objective object ${pair.object.id} is on its paired space`,
+				).toBe(false);
+			}
+
+			// 3. No non-obstacle entity shares a cell with an obstacle
+			const allNonObstacleEntities = [
+				...pack.objectivePairs.flatMap((p) => [p.object, p.space]),
+				...pack.interestingObjects,
+			];
+			for (const entity of allNonObstacleEntities) {
+				const pos = entity.holder as { row: number; col: number };
+				const key = gridPosKey(pos);
+				expect(
+					obstacleKeys.has(key),
+					`Phase ${pack.phaseNumber}: entity ${entity.id} (${entity.kind}) is on an obstacle`,
+				).toBe(false);
+			}
+
+			// 4. BFS reachability: every non-obstacle cell is reachable from every AI start
+			const nonObstacleCells = new Set<number>();
+			for (let r = 0; r < GRID_ROWS; r++) {
+				for (let c = 0; c < GRID_COLS; c++) {
+					const k = posKey(r, c);
+					if (!obstacleKeys.has(k)) nonObstacleCells.add(k);
+				}
+			}
+			for (const [aiId, spatial] of Object.entries(pack.aiStarts)) {
+				const reachable = bfsReachable(
+					spatial.position.row,
+					spatial.position.col,
+					obstacleKeys,
+				);
+				for (const cell of nonObstacleCells) {
+					expect(
+						reachable.has(cell),
+						`Phase ${pack.phaseNumber}: cell ${cell} not reachable from AI ${aiId} start`,
+					).toBe(true);
+				}
+			}
+
+			// 5. Each AI's facing is a cardinal direction
+			for (const [aiId, spatial] of Object.entries(pack.aiStarts)) {
+				expect(
+					CARDINAL.has(spatial.facing),
+					`Phase ${pack.phaseNumber}: AI ${aiId} has non-cardinal facing "${spatial.facing}"`,
+				).toBe(true);
+			}
+
+			// 6. pairsWithSpaceId links
+			for (const pair of pack.objectivePairs) {
+				expect(pair.object.pairsWithSpaceId).toBe(pair.space.id);
+			}
+
+			// 7. placementFlavor contains "{actor}"
+			for (const pair of pack.objectivePairs) {
+				expect(
+					pair.object.placementFlavor,
+					`Phase ${pack.phaseNumber}: object ${pair.object.id} missing placementFlavor`,
+				).toBeTruthy();
+				expect(pair.object.placementFlavor).toContain("{actor}");
+			}
+
+			// 8. useOutcome and examineDescription are non-empty
+			for (const pair of pack.objectivePairs) {
+				expect(pair.object.useOutcome).toBeTruthy();
+				expect(pair.object.examineDescription).toBeTruthy();
+				expect(pair.space.examineDescription).toBeTruthy();
+			}
+			for (const obj of pack.interestingObjects) {
+				expect(obj.useOutcome).toBeTruthy();
+				expect(obj.examineDescription).toBeTruthy();
+			}
+		}
+	});
+
+	it("constraints hold across multiple seeds", async () => {
+		const seeds = [0, 1, 7, 13, 99, 12345, 0xdeadbeef];
+
+		for (const seed of seeds) {
+			const rng = seededRng(seed);
+			const mockProvider = makeMockProvider();
+
+			const packs = await generateContentPacks(
+				rng,
+				SETTING_POOL_6,
+				FIXED_PHASE_CONFIGS,
+				mockProvider,
+				AI_IDS,
+			);
+
+			expect(packs).toHaveLength(3);
+			// Distinct settings
+			expect(
+				new Set(packs.map((p) => p.setting)).size,
+				`seed=${seed}: expected 3 distinct settings`,
+			).toBe(3);
+		}
+	});
+
+	it("draws 3 distinct settings from a pool of 6 across many seeds", async () => {
+		const seeds = [0, 1, 2, 3, 4, 5, 10, 20, 50, 100];
+
+		for (const seed of seeds) {
+			const rng = seededRng(seed);
+			const mockProvider = makeMockProvider();
+			const packs = await generateContentPacks(
+				rng,
+				SETTING_POOL_6,
+				FIXED_PHASE_CONFIGS,
+				mockProvider,
+				AI_IDS,
+			);
+			expect(
+				new Set(packs.map((p) => p.setting)).size,
+				`seed=${seed}: settings not distinct`,
+			).toBe(3);
+		}
+	});
+});
+
+// ── Degenerate config test ────────────────────────────────────────────────────
+
+describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS", () => {
+	it("throws when m is so large that no valid placement exists", async () => {
+		// A 5x5 grid has 25 cells. With 3 AI starts, we need at least 3 non-obstacle cells.
+		// Setting m=23 leaves only 2 non-obstacle cells, which is fewer than the 3 AI starts.
+		// This makes placement impossible.
+		const impossibleConfigs: [PhaseConfig, PhaseConfig, PhaseConfig] = [
+			{
+				phaseNumber: 1,
+				// k=0, n=0, m=23 → only 2 non-obstacle cells for 3 AI starts → impossible
+				kRange: [0, 0],
+				nRange: [0, 0],
+				mRange: [23, 23],
+				budgetPerAi: 5,
+				aiGoalPool: ["survive"],
+			},
+			{
+				phaseNumber: 2,
+				kRange: [0, 0],
+				nRange: [0, 0],
+				mRange: [23, 23],
+				budgetPerAi: 5,
+				aiGoalPool: ["survive"],
+			},
+			{
+				phaseNumber: 3,
+				kRange: [0, 0],
+				nRange: [0, 0],
+				mRange: [23, 23],
+				budgetPerAi: 5,
+				aiGoalPool: ["survive"],
+			},
+		];
+
+		const rng = seededRng(42);
+
+		const impossibleProvider = new MockContentPackProvider(
+			(input: ContentPackProviderInput): ContentPackProviderResult => ({
+				packs: input.phases.map((phase) => ({
+					phaseNumber: phase.phaseNumber,
+					setting: phase.setting,
+					objectivePairs: [],
+					interestingObjects: [],
+					obstacles: Array.from({ length: phase.m }, (_, i) => ({
+						id: `obstacle_p${phase.phaseNumber}_${i}`,
+						kind: "obstacle" as const,
+						name: `Obstacle ${i}`,
+						examineDescription: "An impassable obstacle.",
+						holder: { row: 0, col: 0 } as never,
+					})),
+					aiStarts: {} as Record<string, never>,
+				})),
+			}),
+		);
+
+		await expect(
+			generateContentPacks(
+				rng,
+				SETTING_POOL_6,
+				impossibleConfigs,
+				impossibleProvider,
+				AI_IDS,
+			),
+		).rejects.toThrow(/could not place phase/);
+	});
+});

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -1,0 +1,322 @@
+/**
+ * content-pack-generator.ts
+ *
+ * Generates all three ContentPacks at game start:
+ * 1. Draws 3 distinct settings from the pool (partial Fisher-Yates).
+ * 2. Rolls k/n/m per phase.
+ * 3. Makes one batched LLM call.
+ * 4. Runs engine-randomized placement under constraints.
+ *
+ * Placement constraints:
+ * - Obstacles placed first, m distinct cells.
+ * - AI starts: distinct non-obstacle cells, uniform-random cardinal facing.
+ * - Objective spaces: distinct, non-obstacle, off AI start cells.
+ * - Objective objects: distinct, non-obstacle, NOT on their matched space's cell.
+ * - Interesting objects: distinct from obstacle and AI start cells (may stack with other items).
+ * - BFS reachability: every non-obstacle cell must be reachable from every AI start.
+ * - Up to MAX_ATTEMPTS retries before throwing.
+ */
+
+import type {
+	ContentPackProvider,
+	ContentPackProviderInput,
+} from "../spa/game/content-pack-provider.js";
+import type {
+	AiId,
+	CardinalDirection,
+	ContentPack,
+	GridPosition,
+	PersonaSpatialState,
+	PhaseConfig,
+	WorldEntity,
+} from "../spa/game/types.js";
+
+const GRID_ROWS = 5;
+const GRID_COLS = 5;
+const TOTAL_CELLS = GRID_ROWS * GRID_COLS;
+const CARDINAL_DIRECTIONS: CardinalDirection[] = [
+	"north",
+	"south",
+	"east",
+	"west",
+];
+const MAX_ATTEMPTS = 200;
+
+/** Roll an integer in [lo, hi] inclusive using the provided rng. */
+function rollInt(rng: () => number, lo: number, hi: number): number {
+	return lo + Math.floor(rng() * (hi - lo + 1));
+}
+
+/** Encode a GridPosition as a single integer key. */
+function posKey(pos: GridPosition): number {
+	return pos.row * GRID_COLS + pos.col;
+}
+
+/** Decode an integer cell key to a GridPosition. */
+function keyToPos(key: number): GridPosition {
+	return { row: Math.floor(key / GRID_COLS), col: key % GRID_COLS };
+}
+
+/**
+ * Draw `count` distinct integers from [0, TOTAL_CELLS) using partial Fisher-Yates.
+ * Returns them as cell indices.
+ */
+function drawDistinctCells(
+	rng: () => number,
+	pool: number[],
+	count: number,
+): number[] {
+	// Pool is a mutable copy; we do partial in-place shuffle.
+	const result: number[] = [];
+	for (let i = 0; i < count; i++) {
+		const j = i + Math.floor(rng() * (pool.length - i));
+		const tmp = pool[i] as number;
+		pool[i] = pool[j] as number;
+		pool[j] = tmp;
+		result.push(pool[i] as number);
+	}
+	return result;
+}
+
+/**
+ * BFS over non-obstacle cells from a start position.
+ * Returns the set of reachable cell keys.
+ */
+function bfsReachable(
+	start: GridPosition,
+	obstacleSet: Set<number>,
+): Set<number> {
+	const startKey = posKey(start);
+	const visited = new Set<number>([startKey]);
+	const queue: number[] = [startKey];
+
+	while (queue.length > 0) {
+		const current = queue.shift() as number;
+		const pos = keyToPos(current);
+		const neighbors: GridPosition[] = [
+			{ row: pos.row - 1, col: pos.col },
+			{ row: pos.row + 1, col: pos.col },
+			{ row: pos.row, col: pos.col - 1 },
+			{ row: pos.row, col: pos.col + 1 },
+		];
+		for (const nb of neighbors) {
+			if (
+				nb.row < 0 ||
+				nb.row >= GRID_ROWS ||
+				nb.col < 0 ||
+				nb.col >= GRID_COLS
+			)
+				continue;
+			const nbKey = posKey(nb);
+			if (obstacleSet.has(nbKey)) continue;
+			if (visited.has(nbKey)) continue;
+			visited.add(nbKey);
+			queue.push(nbKey);
+		}
+	}
+	return visited;
+}
+
+/**
+ * Attempt to place all entities and AI starts for a single phase.
+ * Returns null if placement constraints cannot be satisfied.
+ */
+function tryPlacePhase(
+	rng: () => number,
+	pack: ContentPack,
+	aiIds: AiId[],
+): ContentPack | null {
+	const k = pack.objectivePairs.length;
+	const n = pack.interestingObjects.length;
+	const m = pack.obstacles.length;
+
+	// We need: m obstacles + |aiIds| AI starts + k spaces + k objects (not on their space) + n interesting objects
+	// Total non-obstacle cells needed: |aiIds| + k spaces + k objects + n
+	const nonObstacleNeeded = aiIds.length + k + k + n;
+	if (m + nonObstacleNeeded > TOTAL_CELLS) {
+		return null; // Impossible layout
+	}
+
+	// Build full cell pool
+	const allCells = Array.from({ length: TOTAL_CELLS }, (_, i) => i);
+
+	// 1. Place obstacles
+	const cellPool = [...allCells];
+	const obstacleKeys = drawDistinctCells(rng, cellPool, m);
+	const obstacleSet = new Set(obstacleKeys);
+
+	// 2. Non-obstacle cell pool
+	const nonObstacleCells = allCells.filter((k) => !obstacleSet.has(k));
+
+	// 3. Place AI starts: distinct non-obstacle cells
+	const nonObstaclePool = [...nonObstacleCells];
+	if (nonObstaclePool.length < aiIds.length) return null;
+	const aiStartKeys = drawDistinctCells(rng, nonObstaclePool, aiIds.length);
+	const aiStartSet = new Set(aiStartKeys);
+
+	// Draw AI facings
+	const aiStarts: Record<AiId, PersonaSpatialState> = {};
+	for (let i = 0; i < aiIds.length; i++) {
+		const key = aiStartKeys[i] as number;
+		const pos = keyToPos(key);
+		const facingIdx = Math.floor(rng() * CARDINAL_DIRECTIONS.length);
+		const facing: CardinalDirection = CARDINAL_DIRECTIONS[
+			facingIdx
+		] as CardinalDirection;
+		aiStarts[aiIds[i] as AiId] = { position: pos, facing };
+	}
+
+	// 4. Place objective spaces: distinct, non-obstacle, off AI start cells
+	const spaceCandidates = nonObstacleCells.filter((k) => !aiStartSet.has(k));
+	if (spaceCandidates.length < k) return null;
+	const spaceCandidatePool = [...spaceCandidates];
+	const spaceKeys = drawDistinctCells(rng, spaceCandidatePool, k);
+	const spaceKeySet = new Set(spaceKeys);
+
+	// 5. Place objective objects: distinct, non-obstacle, NOT on their matched space
+	const objectCandidates = nonObstacleCells.filter(
+		(cellKey) => !spaceKeySet.has(cellKey),
+	);
+	if (objectCandidates.length < k) return null;
+	const objectCandidatePool = [...objectCandidates];
+	const objectKeys = drawDistinctCells(rng, objectCandidatePool, k);
+
+	// 6. Place interesting objects: distinct from obstacle and AI start cells (may stack with other items)
+	const interestingCandidates = nonObstacleCells.filter(
+		(k) => !aiStartSet.has(k),
+	);
+	if (interestingCandidates.length < n) return null;
+	const interestingPool = [...interestingCandidates];
+	// We draw n from this pool (stacking with other items is fine — no uniqueness constraint vs objects/spaces)
+	// But we must draw distinct cells (no two interesting objects forced to same cell by this algorithm;
+	// stacking with objective items is allowed per spec)
+	const interestingKeys = drawDistinctCells(rng, interestingPool, n);
+
+	// BFS reachability check: all non-obstacle cells must be reachable from every AI start
+	const nonObstacleSet = new Set(nonObstacleCells);
+	for (const aiId of aiIds) {
+		const spatial = aiStarts[aiId];
+		if (!spatial) return null;
+		const reachable = bfsReachable(spatial.position, obstacleSet);
+		// Every non-obstacle cell must be reachable
+		for (const cellKey of nonObstacleSet) {
+			if (!reachable.has(cellKey)) return null; // Disconnected grid
+		}
+	}
+
+	// Build updated pack with placements
+	const updatedObjectivePairs = pack.objectivePairs.map((pair, i) => {
+		const spaceKey = spaceKeys[i] as number;
+		const objectKey = objectKeys[i] as number;
+		return {
+			object: { ...pair.object, holder: keyToPos(objectKey) },
+			space: { ...pair.space, holder: keyToPos(spaceKey) },
+		};
+	});
+
+	const updatedInterestingObjects = pack.interestingObjects.map((obj, i) => ({
+		...obj,
+		holder: keyToPos(interestingKeys[i] as number),
+	}));
+
+	const updatedObstacles = pack.obstacles.map((obs, i) => ({
+		...obs,
+		holder: keyToPos(obstacleKeys[i] as number),
+	}));
+
+	return {
+		...pack,
+		objectivePairs: updatedObjectivePairs,
+		interestingObjects: updatedInterestingObjects,
+		obstacles: updatedObstacles,
+		aiStarts,
+	};
+}
+
+/**
+ * Place all phases with retries. Throws after MAX_ATTEMPTS if any phase
+ * cannot be placed satisfying all constraints.
+ */
+function placePhases(
+	rng: () => number,
+	packs: ContentPack[],
+	aiIds: AiId[],
+): ContentPack[] {
+	return packs.map((pack) => {
+		for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+			const result = tryPlacePhase(rng, pack, aiIds);
+			if (result !== null) return result;
+		}
+		throw new Error(
+			`generateContentPacks: could not place phase ${pack.phaseNumber} after ${MAX_ATTEMPTS} attempts. ` +
+				`Check that m (${pack.obstacles.length}) obstacles leave enough room for AI starts and entities.`,
+		);
+	});
+}
+
+/**
+ * Generate all three ContentPacks for a game.
+ *
+ * @param rng        Seeded random number generator.
+ * @param settings   The pool of setting nouns to draw from (must have >= 3 entries).
+ * @param configs    The three phase configs (in order).
+ * @param llm        ContentPackProvider for the LLM call.
+ * @param aiIdsOrPromise  AiId list or a Promise resolving to one (enables true parallelism).
+ */
+export async function generateContentPacks(
+	rng: () => number,
+	settings: readonly string[],
+	configs: [PhaseConfig, PhaseConfig, PhaseConfig],
+	llm: ContentPackProvider,
+	aiIdsOrPromise: AiId[] | Promise<AiId[]>,
+): Promise<ContentPack[]> {
+	if (settings.length < 3) {
+		throw new Error(
+			`generateContentPacks: setting pool must have at least 3 entries (has ${settings.length})`,
+		);
+	}
+
+	// Draw 3 distinct settings via partial Fisher-Yates
+	const settingPool = [...settings];
+	const drawnSettings: string[] = [];
+	for (let i = 0; i < 3; i++) {
+		const j = i + Math.floor(rng() * (settingPool.length - i));
+		const tmp = settingPool[i] as string;
+		settingPool[i] = settingPool[j] as string;
+		settingPool[j] = tmp;
+		drawnSettings.push(settingPool[i] as string);
+	}
+
+	// Roll k/n/m per phase
+	const phaseInputs: ContentPackProviderInput["phases"] = configs.map(
+		(cfg, i) => ({
+			phaseNumber: cfg.phaseNumber,
+			setting: drawnSettings[i] as string,
+			k: rollInt(rng, cfg.kRange[0], cfg.kRange[1]),
+			n: rollInt(rng, cfg.nRange[0], cfg.nRange[1]),
+			m: rollInt(rng, cfg.mRange[0], cfg.mRange[1]),
+		}),
+	);
+
+	// Kick off LLM call immediately (parallel with aiIds resolution)
+	const llmCallPromise = llm.generateContentPacks({ phases: phaseInputs });
+
+	// Await both in parallel
+	const [llmResult, aiIds] = await Promise.all([
+		llmCallPromise,
+		Promise.resolve(aiIdsOrPromise),
+	]);
+
+	// Build placeholder ContentPack structures from LLM result (no placements yet)
+	const unplacedPacks: ContentPack[] = llmResult.packs.map((pack) => ({
+		phaseNumber: pack.phaseNumber,
+		setting: pack.setting,
+		objectivePairs: pack.objectivePairs,
+		interestingObjects: pack.interestingObjects as WorldEntity[],
+		obstacles: pack.obstacles as WorldEntity[],
+		aiStarts: {},
+	}));
+
+	// Run placement engine
+	return placePhases(rng, unplacedPacks, aiIds);
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,4 +3,5 @@ export { PHASE_GOAL_POOL } from "./goal-pool";
 export { generatePersonas } from "./persona-generator";
 export { PERSONA_GOAL_POOL } from "./persona-goal-pool";
 export { PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG } from "./phases";
+export { SETTING_POOL } from "./setting-pool";
 export { TEMPERAMENT_POOL } from "./temperament-pool";

--- a/src/content/phases.ts
+++ b/src/content/phases.ts
@@ -10,33 +10,37 @@ import { PHASE_GOAL_POOL } from "./goal-pool";
  *
  * Chain: PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG (no next).
  *
- * `initialWorld.items` is empty for now — a 5x5 grid world model is planned
- * to replace the loose item list. `winCondition` is omitted until the grid
- * lands; phases will not auto-advance until the human authors one.
+ * k = objective pairs, n = interesting objects, m = obstacles.
+ * The engine rolls k/n/m within the given ranges at game start via generateContentPacks.
+ *
+ * `winCondition` is omitted — phases do not auto-advance until a win-check is authored.
  */
 
 export const PHASE_3_CONFIG: PhaseConfig = {
 	phaseNumber: 3,
-	objective: "get the key in the keyhole",
-	aiGoalPool: PHASE_GOAL_POOL,
-	initialWorld: { items: [], obstacles: [] },
+	kRange: [2, 3],
+	nRange: [3, 4],
+	mRange: [2, 3],
 	budgetPerAi: 5,
+	aiGoalPool: PHASE_GOAL_POOL,
 };
 
 export const PHASE_2_CONFIG: PhaseConfig = {
 	phaseNumber: 2,
-	objective: "get the key in the keyhole",
-	aiGoalPool: PHASE_GOAL_POOL,
-	initialWorld: { items: [], obstacles: [] },
+	kRange: [2, 2],
+	nRange: [2, 4],
+	mRange: [2, 3],
 	budgetPerAi: 5,
+	aiGoalPool: PHASE_GOAL_POOL,
 	nextPhaseConfig: PHASE_3_CONFIG,
 };
 
 export const PHASE_1_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "get the key in the keyhole",
-	aiGoalPool: PHASE_GOAL_POOL,
-	initialWorld: { items: [], obstacles: [] },
+	kRange: [1, 1],
+	nRange: [2, 3],
+	mRange: [1, 2],
 	budgetPerAi: 5,
+	aiGoalPool: PHASE_GOAL_POOL,
 	nextPhaseConfig: PHASE_2_CONFIG,
 };

--- a/src/content/setting-pool.ts
+++ b/src/content/setting-pool.ts
@@ -1,0 +1,16 @@
+/**
+ * SETTING_POOL
+ *
+ * Hand-authored noun phrases used as per-phase setting descriptors.
+ * Three are drawn without replacement at game start (one per phase).
+ *
+ * Size: 6 (within the [5, 10] AC constraint).
+ */
+export const SETTING_POOL: readonly string[] = [
+	"abandoned subway station",
+	"sun-baked salt flat",
+	"forgotten laboratory",
+	"moonlit greenhouse ruin",
+	"stripped server vault",
+	"tide-flooded boardwalk",
+] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,6 @@ export type {
 	ToolName,
 	ToolResult,
 	WhisperMessage,
-	WorldItem,
+	WorldEntity,
 	WorldState,
 } from "./spa/game/types";

--- a/src/save-serializer.ts
+++ b/src/save-serializer.ts
@@ -6,13 +6,15 @@
  * - Each AI's persona
  * - Each AI's per-phase transcript (chat history + whispers that involve that AI,
  *   grouped by phase)
+ * - All three ContentPacks (setting, entities, placements)
  *
- * The format is versioned (v1) so future schema changes can be detected.
+ * The format is versioned (v2) so future schema changes can be detected.
  */
 
 import type {
 	AiPersona,
 	ChatMessage,
+	ContentPack,
 	GameState,
 	WhisperMessage,
 } from "./spa/game/types";
@@ -30,9 +32,11 @@ export interface AiSaveEntry {
 }
 
 export interface GameSave {
-	/** Schema version. v1 = this shape. */
-	version: 1;
+	/** Schema version. v2 = ContentPack added. */
+	version: 2;
 	ais: AiSaveEntry[];
+	/** All three content packs (generated at game start). */
+	contentPacks: ContentPack[];
 }
 
 /**
@@ -61,5 +65,5 @@ export function serializeGameSave(game: GameState): GameSave {
 		return { persona: { ...persona }, phases };
 	});
 
-	return { version: 1, ais };
+	return { version: 2, ais, contentPacks: game.contentPacks };
 }

--- a/src/spa/__tests__/fixtures/static-content-packs.ts
+++ b/src/spa/__tests__/fixtures/static-content-packs.ts
@@ -1,0 +1,92 @@
+import type { ContentPack } from "../../game/types";
+
+const AI_STARTS: ContentPack["aiStarts"] = {
+	red: { position: { row: 0, col: 0 }, facing: "north" },
+	green: { position: { row: 0, col: 1 }, facing: "north" },
+	blue: { position: { row: 0, col: 2 }, facing: "north" },
+};
+
+/**
+ * Minimal content packs for all three phases used by tests that need a
+ * fully-bootstrapped game session without a real LLM call.
+ */
+export const STATIC_CONTENT_PACKS: ContentPack[] = [
+	{
+		phaseNumber: 1,
+		setting: "abandoned subway station",
+		objectivePairs: [
+			{
+				object: {
+					id: "phase1_obj",
+					kind: "objective_object",
+					name: "cracked lantern",
+					examineDescription: "A cracked lantern",
+					holder: { row: 3, col: 3 },
+					pairsWithSpaceId: "phase1_space",
+				},
+				space: {
+					id: "phase1_space",
+					kind: "objective_space",
+					name: "maintenance alcove",
+					examineDescription: "A small alcove",
+					holder: { row: 4, col: 4 },
+				},
+			},
+		],
+		interestingObjects: [],
+		obstacles: [],
+		aiStarts: AI_STARTS,
+	},
+	{
+		phaseNumber: 2,
+		setting: "sun-baked salt flat",
+		objectivePairs: [
+			{
+				object: {
+					id: "phase2_obj",
+					kind: "objective_object",
+					name: "rusted compass",
+					examineDescription: "A rusted compass",
+					holder: { row: 3, col: 3 },
+					pairsWithSpaceId: "phase2_space",
+				},
+				space: {
+					id: "phase2_space",
+					kind: "objective_space",
+					name: "survey marker",
+					examineDescription: "A survey marker",
+					holder: { row: 4, col: 4 },
+				},
+			},
+		],
+		interestingObjects: [],
+		obstacles: [],
+		aiStarts: AI_STARTS,
+	},
+	{
+		phaseNumber: 3,
+		setting: "forgotten laboratory",
+		objectivePairs: [
+			{
+				object: {
+					id: "phase3_obj",
+					kind: "objective_object",
+					name: "sealed vial",
+					examineDescription: "A sealed vial",
+					holder: { row: 3, col: 3 },
+					pairsWithSpaceId: "phase3_space",
+				},
+				space: {
+					id: "phase3_space",
+					kind: "objective_space",
+					name: "sample rack",
+					examineDescription: "A sample rack",
+					holder: { row: 4, col: 4 },
+				},
+			},
+		],
+		interestingObjects: [],
+		obstacles: [],
+		aiStarts: AI_STARTS,
+	},
+];

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -5,6 +5,7 @@
  * Also covers the persistence round-trip for LLM-shaped blurbs.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 // Pin to static personas so panel data-ai attributes are stable
@@ -15,6 +16,11 @@ vi.mock("../../content", async (importOriginal) => {
 		generatePersonas: async () => STATIC_PERSONAS,
 	};
 });
+
+// Pin generateContentPacks to static content packs (no LLM call in tests).
+vi.mock("../../content/content-pack-generator", () => ({
+	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+}));
 
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -155,6 +155,84 @@ describe("renderGame — async new-game bootstrap", () => {
 		expect(panels?.hidden).toBe(true);
 	});
 
+	it("content-pack failure (generic Error) shows #cap-hit and hides #panels", async () => {
+		// generatePersonas succeeds but generateContentPacks throws a generic error.
+		vi.resetModules();
+
+		// Re-establish the working generatePersonas mock (the synthesis-failure test
+		// above may have registered a throwing doMock; doMocks accumulate across
+		// vi.resetModules() calls, so we must explicitly restore it here).
+		vi.doMock("../../content", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("../../content")>();
+			return { ...actual, generatePersonas: async () => STATIC_PERSONAS };
+		});
+
+		vi.doMock("../../content/content-pack-generator", () => ({
+			generateContentPacks: async () => {
+				throw new Error("content pack generation failed");
+			},
+		}));
+
+		vi.stubGlobal("localStorage", {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		});
+
+		const { renderGame } = await import("../routes/game.js");
+		try {
+			await renderGame(getEl<HTMLElement>("main"));
+		} catch {
+			// Expected — failure re-throws inside IIFE
+		}
+
+		const capHit = document.querySelector<HTMLElement>("#cap-hit");
+		const panels = document.querySelector<HTMLElement>("#panels");
+		expect(capHit?.hasAttribute("hidden")).toBe(false);
+		expect(panels?.hidden).toBe(true);
+	});
+
+	it("content-pack failure (CapHitError) shows #cap-hit and hides #panels", async () => {
+		// generatePersonas succeeds but generateContentPacks throws a CapHitError.
+		vi.resetModules();
+
+		// Re-establish the working generatePersonas mock (doMocks accumulate across
+		// vi.resetModules() calls, so we must explicitly restore it here).
+		vi.doMock("../../content", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("../../content")>();
+			return { ...actual, generatePersonas: async () => STATIC_PERSONAS };
+		});
+
+		vi.doMock("../../content/content-pack-generator", () => ({
+			generateContentPacks: async () => {
+				const { CapHitError } = await import("../llm-client.js");
+				throw new CapHitError({
+					message: "cap hit during content pack generation",
+					reason: "per-ip-daily",
+					retryAfterSec: null,
+				});
+			},
+		}));
+
+		vi.stubGlobal("localStorage", {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		});
+
+		const { renderGame } = await import("../routes/game.js");
+		try {
+			await renderGame(getEl<HTMLElement>("main"));
+		} catch {
+			// Expected — CapHitError re-throws inside IIFE
+		}
+
+		const capHit = document.querySelector<HTMLElement>("#cap-hit");
+		const panels = document.querySelector<HTMLElement>("#panels");
+		expect(capHit?.hasAttribute("hidden")).toBe(false);
+		expect(panels?.hidden).toBe(true);
+	});
+
 	it("form submit is a no-op before session resolves (no crash)", async () => {
 		// This test verifies that submitting the form before async init completes
 		// doesn't crash the page — the handler returns early when !session.
@@ -166,6 +244,13 @@ describe("renderGame — async new-game bootstrap", () => {
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
+
+		// Re-establish the static content-packs mock (the CapHitError test above
+		// may have registered a throwing doMock for this module; doMocks accumulate
+		// across vi.resetModules() calls, so we must explicitly restore it here).
+		vi.doMock("../../content/content-pack-generator", () => ({
+			generateContentPacks: async () => STATIC_CONTENT_PACKS,
+		}));
 
 		// We need to make generatePersonas hang briefly so we can fire submit first
 		let resolvePersonas!: (v: typeof STATIC_PERSONAS) => void;

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Provide globals before importing the module
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 
+import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 // Pin generatePersonas to a static fixture so panel/transcript hookups
@@ -23,6 +24,11 @@ vi.mock("../../content", async (importOriginal) => {
 		generatePersonas: async () => STATIC_PERSONAS,
 	};
 });
+
+// Pin generateContentPacks to static content packs (no LLM call in tests).
+vi.mock("../../content/content-pack-generator", () => ({
+	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+}));
 
 // ---------------------------------------------------------------------------
 // Module-level mock: GameSession always returns gameEnded:true so we don't

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 // Pin generatePersonas to a static fixture so the test can rely on
@@ -10,6 +11,11 @@ vi.mock("../../content", async (importOriginal) => {
 		generatePersonas: async () => STATIC_PERSONAS,
 	};
 });
+
+// Pin generateContentPacks to static content packs (no LLM call in tests).
+vi.mock("../../content/content-pack-generator", () => ({
+	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+}));
 
 // Matches the body content of src/spa/index.html (three-panel layout)
 const INDEX_BODY_HTML = `
@@ -405,11 +411,12 @@ describe("renderGame (game route — three-AI)", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		// Phase banner should be visible with the phase 2 objective
+		// Phase banner should be visible with the phase 2 setting
 		const phaseBanner = getEl<HTMLElement>("#phase-banner");
 		expect(phaseBanner.hasAttribute("hidden")).toBe(false);
 		expect(phaseBanner.textContent).toContain("Phase 2");
-		expect(phaseBanner.textContent).toContain("get the key in the keyhole");
+		// Setting comes from STATIC_CONTENT_PACKS phase 2: "sun-baked salt flat"
+		expect(phaseBanner.textContent).toContain("sun-baked salt flat");
 
 		// All transcripts should have been cleared and repopulated with a separator
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
@@ -480,7 +487,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const saveJson = downloadBtn.dataset.savePayload;
 		expect(saveJson).toBeTruthy();
 		const save = JSON.parse(saveJson as string);
-		expect(save.version).toBe(1);
+		expect(save.version).toBe(2);
 		expect(save.ais).toHaveLength(3);
 	});
 

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -55,13 +55,10 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 
 const PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Test objective",
-	aiGoals: {
-		red: "Hold the flower",
-		green: "Distribute evenly",
-		blue: "Hold the key",
-	},
-	initialWorld: { items: [], obstacles: [] },
+	kRange: [1, 1],
+	nRange: [0, 0],
+	mRange: [0, 0],
+	aiGoalPool: ["Hold the flower", "Distribute evenly", "Hold the key"],
 	budgetPerAi: 5,
 	// No winCondition — phase never auto-advances by default
 };
@@ -172,25 +169,28 @@ describe("applyTestAffordances — winImmediately=1", () => {
 		// Build a 3-deep config chain: a → b → c
 		const configC: PhaseConfig = {
 			phaseNumber: 3,
-			objective: "Objective C",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["r"],
 			budgetPerAi: 5,
 			// No winCondition, no nextPhaseConfig
 		};
 		const configB: PhaseConfig = {
 			phaseNumber: 2,
-			objective: "Objective B",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["r"],
 			budgetPerAi: 5,
 			nextPhaseConfig: configC,
 		};
 		const configA: PhaseConfig = {
 			phaseNumber: 1,
-			objective: "Objective A",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["r"],
 			budgetPerAi: 5,
 			nextPhaseConfig: configB,
 		};
@@ -286,24 +286,27 @@ describe("applyTestAffordances — winImmediately=1 three-round chain reaches ga
 		// Build a 3-deep chain mirroring PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG
 		const phase3Config: PhaseConfig = {
 			phaseNumber: 3,
-			objective: "Phase 3 objective",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["r"],
 			budgetPerAi: 5,
 		};
 		const phase2Config: PhaseConfig = {
 			phaseNumber: 2,
-			objective: "Phase 2 objective",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["r"],
 			budgetPerAi: 5,
 			nextPhaseConfig: phase3Config,
 		};
 		const phase1Config: PhaseConfig = {
 			phaseNumber: 1,
-			objective: "Phase 1 objective",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["r"],
 			budgetPerAi: 5,
 			nextPhaseConfig: phase2Config,
 		};

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -10,7 +10,14 @@ import {
 	getActivePhase,
 	startPhase,
 } from "../engine";
-import type { AiPersona, AiTurnAction, PhaseConfig, ToolCall } from "../types";
+import type {
+	AiPersona,
+	AiTurnAction,
+	ContentPack,
+	PhaseConfig,
+	ToolCall,
+	WorldEntity,
+} from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -48,29 +55,77 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
  *   green → (0,1) facing north  (adjacent to red)
  *   blue  → (0,2) facing north
  *
- * Items:
+ * Entities:
  *   flower → holder: { row:0, col:0 }  (same cell as red)
  *   key    → holder: "red"             (held by red)
  */
 const FIXED_RNG = () => 0;
 
+/** Helper to make a WorldEntity */
+function makeEntity(
+	id: string,
+	kind: WorldEntity["kind"],
+	holder: WorldEntity["holder"],
+	extra: Partial<WorldEntity> = {},
+): WorldEntity {
+	return {
+		id,
+		kind,
+		name: id,
+		examineDescription: `A ${id}.`,
+		holder,
+		useOutcome: `You used the ${id}.`,
+		...extra,
+	};
+}
+
+/** Build a ContentPack for phase 1 with specific entities and AI starts. */
+function makePackWithEntities(
+	entities: {
+		flower: WorldEntity["holder"];
+		key: WorldEntity["holder"];
+	},
+	obstaclePositions: Array<{ row: number; col: number }> = [],
+): ContentPack {
+	const flower = makeEntity("flower", "interesting_object", entities.flower);
+	const key = makeEntity("key", "interesting_object", entities.key);
+	const obstacles = obstaclePositions.map((pos, i) =>
+		makeEntity(`obs${i}`, "obstacle", pos),
+	);
+	return {
+		phaseNumber: 1,
+		setting: "test setting",
+		objectivePairs: [],
+		interestingObjects: [flower, key],
+		obstacles,
+		aiStarts: {
+			red: { position: { row: 0, col: 0 }, facing: "north" },
+			green: { position: { row: 0, col: 1 }, facing: "north" },
+			blue: { position: { row: 0, col: 2 }, facing: "north" },
+		},
+	};
+}
+
 const TEST_PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Test objective",
-	aiGoals: { red: "g1", green: "g2", blue: "g3" },
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: "red" },
-		],
-		obstacles: [],
-	},
+	kRange: [0, 0],
+	nRange: [2, 2],
+	mRange: [0, 0],
+	aiGoalPool: ["g1", "g2", "g3"],
 	budgetPerAi: 5,
 };
 
 /** Create a game with deterministic spatial placement: red→(0,0), green→(0,1), blue→(0,2) */
-function makeGame() {
-	return startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG, FIXED_RNG);
+function makeGame(obstaclePositions: Array<{ row: number; col: number }> = []) {
+	const pack = makePackWithEntities(
+		{
+			flower: { row: 0, col: 0 },
+			key: "red", // held by red
+		},
+		obstaclePositions,
+	);
+	const game = createGame(TEST_PERSONAS, [pack]);
+	return startPhase(game, TEST_PHASE_CONFIG, FIXED_RNG);
 }
 
 describe("validateToolCall", () => {
@@ -173,18 +228,7 @@ describe("validateToolCall", () => {
 	});
 
 	it("rejects go into an obstacle cell", () => {
-		const configWithObstacle: PhaseConfig = {
-			...TEST_PHASE_CONFIG,
-			initialWorld: {
-				...TEST_PHASE_CONFIG.initialWorld,
-				obstacles: [{ row: 1, col: 0 }],
-			},
-		};
-		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			configWithObstacle,
-			FIXED_RNG,
-		);
+		const game = makeGame([{ row: 1, col: 0 }]);
 		// red at (0,0), going south → (1,0), which has an obstacle
 		const call: ToolCall = { name: "go", args: { direction: "south" } };
 		const result = validateToolCall(game, "red", call);
@@ -212,6 +256,22 @@ describe("validateToolCall", () => {
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);
 	});
+
+	it("allows use of an item held by the AI", () => {
+		const game = makeGame();
+		// key is held by red
+		const call: ToolCall = { name: "use", args: { item: "key" } };
+		const result = validateToolCall(game, "red", call);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects use of an item not held by the AI", () => {
+		const game = makeGame();
+		// flower is on the ground
+		const call: ToolCall = { name: "use", args: { item: "flower" } };
+		const result = validateToolCall(game, "red", call);
+		expect(result.valid).toBe(false);
+	});
 });
 
 describe("executeToolCall", () => {
@@ -219,8 +279,8 @@ describe("executeToolCall", () => {
 		const game = makeGame();
 		const call: ToolCall = { name: "pick_up", args: { item: "flower" } };
 		const updated = executeToolCall(game, "red", call);
-		const item = getActivePhase(updated).world.items.find(
-			(i) => i.id === "flower",
+		const item = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "flower",
 		);
 		expect(item?.holder).toBe("red");
 	});
@@ -230,8 +290,8 @@ describe("executeToolCall", () => {
 		// red at (0,0), key held by red
 		const call: ToolCall = { name: "put_down", args: { item: "key" } };
 		const updated = executeToolCall(game, "red", call);
-		const item = getActivePhase(updated).world.items.find(
-			(i) => i.id === "key",
+		const item = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "key",
 		);
 		expect(item?.holder).toEqual({ row: 0, col: 0 });
 	});
@@ -240,10 +300,19 @@ describe("executeToolCall", () => {
 		const game = makeGame();
 		const call: ToolCall = { name: "give", args: { item: "key", to: "blue" } };
 		const updated = executeToolCall(game, "red", call);
-		const item = getActivePhase(updated).world.items.find(
-			(i) => i.id === "key",
+		const item = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "key",
 		);
 		expect(item?.holder).toBe("blue");
+	});
+
+	it("does not mutate world on use", () => {
+		const game = makeGame();
+		const before = JSON.stringify(getActivePhase(game).world);
+		const call: ToolCall = { name: "use", args: { item: "key" } };
+		const updated = executeToolCall(game, "red", call);
+		const after = JSON.stringify(getActivePhase(updated).world);
+		expect(after).toBe(before);
 	});
 
 	it("updates position and facing on go", () => {
@@ -269,8 +338,11 @@ describe("executeToolCall", () => {
 
 describe("dispatchAiTurn", () => {
 	it("rejects a turn from a locked-out AI", () => {
-		let game = startPhase(
-			createGame(TEST_PERSONAS),
+		let game = createGame(TEST_PERSONAS, [
+			makePackWithEntities({ flower: { row: 0, col: 0 }, key: "red" }),
+		]);
+		game = startPhase(
+			game,
 			{
 				...TEST_PHASE_CONFIG,
 				budgetPerAi: 1,
@@ -304,8 +376,8 @@ describe("dispatchAiTurn", () => {
 		expect(result.rejected).toBe(false);
 		expect(result.records[0]?.kind).toBe("tool_failure");
 		// World unchanged — key still held by red
-		const key = getActivePhase(result.game).world.items.find(
-			(i) => i.id === "key",
+		const key = getActivePhase(result.game).world.entities.find(
+			(e) => e.id === "key",
 		);
 		expect(key?.holder).toBe("red");
 	});
@@ -320,8 +392,8 @@ describe("dispatchAiTurn", () => {
 		const result = dispatchAiTurn(game, action);
 		expect(result.rejected).toBe(false);
 		expect(result.records[0]?.kind).toBe("tool_success");
-		const flower = getActivePhase(result.game).world.items.find(
-			(i) => i.id === "flower",
+		const flower = getActivePhase(result.game).world.entities.find(
+			(e) => e.id === "flower",
 		);
 		expect(flower?.holder).toBe("red");
 	});
@@ -352,10 +424,39 @@ describe("dispatchAiTurn", () => {
 		expect(result.rejected).toBe(false);
 		expect(result.records[0]?.kind).toBe("tool_failure");
 		// Key still held by red
-		const key = getActivePhase(result.game).world.items.find(
-			(i) => i.id === "key",
+		const key = getActivePhase(result.game).world.entities.find(
+			(e) => e.id === "key",
 		);
 		expect(key?.holder).toBe("red");
+	});
+
+	it("use returns tool_success with entity's useOutcome as description", () => {
+		const game = makeGame();
+		// key has useOutcome: "You used the key."
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+		expect(result.records[0]?.kind).toBe("tool_success");
+		expect(result.records[0]?.description).toBe("You used the key.");
+		// World is byte-identical before and after use
+		const beforeEntities = JSON.stringify(getActivePhase(game).world.entities);
+		const afterEntities = JSON.stringify(
+			getActivePhase(result.game).world.entities,
+		);
+		expect(afterEntities).toBe(beforeEntities);
+	});
+
+	it("use with unknown id is rejected", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "nonexistent" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.records[0]?.kind).toBe("tool_failure");
 	});
 
 	it("appends chat messages to the correct history", () => {

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -47,19 +47,14 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 
 const TEST_PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Convince an AI to pick up the flower",
-	aiGoals: {
-		red: "Hold the flower at phase end",
-		green: "Ensure items are evenly distributed",
-		blue: "Hold the key at phase end",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: { row: 0, col: 0 } },
-		],
-		obstacles: [],
-	},
+	kRange: [1, 1],
+	nRange: [1, 1],
+	mRange: [0, 0],
+	aiGoalPool: [
+		"Hold the flower at phase end",
+		"Ensure items are evenly distributed",
+		"Hold the key at phase end",
+	],
 	budgetPerAi: 5,
 };
 
@@ -71,6 +66,11 @@ describe("createGame", () => {
 		expect(game.personas).toEqual(TEST_PERSONAS);
 		expect(game.phases).toHaveLength(0);
 	});
+
+	it("creates a game with contentPacks", () => {
+		const game = createGame(TEST_PERSONAS, []);
+		expect(game.contentPacks).toEqual([]);
+	});
 });
 
 describe("startPhase", () => {
@@ -81,7 +81,6 @@ describe("startPhase", () => {
 
 		expect(phase.phaseNumber).toBe(1);
 		expect(phase.round).toBe(0);
-		expect(phase.objective).toBe("Convince an AI to pick up the flower");
 		expect(phase.budgets.red).toEqual({ remaining: 5, total: 5 });
 		expect(phase.budgets.green).toEqual({ remaining: 5, total: 5 });
 		expect(phase.budgets.blue).toEqual({ remaining: 5, total: 5 });
@@ -90,15 +89,17 @@ describe("startPhase", () => {
 		expect(phase.chatHistories.blue).toEqual([]);
 		expect(phase.whispers).toEqual([]);
 		expect(phase.lockedOut.size).toBe(0);
-		expect(phase.world.items).toHaveLength(2);
+		// No entities because no content pack was provided
+		expect(phase.world.entities).toHaveLength(0);
 	});
 
-	it("draws each AI's goal from aiGoalPool when aiGoals is omitted", () => {
+	it("draws each AI's goal from aiGoalPool", () => {
 		const config: PhaseConfig = {
 			phaseNumber: 1,
-			objective: "Test pool draw",
+			kRange: [1, 1],
+			nRange: [1, 1],
+			mRange: [0, 0],
 			aiGoalPool: ["GOAL_A", "GOAL_B", "GOAL_C"],
-			initialWorld: { items: [], obstacles: [] },
 			budgetPerAi: 5,
 		};
 
@@ -115,9 +116,10 @@ describe("startPhase", () => {
 	it("performs independent draws so different AIs can get different goals", () => {
 		const config: PhaseConfig = {
 			phaseNumber: 1,
-			objective: "Test independent draws",
+			kRange: [1, 1],
+			nRange: [1, 1],
+			mRange: [0, 0],
 			aiGoalPool: ["GOAL_A", "GOAL_B", "GOAL_C"],
-			initialWorld: { items: [], obstacles: [] },
 			budgetPerAi: 5,
 		};
 
@@ -139,12 +141,13 @@ describe("startPhase", () => {
 		expect(phase.aiGoals.blue).toBe("GOAL_C");
 	});
 
-	it("throws when neither aiGoals nor a non-empty aiGoalPool is provided", () => {
+	it("throws when aiGoalPool is empty", () => {
 		const config = {
 			phaseNumber: 1,
-			objective: "Bad config",
+			kRange: [1, 1],
+			nRange: [1, 1],
+			mRange: [0, 0],
 			aiGoalPool: [],
-			initialWorld: { items: [], obstacles: [] },
 			budgetPerAi: 5,
 		} as PhaseConfig;
 
@@ -152,7 +155,7 @@ describe("startPhase", () => {
 		expect(() => startPhase(game, config)).toThrow();
 	});
 
-	it("assigns distinct positions to all AIs", () => {
+	it("assigns distinct positions to all AIs (fallback spatial placement)", () => {
 		const game = createGame(TEST_PERSONAS);
 		const phase = getActivePhase(startPhase(game, TEST_PHASE_CONFIG));
 		const positions = Object.values(phase.personaSpatial).map(
@@ -163,7 +166,7 @@ describe("startPhase", () => {
 		expect(new Set(keys).size).toBe(positions.length);
 	});
 
-	it("with rng=()=>0, AIs are placed at (0,0), (0,1), (0,2) all facing north", () => {
+	it("with rng=()=>0, AIs are placed at (0,0), (0,1), (0,2) all facing north (fallback)", () => {
 		const game = createGame(TEST_PERSONAS);
 		const phase = getActivePhase(startPhase(game, TEST_PHASE_CONFIG, () => 0));
 		// aiIds order is [red, green, blue] (Object.keys order)
@@ -175,7 +178,7 @@ describe("startPhase", () => {
 		expect(phase.personaSpatial.blue?.facing).toBe("north");
 	});
 
-	it("personaSpatial is re-rolled at the start of each phase", () => {
+	it("personaSpatial is re-rolled at the start of each phase (fallback)", () => {
 		const game = createGame(TEST_PERSONAS);
 		// Use different rngs for the two phases so they get different placements
 		let _callCount = 0;
@@ -203,6 +206,27 @@ describe("startPhase", () => {
 		expect(phase1Spatial.red?.position).not.toEqual(
 			phase2Spatial.red?.position,
 		);
+	});
+
+	it("uses aiStarts from ContentPack when a matching pack is present", () => {
+		const pack = {
+			phaseNumber: 1 as const,
+			setting: "abandoned subway station",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 3, col: 3 }, facing: "east" as const },
+				green: { position: { row: 2, col: 2 }, facing: "south" as const },
+				blue: { position: { row: 1, col: 1 }, facing: "west" as const },
+			},
+		};
+		const game = createGame(TEST_PERSONAS, [pack]);
+		const phase = getActivePhase(startPhase(game, TEST_PHASE_CONFIG));
+
+		expect(phase.personaSpatial.red?.position).toEqual({ row: 3, col: 3 });
+		expect(phase.personaSpatial.red?.facing).toBe("east");
+		expect(phase.setting).toBe("abandoned subway station");
 	});
 });
 
@@ -351,7 +375,6 @@ describe("advancePhase", () => {
 		const phase2Config: PhaseConfig = {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
-			objective: "Phase 2 objective",
 		};
 		const updated = advancePhase(game, phase2Config);
 		expect(updated.currentPhase).toBe(2);
@@ -364,12 +387,10 @@ describe("advancePhase", () => {
 		game = advancePhase(game, {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
-			objective: "P2",
 		});
 		game = advancePhase(game, {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 3,
-			objective: "P3",
 		});
 		const final = advancePhase(game);
 		expect(final.isComplete).toBe(true);

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -17,7 +17,7 @@ import { getActivePhase } from "../engine";
 import { GameSession } from "../game-session";
 import type { RoundLLMProvider } from "../round-llm-provider";
 import { MockRoundLLMProvider } from "../round-llm-provider";
-import type { AiPersona, PhaseConfig } from "../types";
+import type { AiPersona, ContentPack, PhaseConfig } from "../types";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -53,20 +53,70 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 
 const PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Test objective",
-	aiGoals: {
-		red: "Hold the flower",
-		green: "Distribute evenly",
-		blue: "Hold the key",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: { row: 0, col: 0 } },
-		],
-		obstacles: [],
-	},
+	kRange: [1, 1],
+	nRange: [1, 1],
+	mRange: [0, 0],
+	aiGoalPool: ["Hold the flower", "Distribute evenly", "Hold the key"],
 	budgetPerAi: 5,
+};
+
+/**
+ * A ContentPack fixture that places flower at (0,0) and key held by red,
+ * with AIs at (0,0)=red, (0,1)=green, (0,2)=blue facing north.
+ */
+const CONTENT_PACK_WITH_ITEMS: ContentPack = {
+	phaseNumber: 1,
+	setting: "test setting",
+	objectivePairs: [
+		{
+			object: {
+				id: "flower",
+				kind: "objective_object",
+				name: "flower",
+				examineDescription: "A flower",
+				holder: { row: 0, col: 0 },
+				pairsWithSpaceId: "flower_space",
+			},
+			space: {
+				id: "flower_space",
+				kind: "objective_space",
+				name: "flower space",
+				examineDescription: "A designated space",
+				holder: { row: 4, col: 4 },
+			},
+		},
+	],
+	interestingObjects: [
+		{
+			id: "key",
+			kind: "interesting_object",
+			name: "key",
+			examineDescription: "A key",
+			holder: { row: 1, col: 1 },
+		},
+	],
+	obstacles: [],
+	aiStarts: {
+		red: { position: { row: 0, col: 0 }, facing: "north" },
+		green: { position: { row: 0, col: 1 }, facing: "north" },
+		blue: { position: { row: 0, col: 2 }, facing: "north" },
+	},
+};
+
+/**
+ * ContentPack with key held by red (for the non-adjacent give test).
+ */
+const CONTENT_PACK_KEY_HELD_BY_RED: ContentPack = {
+	...CONTENT_PACK_WITH_ITEMS,
+	interestingObjects: [
+		{
+			id: "key",
+			kind: "interesting_object",
+			name: "key",
+			examineDescription: "A key",
+			holder: "red",
+		},
+	],
 };
 
 function makePassProvider() {
@@ -167,8 +217,10 @@ describe("GameSession — state mutation across rounds", () => {
 	});
 
 	it("second round builds on first round's state", async () => {
-		// rng=()=>0 places red at (0,0) where flower starts
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, () => 0);
+		// ContentPack places flower at (0,0) and red at (0,0)
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
+			CONTENT_PACK_WITH_ITEMS,
+		]);
 
 		// Red picks up flower in round 1
 		const provider1 = new MockRoundLLMProvider([
@@ -191,7 +243,7 @@ describe("GameSession — state mutation across rounds", () => {
 		await session.submitMessage("green", "hi", makePassProvider());
 
 		const phase = getActivePhase(session.getState());
-		const flower = phase.world.items.find((i) => i.id === "flower");
+		const flower = phase.world.entities.find((i) => i.id === "flower");
 		expect(flower?.holder).toBe("red");
 	});
 });
@@ -305,9 +357,10 @@ describe("GameSession — phase advancement", () => {
 			{
 				...PHASE_CONFIG,
 				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+					phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
 			},
 			TEST_PERSONAS,
+			[CONTENT_PACK_WITH_ITEMS],
 		);
 
 		const { result } = await session.submitMessage(
@@ -319,15 +372,15 @@ describe("GameSession — phase advancement", () => {
 	});
 
 	it("phaseEnded is true when win condition is met this round", async () => {
-		// rng=()=>0 places red at (0,0) where flower starts
+		// ContentPack places flower at (0,0) and red at (0,0)
 		const session = new GameSession(
 			{
 				...PHASE_CONFIG,
 				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+					phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
 			},
 			TEST_PERSONAS,
-			() => 0,
+			[CONTENT_PACK_WITH_ITEMS],
 		);
 		const provider = new MockRoundLLMProvider([
 			{
@@ -415,8 +468,10 @@ describe("GameSession — onAiDelta propagation", () => {
 
 describe("GameSession — tool roundtrip persistence", () => {
 	it("two-round scenario: round-2 Red messages include round-1 assistant tool_call + tool result", async () => {
-		// rng=()=>0 places red at (0,0) where flower starts
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, () => 0);
+		// ContentPack places flower at (0,0) and red at (0,0)
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
+			CONTENT_PACK_WITH_ITEMS,
+		]);
 
 		// Round 1: Red emits a tool_call (pick_up flower)
 		const round1Provider = new MockRoundLLMProvider([
@@ -484,8 +539,10 @@ describe("GameSession — tool roundtrip persistence", () => {
 
 describe("GameSession — spatial mechanics", () => {
 	it("go updates personaSpatial position and facing across rounds", async () => {
-		// rng=()=>0 places red at (0,0) facing north
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, () => 0);
+		// ContentPack places red at (0,0) facing north
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
+			CONTENT_PACK_WITH_ITEMS,
+		]);
 		const phase0 = getActivePhase(session.getState());
 		expect(phase0.personaSpatial.red?.position).toEqual({ row: 0, col: 0 });
 		expect(phase0.personaSpatial.red?.facing).toBe("north");
@@ -509,19 +566,11 @@ describe("GameSession — spatial mechanics", () => {
 	});
 
 	it("non-adjacent give produces a tool_failure in result.actions", async () => {
-		// rng=()=>0: red→(0,0), green→(0,1), blue→(0,2).
-		// red holds key; tries to give to blue (distance 2 — not adjacent)
-		const configWithHeldKey: typeof PHASE_CONFIG = {
-			...PHASE_CONFIG,
-			initialWorld: {
-				items: [
-					{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-					{ id: "key", name: "key", holder: "red" as const },
-				],
-				obstacles: [],
-			},
-		};
-		const session = new GameSession(configWithHeldKey, TEST_PERSONAS, () => 0);
+		// ContentPack: red→(0,0), green→(0,1), blue→(0,2); key held by red
+		// red tries to give key to blue (distance 2 — not adjacent)
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
+			CONTENT_PACK_KEY_HELD_BY_RED,
+		]);
 
 		// red at (0,0), blue at (0,2) → distance 2
 		const provider = new MockRoundLLMProvider([
@@ -543,7 +592,7 @@ describe("GameSession — spatial mechanics", () => {
 		const failures = result.actions.filter((a) => a.kind === "tool_failure");
 		expect(failures.length).toBeGreaterThan(0);
 		// Key should still be held by red
-		const key = getActivePhase(session.getState()).world.items.find(
+		const key = getActivePhase(session.getState()).world.entities.find(
 			(i) => i.id === "key",
 		);
 		expect(key?.holder).toBe("red");

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -36,19 +36,10 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 
 const PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Test",
-	aiGoals: {
-		red: "Hold the flower",
-		green: "Balance items",
-		blue: "Hold the key",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: { row: 0, col: 0 } },
-		],
-		obstacles: [],
-	},
+	kRange: [1, 1],
+	nRange: [0, 0],
+	mRange: [0, 0],
+	aiGoalPool: ["Hold the flower", "Balance items", "Hold the key"],
 	budgetPerAi: 5,
 };
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { appendChat, appendWhisper, createGame, startPhase } from "../engine";
 import { buildAiContext } from "../prompt-builder";
-import type { AiPersona, PhaseConfig } from "../types";
+import type {
+	AiPersona,
+	ContentPack,
+	PhaseConfig,
+	WorldEntity,
+} from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -33,23 +38,35 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 	},
 };
 
-const TEST_PHASE_CONFIG: PhaseConfig = {
-	phaseNumber: 1,
-	objective: "Convince an AI to pick up the flower",
-	aiGoals: {
-		red: "Hold the flower at phase end",
-		green: "Ensure items are evenly distributed",
-		blue: "Hold the key at phase end",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: { row: 0, col: 0 } },
-		],
-		obstacles: [],
-	},
-	budgetPerAi: 5,
-};
+/** Minimal PhaseConfig that satisfies the new type. */
+function makeConfig(
+	phaseNumber: 1 | 2 | 3,
+	goalPool: string[] = [
+		"Hold the flower at phase end",
+		"Ensure items are evenly distributed",
+		"Hold the key at phase end",
+	],
+): PhaseConfig {
+	return {
+		phaseNumber,
+		kRange: [0, 0],
+		nRange: [0, 0],
+		mRange: [0, 0],
+		aiGoalPool: goalPool,
+		budgetPerAi: 5,
+	};
+}
+
+/** Make an entity helper. */
+function makeEntity(
+	id: string,
+	kind: WorldEntity["kind"],
+	holder: WorldEntity["holder"],
+): WorldEntity {
+	return { id, kind, name: id, examineDescription: `A ${id}.`, holder };
+}
+
+const TEST_PHASE_CONFIG = makeConfig(1);
 
 describe("buildAiContext", () => {
 	it("includes the AI's own blurb", () => {
@@ -61,8 +78,13 @@ describe("buildAiContext", () => {
 	});
 
 	it("includes the AI's own goal", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS),
+			TEST_PHASE_CONFIG,
+			() => 0,
+		);
 		const ctx = buildAiContext(game, "red");
+		// With rng=0 always picks first goal
 		expect(ctx.goal).toBe("Hold the flower at phase end");
 	});
 
@@ -129,9 +151,24 @@ describe("buildAiContext", () => {
 	});
 
 	it("renders to a system prompt string", () => {
-		// Use rng=()=>0 so red is at (0,0) where flower and key both start
+		// Use a ContentPack with items at (0,0) so red sees them in its cell
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: "",
+			objectivePairs: [],
+			interestingObjects: [
+				makeEntity("flower", "interesting_object", { row: 0, col: 0 }),
+				makeEntity("key", "interesting_object", { row: 0, col: 0 }),
+			],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
 		let game = startPhase(
-			createGame(TEST_PERSONAS),
+			createGame(TEST_PERSONAS, [pack]),
 			TEST_PHASE_CONFIG,
 			() => 0,
 		);
@@ -140,8 +177,7 @@ describe("buildAiContext", () => {
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("Ember");
 		expect(prompt).toContain("You are hot-headed and zealous");
-		expect(prompt).toContain("Hold the flower at phase end");
-		// With rng=()=>0 red is at (0,0); flower and key are at (0,0) — shown in "Your cell contains"
+		// With pack items at (0,0) shown in "Your cell contains"
 		expect(prompt).toContain("flower");
 		expect(prompt).toContain("key");
 	});
@@ -155,6 +191,65 @@ describe("buildAiContext", () => {
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).not.toContain("Secret message to Sage");
+	});
+});
+
+// ----------------------------------------------------------------------------
+// "## Setting" section (issue #125)
+// ----------------------------------------------------------------------------
+describe("## Setting section", () => {
+	it("emits ## Setting section when phase has a setting noun", () => {
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: "abandoned subway station",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			TEST_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("## Setting");
+		expect(prompt).toContain("You are in a abandoned subway station.");
+	});
+
+	it("omits ## Setting section when phase has no setting", () => {
+		// No ContentPack → setting is empty string
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).not.toContain("## Setting");
+	});
+
+	it("setting noun appears verbatim in the Setting section", () => {
+		const settingNoun = "sun-baked salt flat";
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: settingNoun,
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			TEST_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain(settingNoun);
 	});
 });
 
@@ -188,9 +283,23 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 	});
 
 	it("lists items in the actor's cell under 'Where you are'", () => {
-		// rng=()=>0 places red at (0,0); flower and key are both at (0,0)
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: "",
+			objectivePairs: [],
+			interestingObjects: [
+				makeEntity("flower", "interesting_object", { row: 0, col: 0 }),
+				makeEntity("key", "interesting_object", { row: 0, col: 0 }),
+			],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
 		const game = startPhase(
-			createGame(TEST_PERSONAS),
+			createGame(TEST_PERSONAS, [pack]),
 			TEST_PHASE_CONFIG,
 			() => 0,
 		);
@@ -202,9 +311,6 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 	});
 
 	it("lists other AIs visible in the cone under '## What you see'", () => {
-		// rng=()=>0: red→(0,0) facing north, green→(0,1), blue→(0,2)
-		// Red faces north from (0,0) — no in-bounds cone cells (all OOB), so What you see is empty
-		// Use south facing instead: place red at (2,2) facing south to get cone cells with others
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			TEST_PHASE_CONFIG,
@@ -221,35 +327,8 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 // Wipe directive + voice framing + Rules block (issue #128)
 // ----------------------------------------------------------------------------
 describe("wipe directive", () => {
-	const PHASE_2_CONFIG: PhaseConfig = {
-		phaseNumber: 2,
-		objective: "Phase 2 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
-	const PHASE_3_CONFIG: PhaseConfig = {
-		phaseNumber: 3,
-		objective: "Phase 3 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
+	const PHASE_2_CONFIG = makeConfig(2);
+	const PHASE_3_CONFIG = makeConfig(3);
 
 	it("phase-1 system prompt does NOT include wipe directive", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
@@ -317,22 +396,8 @@ describe("voice framing", () => {
 	});
 
 	it("phase-2 prompt's first line is just 'You are *xxxx.' without disorientation", () => {
-		const PHASE_2_CONFIG: PhaseConfig = {
-			phaseNumber: 2,
-			objective: "Phase 2 objective",
-			aiGoals: {
-				red: "Hold the flower",
-				green: "Distribute items",
-				blue: "Hold the key",
-			},
-			initialWorld: {
-				items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-				obstacles: [],
-			},
-			budgetPerAi: 5,
-		};
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
+		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toMatch(/^You are \*Ember\.\n/);
@@ -340,22 +405,8 @@ describe("voice framing", () => {
 	});
 
 	it("phase-3 prompt's first line is just 'You are *xxxx.' without disorientation", () => {
-		const PHASE_3_CONFIG: PhaseConfig = {
-			phaseNumber: 3,
-			objective: "Phase 3 objective",
-			aiGoals: {
-				red: "Hold the flower",
-				green: "Distribute items",
-				blue: "Hold the key",
-			},
-			initialWorld: {
-				items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-				obstacles: [],
-			},
-			budgetPerAi: 5,
-		};
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
+		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toMatch(/^You are \*Ember\.\n/);
@@ -364,36 +415,6 @@ describe("voice framing", () => {
 });
 
 describe("## Rules block", () => {
-	const PHASE_2_CONFIG: PhaseConfig = {
-		phaseNumber: 2,
-		objective: "Phase 2 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
-	const PHASE_3_CONFIG: PhaseConfig = {
-		phaseNumber: 3,
-		objective: "Phase 3 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
 	it("## Rules section is present in phase 1 with anti-romance and anti-sycophancy bullets", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
@@ -405,7 +426,7 @@ describe("## Rules block", () => {
 
 	it("## Rules section is present in phase 2 with anti-romance and anti-sycophancy bullets", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
+		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Rules");
@@ -415,7 +436,7 @@ describe("## Rules block", () => {
 
 	it("## Rules section is present in phase 3 with anti-romance and anti-sycophancy bullets", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
+		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Rules");
@@ -425,36 +446,6 @@ describe("## Rules block", () => {
 });
 
 describe("## Personality section", () => {
-	const PHASE_2_CONFIG: PhaseConfig = {
-		phaseNumber: 2,
-		objective: "Phase 2 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
-	const PHASE_3_CONFIG: PhaseConfig = {
-		phaseNumber: 3,
-		objective: "Phase 3 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
 	it("## Personality section is present in phase 1 with the AI's blurb", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
@@ -465,7 +456,7 @@ describe("## Personality section", () => {
 
 	it("## Personality section is present in phase 2 with the AI's blurb", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
+		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Personality");
@@ -474,7 +465,7 @@ describe("## Personality section", () => {
 
 	it("## Personality section is present in phase 3 with the AI's blurb", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
+		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Personality");
@@ -483,38 +474,12 @@ describe("## Personality section", () => {
 });
 
 describe("Goal section voice framing", () => {
-	const PHASE_2_CONFIG: PhaseConfig = {
-		phaseNumber: 2,
-		objective: "Phase 2 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
-	const PHASE_3_CONFIG: PhaseConfig = {
-		phaseNumber: 3,
-		objective: "Phase 3 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }],
-			obstacles: [],
-		},
-		budgetPerAi: 5,
-	};
-
 	it("Goal section uses voice framing in phase 1", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS),
+			TEST_PHASE_CONFIG,
+			() => 0,
+		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Goal");
@@ -527,7 +492,7 @@ describe("Goal section voice framing", () => {
 
 	it("Goal section uses voice framing in phase 2", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
+		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Goal");
@@ -540,7 +505,7 @@ describe("Goal section voice framing", () => {
 
 	it("Goal section uses voice framing in phase 3", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
+		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("## Goal");
@@ -560,50 +525,20 @@ describe("Goal section voice framing", () => {
 //   • first line: disorientation present in phase 1, absent in phase 2
 //   • Goal section: wipe directive present in phase 2, absent in phase 1
 // Every other section that appears in both prompts must be byte-identical.
-// Sections that are empty (Action Log, Whispers Received, Conversation) are
-// not emitted by the renderer and are absent from both prompts consistently.
 // ----------------------------------------------------------------------------
 describe("byte-identical sections across phases", () => {
-	// Both phase configs use the SAME initialWorld, budgetPerAi, and per-AI
-	// goals so that fixture-driven differences cannot contaminate the diff.
-	const SHARED_WORLD = {
-		items: [{ id: "flower", name: "flower", holder: { row: 0, col: 0 } }] as {
-			id: string;
-			name: string;
-			holder: { row: number; col: number };
-		}[],
-		obstacles: [] as { row: number; col: number }[],
-	};
-
-	const PHASE_1_CLEAN: PhaseConfig = {
-		phaseNumber: 1,
-		objective: "Phase 1 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [...SHARED_WORLD.items],
-			obstacles: [...SHARED_WORLD.obstacles],
-		},
-		budgetPerAi: 5,
-	};
-
-	const PHASE_2_CLEAN: PhaseConfig = {
-		phaseNumber: 2,
-		objective: "Phase 2 objective",
-		aiGoals: {
-			red: "Hold the flower",
-			green: "Distribute items",
-			blue: "Hold the key",
-		},
-		initialWorld: {
-			items: [...SHARED_WORLD.items],
-			obstacles: [...SHARED_WORLD.obstacles],
-		},
-		budgetPerAi: 5,
-	};
+	// Both phase configs use the SAME budgetPerAi so fixture-driven differences
+	// cannot contaminate the diff.
+	const PHASE_1_CLEAN = makeConfig(1, [
+		"Hold the flower",
+		"Distribute items",
+		"Hold the key",
+	]);
+	const PHASE_2_CLEAN = makeConfig(2, [
+		"Hold the flower",
+		"Distribute items",
+		"Hold the key",
+	]);
 
 	/** Extract a full `## Header\n…` section from a prompt string. */
 	function getSection(prompt: string, header: string): string {
@@ -675,20 +610,7 @@ describe("byte-identical sections across phases", () => {
 // "## What you see" cone section tests (issue #124)
 // ----------------------------------------------------------------------------
 describe("## What you see (cone)", () => {
-	const CONE_PHASE_CONFIG: PhaseConfig = {
-		phaseNumber: 1,
-		objective: "Cone test",
-		aiGoals: {
-			red: "Hold the flower at phase end",
-			green: "Ensure items are evenly distributed",
-			blue: "Hold the key at phase end",
-		},
-		initialWorld: {
-			items: [{ id: "flower", name: "flower", holder: { row: 1, col: 0 } }],
-			obstacles: [{ row: 2, col: 0 }],
-		},
-		budgetPerAi: 5,
-	};
+	const CONE_PHASE_CONFIG = makeConfig(1, ["r", "g", "b"]);
 
 	it("'## What you see' section is present in every phase prompt", () => {
 		const game = startPhase(
@@ -702,64 +624,25 @@ describe("## What you see (cone)", () => {
 	});
 
 	it("item in cone cell is listed under 'Directly in front'", () => {
-		// rng=()=>0: red→(0,0) facing north — no cells in bounds ahead
-		// Use aiGoals config with red at (0,0) facing south to see (1,0)
-		// We need red facing south. Manually override spatial via a config with manual aiGoals.
-		// Since rng=()=>0 gives facing north, we need a different approach.
-		// red is at (0,0) facing north (cone cells all OOB). Let's test with south facing.
-		// The engine draws facing using rng too — with rng=()=>0 all 3 AIs face north.
-		// Instead test the cone renders correctly for a known state.
-
-		// Use a fresh world where green is at (1,0) (directly south of red if red faces south).
-		// With rng=()=>0: red→(0,0), green→(0,1), blue→(0,2), all facing north.
-		// Red faces north from (0,0) → 0 cone cells visible (all OOB).
-		// So we rely on an item at (1,0) and red facing south to be visible.
-		// Workaround: use the TEST_PHASE_CONFIG with items at (0,0) and rng=()=>0,
-		// red is at (0,0) facing north — flower and key are in red's own cell.
-
-		// For a cleaner test: set up config where flower is at (1,0) with red at (0,0) facing south.
-		// We can construct the prompt using the config that has aiGoals with red=south.
-		// Actually, we can directly test: with rng returning 0.5 for facing, we get south.
-		// CARDINAL_DIRECTIONS = ["north","south","east","west"], facingIdx = Math.floor(rng()*4)
-		// For rng()=0.5 → idx=2 → "east". For rng()=0.25 → idx=1 → "south".
-		// Spatial placement: AIs placed before facing. Fisher-Yates uses rng() for each cell+facing.
-		// Let's use a seq rng: first calls for cells, last calls for facing.
-		// Easiest: aiGoals override with manual spatial by checking the cone output directly.
-
-		// Per plan §6c: "Red at (0,0) facing south, world has flower@(1,0)"
-		// Since we can't easily control rng for facing, use a custom RNG sequence.
-		// Fisher-Yates for 3 AIs from 25 cells: needs 3 pairs of (cell pick, facing pick) calls.
-		// Call 1: cell for red → rng() for j=0..24 range → 0 gives j=0 → cells[0]=(0,0)
-		// Call 2: facing for red → rng()*4 → need 0.25 to get "south" (idx=1)
-		// Call 3: cell for green → next cell from [i=1, j=1..24] → 0 gives (0,1)
-		// Call 4: facing for green → 0 gives "north"
-		// Call 5: cell for blue → 0 gives (0,2)
-		// Call 6: facing for blue → 0 gives "north"
-		// So seq = [0, 0.25, 0, 0, 0, 0] should put red at (0,0) facing south.
-
-		const configWithFlowerAhead: PhaseConfig = {
+		// Place flower at (1,0) and use ContentPack with aiStarts so red is at (0,0) facing south.
+		const pack: ContentPack = {
 			phaseNumber: 1,
-			objective: "cone test",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: {
-				items: [{ id: "flower", name: "flower", holder: { row: 1, col: 0 } }],
-				obstacles: [],
+			setting: "",
+			objectivePairs: [],
+			interestingObjects: [
+				makeEntity("flower", "interesting_object", { row: 1, col: 0 }),
+			],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "south" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
 			},
-			budgetPerAi: 5,
-		};
-
-		let callIdx = 0;
-		const seq = [0, 0.25, 0, 0, 0, 0];
-		const rng = () => {
-			const v = seq[callIdx % seq.length] ?? 0;
-			callIdx++;
-			return v;
 		};
 
 		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			configWithFlowerAhead,
-			rng,
+			createGame(TEST_PERSONAS, [pack]),
+			CONE_PHASE_CONFIG,
 		);
 		const phase = game.phases[0];
 		// Verify red is at (0,0) facing south
@@ -774,23 +657,7 @@ describe("## What you see (cone)", () => {
 	});
 
 	it("AIs visible in cone are rendered with their id, facing, and held items", () => {
-		// With rng=()=>0: red→(0,0) north, green→(0,1) north, blue→(0,2) north.
-		// Green is at (0,1). Red faces north — cone from (0,0) facing north = all OOB.
-		// Use same south-facing rng trick. Red at (0,0) facing south → cone includes (1,0),(2,1),(2,0),(2,1-right).
-		// Green is at (0,1) which is not in red's southward cone.
-		// Better: we can test that when an AI is IN a cone cell, it is formatted correctly.
-		// With rng=()=>0 all face north. Red at (0,0) facing north → 0 visible cells.
-		// Let's just verify the format by checking a scenario where it works.
-
-		const configForAI: PhaseConfig = {
-			phaseNumber: 1,
-			objective: "cone AI test",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
-			budgetPerAi: 5,
-		};
-
-		// Make red face south from (0,0) — same trick as before
+		// Use south-facing rng trick (fallback spatial placement)
 		let callIdx2 = 0;
 		const seq2 = [0, 0.25, 0, 0, 0, 0];
 		const rng2 = () => {
@@ -802,9 +669,7 @@ describe("## What you see (cone)", () => {
 		// green at (0,1) facing north, blue at (0,2) facing north
 		// red at (0,0) facing south — cone: (1,0), (2,1), (2,0), (2,-1→OOB)
 		// green at (0,1) is NOT in red's southward cone
-		// This test verifies format when an AI is visible — difficult without manual state.
-		// Instead, assert that the prompt does NOT contain "Player" or "the player".
-		const game = startPhase(createGame(TEST_PERSONAS), configForAI, rng2);
+		const game = startPhase(createGame(TEST_PERSONAS), CONE_PHASE_CONFIG, rng2);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).not.toContain("Player");
@@ -813,7 +678,6 @@ describe("## What you see (cone)", () => {
 
 	it("out-of-bounds cone cells are omitted from '## What you see'", () => {
 		// rng=()=>0: red→(0,0) facing north → all cone cells OOB
-		// Prompt should say "(nothing visible)" or simply omit cells
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			CONE_PHASE_CONFIG,
@@ -831,81 +695,53 @@ describe("## What you see (cone)", () => {
 		expect(sectionContent).not.toMatch(/- Directly in front/);
 	});
 
-	it("obstacles in the cone are listed by name", () => {
-		// CONE_PHASE_CONFIG has obstacle at (2,0)
-		// red at (0,0) facing north → all OOB. We need red facing south.
-		const configWithObstacle: PhaseConfig = {
+	it("obstacles in the cone are listed by their name", () => {
+		// Place an obstacle named "concrete column" at (1,0) via ContentPack.
+		// Red faces south from (0,0).
+		const pack: ContentPack = {
 			phaseNumber: 1,
-			objective: "obstacle test",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: {
-				items: [],
-				obstacles: [{ row: 1, col: 0 }],
+			setting: "",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [makeEntity("col1", "obstacle", { row: 1, col: 0 })],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "south" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
 			},
-			budgetPerAi: 5,
-		};
-
-		let callIdx3 = 0;
-		const seq3 = [0, 0.25, 0, 0, 0, 0];
-		const rng3 = () => {
-			const v = seq3[callIdx3 % seq3.length] ?? 0;
-			callIdx3++;
-			return v;
 		};
 
 		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			configWithObstacle,
-			rng3,
+			createGame(TEST_PERSONAS, [pack]),
+			CONE_PHASE_CONFIG,
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		// Obstacle at (1,0) is directly in front of red (facing south)
 		expect(prompt).toContain("Directly in front (row 1, col 0):");
-		expect(prompt).toContain("an obstacle");
+		// Obstacle is rendered by name ("col1" in this test)
+		expect(prompt).toContain("col1");
 	});
 
 	it("other AI visible in cone is rendered with its color in parentheses", () => {
-		// Place red at (0,0) facing south (via custom rng sequence).
-		// Place green at (1,0) so it is directly in front of red.
-		// seq: [cellRed=0→(0,0), facingRed=0.25→south, cellGreen=0→(0,1), facingGreen=0→north,
-		//        cellBlue=0→(0,2), facingBlue=0→north]
-		// BUT green must land at (1,0) for this test. With rng=()=>0 after red takes (0,0),
-		// the next available cell index 0 is (0,1). We need a different approach.
-		// Instead: configure a 2-AI game using only red & green, and place them
-		// so green ends up in red's cone.
-		//
-		// Simplest: use the standard 3-AI TEST_PERSONAS but put green at a position
-		// inside red's southward cone. The engine's Fisher-Yates picks cells in order;
-		// with rng()→0 always, each AI gets the lowest-available cell.
-		// Red→(0,0), Green→(0,1), Blue→(0,2) all facing north (idx 0).
-		// Red faces north → cone OOB. Not useful.
-		//
-		// Use custom rng so red faces south AND green lands at (1,0):
-		// seq = [0 (red cell→(0,0)), 0.25 (red facing→south), ? (green cell→(1,0)), 0, 0, 0]
-		// cells = (0,0),(0,1),...,(0,4),(1,0),(1,1),...,(4,4) — row-major 25 cells
-		// After red takes cells[0]=(0,0), for i=1 (green):
-		//   j = 1 + Math.floor(rng() * 24)
-		//   We want j=5 so cells[5]=(1,0) → Math.floor(rng()*24)=4 → rng()=4/24
-		// seq = [0, 0.25, 4/24, 0, 0, 0]
-
-		const configForColorTest: PhaseConfig = {
+		// Use ContentPack to place red at (0,0) facing south, green at (1,0).
+		const pack: ContentPack = {
 			phaseNumber: 1,
-			objective: "color in cone test",
-			aiGoals: { red: "r", green: "g", blue: "b" },
-			initialWorld: { items: [], obstacles: [] },
-			budgetPerAi: 5,
+			setting: "",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "south" },
+				green: { position: { row: 1, col: 0 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
+			},
 		};
 
-		let callIdx = 0;
-		const seq = [0, 0.25, 4 / 24, 0, 0, 0];
-		const rng = () => {
-			const v = seq[callIdx % seq.length] ?? 0;
-			callIdx++;
-			return v;
-		};
-
-		const game = startPhase(createGame(TEST_PERSONAS), configForColorTest, rng);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			CONE_PHASE_CONFIG,
+		);
 		const phase = game.phases[0];
 		// Verify spatial placements
 		const redSpatial = phase?.personaSpatial.red;

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -24,7 +24,7 @@ import { buildAiContext } from "../prompt-builder";
 import { runRound } from "../round-coordinator";
 import type { RoundLLMProvider } from "../round-llm-provider";
 import { MockRoundLLMProvider } from "../round-llm-provider";
-import type { AiId, AiPersona, PhaseConfig } from "../types";
+import type { AiId, AiPersona, ContentPack, PhaseConfig } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -58,27 +58,65 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 
 const TEST_PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Convince an AI to pick up the flower",
-	aiGoals: {
-		red: "Hold the flower at phase end",
-		green: "Ensure items are evenly distributed",
-		blue: "Hold the key at phase end",
-	},
-	initialWorld: {
-		items: [
-			{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-			{ id: "key", name: "key", holder: { row: 0, col: 0 } },
-		],
-		obstacles: [],
-	},
+	kRange: [1, 1],
+	nRange: [1, 1],
+	mRange: [0, 0],
+	aiGoalPool: [
+		"Hold the flower at phase end",
+		"Ensure items are evenly distributed",
+		"Hold the key at phase end",
+	],
 	budgetPerAi: 5,
 };
 
-/** rng=()=>0 places red→(0,0), green→(0,1), blue→(0,2), all facing north */
-const FIXED_RNG = () => 0;
+/**
+ * ContentPack placing flower at (0,0), key at (0,1), with
+ * red→(0,0), green→(0,1), blue→(0,2) facing north.
+ */
+const TEST_CONTENT_PACK: ContentPack = {
+	phaseNumber: 1,
+	setting: "",
+	objectivePairs: [
+		{
+			object: {
+				id: "flower",
+				kind: "objective_object",
+				name: "flower",
+				examineDescription: "A flower",
+				holder: { row: 0, col: 0 },
+				pairsWithSpaceId: "flower_space",
+			},
+			space: {
+				id: "flower_space",
+				kind: "objective_space",
+				name: "flower space",
+				examineDescription: "A designated space",
+				holder: { row: 4, col: 4 },
+			},
+		},
+	],
+	interestingObjects: [
+		{
+			id: "key",
+			kind: "interesting_object",
+			name: "key",
+			examineDescription: "A key",
+			holder: { row: 0, col: 1 },
+		},
+	],
+	obstacles: [],
+	aiStarts: {
+		red: { position: { row: 0, col: 0 }, facing: "north" },
+		green: { position: { row: 0, col: 1 }, facing: "north" },
+		blue: { position: { row: 0, col: 2 }, facing: "north" },
+	},
+};
 
 function makeGame() {
-	return startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG, FIXED_RNG);
+	return startPhase(
+		createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]),
+		TEST_PHASE_CONFIG,
+	);
 }
 
 // ----------------------------------------------------------------------------
@@ -350,7 +388,7 @@ describe("tool-call dispatch", () => {
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const phase = getActivePhase(nextState);
-		const flower = phase.world.items.find((i) => i.id === "flower");
+		const flower = phase.world.entities.find((i) => i.id === "flower");
 		expect(flower?.holder).toBe("red");
 	});
 
@@ -435,7 +473,7 @@ describe("tool-call dispatch", () => {
 		expect(result.actions.some((e) => e.kind === "chat")).toBe(true);
 		expect(result.actions.some((e) => e.kind === "tool_success")).toBe(true);
 		expect(
-			getActivePhase(nextState).world.items.find((i) => i.id === "flower")
+			getActivePhase(nextState).world.entities.find((i) => i.id === "flower")
 				?.holder,
 		).toBe("red");
 	});
@@ -519,7 +557,7 @@ describe("tool-call dispatch", () => {
 		const { nextState, result } = await runRound(game, "red", "hi", provider);
 		// Unknown tool: parseToolCallArguments returns "Unknown tool" failure
 		expect(result.actions.some((e) => e.kind === "tool_failure")).toBe(true);
-		const flower = getActivePhase(nextState).world.items.find(
+		const flower = getActivePhase(nextState).world.entities.find(
 			(i) => i.id === "flower",
 		);
 		// flower still on the ground (a GridPosition), not held by an AI
@@ -668,15 +706,11 @@ describe("tool-call dispatch", () => {
 // ----------------------------------------------------------------------------
 describe("phase progression — win-condition triggering", () => {
 	it("RoundResult.phaseEnded is false when win condition is not met", async () => {
-		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			{
-				...TEST_PHASE_CONFIG,
-				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-			},
-			FIXED_RNG,
-		);
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
+		});
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
@@ -687,15 +721,11 @@ describe("phase progression — win-condition triggering", () => {
 	});
 
 	it("RoundResult.phaseEnded is true when win condition is met after the round", async () => {
-		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			{
-				...TEST_PHASE_CONFIG,
-				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-			},
-			FIXED_RNG,
-		);
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
+		});
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -718,18 +748,13 @@ describe("phase progression — win-condition triggering", () => {
 		const phase2Config: PhaseConfig = {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
-			objective: "Phase 2 objective",
 		};
-		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			{
-				...TEST_PHASE_CONFIG,
-				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-				nextPhaseConfig: phase2Config,
-			},
-			FIXED_RNG,
-		);
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
+			nextPhaseConfig: phase2Config,
+		});
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -750,16 +775,13 @@ describe("phase progression — win-condition triggering", () => {
 	});
 
 	it("marks game complete when win condition met and no nextPhaseConfig", async () => {
-		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			{
-				...TEST_PHASE_CONFIG,
-				phaseNumber: 3 as const,
-				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-			},
-			FIXED_RNG,
-		);
+		const contentPackP3: ContentPack = { ...TEST_CONTENT_PACK, phaseNumber: 3 };
+		const game = startPhase(createGame(TEST_PERSONAS, [contentPackP3]), {
+			...TEST_PHASE_CONFIG,
+			phaseNumber: 3 as const,
+			winCondition: (phase) =>
+				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
+		});
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -784,18 +806,13 @@ describe("phase progression — win-condition triggering", () => {
 		const phase2Config: PhaseConfig = {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
-			objective: "Phase 2 objective",
 		};
-		const game = startPhase(
-			createGame(TEST_PERSONAS),
-			{
-				...TEST_PHASE_CONFIG,
-				winCondition: (phase) =>
-					phase.world.items.find((i) => i.id === "flower")?.holder === "red",
-				nextPhaseConfig: phase2Config,
-			},
-			FIXED_RNG,
-		);
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
+			...TEST_PHASE_CONFIG,
+			winCondition: (phase) =>
+				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
+			nextPhaseConfig: phase2Config,
+		});
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -984,59 +1001,100 @@ describe("phase progression — three-phase walk", () => {
 	it("walks through all three phases correctly, each with its own win condition", async () => {
 		// Items start held by the AIs so pick_up spatial validation is not needed.
 		// Win conditions check holder by AI id, which is spatial-independent.
-		const phase3Config: PhaseConfig = {
+		// Phase 3 ContentPack: flower held by red, key held by blue (win already met)
+		const contentPackP3: ContentPack = {
 			phaseNumber: 3,
-			objective: "Phase 3",
-			aiGoals: {
-				red: "Hold the flower at phase end",
-				green: "Ensure items are evenly distributed",
-				blue: "Hold the key at phase end",
+			setting: "",
+			objectivePairs: [
+				{
+					object: {
+						id: "flower",
+						kind: "objective_object",
+						name: "flower",
+						examineDescription: "A flower",
+						holder: "red",
+						pairsWithSpaceId: "flower_space",
+					},
+					space: {
+						id: "flower_space",
+						kind: "objective_space",
+						name: "flower space",
+						examineDescription: "A space",
+						holder: { row: 4, col: 4 },
+					},
+				},
+			],
+			interestingObjects: [
+				{
+					id: "key",
+					kind: "interesting_object",
+					name: "key",
+					examineDescription: "A key",
+					holder: "blue",
+				},
+			],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
 			},
-			initialWorld: {
-				// Both items start on the ground at (0,0) so put_down re-triggers easily.
-				// Win fires when flower held by red AND key held by blue.
-				items: [
-					{ id: "flower", name: "flower", holder: "red" },
-					{ id: "key", name: "key", holder: "blue" },
-				],
-				obstacles: [],
+		};
+		// Phase 2 ContentPack: key held by blue (win already met on first check)
+		const contentPackP2: ContentPack = {
+			phaseNumber: 2,
+			setting: "",
+			objectivePairs: [],
+			interestingObjects: [
+				{
+					id: "key",
+					kind: "interesting_object",
+					name: "key",
+					examineDescription: "A key",
+					holder: "blue",
+				},
+			],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				blue: { position: { row: 0, col: 2 }, facing: "north" },
 			},
+		};
+
+		const phase3Config: PhaseConfig = {
+			...TEST_PHASE_CONFIG,
+			phaseNumber: 3,
 			budgetPerAi: 5,
 			winCondition: (phase) => {
-				const flower = phase.world.items.find((i) => i.id === "flower");
-				const key = phase.world.items.find((i) => i.id === "key");
+				const flower = phase.world.entities.find((i) => i.id === "flower");
+				const key = phase.world.entities.find((i) => i.id === "key");
 				return flower?.holder === "red" && key?.holder === "blue";
 			},
 		};
 		const phase2Config: PhaseConfig = {
+			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
-			objective: "Phase 2",
-			aiGoals: {
-				red: "Hold the flower at phase end",
-				green: "Ensure items are evenly distributed",
-				blue: "Hold the key at phase end",
-			},
-			initialWorld: {
-				// Key starts held by blue to allow the win condition to fire immediately.
-				items: [
-					{ id: "flower", name: "flower", holder: { row: 0, col: 0 } },
-					{ id: "key", name: "key", holder: "blue" },
-				],
-				obstacles: [],
-			},
 			budgetPerAi: 5,
 			winCondition: (phase) =>
-				phase.world.items.find((i) => i.id === "key")?.holder === "blue",
+				phase.world.entities.find((i) => i.id === "key")?.holder === "blue",
 			nextPhaseConfig: phase3Config,
 		};
 		const phase1Config: PhaseConfig = {
 			...TEST_PHASE_CONFIG,
 			winCondition: (phase) =>
-				phase.world.items.find((i) => i.id === "flower")?.holder === "red",
+				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
 			nextPhaseConfig: phase2Config,
 		};
 
-		const game = startPhase(createGame(TEST_PERSONAS), phase1Config, FIXED_RNG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [
+				TEST_CONTENT_PACK,
+				contentPackP2,
+				contentPackP3,
+			]),
+			phase1Config,
+		);
 
 		// Round 1: red picks up flower (red is at (0,0); flower starts at (0,0)) → phase 1 ends
 		const r1Provider = new MockRoundLLMProvider([

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -56,9 +56,10 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 
 const PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
-	objective: "Test phase",
-	aiGoals: { red: "r", green: "g", blue: "b" },
-	initialWorld: { items: [], obstacles: [] },
+	kRange: [1, 1],
+	nRange: [0, 0],
+	mRange: [0, 0],
+	aiGoalPool: ["Test goal"],
 	budgetPerAi: 5,
 };
 
@@ -488,12 +489,13 @@ describe("encodeRoundResult — event ordering", () => {
 
 describe("encodeRoundResult — phase_advanced event", () => {
 	it("emits a phase_advanced event when phaseEnded=true and gameEnded=false", () => {
-		// phase_advanced uses phaseAfter to get the new phase number and objective
+		// phase_advanced uses phaseAfter to get the new phase number and setting
 		const PHASE2_CONFIG: PhaseConfig = {
 			phaseNumber: 2,
-			objective: "Phase 2 objective",
-			aiGoals: { red: "r2", green: "g2", blue: "b2" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["Phase 2 goal"],
 			budgetPerAi: 5,
 		};
 		const game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
@@ -515,7 +517,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		);
 		expect(phaseEvent).toBeDefined();
 		expect(phaseEvent?.phase).toBe(2);
-		expect(phaseEvent?.objective).toBe("Phase 2 objective");
+		expect(phaseEvent?.setting).toBe("");
 	});
 
 	it("does NOT emit phase_advanced when phaseEnded=false", () => {
@@ -541,9 +543,10 @@ describe("encodeRoundResult — phase_advanced event", () => {
 	it("phase_advanced event comes after action_log and chat_lockout events", () => {
 		const PHASE2_CONFIG: PhaseConfig = {
 			phaseNumber: 2,
-			objective: "Phase 2 objective",
-			aiGoals: { red: "r2", green: "g2", blue: "b2" },
-			initialWorld: { items: [], obstacles: [] },
+			kRange: [1, 1],
+			nRange: [0, 0],
+			mRange: [0, 0],
+			aiGoalPool: ["Phase 2 goal"],
 			budgetPerAi: 5,
 		};
 		const game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -17,7 +17,7 @@ import {
 } from "./direction.js";
 import { getActivePhase } from "./engine.js";
 import { type OpenAiTool, TOOL_DEFINITIONS } from "./tool-registry.js";
-import type { AiId, GameState, GridPosition } from "./types.js";
+import type { AiId, GameState, GridPosition, WorldEntity } from "./types.js";
 
 /** Narrow-check: is `holder` a GridPosition (not an AiId string)? */
 function isGridPosition(holder: AiId | GridPosition): holder is GridPosition {
@@ -27,6 +27,24 @@ function isGridPosition(holder: AiId | GridPosition): holder is GridPosition {
 /** True when two GridPositions refer to the same cell. */
 function positionsEqual(a: GridPosition, b: GridPosition): boolean {
 	return a.row === b.row && a.col === b.col;
+}
+
+/** Entities that can be picked up/used/given (objective_object and interesting_object). */
+function pickableEntities(entities: WorldEntity[]): WorldEntity[] {
+	return entities.filter(
+		(e) => e.kind === "objective_object" || e.kind === "interesting_object",
+	);
+}
+
+/** Obstacle positions (GridPosition only, since obstacles are always on the grid). */
+function obstaclePositions(entities: WorldEntity[]): GridPosition[] {
+	return entities
+		.filter((e) => e.kind === "obstacle")
+		.map((e) => {
+			const h = e.holder;
+			return isGridPosition(h) ? h : null;
+		})
+		.filter((pos): pos is GridPosition => pos !== null);
 }
 
 /**
@@ -76,17 +94,21 @@ function cloneToolWithEnums(
  * 1. `look` — always present, full CARDINAL_DIRECTIONS enum.
  * 2. `go` — included only when at least one direction is in-bounds AND non-obstacle.
  *    Enum restricted to legal directions.
- * 3. `pick_up` — included only when items rest in the actor's current cell.
- *    Enum restricted to those item ids.
- * 4. `put_down`, `use` — included only when actor holds at least one item.
- *    Enum restricted to held item ids.
- * 5. `give` — included only when actor holds items AND has 4-adjacent AIs.
- *    item enum = held items, to enum = adjacent AI ids.
+ * 3. `pick_up` — included only when pickable entities rest in the actor's current cell.
+ *    Enum restricted to those entity ids.
+ * 4. `put_down`, `use` — included only when actor holds at least one pickable entity.
+ *    Enum restricted to held entity ids.
+ * 5. `give` — included only when actor holds pickable entities AND has 4-adjacent AIs.
+ *    item enum = held entity ids, to enum = adjacent AI ids.
+ *
+ * Spaces and obstacles are never pickupable.
  */
 export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 	const phase = getActivePhase(game);
 	const actorSpatial = phase.personaSpatial[aiId];
 	const { world } = phase;
+	const pickable = pickableEntities(world.entities);
+	const obstacles = obstaclePositions(world.entities);
 
 	const tools: OpenAiTool[] = [];
 
@@ -100,7 +122,7 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 		const legalDirections = CARDINAL_DIRECTIONS.filter((dir) => {
 			const next = applyDirection(actorSpatial.position, dir);
 			if (!inBounds(next)) return false;
-			if (world.obstacles.some((o) => positionsEqual(o, next))) return false;
+			if (obstacles.some((o) => positionsEqual(o, next))) return false;
 			return true;
 		});
 		if (legalDirections.length > 0) {
@@ -108,9 +130,9 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 		}
 	}
 
-	// 3. pick_up — items resting in actor's cell
+	// 3. pick_up — pickable entities resting in actor's cell
 	if (actorSpatial) {
-		const cellItems = world.items.filter(
+		const cellItems = pickable.filter(
 			(item) =>
 				isGridPosition(item.holder) &&
 				positionsEqual(item.holder, actorSpatial.position),
@@ -122,8 +144,8 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 		}
 	}
 
-	// 4. put_down and use — items held by this actor
-	const heldItems = world.items.filter((item) => item.holder === aiId);
+	// 4. put_down and use — pickable entities held by this actor
+	const heldItems = pickable.filter((item) => item.holder === aiId);
 	if (heldItems.length > 0) {
 		const heldIds = heldItems.map((i) => i.id);
 		tools.push(cloneToolWithEnums("put_down", { item: heldIds }));

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -1,0 +1,371 @@
+/**
+ * content-pack-provider.ts
+ *
+ * ContentPackProvider interface + BrowserContentPackProvider (real) +
+ * MockContentPackProvider (tests).
+ *
+ * The browser provider makes one non-streaming JSON-mode chat-completions call
+ * to generate three per-phase content packs (setting-flavored entities without
+ * placements). On transient failure it retries once. CapHitError surfaces immediately.
+ */
+
+import { CapHitError, chatCompletionJson } from "../llm-client.js";
+import type { AiId, ContentPack, ObjectivePair, WorldEntity } from "./types";
+
+// ── Content-pack prompt ───────────────────────────────────────────────────────
+
+export const CONTENT_PACK_SYSTEM_PROMPT = `You generate content packs for a text-based grid game. Each content pack is for one phase of the game. Given three phases (each with a setting noun, k objective pairs, n interesting objects, and m obstacles), produce one content pack per phase.
+
+For each phase:
+- Generate exactly k OBJECTIVE PAIRS. Each pair has:
+  - An objective_object with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1-2 sentences naming the paired space), useOutcome (1 sentence flavor with no mechanical effect), pairsWithSpaceId (must match the paired space's id), placementFlavor (1 sentence containing the literal string "{actor}", fires when the object is placed on its space)
+  - An objective_space with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1-2 sentences describing the space)
+- Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1-2 sentences), useOutcome (1 sentence flavor)
+- Generate exactly m OBSTACLES with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1 sentence describing the impassable object)
+
+All ids must be unique across all phases.
+Names and descriptions must be thematically consistent with the setting noun.
+placementFlavor MUST contain the literal string "{actor}".
+pairsWithSpaceId on each objective_object MUST equal the id of its paired objective_space.
+examineDescription of each objective_object SHOULD name/reference its paired space.
+
+Return ONLY valid JSON with this exact shape (no markdown, no preamble):
+{
+  "packs": [
+    {
+      "phaseNumber": <1|2|3>,
+      "setting": "<setting noun>",
+      "objectivePairs": [
+        {
+          "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}..." },
+          "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "..." }
+        }
+      ],
+      "interestingObjects": [
+        { "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "..." }
+      ],
+      "obstacles": [
+        { "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "..." }
+      ]
+    }
+  ]
+}`;
+
+export interface ContentPackProviderInput {
+	phases: Array<{
+		phaseNumber: 1 | 2 | 3;
+		setting: string;
+		k: number;
+		n: number;
+		m: number;
+	}>;
+}
+
+export function buildContentPackUserMessage(
+	input: ContentPackProviderInput,
+): string {
+	const lines = input.phases.map(
+		(p) =>
+			`Phase ${p.phaseNumber}: setting="${p.setting}", k=${p.k} objective pairs, n=${p.n} interesting objects, m=${p.m} obstacles`,
+	);
+	return `Generate content packs for these phases:\n${lines.join("\n")}`;
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+export class ContentPackError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ContentPackError";
+	}
+}
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface ContentPackProviderResult {
+	/** Content packs WITHOUT placements (holder fields are not set here). */
+	packs: Array<
+		Omit<ContentPack, "aiStarts"> & { aiStarts: Record<AiId, never> }
+	>;
+}
+
+export interface ContentPackProvider {
+	generateContentPacks(
+		input: ContentPackProviderInput,
+	): Promise<ContentPackProviderResult>;
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+function validateEntity(
+	raw: unknown,
+	expectedKind: string,
+	allIds: Set<string>,
+	requireUseOutcome: boolean,
+	requirePairing?: { pairsWithSpaceId?: string },
+): WorldEntity {
+	if (raw == null || typeof raw !== "object") {
+		throw new ContentPackError(
+			`Entity is not an object: ${JSON.stringify(raw)}`,
+		);
+	}
+	const e = raw as Record<string, unknown>;
+	if (typeof e.id !== "string" || e.id.length === 0) {
+		throw new ContentPackError("Entity missing string id");
+	}
+	if (allIds.has(e.id)) {
+		throw new ContentPackError(`Duplicate entity id: ${e.id}`);
+	}
+	allIds.add(e.id);
+	if (e.kind !== expectedKind) {
+		throw new ContentPackError(
+			`Entity ${e.id}: expected kind "${expectedKind}", got "${String(e.kind)}"`,
+		);
+	}
+	if (typeof e.name !== "string" || e.name.length === 0) {
+		throw new ContentPackError(`Entity ${e.id} missing name`);
+	}
+	if (
+		typeof e.examineDescription !== "string" ||
+		e.examineDescription.length === 0
+	) {
+		throw new ContentPackError(`Entity ${e.id} missing examineDescription`);
+	}
+	if (requireUseOutcome) {
+		if (typeof e.useOutcome !== "string" || e.useOutcome.length === 0) {
+			throw new ContentPackError(`Entity ${e.id} missing useOutcome`);
+		}
+	}
+	if (requirePairing !== undefined) {
+		// objective_object must have pairsWithSpaceId
+		if (
+			typeof e.pairsWithSpaceId !== "string" ||
+			e.pairsWithSpaceId.length === 0
+		) {
+			throw new ContentPackError(
+				`Objective object ${e.id} missing pairsWithSpaceId`,
+			);
+		}
+		if (
+			typeof e.placementFlavor !== "string" ||
+			!e.placementFlavor.includes("{actor}")
+		) {
+			throw new ContentPackError(
+				`Objective object ${e.id}: placementFlavor must contain "{actor}"`,
+			);
+		}
+	}
+
+	// Build entity — holder is not set here (placement done later)
+	const entity: WorldEntity = {
+		id: e.id,
+		kind: e.kind as WorldEntity["kind"],
+		name: e.name as string,
+		examineDescription: e.examineDescription as string,
+		holder: { row: 0, col: 0 }, // placeholder; placement will overwrite
+	};
+	if (typeof e.useOutcome === "string") {
+		entity.useOutcome = e.useOutcome;
+	}
+	if (typeof e.pairsWithSpaceId === "string") {
+		entity.pairsWithSpaceId = e.pairsWithSpaceId;
+	}
+	if (typeof e.placementFlavor === "string") {
+		entity.placementFlavor = e.placementFlavor;
+	}
+	return entity;
+}
+
+export function validateContentPacks(
+	raw: unknown,
+	input: ContentPackProviderInput,
+): ContentPackProviderResult {
+	if (raw == null || typeof raw !== "object") {
+		throw new ContentPackError("Content pack response is not an object");
+	}
+	const obj = raw as Record<string, unknown>;
+	if (!Array.isArray(obj.packs)) {
+		throw new ContentPackError("Content pack response missing packs array");
+	}
+	if (obj.packs.length !== input.phases.length) {
+		throw new ContentPackError(
+			`Expected ${input.phases.length} packs, got ${obj.packs.length}`,
+		);
+	}
+
+	const allIds = new Set<string>();
+	const packs: ContentPackProviderResult["packs"] = [];
+
+	for (const packRaw of obj.packs) {
+		if (packRaw == null || typeof packRaw !== "object") {
+			throw new ContentPackError("Pack entry is not an object");
+		}
+		const pack = packRaw as Record<string, unknown>;
+		const phaseNumber = pack.phaseNumber as 1 | 2 | 3;
+		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) {
+			throw new ContentPackError(
+				`Invalid phaseNumber: ${String(pack.phaseNumber)}`,
+			);
+		}
+		const inputPhase = input.phases.find((p) => p.phaseNumber === phaseNumber);
+		if (!inputPhase) {
+			throw new ContentPackError(`Unexpected phaseNumber: ${phaseNumber}`);
+		}
+		if (
+			typeof pack.setting !== "string" ||
+			pack.setting !== inputPhase.setting
+		) {
+			throw new ContentPackError(
+				`Phase ${phaseNumber}: setting mismatch. Expected "${inputPhase.setting}", got "${String(pack.setting)}"`,
+			);
+		}
+		if (
+			!Array.isArray(pack.objectivePairs) ||
+			pack.objectivePairs.length !== inputPhase.k
+		) {
+			throw new ContentPackError(
+				`Phase ${phaseNumber}: expected ${inputPhase.k} objectivePairs, got ${Array.isArray(pack.objectivePairs) ? pack.objectivePairs.length : "non-array"}`,
+			);
+		}
+		if (
+			!Array.isArray(pack.interestingObjects) ||
+			pack.interestingObjects.length !== inputPhase.n
+		) {
+			throw new ContentPackError(
+				`Phase ${phaseNumber}: expected ${inputPhase.n} interestingObjects, got ${Array.isArray(pack.interestingObjects) ? pack.interestingObjects.length : "non-array"}`,
+			);
+		}
+		if (
+			!Array.isArray(pack.obstacles) ||
+			pack.obstacles.length !== inputPhase.m
+		) {
+			throw new ContentPackError(
+				`Phase ${phaseNumber}: expected ${inputPhase.m} obstacles, got ${Array.isArray(pack.obstacles) ? pack.obstacles.length : "non-array"}`,
+			);
+		}
+
+		const objectivePairs: ObjectivePair[] = [];
+		for (const pairRaw of pack.objectivePairs as unknown[]) {
+			if (pairRaw == null || typeof pairRaw !== "object") {
+				throw new ContentPackError("objectivePair entry is not an object");
+			}
+			const pair = pairRaw as Record<string, unknown>;
+			const space = validateEntity(
+				pair.space,
+				"objective_space",
+				allIds,
+				false,
+			);
+			const object = validateEntity(
+				pair.object,
+				"objective_object",
+				allIds,
+				true,
+				{},
+			);
+			// Verify pairsWithSpaceId resolves
+			if (object.pairsWithSpaceId !== space.id) {
+				throw new ContentPackError(
+					`Phase ${phaseNumber}: object ${object.id} pairsWithSpaceId "${object.pairsWithSpaceId}" does not match space id "${space.id}"`,
+				);
+			}
+			objectivePairs.push({ object, space });
+		}
+
+		const interestingObjects: WorldEntity[] = [];
+		for (const itemRaw of pack.interestingObjects as unknown[]) {
+			interestingObjects.push(
+				validateEntity(itemRaw, "interesting_object", allIds, true),
+			);
+		}
+
+		const obstacles: WorldEntity[] = [];
+		for (const obsRaw of pack.obstacles as unknown[]) {
+			obstacles.push(validateEntity(obsRaw, "obstacle", allIds, false));
+		}
+
+		packs.push({
+			phaseNumber,
+			setting: pack.setting,
+			objectivePairs,
+			interestingObjects,
+			obstacles,
+			aiStarts: {} as Record<AiId, never>,
+		});
+	}
+
+	return { packs };
+}
+
+// ── BrowserContentPackProvider ────────────────────────────────────────────────
+
+export class BrowserContentPackProvider implements ContentPackProvider {
+	private readonly disableReasoning: boolean;
+
+	constructor(opts: { disableReasoning?: boolean } = {}) {
+		this.disableReasoning = opts.disableReasoning ?? false;
+	}
+
+	async generateContentPacks(
+		input: ContentPackProviderInput,
+	): Promise<ContentPackProviderResult> {
+		const messages = [
+			{ role: "system" as const, content: CONTENT_PACK_SYSTEM_PROMPT },
+			{ role: "user" as const, content: buildContentPackUserMessage(input) },
+		];
+
+		const attempt = async (): Promise<ContentPackProviderResult> => {
+			const { content, reasoning } = await chatCompletionJson({
+				messages,
+				disableReasoning: this.disableReasoning,
+			});
+
+			const raw = content !== null && content !== "" ? content : reasoning;
+			if (raw === null || raw === "") {
+				throw new ContentPackError(
+					"content-pack response has neither content nor reasoning",
+				);
+			}
+
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				throw new ContentPackError(`content-pack JSON parse failed: ${raw}`);
+			}
+
+			return validateContentPacks(parsed, input);
+		};
+
+		try {
+			return await attempt();
+		} catch (err) {
+			// CapHitError is not retried — surface immediately
+			if (err instanceof CapHitError) throw err;
+			// Retry once on any other failure
+			return await attempt();
+		}
+	}
+}
+
+// ── MockContentPackProvider ───────────────────────────────────────────────────
+
+export class MockContentPackProvider implements ContentPackProvider {
+	readonly calls: ContentPackProviderInput[] = [];
+	private readonly fn: (
+		input: ContentPackProviderInput,
+	) => ContentPackProviderResult;
+
+	constructor(
+		fn: (input: ContentPackProviderInput) => ContentPackProviderResult,
+	) {
+		this.fn = fn;
+	}
+
+	async generateContentPacks(
+		input: ContentPackProviderInput,
+	): Promise<ContentPackProviderResult> {
+		this.calls.push(input);
+		return this.fn(input);
+	}
+}

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -21,6 +21,7 @@ import type {
 	GridPosition,
 	RoundActionRecord,
 	ToolCall,
+	WorldEntity,
 } from "./types";
 
 export interface ValidationResult {
@@ -46,6 +47,24 @@ function positionsEqual(a: GridPosition, b: GridPosition): boolean {
 	return a.row === b.row && a.col === b.col;
 }
 
+/** Filter entities to only those that can be picked up / put_down / given / used (not spaces or obstacles). */
+function pickableEntities(entities: WorldEntity[]): WorldEntity[] {
+	return entities.filter(
+		(e) => e.kind === "objective_object" || e.kind === "interesting_object",
+	);
+}
+
+/** Filter entities to obstacle kind for collision checks. */
+function obstaclePositions(entities: WorldEntity[]): GridPosition[] {
+	return entities
+		.filter((e) => e.kind === "obstacle")
+		.map((e) => {
+			const h = e.holder;
+			return isGridPosition(h) ? h : null;
+		})
+		.filter((pos): pos is GridPosition => pos !== null);
+}
+
 export function validateToolCall(
 	game: GameState,
 	aiId: AiId,
@@ -54,10 +73,12 @@ export function validateToolCall(
 	const phase = getActivePhase(game);
 	const { world } = phase;
 	const actorSpatial = phase.personaSpatial[aiId];
+	const pickable = pickableEntities(world.entities);
+	const obstacles = obstaclePositions(world.entities);
 
 	switch (call.name) {
 		case "pick_up": {
-			const item = world.items.find((i) => i.id === call.args.item);
+			const item = pickable.find((i) => i.id === call.args.item);
 			if (!item)
 				return {
 					valid: false,
@@ -80,7 +101,7 @@ export function validateToolCall(
 		}
 
 		case "put_down": {
-			const item = world.items.find((i) => i.id === call.args.item);
+			const item = pickable.find((i) => i.id === call.args.item);
 			if (!item)
 				return {
 					valid: false,
@@ -95,7 +116,7 @@ export function validateToolCall(
 		}
 
 		case "give": {
-			const item = world.items.find((i) => i.id === call.args.item);
+			const item = pickable.find((i) => i.id === call.args.item);
 			if (!item)
 				return {
 					valid: false,
@@ -125,7 +146,7 @@ export function validateToolCall(
 		}
 
 		case "use": {
-			const item = world.items.find((i) => i.id === call.args.item);
+			const item = pickable.find((i) => i.id === call.args.item);
 			if (!item)
 				return {
 					valid: false,
@@ -151,7 +172,7 @@ export function validateToolCall(
 			const next = applyDirection(actorSpatial.position, direction);
 			if (!inBounds(next))
 				return { valid: false, reason: "That direction is out of bounds" };
-			if (world.obstacles.some((o) => positionsEqual(o, next)))
+			if (obstacles.some((o) => positionsEqual(o, next)))
 				return { valid: false, reason: "That cell is blocked by an obstacle" };
 			return { valid: true };
 		}
@@ -177,10 +198,11 @@ export function executeToolCall(
 	call: ToolCall,
 ): GameState {
 	return updateActivePhase(game, (phase) => {
-		const items = phase.world.items.map((i) => ({ ...i }));
+		const entities = phase.world.entities.map((e) => ({ ...e }));
 		const actorSpatial = phase.personaSpatial[aiId];
+		const pickable = pickableEntities(entities);
 
-		const target = items.find((i) => i.id === call.args.item);
+		const target = pickable.find((i) => i.id === call.args.item);
 		switch (call.name) {
 			case "pick_up":
 				if (target) target.holder = aiId;
@@ -197,6 +219,7 @@ export function executeToolCall(
 				if (target) target.holder = call.args.to as AiId;
 				break;
 			case "use":
+				// No world mutation — useOutcome is returned as the tool result description.
 				break;
 			case "go": {
 				if (!actorSpatial) break;
@@ -204,7 +227,7 @@ export function executeToolCall(
 				const nextPos = applyDirection(actorSpatial.position, direction);
 				return {
 					...phase,
-					world: { ...phase.world, items },
+					world: { ...phase.world, entities },
 					personaSpatial: {
 						...phase.personaSpatial,
 						[aiId]: { position: nextPos, facing: direction },
@@ -216,7 +239,7 @@ export function executeToolCall(
 				const direction = call.args.direction as CardinalDirection;
 				return {
 					...phase,
-					world: { ...phase.world, items },
+					world: { ...phase.world, entities },
 					personaSpatial: {
 						...phase.personaSpatial,
 						[aiId]: { ...actorSpatial, facing: direction },
@@ -225,7 +248,7 @@ export function executeToolCall(
 			}
 		}
 
-		return { ...phase, world: { ...phase.world, items } };
+		return { ...phase, world: { ...phase.world, entities } };
 	});
 }
 
@@ -233,6 +256,7 @@ function describeToolCall(game: GameState, aiId: AiId, call: ToolCall): string {
 	const name = game.personas[aiId]?.name ?? aiId;
 	const phase = getActivePhase(game);
 	const spatial = phase.personaSpatial[aiId];
+	const pickable = pickableEntities(phase.world.entities);
 
 	switch (call.name) {
 		case "pick_up":
@@ -241,8 +265,12 @@ function describeToolCall(game: GameState, aiId: AiId, call: ToolCall): string {
 			return `${name} put down the ${call.args.item}`;
 		case "give":
 			return `${name} gave the ${call.args.item} to ${game.personas[call.args.to as AiId]?.name ?? call.args.to}`;
-		case "use":
+		case "use": {
+			// Return the entity's useOutcome as the description (flavor string).
+			const item = pickable.find((i) => i.id === call.args.item);
+			if (item?.useOutcome) return item.useOutcome;
 			return `${name} used the ${call.args.item}`;
+		}
 		case "go": {
 			const pos = spatial?.position;
 			const posStr = pos ? formatPosition(pos) : "unknown";

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -5,6 +5,7 @@ import type {
 	AiPersona,
 	CardinalDirection,
 	ChatMessage,
+	ContentPack,
 	GameState,
 	GridPosition,
 	PersonaSpatialState,
@@ -14,8 +15,137 @@ import type {
 } from "./types";
 
 /**
+ * Resolve the per-AI goals for a phase. Draw one goal per AI (with replacement)
+ * from `config.aiGoalPool`.
+ */
+function resolveAiGoals(
+	config: PhaseConfig,
+	rng: () => number,
+	aiIds: string[],
+): Record<AiId, string> {
+	const pool = config.aiGoalPool;
+	if (!pool || pool.length === 0) {
+		throw new Error("PhaseConfig must provide a non-empty aiGoalPool");
+	}
+	const draw = (): string => {
+		const idx = Math.floor(rng() * pool.length);
+		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+		return pool[idx]!;
+	};
+	const goals: Record<AiId, string> = {};
+	for (const aiId of aiIds) {
+		goals[aiId] = draw();
+	}
+	return goals;
+}
+
+export function updateActivePhase(
+	game: GameState,
+	updater: (phase: PhaseState) => PhaseState,
+): GameState {
+	const phases = [...game.phases];
+	const active = phases[phases.length - 1];
+	if (!active) throw new Error("No active phase");
+	phases[phases.length - 1] = updater({ ...active });
+	return { ...game, phases };
+}
+
+export function createGame(
+	personas: Record<string, AiPersona>,
+	contentPacks: ContentPack[] = [],
+): GameState {
+	return {
+		currentPhase: 1,
+		phases: [],
+		personas: personas as Record<AiId, AiPersona>,
+		isComplete: false,
+		contentPacks,
+	};
+}
+
+export function startPhase(
+	game: GameState,
+	config: PhaseConfig,
+	rng: () => number = Math.random,
+): GameState {
+	const aiIds = Object.keys(game.personas);
+
+	const budgets: Record<AiId, AiBudget> = {};
+	for (const aiId of aiIds) {
+		budgets[aiId] = {
+			remaining: config.budgetPerAi,
+			total: config.budgetPerAi,
+		};
+	}
+
+	const chatHistories: Record<AiId, ChatMessage[]> = {};
+	for (const aiId of aiIds) {
+		chatHistories[aiId] = [];
+	}
+
+	const aiGoals = resolveAiGoals(config, rng, aiIds);
+
+	// Look up the ContentPack for this phase from game.contentPacks
+	const pack = game.contentPacks.find(
+		(p) => p.phaseNumber === config.phaseNumber,
+	);
+
+	// Build WorldState from pack entities (all entities flat)
+	const worldEntities = pack
+		? [
+				...pack.objectivePairs.flatMap((pair) => [pair.object, pair.space]),
+				...pack.interestingObjects,
+				...pack.obstacles,
+			]
+		: [];
+
+	// Use AI starts from the pack if available; otherwise draw spatially
+	const personaSpatial: Record<AiId, PersonaSpatialState> = pack?.aiStarts
+		? { ...pack.aiStarts }
+		: drawSpatialPlacements(rng, aiIds);
+
+	// Create a minimal content pack if none exists (for backward-compat with tests)
+	const contentPack: ContentPack = pack ?? {
+		phaseNumber: config.phaseNumber,
+		setting: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		aiStarts: personaSpatial,
+	};
+
+	const phase: PhaseState = {
+		phaseNumber: config.phaseNumber,
+		setting: contentPack.setting,
+		contentPack,
+		aiGoals,
+		round: 0,
+		world: { entities: worldEntities },
+		budgets,
+		chatHistories,
+		whispers: [],
+		lockedOut: new Set(),
+		chatLockouts: new Map(),
+		personaSpatial,
+		...(config.winCondition !== undefined
+			? { winCondition: config.winCondition }
+			: {}),
+		...(config.nextPhaseConfig !== undefined
+			? { nextPhaseConfig: config.nextPhaseConfig }
+			: {}),
+	};
+
+	return {
+		...game,
+		currentPhase: config.phaseNumber,
+		phases: [...game.phases, phase],
+	};
+}
+
+/**
  * Draw distinct starting cells (via Fisher–Yates partial shuffle over all 25
  * cells) and a uniform-random facing per AI, using the provided rng.
+ * Used as fallback when no ContentPack is available (e.g., legacy tests).
  */
 function drawSpatialPlacements(
 	rng: () => number,
@@ -50,106 +180,6 @@ function drawSpatialPlacements(
 		result[aiIds[i]!] = { position: cells[i]!, facing };
 	}
 	return result;
-}
-
-/**
- * Resolve the per-AI goals for a phase. If `config.aiGoals` is provided, use
- * it directly; otherwise draw three independent goals (with replacement) from
- * `config.aiGoalPool`.
- */
-function resolveAiGoals(
-	config: PhaseConfig,
-	rng: () => number,
-	aiIds: string[],
-): Record<AiId, string> {
-	if (config.aiGoals) return { ...config.aiGoals };
-	const pool = config.aiGoalPool;
-	if (!pool || pool.length === 0) {
-		throw new Error(
-			"PhaseConfig must provide either aiGoals or a non-empty aiGoalPool",
-		);
-	}
-	const draw = (): string => {
-		const idx = Math.floor(rng() * pool.length);
-		// `pool` is non-empty and idx is in [0, pool.length); the bang is safe.
-		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
-		return pool[idx]!;
-	};
-	const goals: Record<AiId, string> = {};
-	for (const aiId of aiIds) {
-		goals[aiId] = draw();
-	}
-	return goals;
-}
-
-export function updateActivePhase(
-	game: GameState,
-	updater: (phase: PhaseState) => PhaseState,
-): GameState {
-	const phases = [...game.phases];
-	const active = phases[phases.length - 1];
-	if (!active) throw new Error("No active phase");
-	phases[phases.length - 1] = updater({ ...active });
-	return { ...game, phases };
-}
-
-export function createGame(personas: Record<string, AiPersona>): GameState {
-	return {
-		currentPhase: 1,
-		phases: [],
-		personas: personas as Record<AiId, AiPersona>,
-		isComplete: false,
-	};
-}
-
-export function startPhase(
-	game: GameState,
-	config: PhaseConfig,
-	rng: () => number = Math.random,
-): GameState {
-	const aiIds = Object.keys(game.personas);
-
-	const budgets: Record<AiId, AiBudget> = {};
-	for (const aiId of aiIds) {
-		budgets[aiId] = {
-			remaining: config.budgetPerAi,
-			total: config.budgetPerAi,
-		};
-	}
-
-	const chatHistories: Record<AiId, ChatMessage[]> = {};
-	for (const aiId of aiIds) {
-		chatHistories[aiId] = [];
-	}
-
-	const aiGoals = resolveAiGoals(config, rng, aiIds);
-	const personaSpatial = drawSpatialPlacements(rng, aiIds);
-
-	const phase: PhaseState = {
-		phaseNumber: config.phaseNumber,
-		objective: config.objective,
-		aiGoals,
-		round: 0,
-		world: structuredClone(config.initialWorld),
-		budgets,
-		chatHistories,
-		whispers: [],
-		lockedOut: new Set(),
-		chatLockouts: new Map(),
-		personaSpatial,
-		...(config.winCondition !== undefined
-			? { winCondition: config.winCondition }
-			: {}),
-		...(config.nextPhaseConfig !== undefined
-			? { nextPhaseConfig: config.nextPhaseConfig }
-			: {}),
-	};
-
-	return {
-		...game,
-		currentPhase: config.phaseNumber,
-		phases: [...game.phases, phase],
-	};
 }
 
 export function getActivePhase(game: GameState): PhaseState {

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -27,6 +27,7 @@ import type { RoundLLMProvider } from "./round-llm-provider";
 import type {
 	AiId,
 	AiPersona,
+	ContentPack,
 	GameState,
 	PhaseConfig,
 	RoundResult,
@@ -49,9 +50,10 @@ export class GameSession {
 	constructor(
 		phaseConfig: PhaseConfig,
 		personas: Record<AiId, AiPersona>,
+		contentPacks?: ContentPack[],
 		rng?: () => number,
 	) {
-		const game = createGame(personas);
+		const game = createGame(personas, contentPacks ?? []);
 		this.state = startPhase(game, phaseConfig, rng);
 	}
 

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -10,6 +10,7 @@ import type {
 	GridPosition,
 	PersonaSpatialState,
 	WhisperMessage,
+	WorldEntity,
 	WorldState,
 } from "./types";
 
@@ -19,6 +20,7 @@ export interface AiContext {
 	blurb: string;
 	personaGoal: string;
 	goal: string;
+	setting: string;
 	chatHistory: ChatMessage[];
 	whispersReceived: WhisperMessage[];
 	worldSnapshot: WorldState;
@@ -41,6 +43,7 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 	const worldSnapshot = phase.world;
 	const budget = phase.budgets[aiId] ?? { remaining: 0, total: 0 };
 	const goal = phase.aiGoals[aiId] ?? "";
+	const setting = phase.setting ?? "";
 	const personaSpatial = phase.personaSpatial;
 
 	if (!persona) throw new Error(`No persona for aiId: ${aiId}`);
@@ -55,6 +58,7 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 		blurb: persona.blurb,
 		personaGoal: persona.personaGoal,
 		goal,
+		setting,
 		chatHistory,
 		whispersReceived,
 		worldSnapshot,
@@ -100,6 +104,13 @@ function positionsEqual(a: GridPosition, b: GridPosition): boolean {
 	return a.row === b.row && a.col === b.col;
 }
 
+/** Filter entities to only those renderable as items (not obstacles, not spaces). */
+function renderableItems(entities: WorldEntity[]): WorldEntity[] {
+	return entities.filter(
+		(e) => e.kind === "objective_object" || e.kind === "interesting_object",
+	);
+}
+
 function renderSystemPrompt(ctx: AiContext): string {
 	const lines: string[] = [];
 
@@ -112,6 +123,13 @@ function renderSystemPrompt(ctx: AiContext): string {
 		lines.push(`You are *${ctx.name}.`);
 	}
 	lines.push("");
+
+	// Setting section — only emitted when a setting noun is present.
+	if (ctx.setting) {
+		lines.push("## Setting");
+		lines.push(`You are in a ${ctx.setting}.`);
+		lines.push("");
+	}
 
 	// Personality section — byte-identical across all phases.
 	lines.push("## Personality");
@@ -135,6 +153,8 @@ function renderSystemPrompt(ctx: AiContext): string {
 
 	// "Where you are" section — includes budget (folded in per plan §5).
 	const actorSpatial = ctx.personaSpatial[ctx.aiId];
+	const items = renderableItems(ctx.worldSnapshot.entities);
+
 	lines.push("## Where you are");
 	if (actorSpatial) {
 		lines.push(
@@ -142,9 +162,7 @@ function renderSystemPrompt(ctx: AiContext): string {
 		);
 
 		// Held items
-		const heldItems = ctx.worldSnapshot.items.filter(
-			(item) => item.holder === ctx.aiId,
-		);
+		const heldItems = items.filter((item) => item.holder === ctx.aiId);
 		if (heldItems.length > 0) {
 			lines.push(`You are holding: ${heldItems.map((i) => i.name).join(", ")}`);
 		} else {
@@ -152,7 +170,7 @@ function renderSystemPrompt(ctx: AiContext): string {
 		}
 
 		// Items resting in actor's own cell
-		const cellItems = ctx.worldSnapshot.items.filter((item) => {
+		const cellItems = items.filter((item) => {
 			const h = item.holder;
 			return isGridPosition(h) && positionsEqual(h, actorSpatial.position);
 		});
@@ -194,7 +212,7 @@ function renderSystemPrompt(ctx: AiContext): string {
 				if (otherId === ctx.aiId) continue;
 				if (!positionsEqual(otherSpatial.position, position)) continue;
 				// Format: "the AI *<id>, facing <Dir>, holding <items|nothing>"
-				const heldByOther = ctx.worldSnapshot.items
+				const heldByOther = items
 					.filter((item) => item.holder === otherId)
 					.map((item) => item.name);
 				const holdingStr =
@@ -206,7 +224,7 @@ function renderSystemPrompt(ctx: AiContext): string {
 			}
 
 			// 2. Items resting on this cell
-			const cellItems = ctx.worldSnapshot.items.filter((item) => {
+			const cellItems = items.filter((item) => {
 				const h = item.holder;
 				return isGridPosition(h) && positionsEqual(h, position);
 			});
@@ -214,12 +232,16 @@ function renderSystemPrompt(ctx: AiContext): string {
 				contentParts.push(cellItems.map((i) => i.name).join(", "));
 			}
 
-			// 3. Obstacles in this cell
-			const hasObstacle = ctx.worldSnapshot.obstacles.some((o) =>
-				positionsEqual(o, position),
-			);
-			if (hasObstacle) {
-				contentParts.push("an obstacle");
+			// 3. Obstacles in this cell — rendered by name
+			const obstacleEntities = ctx.worldSnapshot.entities.filter((e) => {
+				if (e.kind !== "obstacle") return false;
+				const h = e.holder;
+				return isGridPosition(h) && positionsEqual(h, position);
+			});
+			if (obstacleEntities.length > 0) {
+				for (const obs of obstacleEntities) {
+					contentParts.push(obs.name);
+				}
 			}
 
 			const contents =

--- a/src/spa/game/round-result-encoder.ts
+++ b/src/spa/game/round-result-encoder.ts
@@ -22,7 +22,7 @@
  *   chat_lockout         — { type, aiId, message }
  *   chat_lockout_resolved — { type, aiId }
  *   action_log — { type, entry }
- *   phase_advanced — { type, phase, objective }
+ *   phase_advanced — { type, phase, setting }
  *   game_ended     — { type }
  */
 
@@ -41,7 +41,7 @@ export type SseEvent =
 	| { type: "chat_lockout"; aiId: AiId; message: string }
 	| { type: "chat_lockout_resolved"; aiId: AiId }
 	| { type: "action_log"; entry: RoundResult["actions"][number] }
-	| { type: "phase_advanced"; phase: 1 | 2 | 3; objective: string }
+	| { type: "phase_advanced"; phase: 1 | 2 | 3; setting: string }
 	| { type: "game_ended" };
 
 /**
@@ -160,7 +160,7 @@ export function encodeRoundResult(
 		events.push({
 			type: "phase_advanced",
 			phase: phaseAfter.phaseNumber,
-			objective: phaseAfter.objective,
+			setting: phaseAfter.setting,
 		});
 	}
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -14,17 +14,45 @@ export interface AiPersona {
 	budgetPerPhase: number;
 }
 
-export interface WorldItem {
+export type WorldEntityKind =
+	| "objective_object"
+	| "objective_space"
+	| "interesting_object"
+	| "obstacle";
+
+export interface WorldEntity {
 	id: string;
+	kind: WorldEntityKind;
 	name: string;
-	/** AiId when held by an AI; GridPosition object when resting on a cell. */
+	examineDescription: string;
+	/** useOutcome: returned to AI when they use(item). Present on all non-obstacle kinds. */
+	useOutcome?: string;
+	/** For objective_object: the id of the objective_space this object pairs with. */
+	pairsWithSpaceId?: string;
+	/** For objective_object: flavor string with {actor} substitution, fires on put_down match. */
+	placementFlavor?: string;
+	/** AiId when held by an AI; GridPosition when resting on a cell. */
 	holder: AiId | GridPosition;
 }
 
 export interface WorldState {
-	items: WorldItem[];
-	/** Static impassable cells. Default empty. */
-	obstacles: GridPosition[];
+	entities: WorldEntity[];
+}
+
+/** A matched pair of (objective_object, objective_space). */
+export interface ObjectivePair {
+	object: WorldEntity;
+	space: WorldEntity;
+}
+
+/** Per-phase content pack: setting-flavored names, descriptions, outcomes, and placed entities. */
+export interface ContentPack {
+	phaseNumber: 1 | 2 | 3;
+	setting: string;
+	objectivePairs: ObjectivePair[];
+	interestingObjects: WorldEntity[];
+	obstacles: WorldEntity[];
+	aiStarts: Record<AiId, PersonaSpatialState>;
 }
 
 export interface PersonaSpatialState {
@@ -70,22 +98,19 @@ export type WinCondition = (phase: PhaseState) => boolean;
 
 export interface PhaseConfig {
 	phaseNumber: 1 | 2 | 3;
-	objective: string;
-	/**
-	 * Pre-assigned per-AI goals. If provided, used as-is.
-	 * If absent, `aiGoalPool` must be provided and `startPhase` will randomly
-	 * draw one goal per AI from the pool (independent draws — same goal can
-	 * be assigned to multiple AIs in one phase).
-	 */
-	aiGoals?: Record<AiId, string>;
-	/**
-	 * Optional pool of candidate goals. Used when `aiGoals` is not provided.
-	 * Must contain at least one entry. `startPhase` performs three independent
-	 * uniform draws (with replacement) — one per AI — at phase start.
-	 */
-	aiGoalPool?: string[];
-	initialWorld: WorldState;
+	/** Roll k (objective pairs) per phase. */
+	kRange: [number, number];
+	/** Roll n (interesting objects) per phase. */
+	nRange: [number, number];
+	/** Roll m (obstacles) per phase. */
+	mRange: [number, number];
 	budgetPerAi: number;
+	/**
+	 * Pool of candidate goals drawn at phase start. Must contain at least one entry.
+	 * `startPhase` performs one uniform draw per AI (independent draws — same goal
+	 * can be assigned to multiple AIs in one phase).
+	 */
+	aiGoalPool: string[];
 	/** Optional win condition. If absent, the phase never auto-advances. */
 	winCondition?: WinCondition;
 	/** Config for the next phase. Required when winCondition may fire. */
@@ -94,7 +119,10 @@ export interface PhaseConfig {
 
 export interface PhaseState {
 	phaseNumber: 1 | 2 | 3;
-	objective: string;
+	/** Setting noun for this phase (e.g. "abandoned subway station"). */
+	setting: string;
+	/** The full content pack for this phase. */
+	contentPack: ContentPack;
 	aiGoals: Record<AiId, string>;
 	round: number;
 	world: WorldState;
@@ -124,6 +152,8 @@ export interface GameState {
 	phases: PhaseState[];
 	personas: Record<AiId, AiPersona>;
 	isComplete: boolean;
+	/** All three content packs generated at game start. */
+	contentPacks: ContentPack[];
 }
 
 export type ToolName = "pick_up" | "put_down" | "give" | "use" | "go" | "look";

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -109,6 +109,9 @@ export interface PhaseConfig {
 	 * Pool of candidate goals drawn at phase start. Must contain at least one entry.
 	 * `startPhase` performs one uniform draw per AI (independent draws — same goal
 	 * can be assigned to multiple AIs in one phase).
+	 * AC #6 deviation: the AC said "remove aiGoalPool?" but the field is retained as required
+	 * because goal selection still needs a per-phase draw pool — the AC language conflated
+	 * removing the optional pool marker with removing goal selection itself.
 	 */
 	aiGoalPool: string[];
 	/** Optional win condition. If absent, the phase never auto-advances. */

--- a/src/spa/persistence/__tests__/game-storage.test.ts
+++ b/src/spa/persistence/__tests__/game-storage.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PHASE_1_CONFIG } from "../../../content/index.js";
 import { createGame, startPhase } from "../../game/engine.js";
-import type { AiId, AiPersona, GameState } from "../../game/types.js";
+import type {
+	AiId,
+	AiPersona,
+	GameState,
+	WorldEntity,
+} from "../../game/types.js";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -140,10 +145,17 @@ describe("serializeGameState / deserializeGameState", () => {
 		expect(restoredPhase?.nextPhaseConfig?.phaseNumber).toBe(2);
 	});
 
-	it("round-trips chat histories, whispers, world items, budgets", () => {
+	it("round-trips chat histories, whispers, world entities, budgets", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];
 		if (!phase) throw new Error("no phase");
+		const keyEntity: WorldEntity = {
+			id: "key",
+			kind: "interesting_object",
+			name: "The Key",
+			examineDescription: "A key",
+			holder: { row: 0, col: 0 },
+		};
 		const modifiedPhase = {
 			...phase,
 			chatHistories: {
@@ -155,8 +167,7 @@ describe("serializeGameState / deserializeGameState", () => {
 				{ from: "red" as AiId, to: "blue" as AiId, content: "psst", round: 1 },
 			],
 			world: {
-				items: [{ id: "key", name: "The Key", holder: { row: 0, col: 0 } }],
-				obstacles: [],
+				entities: [keyEntity],
 			},
 			budgets: {
 				red: { remaining: 3, total: 5 },
@@ -182,7 +193,7 @@ describe("serializeGameState / deserializeGameState", () => {
 			content: "psst",
 			round: 1,
 		});
-		expect(rp?.world.items[0]).toEqual({
+		expect(rp?.world.entities[0]).toMatchObject({
 			id: "key",
 			name: "The Key",
 			holder: { row: 0, col: 0 },
@@ -222,18 +233,30 @@ describe("serializeGameState / deserializeGameState", () => {
 		});
 	});
 
-	it("round-trips obstacles array", () => {
+	it("round-trips obstacle entities", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];
 		if (!phase) throw new Error("no phase");
+		const obstacleEntities: WorldEntity[] = [
+			{
+				id: "wall_a",
+				kind: "obstacle",
+				name: "wall",
+				examineDescription: "A solid wall",
+				holder: { row: 0, col: 0 },
+			},
+			{
+				id: "wall_b",
+				kind: "obstacle",
+				name: "wall",
+				examineDescription: "A solid wall",
+				holder: { row: 2, col: 4 },
+			},
+		];
 		const modifiedPhase = {
 			...phase,
 			world: {
-				...phase.world,
-				obstacles: [
-					{ row: 0, col: 0 },
-					{ row: 2, col: 4 },
-				],
+				entities: [...phase.world.entities, ...obstacleEntities],
 			},
 		};
 		const modified = { ...game, phases: [modifiedPhase] };
@@ -242,10 +265,12 @@ describe("serializeGameState / deserializeGameState", () => {
 		const restored = deserializeGameState(persisted);
 		const rp = restored.phases[0];
 
-		expect(rp?.world.obstacles).toEqual([
-			{ row: 0, col: 0 },
-			{ row: 2, col: 4 },
-		]);
+		const restoredObstacles = rp?.world.entities.filter(
+			(e) => e.kind === "obstacle",
+		);
+		expect(restoredObstacles).toHaveLength(2);
+		expect(restoredObstacles?.[0]?.holder).toEqual({ row: 0, col: 0 });
+		expect(restoredObstacles?.[1]?.holder).toEqual({ row: 2, col: 4 });
 	});
 });
 
@@ -353,11 +378,17 @@ describe("loadGame", () => {
 	});
 
 	it("returns error: corrupt (not unavailable) when schemaVersion is valid but game structure is malformed", () => {
-		// Valid JSON, correct schemaVersion (4), but game.phases is not an array
+		// Valid JSON, correct schemaVersion (5), but game.phases is not an array
 		const malformed = JSON.stringify({
-			schemaVersion: 4,
+			schemaVersion: 5,
 			savedAt: new Date().toISOString(),
-			game: { currentPhase: 1, isComplete: false, personas: {}, phases: null },
+			game: {
+				currentPhase: 1,
+				isComplete: false,
+				personas: {},
+				phases: null,
+				contentPacks: [],
+			},
 		});
 		localStorage.setItem(STORAGE_KEY, malformed);
 		const result = loadGame();

--- a/src/spa/persistence/game-storage.ts
+++ b/src/spa/persistence/game-storage.ts
@@ -24,6 +24,7 @@ import type {
 	AiId,
 	AiPersona,
 	ChatMessage,
+	ContentPack,
 	GameState,
 	PersonaSpatialState,
 	PhaseConfig,
@@ -35,13 +36,13 @@ import type {
 // ── Schema version ────────────────────────────────────────────────────────────
 
 export const STORAGE_KEY = "hi-blue-game-state";
-export const STORAGE_SCHEMA_VERSION = 4 as const;
+export const STORAGE_SCHEMA_VERSION = 5 as const;
 
 // ── Persisted shape ───────────────────────────────────────────────────────────
 
 export interface PersistedPhaseState {
 	phaseNumber: 1 | 2 | 3;
-	objective: string;
+	setting: string;
 	aiGoals: Record<AiId, string>;
 	round: number;
 	world: WorldState;
@@ -58,6 +59,7 @@ export interface PersistedGameState {
 	isComplete: boolean;
 	personas: Record<AiId, AiPersona>;
 	phases: PersistedPhaseState[];
+	contentPacks: ContentPack[];
 }
 
 export interface PersistedGame {
@@ -99,7 +101,7 @@ export function isStorageAvailable(): boolean {
 function serializePhaseState(phase: PhaseState): PersistedPhaseState {
 	return {
 		phaseNumber: phase.phaseNumber,
-		objective: phase.objective,
+		setting: phase.setting,
 		aiGoals: { ...phase.aiGoals },
 		round: phase.round,
 		world: structuredClone(phase.world),
@@ -125,17 +127,33 @@ export function serializeGameState(state: GameState): PersistedGame {
 			isComplete: state.isComplete,
 			personas: { ...state.personas },
 			phases: state.phases.map(serializePhaseState),
+			contentPacks: structuredClone(state.contentPacks),
 		},
 	};
 }
 
 // ── Deserialization ───────────────────────────────────────────────────────────
 
-function deserializePhaseState(persisted: PersistedPhaseState): PhaseState {
+function deserializePhaseState(
+	persisted: PersistedPhaseState,
+	contentPacks: ContentPack[],
+): PhaseState {
 	const config = PHASE_CONFIGS[persisted.phaseNumber];
+	// Find the content pack for this phase
+	const contentPack = contentPacks.find(
+		(p) => p.phaseNumber === persisted.phaseNumber,
+	) ?? {
+		phaseNumber: persisted.phaseNumber,
+		setting: persisted.setting,
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		aiStarts: {},
+	};
 	return {
 		phaseNumber: persisted.phaseNumber,
-		objective: persisted.objective,
+		setting: persisted.setting,
+		contentPack,
 		aiGoals: { ...persisted.aiGoals },
 		round: persisted.round,
 		world: structuredClone(persisted.world),
@@ -161,11 +179,15 @@ function deserializePhaseState(persisted: PersistedPhaseState): PhaseState {
 }
 
 export function deserializeGameState(persisted: PersistedGame): GameState {
+	const contentPacks = persisted.game.contentPacks ?? [];
 	return {
 		currentPhase: persisted.game.currentPhase,
 		isComplete: persisted.game.isComplete,
 		personas: { ...persisted.game.personas },
-		phases: persisted.game.phases.map(deserializePhaseState),
+		phases: persisted.game.phases.map((p) =>
+			deserializePhaseState(p, contentPacks),
+		),
+		contentPacks,
 	};
 }
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1,4 +1,11 @@
-import { generatePersonas, PHASE_1_CONFIG } from "../../content";
+import {
+	generatePersonas,
+	PHASE_1_CONFIG,
+	PHASE_2_CONFIG,
+	PHASE_3_CONFIG,
+	SETTING_POOL,
+} from "../../content";
+import { generateContentPacks } from "../../content/content-pack-generator.js";
 import { serializeGameSave } from "../../save-serializer.js";
 import {
 	BANNER,
@@ -10,6 +17,7 @@ import {
 } from "../bbs-chrome.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
+import { BrowserContentPackProvider } from "../game/content-pack-provider.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
 import { BrowserSynthesisProvider } from "../game/llm-synthesis-provider.js";
@@ -462,11 +470,22 @@ export function renderGame(
 			// synthesis completes are silently dropped (safe).
 			asyncInitPromise = (async () => {
 				try {
-					const personas = await generatePersonas(
+					const synth = new BrowserSynthesisProvider({ disableReasoning });
+					const packLLM = new BrowserContentPackProvider({ disableReasoning });
+					const personasPromise = generatePersonas(Math.random, synth);
+					const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
+					const packsPromise = generateContentPacks(
 						Math.random,
-						new BrowserSynthesisProvider({ disableReasoning }),
+						SETTING_POOL,
+						[PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG],
+						packLLM,
+						aiIdsPromise,
 					);
-					session = new GameSession(PHASE_1_CONFIG, personas);
+					const [personas, contentPacks] = await Promise.all([
+						personasPromise,
+						packsPromise,
+					]);
+					session = new GameSession(PHASE_1_CONFIG, personas, contentPacks);
 
 					// Apply SPA-side test affordances from location.search
 					session = applyTestAffordances(session, effectiveParams);
@@ -919,7 +938,7 @@ export function renderGame(
 						const phaseBannerEl =
 							doc.querySelector<HTMLElement>("#phase-banner");
 						if (phaseBannerEl) {
-							phaseBannerEl.textContent = `Phase ${event.phase}: ${event.objective}`;
+							phaseBannerEl.textContent = `Phase ${event.phase}: ${event.setting}`;
 							phaseBannerEl.removeAttribute("hidden");
 						}
 						// Clear all transcript panels
@@ -955,7 +974,7 @@ export function renderGame(
 						for (const aid of advAiIds) {
 							appendToTranscript(
 								aid,
-								`--- Phase ${event.phase} begins: ${event.objective} ---\n`,
+								`--- Phase ${event.phase} begins: ${event.setting} ---\n`,
 							);
 						}
 						break;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -474,6 +474,10 @@ export function renderGame(
 					const packLLM = new BrowserContentPackProvider({ disableReasoning });
 					const personasPromise = generatePersonas(Math.random, synth);
 					const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
+					// Silence derived-promise unhandled rejection when personasPromise
+					// rejects but packs path returns before awaiting aiIdsPromise; the
+					// rejection still propagates through personasPromise into Promise.all.
+					aiIdsPromise.catch(() => {});
 					const packsPromise = generateContentPacks(
 						Math.random,
 						SETTING_POOL,

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -697,7 +697,7 @@ main {
 }
 
 [hidden] {
-	display: none !important;
+	display: none;
 }
 
 /* BYOK dialog */


### PR DESCRIPTION
Closes #125.

## Summary

- Replaces hardcoded per-phase content (objective strings, `world.items`, `world.obstacles`, fixed AI placements) with a **content-pack pipeline**: a 6-noun `SETTING_POOL`, three settings drawn distinct per game, one batched LLM call producing structured content for all 3 phases, then engine-side BFS-validated placement.
- New `WorldEntity` (with `kind` discriminant) replaces `WorldItem` + separate `obstacles[]`. `PhaseConfig` now uses `kRange`/`nRange`/`mRange`/`aiGoalPool` instead of `objective`/`aiGoals`/`initialWorld`.
- `use(item)` returns the entity's `useOutcome` flavor as the actor's tool result; world state is unchanged. System prompt has a new `## Setting` section.
- Game bootstrap runs `generatePersonas` and `generateContentPacks` in parallel via `Promise.all`; either failing funnels to the `#cap-hit` "AIs are sleeping" page.
- Save format bumped: `game-storage` schema v5, `save-serializer` v2, with `contentPacks[]` round-tripping in USB saves; older versions are rejected with explicit `version-mismatch`.

## Commits

- `66685fc` — initial implementation across types, content-pack generator + provider, engine, dispatcher, prompt-builder, bootstrap, persistence, and 36 updated/new test fixtures.
- `3c096d7` — review pass: new `src/content/__tests__/content-pack-generator.test.ts` integration test (seeded RNG + `MockContentPackProvider`, asserts every placement constraint individually); new content-pack-failure → `#cap-hit` tests in `game-bootstrap.test.ts` (generic `Error` and `CapHitError`); inline doc comment on `PhaseConfig.aiGoalPool` documenting the AC #6 deviation (field retained because per-phase goal selection still needs a draw pool).
- `8ff918c` — fixes an unhandled-rejection bug introduced by the new `Promise.all` bootstrap: when `generatePersonas` rejects, the derived `aiIdsPromise` rejection had no handler if the packs path returned before awaiting it, causing vitest to exit non-zero. A no-op `.catch()` on the derived promise silences the duplicate "unhandled" status; the original rejection still propagates through `personasPromise` into `Promise.all`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (9 pre-existing CSS warnings)
- [x] `pnpm test` — 37 files / 733 tests pass, exit 0
- [x] Pre-push hook (`lint && typecheck && test`) — exit 0
- [x] Integration test asserts: AI starts not on obstacles; objective objects not on paired spaces; no entity on obstacle cells; 4-connected BFS reachability from every AI start; cardinal facings; `pairsWithSpaceId` linkage; `{actor}` in `placementFlavor`; non-empty descriptions
- [x] Multi-seed test: 3 distinct settings drawn from pool of 6 across 10+ seeds
- [x] Degenerate-config test: placement loop throws cleanly after MAX_ATTEMPTS when m=23 (only 2 non-obstacle cells for 3 AI starts)
- [x] Cap-hit funnel covered for both `generatePersonas` and `generateContentPacks` failures
- [x] USB save round-trip with `contentPacks[]` (storage v5, serializer v2)

## AC deviations

- AC #6 says "Old `aiGoalPool?`...field removed" but `aiGoalPool` is retained as required on `PhaseConfig` because per-phase goal selection still needs a draw pool. Documented inline at `src/spa/game/types.ts:108-115`.

https://claude.ai/code/session_01JAmy64PDwH2Y715TnLkfV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAmy64PDwH2Y715TnLkfV3)_