### PR TITLE
feat(spa): collapse layout into bento at <=720px

### DIFF
--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -1,20 +1,33 @@
 import type { AiPersona } from "./game/types";
 
-const BANNER_LINES = [
-	"   ██╗  ██╗██╗      ██████╗ ██╗     ██╗   ██╗███████╗",
-	"   ██║  ██║██║      ██╔══██╗██║     ██║   ██║██╔════╝",
-	"   ███████║██║█████╗██████╔╝██║     ██║   ██║█████╗  ",
-	"   ██╔══██║██║╚════╝██╔══██╗██║     ██║   ██║██╔══╝  ",
-	"   ██║  ██║██║      ██████╔╝███████╗╚██████╔╝███████╗   bbs terminal · v0.3 · amber ",
-	"   ╚═╝  ╚═╝╚═╝      ╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝",
+// Each line is split into amber prefix (HI-), blue middle (BLUE block
+// letters), and optional amber suffix (the meta line on row 5). The blue
+// segment is 33 chars wide on every row, so column alignment is preserved.
+const BANNER_SEGMENTS: ReadonlyArray<readonly [string, string, string]> = [
+	["   ██╗  ██╗██╗      ", "██████╗ ██╗     ██╗   ██╗███████╗", ""],
+	["   ██║  ██║██║      ", "██╔══██╗██║     ██║   ██║██╔════╝", ""],
+	["   ███████║██║█████╗", "██████╔╝██║     ██║   ██║█████╗  ", ""],
+	["   ██╔══██║██║╚════╝", "██╔══██╗██║     ██║   ██║██╔══╝  ", ""],
+	[
+		"   ██║  ██║██║      ",
+		"██████╔╝███████╗╚██████╔╝███████╗",
+		"   bbs terminal · v0.3 · amber ",
+	],
+	["   ╚═╝  ╚═╝╚═╝      ", "╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝", ""],
 ] as const;
 
+/** Banner as HTML — the BLUE block letters are wrapped in `.banner-blue`. */
 export const BANNER: string = (() => {
-	const w = Math.max(...BANNER_LINES.map((l) => [...l].length));
-	const pad = (s: string): string => s + " ".repeat(w - [...s].length);
+	const len = (s: string): number => [...s].length;
+	const lineLen = (seg: readonly [string, string, string]): number =>
+		len(seg[0]) + len(seg[1]) + len(seg[2]);
+	const w = Math.max(...BANNER_SEGMENTS.map(lineLen));
 	const top = ` ╔${"═".repeat(w + 2)}╗`;
 	const bot = ` ╚${"═".repeat(w + 2)}╝`;
-	const body = BANNER_LINES.map((l) => ` ║ ${pad(l)} ║`);
+	const body = BANNER_SEGMENTS.map(([a, b, c]) => {
+		const pad = " ".repeat(w - lineLen([a, b, c]));
+		return ` ║ ${a}<span class="banner-blue">${b}</span>${c}${pad} ║`;
+	});
 	return [top, ...body, bot].join("\n");
 })();
 

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<title>hi-blue · BBS terminal</title>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -627,7 +627,7 @@ export function renderGame(
 
 	// One-time chrome: ASCII banner + initial top-info row.
 	const bannerEl = doc.querySelector<HTMLElement>("#banner");
-	if (bannerEl && !bannerEl.textContent) bannerEl.textContent = BANNER;
+	if (bannerEl && !bannerEl.innerHTML) bannerEl.innerHTML = BANNER;
 	const sessionId = getOrMintSessionId();
 	const topinfoLeftEl = doc.querySelector<HTMLElement>("#topinfo-left");
 	const topinfoRightEl = doc.querySelector<HTMLElement>("#topinfo-right");

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -782,3 +782,81 @@ main {
 #byok-close {
 	margin-top: 8px;
 }
+
+/* Responsive — narrow viewports collapse to a "bento": one main panel for the
+   currently @-addressed daemon, the other two as ~88px strip cards below. */
+@media (max-width: 720px) {
+	html,
+	body {
+		font-size: 12px;
+	}
+
+	#stage {
+		padding: 12px 12px 10px;
+		gap: 6px;
+	}
+
+	.banner {
+		display: none;
+	}
+
+	.topinfo {
+		font-size: 10px;
+		padding-bottom: 4px;
+	}
+
+	#panels.row {
+		display: grid;
+		grid-template-rows: minmax(0, 1fr) 88px;
+		grid-template-columns: 1fr 1fr;
+		gap: 6px;
+	}
+
+	.ai-panel {
+		grid-row: 2;
+		min-height: 0;
+	}
+
+	.ai-panel .panel-meta {
+		display: none;
+	}
+
+	.ai-panel .scroll {
+		overflow: hidden;
+		font-size: 11px;
+		padding: 4px 6px;
+	}
+
+	.ai-panel.panel--addressed,
+	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child {
+		grid-row: 1;
+		grid-column: 1 / -1;
+	}
+
+	.ai-panel.panel--addressed .panel-meta,
+	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child .panel-meta {
+		display: block;
+	}
+
+	.ai-panel.panel--addressed .scroll,
+	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child .scroll {
+		overflow-y: auto;
+		font-size: inherit;
+		padding: 2px 10px 12px;
+	}
+
+	.cmd {
+		padding: 8px 0 2px;
+		gap: 6px;
+	}
+
+	.cmd input {
+		font-size: 12px;
+	}
+
+	.cmd .send {
+		font-size: 10px;
+		padding: 2px 6px;
+		letter-spacing: 0.1em;
+	}
+}

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -4,6 +4,7 @@
 	--bg: #0b0700;
 	--amber: #ffb454;
 	--amber-dim: #7a5a2c;
+	--blue: #7fb6ff;
 	--you: #fff5e0;
 	--err: #ff7b6b;
 }
@@ -111,6 +112,13 @@ header {
 	font-size: 13px;
 	letter-spacing: 0;
 	color: var(--amber);
+}
+
+.banner-blue {
+	color: var(--blue);
+	text-shadow:
+		0 0 1px var(--blue),
+		0 0 6px rgba(127, 182, 255, 0.5);
 }
 
 /* Top-info row */


### PR DESCRIPTION
Adds a @media (max-width: 720px) block that swaps the 3-panel BBS
layout for a one-main-plus-two-strip-cards bento on narrow viewports.
The currently @-addressed daemon (or the first panel as fallback via
:has()) takes the full top row; the other two compress into 88px
strip cards below. Banner is hidden, paddings tightened, and the
composer scaled down. No JS changes — existing data-ai +
.panel--addressed wiring already drives the swap when the user types
or taps a strip card.