### PR TITLE
Document Daemon and Session terminology in CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,6 +14,10 @@ _Avoid_: Character, AI personality (when referring to the whole object).
 The user-facing register for **Persona** — a Persona as it appears in play (occupying a panel, with budget, lockout, conversation log). Code and domain documentation say **Persona**; the BBS chrome and player-facing copy say **Daemon** (e.g. "daemons online" in the topinfo, `*xxxx.txt` files in the **Session** picker). One Daemon per Persona per **Session**.
 _Avoid_: AI (too generic), bot, agent.
 
+**Session**:
+A single playthrough — the unit of save. Identified by a 4-hex token like `0x478F` minted at Session creation, shown in the topinfo bar throughout, and used as the Session's directory name in the **Session** picker. Each Session contains three **Daemon**s plus the sealed engine state. Multiple Sessions can coexist in localStorage; only one is *active* at a time. Replaces the previous single-key save model and the previous browser-wide session-id minted by `getOrMintSessionId`.
+_Avoid_: Save, slot (use Session), playthrough, run.
+
 **AiId**:
 The 4-character `*xxxx` lowercase-alphanumeric handle (e.g. `*3kw7`). The Persona's stable identifier across the playthrough. Decoupled from color and from any "red/green/blue" notion.
 _Avoid_: "the red AI" — color is rendering, not identity.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,6 +10,10 @@ A browser game where the player negotiates with three personality-distinct AIs o
 The full per-AI character object: identity (`*xxxx` name, color), two **Temperament**s, a **Persona Goal**, and a synthesized personality blurb. Generated procedurally at game start; stable across the three phases of a single playthrough.
 _Avoid_: Character, AI personality (when referring to the whole object).
 
+**Daemon**:
+The user-facing register for **Persona** — a Persona as it appears in play (occupying a panel, with budget, lockout, conversation log). Code and domain documentation say **Persona**; the BBS chrome and player-facing copy say **Daemon** (e.g. "daemons online" in the topinfo, `*xxxx.txt` files in the **Session** picker). One Daemon per Persona per **Session**.
+_Avoid_: AI (too generic), bot, agent.
+
 **AiId**:
 The 4-character `*xxxx` lowercase-alphanumeric handle (e.g. `*3kw7`). The Persona's stable identifier across the playthrough. Decoupled from color and from any "red/green/blue" notion.
 _Avoid_: "the red AI" — color is rendering, not identity.


### PR DESCRIPTION
## Summary
Added domain terminology documentation for two core concepts: **Daemon** and **Session**. These definitions clarify the distinction between code/domain language and player-facing UI terminology, and establish the Session as the primary save unit.

## Key Changes
- **Daemon**: Documented as the user-facing register for Persona, explaining that code uses "Persona" while the BBS UI and player-facing copy use "Daemon" (e.g., in topinfo and Session picker). Includes guidance on terminology to avoid.
- **Session**: Documented as a single playthrough unit identified by a 4-hex token (e.g., `0x478F`), explaining the new multi-session localStorage model that replaces the previous single-key save approach. Clarifies that each Session contains three Daemons and sealed engine state.

## Notable Details
- Both definitions include "_Avoid_" sections to guide consistent terminology usage across codebase and documentation
- Session definition explicitly notes the deprecation of the previous `getOrMintSessionId` single-session model
- Maintains consistency with existing CONTEXT.md style and structure (similar to the AiId definition below)

https://claude.ai/code/session_01LRTQLj8QoiqELB93YWdGQs