### PR TITLE
Mobile bento layout: fix zero-width panels + polish previews

### DIFF
--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -69,6 +69,55 @@ test("bento layout: panels have non-zero geometry inside their grid cells", asyn
 	expect(addressed[2]?.w).toBeGreaterThan(100);
 });
 
+test("strip-card label: panel-name renders on the TOP edge, not the bottom", async ({
+	page,
+}) => {
+	await stubChatCompletions(page, ["hi"]);
+	await page.goto("/");
+	const handles = await getAiHandles(page);
+
+	// Address middle panel so panels[0] and panels[2] are strip cards.
+	await page.locator("#prompt").fill(`${handles.mention(1)} hello`);
+	await page.waitForFunction(
+		() => document.querySelectorAll(".panel--addressed").length === 1,
+	);
+
+	const labels = await page.evaluate(() => {
+		const all = Array.from(
+			document.querySelectorAll<HTMLElement>("article.ai-panel"),
+		);
+		return all.map((p) => {
+			const top = p.querySelector<HTMLElement>(".brow-top .panel-name");
+			const bot = p.querySelector<HTMLElement>(".brow-bot .panel-name");
+			return {
+				addressed: p.classList.contains("panel--addressed"),
+				topVisible: top ? getComputedStyle(top).display !== "none" : false,
+				topText: top?.textContent ?? "",
+				botVisible: bot ? getComputedStyle(bot).display !== "none" : false,
+				botText: bot?.textContent ?? "",
+			};
+		});
+	});
+
+	// Strip cards (indices 0 and 2): label on TOP, not on bottom.
+	for (const idx of [0, 2]) {
+		const l = labels[idx];
+		if (!l) throw new Error(`no label probe for index ${idx}`);
+		expect(l.addressed).toBe(false);
+		expect(l.topVisible).toBe(true);
+		expect(l.topText).toMatch(/^\*\S+ :: @\S+$/);
+		expect(l.botVisible).toBe(false);
+	}
+
+	// Main panel (addressed): label still on bottom.
+	const main = labels[1];
+	if (!main) throw new Error("no main probe");
+	expect(main.addressed).toBe(true);
+	expect(main.topVisible).toBe(false);
+	expect(main.botVisible).toBe(true);
+	expect(main.botText).toMatch(/^\*\S+ :: @\S+$/);
+});
+
 test("strip-card preview: latest line visible + per-line ellipsis", async ({
 	page,
 }) => {
@@ -186,6 +235,52 @@ test("strip-card preview: latest line visible + per-line ellipsis", async ({
 		return line ? getComputedStyle(line).whiteSpace : null;
 	}, handles.ids[1]);
 	expect(mainWhiteSpace).toBe("pre-wrap");
+});
+
+test("strip-card preview: streamed AI tokens with embedded \\n stay in one msg-line", async ({
+	page,
+}) => {
+	// Stream a multi-line AI response. Even though the SSE body emits two
+	// hard \n characters mid-message, the entire AI message must collapse
+	// into a single .msg-line so the strip-card preview shows one line.
+	await stubChatCompletions(page, [
+		"first line of message\nsecond line\nthird",
+	]);
+	await page.goto("/");
+	const handles = await getAiHandles(page);
+
+	// Send a message addressed to panel 0 so it streams there.
+	await page.locator("#prompt").fill(`${handles.mention(0)} hi`);
+	await page.locator("#send").click();
+
+	// Wait for the response to land in panel 0's transcript.
+	const transcript = page.locator(`[data-transcript="${handles.ids[0]}"]`);
+	await expect(transcript).toContainText("third");
+
+	const lineShape = await page.evaluate((aiId) => {
+		const t = document.querySelector<HTMLElement>(
+			`[data-transcript="${aiId}"]`,
+		);
+		const lines = Array.from(
+			t?.querySelectorAll<HTMLElement>(".msg-line") ?? [],
+		);
+		// Find the AI message line (the one with .msg-prefix).
+		const aiLine = lines.find((l) => l.querySelector(".msg-prefix"));
+		return {
+			lineCount: lines.length,
+			aiLineText: aiLine?.textContent ?? "",
+			// Total msg-lines that contain msg-prefix (= number of AI messages).
+			aiMessageCount: lines.filter((l) => l.querySelector(".msg-prefix"))
+				.length,
+		};
+	}, handles.ids[0]);
+
+	// Exactly one AI message → exactly one msg-line for it.
+	expect(lineShape.aiMessageCount).toBe(1);
+	// All three lines of content are in that one msg-line.
+	expect(lineShape.aiLineText).toContain("first line of message");
+	expect(lineShape.aiLineText).toContain("second line");
+	expect(lineShape.aiLineText).toContain("third");
 });
 
 test("mobile header: HI-BLUE title visible left, cog right; compact topinfo", async ({

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -206,6 +206,13 @@ test("mobile header: HI-BLUE title visible left, cog right; compact topinfo", as
 		const tMobile = document.querySelector<HTMLElement>("#topinfo-mobile");
 		const tLeft = document.querySelector<HTMLElement>("#topinfo-left");
 		const tRight = document.querySelector<HTMLElement>("#topinfo-right");
+		const tStatus = document.querySelector<HTMLElement>(
+			"#topinfo-mobile-status",
+		);
+		const okSpan = tStatus?.querySelector<HTMLElement>(".ok");
+		const okCs = okSpan ? getComputedStyle(okSpan) : null;
+		const mobileRect = tMobile?.getBoundingClientRect();
+		const statusRect = tStatus?.getBoundingClientRect();
 		return {
 			titleVisible: titleCs?.display !== "none",
 			titleText: title?.textContent ?? "",
@@ -217,8 +224,15 @@ test("mobile header: HI-BLUE title visible left, cog right; compact topinfo", as
 				? getComputedStyle(tMobile).display !== "none"
 				: false,
 			mobileText: tMobile?.textContent ?? "",
+			mobileRight: mobileRect?.right ?? 0,
 			leftHidden: tLeft ? getComputedStyle(tLeft).display === "none" : false,
 			rightHidden: tRight ? getComputedStyle(tRight).display === "none" : false,
+			statusVisible: tStatus
+				? getComputedStyle(tStatus).display !== "none"
+				: false,
+			statusText: tStatus?.textContent ?? "",
+			statusLeft: statusRect?.x ?? 0,
+			okColor: okCs?.color ?? null,
 		};
 	});
 
@@ -240,4 +254,12 @@ test("mobile header: HI-BLUE title visible left, cog right; compact topinfo", as
 	expect(probe.mobileText).not.toContain("SESSION");
 	expect(probe.mobileText).not.toContain("PHASE");
 	expect(probe.mobileText).not.toContain("daemons");
+
+	// "● stable" indicator visible on the right, in green.
+	expect(probe.statusVisible).toBe(true);
+	expect(probe.statusText.trim()).toBe("● stable");
+	// .ok green: #8df27f → rgb(141, 242, 127)
+	expect(probe.okColor).toBe("rgb(141, 242, 127)");
+	// status sits to the right of the compact session/phase/turn text.
+	expect(probe.statusLeft).toBeGreaterThanOrEqual(probe.mobileRight);
 });

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -187,3 +187,57 @@ test("strip-card preview: latest line visible + per-line ellipsis", async ({
 	}, handles.ids[1]);
 	expect(mainWhiteSpace).toBe("pre-wrap");
 });
+
+test("mobile header: HI-BLUE title visible left, cog right; compact topinfo", async ({
+	page,
+}) => {
+	await stubChatCompletions(page, ["hi"]);
+	await page.goto("/");
+	await getAiHandles(page);
+
+	const probe = await page.evaluate(() => {
+		const title = document.querySelector<HTMLElement>(".mobile-title");
+		const blueSpan = title?.querySelector<HTMLElement>(".banner-blue");
+		const cog = document.querySelector<HTMLElement>("#byok-cog");
+		const titleRect = title?.getBoundingClientRect();
+		const cogRect = cog?.getBoundingClientRect();
+		const titleCs = title ? getComputedStyle(title) : null;
+		const blueCs = blueSpan ? getComputedStyle(blueSpan) : null;
+		const tMobile = document.querySelector<HTMLElement>("#topinfo-mobile");
+		const tLeft = document.querySelector<HTMLElement>("#topinfo-left");
+		const tRight = document.querySelector<HTMLElement>("#topinfo-right");
+		return {
+			titleVisible: titleCs?.display !== "none",
+			titleText: title?.textContent ?? "",
+			titleX: titleRect?.x ?? -1,
+			titleW: titleRect?.width ?? 0,
+			cogX: cogRect?.x ?? -1,
+			blueColor: blueCs?.color ?? null,
+			mobileVisible: tMobile
+				? getComputedStyle(tMobile).display !== "none"
+				: false,
+			mobileText: tMobile?.textContent ?? "",
+			leftHidden: tLeft ? getComputedStyle(tLeft).display === "none" : false,
+			rightHidden: tRight ? getComputedStyle(tRight).display === "none" : false,
+		};
+	});
+
+	expect(probe.titleVisible).toBe(true);
+	expect(probe.titleText).toBe("HI-BLUE");
+	// Title sits left of the cog.
+	expect(probe.titleX).toBeLessThan(probe.cogX);
+	expect(probe.titleW).toBeGreaterThan(0);
+	// "BLUE" inner span is rendered with the blue color (#7fb6ff).
+	expect(probe.blueColor).toBe("rgb(127, 182, 255)");
+
+	// Compact topinfo replaces the long form on mobile.
+	expect(probe.mobileVisible).toBe(true);
+	expect(probe.leftHidden).toBe(true);
+	expect(probe.rightHidden).toBe(true);
+	// Format: "0xXXXX · 01/03 · TRN N" — assert structure with regex.
+	expect(probe.mobileText).toMatch(/^0x[0-9A-F]{4} · \d{2}\/\d{2} · TRN \d+$/);
+	// And it shouldn't include the desktop labels.
+	expect(probe.mobileText).not.toContain("SESSION");
+	expect(probe.mobileText).not.toContain("PHASE");
+	expect(probe.mobileText).not.toContain("daemons");
+});

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for the bento layout at <=720px.
+ *
+ * Bug history: `.ai-panel { flex: 1 1 0; width: 0 }` from the desktop flex
+ * row leaked into the bento grid context, collapsing every panel to 0px
+ * wide even though the grid cells were sized correctly. Fix overrides
+ * `flex` / `width` inside the `@media (max-width: 720px)` block.
+ */
+import { expect, test } from "@playwright/test";
+import { getAiHandles, stubChatCompletions } from "./helpers";
+
+test.use({ viewport: { width: 375, height: 667 } });
+
+test("bento layout: panels have non-zero geometry inside their grid cells", async ({
+	page,
+}) => {
+	await stubChatCompletions(page, ["hi"]);
+	await page.goto("/");
+
+	const handles = await getAiHandles(page);
+
+	// No-address: first panel should be the main, others strip cards.
+	const noAddress = await page.evaluate(() => {
+		const panels = Array.from(
+			document.querySelectorAll<HTMLElement>("article.ai-panel"),
+		);
+		return panels.map((p) => {
+			const r = p.getBoundingClientRect();
+			return { w: r.width, h: r.height, gridRow: getComputedStyle(p).gridRow };
+		});
+	});
+	// Main panel (first child) spans both columns → ~viewport width.
+	expect(noAddress[0]?.gridRow).toBe("1");
+	expect(noAddress[0]?.w).toBeGreaterThan(300);
+	expect(noAddress[0]?.h).toBeGreaterThan(200);
+	// Strip cards must not be zero-width.
+	expect(noAddress[1]?.gridRow).toBe("2");
+	expect(noAddress[1]?.w).toBeGreaterThan(100);
+	expect(noAddress[2]?.gridRow).toBe("2");
+	expect(noAddress[2]?.w).toBeGreaterThan(100);
+
+	// @-address middle panel → it becomes the main, others demote to strip.
+	await page.locator("#prompt").fill(`${handles.mention(1)} hello`);
+	await page.waitForFunction(
+		() => document.querySelectorAll(".panel--addressed").length === 1,
+	);
+	const addressed = await page.evaluate(() => {
+		const panels = Array.from(
+			document.querySelectorAll<HTMLElement>("article.ai-panel"),
+		);
+		return panels.map((p) => {
+			const r = p.getBoundingClientRect();
+			return {
+				w: r.width,
+				h: r.height,
+				gridRow: getComputedStyle(p).gridRow,
+				addressed: p.classList.contains("panel--addressed"),
+			};
+		});
+	});
+	expect(addressed[1]?.addressed).toBe(true);
+	expect(addressed[1]?.gridRow).toBe("1");
+	expect(addressed[1]?.w).toBeGreaterThan(300);
+	expect(addressed[1]?.h).toBeGreaterThan(200);
+	expect(addressed[0]?.gridRow).toBe("2");
+	expect(addressed[0]?.w).toBeGreaterThan(100);
+	expect(addressed[2]?.gridRow).toBe("2");
+	expect(addressed[2]?.w).toBeGreaterThan(100);
+});

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -237,6 +237,67 @@ test("strip-card preview: latest line visible + per-line ellipsis", async ({
 	expect(mainWhiteSpace).toBe("pre-wrap");
 });
 
+test("strip-card preview: restored multi-line AI message stays in one msg-line", async ({
+	page,
+}) => {
+	// Regression: renderRestoredTranscript used to split on every `\n`,
+	// so a saved AI message containing internal newlines came back as
+	// multiple .msg-line divs after a reload — each appearing as its own
+	// ellipsis-truncated line in the strip-card preview.
+	await stubChatCompletions(page, [
+		"first line of saved msg\nsecond line\nthird",
+	]);
+	await page.goto("/");
+	const handles = await getAiHandles(page);
+
+	// Send a message addressed to panel 0 so the AI responds there.
+	await page.locator("#prompt").fill(`${handles.mention(0)} hi`);
+	await page.locator("#send").click();
+	const transcript0 = page.locator(`[data-transcript="${handles.ids[0]}"]`);
+	await expect(transcript0).toContainText("third");
+	// Wait for the save to land in localStorage.
+	await expect
+		.poll(() => page.evaluate(() => localStorage.getItem("hi-blue-game-state")))
+		.not.toBeNull();
+
+	// Reload — this exercises the renderRestoredTranscript path.
+	await page.reload();
+	await stubChatCompletions(page, ["restubbed"]);
+	await expect(page.locator("#composer")).toBeVisible();
+	const handles2 = await getAiHandles(page);
+
+	// Demote panel 0 to strip card by addressing panel 1.
+	await page.locator("#prompt").fill(`${handles2.mention(1)} hello`);
+	await page.waitForFunction(
+		() => document.querySelectorAll(".panel--addressed").length === 1,
+	);
+
+	const restored = await page.evaluate((aiId) => {
+		const t = document.querySelector<HTMLElement>(
+			`[data-transcript="${aiId}"]`,
+		);
+		const lines = Array.from(
+			t?.querySelectorAll<HTMLElement>(".msg-line") ?? [],
+		);
+		const aiLines = lines.filter((l) => l.querySelector(".msg-prefix"));
+		const aiLine = aiLines[0];
+		return {
+			aiLineCount: aiLines.length,
+			aiLineText: aiLine?.textContent ?? "",
+			aiLineHeight: aiLine?.getBoundingClientRect().height ?? 0,
+		};
+	}, handles.ids[0]);
+
+	// Exactly one msg-line for the AI message — even though it contains
+	// two internal \n chars in the saved string.
+	expect(restored.aiLineCount).toBe(1);
+	expect(restored.aiLineText).toContain("first line of saved msg");
+	expect(restored.aiLineText).toContain("second line");
+	expect(restored.aiLineText).toContain("third");
+	// nowrap collapses internal \n → one visual line ≈ 16px tall.
+	expect(restored.aiLineHeight).toBeLessThan(22);
+});
+
 test("strip-card preview: streamed AI tokens with embedded \\n stay in one msg-line", async ({
 	page,
 }) => {

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -1,10 +1,11 @@
 /**
- * Regression test for the bento layout at <=720px.
+ * Regression tests for the <=720px bento layout.
  *
- * Bug history: `.ai-panel { flex: 1 1 0; width: 0 }` from the desktop flex
- * row leaked into the bento grid context, collapsing every panel to 0px
- * wide even though the grid cells were sized correctly. Fix overrides
- * `flex` / `width` inside the `@media (max-width: 720px)` block.
+ * Bug history:
+ *   - `.ai-panel { flex: 1 1 0; width: 0 }` from the desktop flex row leaked
+ *     into the bento grid context, collapsing every panel to 0px wide.
+ *   - Strip-card transcript previewed the OLDEST messages (clipped at the
+ *     bottom) and wrapped long messages onto multiple lines, hiding context.
  */
 import { expect, test } from "@playwright/test";
 import { getAiHandles, stubChatCompletions } from "./helpers";
@@ -66,4 +67,123 @@ test("bento layout: panels have non-zero geometry inside their grid cells", asyn
 	expect(addressed[0]?.w).toBeGreaterThan(100);
 	expect(addressed[2]?.gridRow).toBe("2");
 	expect(addressed[2]?.w).toBeGreaterThan(100);
+});
+
+test("strip-card preview: latest line visible + per-line ellipsis", async ({
+	page,
+}) => {
+	await stubChatCompletions(page, ["hi"]);
+	await page.goto("/");
+
+	const handles = await getAiHandles(page);
+
+	// Address middle panel so panels[0] and panels[2] become strip cards.
+	// Inject a transcript with many lines, including a wide one that would
+	// otherwise wrap, into a strip-card panel.
+	await page.locator("#prompt").fill(`${handles.mention(1)} hello`);
+	await page.waitForFunction(
+		() => document.querySelectorAll(".panel--addressed").length === 1,
+	);
+
+	const stripId = handles.ids[0];
+	await page.evaluate((aiId) => {
+		const t = document.querySelector<HTMLElement>(
+			`[data-transcript="${aiId}"]`,
+		);
+		if (!t) throw new Error("transcript not found");
+		t.textContent = "";
+		const lines = [
+			"> *one alpha\n",
+			"> *one bravo\n",
+			"> *one charlie this message is much longer than the strip card width and would wrap onto a second visual line if nowrap+ellipsis weren't applied\n",
+			"> *one delta\n",
+			"> *one echo\n",
+			"> *one foxtrot\n",
+			"> *one golf\n",
+			"> *one LATEST_MARKER\n",
+		];
+		for (const text of lines) {
+			const div = document.createElement("div");
+			div.className = "msg-line";
+			div.textContent = text;
+			t.appendChild(div);
+		}
+	}, stripId);
+
+	const probe = await page.evaluate((aiId) => {
+		const panel = document.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
+		const scroll = panel?.querySelector<HTMLElement>(".scroll");
+		const lines = Array.from(
+			panel?.querySelectorAll<HTMLElement>(".msg-line") ?? [],
+		);
+		const last = lines[lines.length - 1];
+		const wide = lines.find((l) => l.textContent?.includes("charlie"));
+		const scrollRect = scroll?.getBoundingClientRect();
+		const lastRect = last?.getBoundingClientRect();
+		const wideRect = wide?.getBoundingClientRect();
+		const wideCs = wide ? getComputedStyle(wide) : null;
+		return {
+			scrollRect: scrollRect && {
+				top: scrollRect.top,
+				bottom: scrollRect.bottom,
+				w: scrollRect.width,
+			},
+			lastText: last?.textContent ?? "",
+			lastRect: lastRect && {
+				top: lastRect.top,
+				bottom: lastRect.bottom,
+				w: lastRect.width,
+			},
+			wideText: wide?.textContent ?? "",
+			wideRect: wideRect && {
+				w: wideRect.width,
+				h: wideRect.height,
+			},
+			wideWhiteSpace: wideCs?.whiteSpace ?? null,
+			wideTextOverflow: wideCs?.textOverflow ?? null,
+			wideOverflow: wideCs?.overflow ?? null,
+			wideScrollWidth: wide?.scrollWidth ?? 0,
+		};
+	}, stripId);
+
+	// (a) Latest line is visible inside the .scroll viewport (not clipped off).
+	expect(probe.lastText).toContain("LATEST_MARKER");
+	expect(probe.lastRect).toBeTruthy();
+	expect(probe.scrollRect).toBeTruthy();
+	if (!probe.lastRect || !probe.scrollRect) throw new Error("no rects");
+	expect(probe.lastRect.bottom).toBeLessThanOrEqual(
+		probe.scrollRect.bottom + 1,
+	);
+	expect(probe.lastRect.bottom).toBeGreaterThan(probe.scrollRect.top);
+
+	// (b) The wide line uses nowrap + ellipsis: it's exactly one line tall
+	// and its scrollWidth (intrinsic) exceeds its rendered width (clipped).
+	expect(probe.wideWhiteSpace).toBe("nowrap");
+	expect(probe.wideTextOverflow).toBe("ellipsis");
+	expect(probe.wideOverflow).toBe("hidden");
+	if (!probe.wideRect) throw new Error("no wide rect");
+	// One line of 11px font with line-height 1.45 ≈ 16px. Allow up to 22.
+	expect(probe.wideRect.h).toBeLessThan(22);
+	expect(probe.wideScrollWidth).toBeGreaterThan(probe.wideRect.w);
+
+	// (c) Main panel keeps multi-line wrap behavior: its msg-lines compute
+	// to white-space: pre-wrap, not nowrap.
+	const mainWhiteSpace = await page.evaluate((aiId) => {
+		const panel = document.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
+		// inject a line so we have one to inspect
+		const t = panel?.querySelector<HTMLElement>(".transcript");
+		if (t) {
+			const div = document.createElement("div");
+			div.className = "msg-line";
+			div.textContent = "main mode line\n";
+			t.appendChild(div);
+		}
+		const line = panel?.querySelector<HTMLElement>(".msg-line:last-child");
+		return line ? getComputedStyle(line).whiteSpace : null;
+	}, handles.ids[1]);
+	expect(mainWhiteSpace).toBe("pre-wrap");
 });

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -89,6 +89,13 @@ export function formatTopInfoLeft(i: TopInfoInputs): string {
 	return `SESSION ${i.sessionId} · PHASE ${phase} · TURN ${turn}`;
 }
 
+/** Compact form rendered into `#topinfo-mobile` for the <=720px bento
+ * layout — drops the labels and the daemons-online/connection trailer. */
+export function formatTopInfoMobile(i: TopInfoInputs): string {
+	const phase = `${String(i.phaseNumber).padStart(2, "0")}/${String(i.totalPhases).padStart(2, "0")}`;
+	return `${i.sessionId} · ${phase} · TRN ${i.turn}`;
+}
+
 /** Prefix portion of the topinfo right cell — the "● connection stable"
  * trailer is appended at the call site as a span so it can carry its own
  * green color. Kept here so the daemons-online wording stays in one place. */

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -12,11 +12,13 @@
 	<body>
 		<div id="stage">
 			<header>
+				<span class="mobile-title" aria-hidden="true">HI-<span class="banner-blue">BLUE</span></span>
 				<button id="byok-cog" type="button" aria-label="Settings" title="Settings">[ ⚙ ]</button>
 			</header>
 			<pre class="banner" id="banner" aria-hidden="true"></pre>
 			<div id="topinfo" class="topinfo">
 				<span id="topinfo-left"></span>
+				<span id="topinfo-mobile"></span>
 				<span id="topinfo-right"></span>
 			</div>
 			<main>

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -28,6 +28,7 @@
 					<article class="ai-panel panel">
 						<div class="brow brow-top">
 							<span class="corner corner-tl"></span>
+							<span class="brow-label panel-name"></span>
 							<span class="brow-fill brow-fill-thin"></span>
 							<span class="brow-fill brow-fill-heavy"></span>
 							<span class="corner corner-tr"></span>
@@ -53,6 +54,7 @@
 					<article class="ai-panel panel">
 						<div class="brow brow-top">
 							<span class="corner corner-tl"></span>
+							<span class="brow-label panel-name"></span>
 							<span class="brow-fill brow-fill-thin"></span>
 							<span class="brow-fill brow-fill-heavy"></span>
 							<span class="corner corner-tr"></span>
@@ -78,6 +80,7 @@
 					<article class="ai-panel panel">
 						<div class="brow brow-top">
 							<span class="corner corner-tl"></span>
+							<span class="brow-label panel-name"></span>
 							<span class="brow-fill brow-fill-thin"></span>
 							<span class="brow-fill brow-fill-heavy"></span>
 							<span class="corner corner-tr"></span>

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -19,6 +19,7 @@
 			<div id="topinfo" class="topinfo">
 				<span id="topinfo-left"></span>
 				<span id="topinfo-mobile"></span>
+				<span id="topinfo-mobile-status" aria-hidden="true"><span class="ok"> ● stable</span></span>
 				<span id="topinfo-right"></span>
 			</div>
 			<main>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -49,10 +49,15 @@ function transcriptName(name: string): string {
 const AI_PREFIX_RE = /^> \*(\S+) /;
 
 /** Render a saved transcript string into the given element by parsing
- * lines and wrapping each in a `.msg-line` block. AI prefix portions
- * (`> *<handle> `) become `.msg-prefix` spans tinted with the persona's
- * color; player lines (`> <msg>`) become `.msg-you` spans. The per-line
- * wrapper is what enables strip-card mode to apply nowrap+ellipsis. */
+ * lines and wrapping each logical message in a `.msg-line` block. AI
+ * prefix portions (`> *<handle> `) become `.msg-prefix` spans tinted
+ * with the persona's color; player lines (`> <msg>`) become `.msg-you`
+ * spans. Lines starting with `[` (bracketed system messages) or `--- `
+ * (phase separators) become their own standalone msg-line. Any other
+ * orphan amber line is treated as a continuation of the preceding AI
+ * msg-line — this matches the live `appendAiTokens` behavior, where an
+ * AI response with embedded `\n` collapses into a single msg-line so
+ * strip-card mode can render it as one ellipsis-truncated line. */
 function renderRestoredTranscript(
 	transcript: HTMLElement,
 	saved: string,
@@ -62,9 +67,17 @@ function renderRestoredTranscript(
 	transcript.textContent = "";
 	if (!saved) return;
 	const lines = saved.split(/(?<=\n)/);
+	// Tracks the most recently opened AI msg-line so consecutive orphan
+	// continuation lines (no prefix, not a system marker) can be merged
+	// into it instead of becoming new msg-lines.
+	let currentAiLine: HTMLElement | null = null;
+	const startNewMsgLine = (): HTMLElement => {
+		const el = doc.createElement("div");
+		el.className = "msg-line";
+		transcript.appendChild(el);
+		return el;
+	};
 	for (const line of lines) {
-		const lineEl = doc.createElement("div");
-		lineEl.className = "msg-line";
 		const m = AI_PREFIX_RE.exec(line);
 		if (m?.[1]) {
 			const handle = m[1];
@@ -78,18 +91,25 @@ function renderRestoredTranscript(
 				prefix.style.setProperty("--prefix-color", persona.color);
 			}
 			prefix.textContent = prefixText;
+			const lineEl = startNewMsgLine();
 			lineEl.appendChild(prefix);
 			const rest = line.slice(prefixText.length);
 			if (rest) lineEl.appendChild(doc.createTextNode(rest));
+			currentAiLine = lineEl;
 		} else if (line.startsWith("> ")) {
 			const span = doc.createElement("span");
 			span.className = "msg-you";
 			span.textContent = line;
-			lineEl.appendChild(span);
+			startNewMsgLine().appendChild(span);
+			currentAiLine = null;
+		} else if (line.startsWith("[") || line.startsWith("--- ")) {
+			startNewMsgLine().appendChild(doc.createTextNode(line));
+			currentAiLine = null;
+		} else if (currentAiLine) {
+			currentAiLine.appendChild(doc.createTextNode(line));
 		} else {
-			lineEl.appendChild(doc.createTextNode(line));
+			startNewMsgLine().appendChild(doc.createTextNode(line));
 		}
-		transcript.appendChild(lineEl);
 	}
 }
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -48,11 +48,10 @@ function transcriptName(name: string): string {
 const AI_PREFIX_RE = /^> \*(\S+) /;
 
 /** Render a saved transcript string into the given element by parsing
- * lines and wrapping AI prefix portions (`> *<handle> `) in `.msg-prefix`
- * spans tinted with the persona's color and other `> ` lines (player
- * messages, format `> <msg>`) in `.msg-you` spans. The remainder of an
- * AI line is appended as a plain text node (amber). Replaces any
- * existing children. */
+ * lines and wrapping each in a `.msg-line` block. AI prefix portions
+ * (`> *<handle> `) become `.msg-prefix` spans tinted with the persona's
+ * color; player lines (`> <msg>`) become `.msg-you` spans. The per-line
+ * wrapper is what enables strip-card mode to apply nowrap+ellipsis. */
 function renderRestoredTranscript(
 	transcript: HTMLElement,
 	saved: string,
@@ -61,10 +60,10 @@ function renderRestoredTranscript(
 	const doc = transcript.ownerDocument;
 	transcript.textContent = "";
 	if (!saved) return;
-	// Split on \n boundaries while keeping the trailing newlines as their
-	// own segments so we can preserve the exact original text.
 	const lines = saved.split(/(?<=\n)/);
 	for (const line of lines) {
+		const lineEl = doc.createElement("div");
+		lineEl.className = "msg-line";
 		const m = AI_PREFIX_RE.exec(line);
 		if (m?.[1]) {
 			const handle = m[1];
@@ -78,19 +77,18 @@ function renderRestoredTranscript(
 				prefix.style.setProperty("--prefix-color", persona.color);
 			}
 			prefix.textContent = prefixText;
-			transcript.appendChild(prefix);
+			lineEl.appendChild(prefix);
 			const rest = line.slice(prefixText.length);
-			if (rest) transcript.appendChild(doc.createTextNode(rest));
-			continue;
-		}
-		if (line.startsWith("> ")) {
+			if (rest) lineEl.appendChild(doc.createTextNode(rest));
+		} else if (line.startsWith("> ")) {
 			const span = doc.createElement("span");
 			span.className = "msg-you";
 			span.textContent = line;
-			transcript.appendChild(span);
-			continue;
+			lineEl.appendChild(span);
+		} else {
+			lineEl.appendChild(doc.createTextNode(line));
 		}
-		transcript.appendChild(doc.createTextNode(line));
+		transcript.appendChild(lineEl);
 	}
 }
 
@@ -431,11 +429,13 @@ export function renderGame(
 					const persona = restoredPersonas[aiId];
 					const personaName = persona?.name ?? aiId;
 					for (const msg of restoredPhase.chatHistories[aiId] ?? []) {
+						const lineEl = doc.createElement("div");
+						lineEl.className = "msg-line";
 						if (msg.role === "player") {
 							const span = doc.createElement("span");
 							span.className = "msg-you";
 							span.textContent = `> ${msg.content}\n`;
-							transcript.appendChild(span);
+							lineEl.appendChild(span);
 						} else {
 							const prefixSpan = doc.createElement("span");
 							prefixSpan.className = "msg-prefix";
@@ -443,9 +443,10 @@ export function renderGame(
 								prefixSpan.style.setProperty("--prefix-color", persona.color);
 							}
 							prefixSpan.textContent = `> *${transcriptName(personaName)} `;
-							transcript.appendChild(prefixSpan);
-							transcript.appendChild(doc.createTextNode(`${msg.content}\n`));
+							lineEl.appendChild(prefixSpan);
+							lineEl.appendChild(doc.createTextNode(`${msg.content}\n`));
 						}
+						transcript.appendChild(lineEl);
 					}
 				}
 			});
@@ -726,37 +727,78 @@ export function renderGame(
 		if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
 	}
 
-	// Helper: append plain text (amber default) as a text node — preserves
-	// any existing element children (.msg-you, .msg-prefix) in the transcript.
+	// Helper: open a fresh empty `.msg-line` div as a child of the transcript
+	// and return it. Use for events that semantically start a new line
+	// (player message, AI prefix, restored message).
+	function startMsgLine(transcript: HTMLElement): HTMLElement {
+		const div = doc.createElement("div");
+		div.className = "msg-line";
+		transcript.appendChild(div);
+		return div;
+	}
+
+	// Helper: return the current open msg-line (last child whose text
+	// hasn't been terminated by a `\n`), creating a fresh one if needed.
+	// Use for streaming tokens that continue an in-progress line.
+	function getOrCreateMsgLine(transcript: HTMLElement): HTMLElement {
+		const last = transcript.lastElementChild as HTMLElement | null;
+		if (
+			last?.classList.contains("msg-line") &&
+			!(last.textContent ?? "").endsWith("\n")
+		) {
+			return last;
+		}
+		return startMsgLine(transcript);
+	}
+
+	// Helper: append plain text (amber default), tracking msg-line boundaries
+	// so a streamed `\n` closes the current line and subsequent text starts
+	// a fresh one. Preserves existing .msg-you / .msg-prefix children.
 	function appendToTranscript(aiId: AiId, text: string): void {
 		const el = getTranscript(aiId);
 		if (!el) return;
-		el.appendChild(doc.createTextNode(text));
+		let remaining = text;
+		while (remaining.length > 0) {
+			const line = getOrCreateMsgLine(el);
+			const nlIdx = remaining.indexOf("\n");
+			if (nlIdx === -1) {
+				line.appendChild(doc.createTextNode(remaining));
+				remaining = "";
+			} else {
+				line.appendChild(doc.createTextNode(remaining.slice(0, nlIdx + 1)));
+				remaining = remaining.slice(nlIdx + 1);
+			}
+		}
 		scrollToBottom(el);
 	}
 
-	// Helper: append a player line wrapped in a .msg-you span (warm white).
+	// Helper: append a player line wrapped in a .msg-you span (warm white)
+	// inside its own .msg-line block.
 	function appendPlayerLine(aiId: AiId, text: string): void {
 		const el = getTranscript(aiId);
 		if (!el) return;
+		const line = startMsgLine(el);
 		const span = doc.createElement("span");
 		span.className = "msg-you";
 		span.textContent = text;
-		el.appendChild(span);
+		line.appendChild(span);
 		scrollToBottom(el);
 	}
 
 	// Helper: append an AI persona-prefix span (`> *<handle> `) tinted with
-	// the persona's color. The trailing space is included in the span.
+	// the persona's color, opening a fresh .msg-line block for it. The
+	// streaming AI tokens that follow continue inside the same .msg-line
+	// until a `\n` closes the message.
 	function appendAiPrefix(aiId: AiId, personaName: string): void {
 		const el = getTranscript(aiId);
 		if (!el) return;
+		const line = startMsgLine(el);
 		const span = doc.createElement("span");
 		span.className = "msg-prefix";
 		const color = session?.getState().personas[aiId]?.color;
 		if (color) span.style.setProperty("--prefix-color", color);
 		span.textContent = `> *${transcriptName(personaName)} `;
-		el.appendChild(span);
+		line.appendChild(span);
 		scrollToBottom(el);
 	}
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -10,6 +10,7 @@ import { serializeGameSave } from "../../save-serializer.js";
 import {
 	BANNER,
 	formatTopInfoLeft,
+	formatTopInfoMobile,
 	formatTopInfoRight,
 	getOrMintSessionId,
 	initPanelChrome,
@@ -632,6 +633,7 @@ export function renderGame(
 	const sessionId = getOrMintSessionId();
 	const topinfoLeftEl = doc.querySelector<HTMLElement>("#topinfo-left");
 	const topinfoRightEl = doc.querySelector<HTMLElement>("#topinfo-right");
+	const topinfoMobileEl = doc.querySelector<HTMLElement>("#topinfo-mobile");
 
 	function refreshTopInfo(): void {
 		if (!session) return;
@@ -662,6 +664,9 @@ export function renderGame(
 		okSpan.className = "ok";
 		okSpan.textContent = TOPINFO_RIGHT_OK_TEXT;
 		topinfoRightEl.appendChild(okSpan);
+		if (topinfoMobileEl) {
+			topinfoMobileEl.textContent = formatTopInfoMobile(inputs);
+		}
 	}
 
 	refreshTopInfo();

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -742,38 +742,28 @@ export function renderGame(
 		return div;
 	}
 
-	// Helper: return the current open msg-line (last child whose text
-	// hasn't been terminated by a `\n`), creating a fresh one if needed.
-	// Use for streaming tokens that continue an in-progress line.
-	function getOrCreateMsgLine(transcript: HTMLElement): HTMLElement {
-		const last = transcript.lastElementChild as HTMLElement | null;
-		if (
-			last?.classList.contains("msg-line") &&
-			!(last.textContent ?? "").endsWith("\n")
-		) {
-			return last;
-		}
-		return startMsgLine(transcript);
-	}
-
-	// Helper: append plain text (amber default), tracking msg-line boundaries
-	// so a streamed `\n` closes the current line and subsequent text starts
-	// a fresh one. Preserves existing .msg-you / .msg-prefix children.
-	function appendToTranscript(aiId: AiId, text: string): void {
+	// Helper: append streamed AI tokens to the current AI message's msg-line.
+	// Embedded `\n` characters do NOT split into new msg-lines — the entire
+	// AI message stays in one msg-line so strip-card preview can render it
+	// as a single ellipsis-truncated line. The line opened by appendAiPrefix
+	// is the target; if missing for any reason, a fallback line is opened.
+	function appendAiTokens(aiId: AiId, text: string): void {
 		const el = getTranscript(aiId);
 		if (!el) return;
-		let remaining = text;
-		while (remaining.length > 0) {
-			const line = getOrCreateMsgLine(el);
-			const nlIdx = remaining.indexOf("\n");
-			if (nlIdx === -1) {
-				line.appendChild(doc.createTextNode(remaining));
-				remaining = "";
-			} else {
-				line.appendChild(doc.createTextNode(remaining.slice(0, nlIdx + 1)));
-				remaining = remaining.slice(nlIdx + 1);
-			}
-		}
+		const last = el.lastElementChild as HTMLElement | null;
+		const line = last?.classList.contains("msg-line") ? last : startMsgLine(el);
+		line.appendChild(doc.createTextNode(text));
+		scrollToBottom(el);
+	}
+
+	// Helper: append a system-generated line (phase separator, lockout text,
+	// error brackets) as its own .msg-line block. Always opens a fresh line
+	// — never merges into an in-progress AI message.
+	function appendStandaloneLine(aiId: AiId, text: string): void {
+		const el = getTranscript(aiId);
+		if (!el) return;
+		const line = startMsgLine(el);
+		line.appendChild(doc.createTextNode(text));
 		scrollToBottom(el);
 	}
 
@@ -893,7 +883,7 @@ export function renderGame(
 				appendAiPrefix(aiId, personaName);
 				liveAis.add(aiId);
 			}
-			appendToTranscript(aiId, text);
+			appendAiTokens(aiId, text);
 		};
 
 		try {
@@ -937,7 +927,7 @@ export function renderGame(
 						if (speakingAi) {
 							if (!liveAis.has(speakingAi)) {
 								// Synthetic path: append token and pace.
-								appendToTranscript(speakingAi, event.text);
+								appendAiTokens(speakingAi, event.text);
 							}
 							// Live path: text already painted; still await pace() so the
 							// overall timing shape is preserved (important for token-pacing
@@ -948,7 +938,7 @@ export function renderGame(
 
 					case "ai_end":
 						if (speakingAi) {
-							appendToTranscript(speakingAi, "\n");
+							appendAiTokens(speakingAi, "\n");
 						}
 						speakingAi = null;
 						break;
@@ -958,12 +948,12 @@ export function renderGame(
 						break;
 
 					case "lockout":
-						appendToTranscript(event.aiId, `[${event.content}]\n`);
+						appendStandaloneLine(event.aiId, `[${event.content}]\n`);
 						break;
 
 					case "chat_lockout":
 						setChatLockout(event.aiId, true);
-						appendToTranscript(event.aiId, `[${event.message}]\n`);
+						appendStandaloneLine(event.aiId, `[${event.message}]\n`);
 						break;
 
 					case "chat_lockout_resolved":
@@ -1018,7 +1008,7 @@ export function renderGame(
 						}
 						// Append phase separator to each transcript
 						for (const aid of advAiIds) {
-							appendToTranscript(
+							appendStandaloneLine(
 								aid,
 								`--- Phase ${event.phase} begins: ${event.setting} ---\n`,
 							);

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -864,7 +864,11 @@ main {
 		display: grid;
 		grid-template-rows: minmax(0, 1fr) 88px;
 		grid-template-columns: 1fr 1fr;
-		gap: 6px;
+		/* Row gap is larger so the main panel sits clearly apart from the
+		   strip-card previews; column gap stays tight between the two
+		   side-by-side strip cards. */
+		row-gap: 14px;
+		column-gap: 6px;
 	}
 
 	.ai-panel {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -104,6 +104,19 @@ header {
 	color: var(--amber);
 }
 
+/* Mobile-only header title — desktop uses the giant ASCII banner instead. */
+.mobile-title {
+	display: none;
+	font-size: 13px;
+	letter-spacing: 0.18em;
+	color: var(--amber);
+	padding: 2px 0;
+}
+
+#topinfo-mobile {
+	display: none;
+}
+
 /* Banner */
 .banner {
 	margin: 0;
@@ -812,6 +825,24 @@ main {
 	}
 
 	.banner {
+		display: none;
+	}
+
+	header {
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.mobile-title {
+		display: inline;
+	}
+
+	#topinfo-mobile {
+		display: inline;
+	}
+
+	#topinfo-left,
+	#topinfo-right {
 		display: none;
 	}
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -113,7 +113,8 @@ header {
 	padding: 2px 0;
 }
 
-#topinfo-mobile {
+#topinfo-mobile,
+#topinfo-mobile-status {
 	display: none;
 }
 
@@ -837,7 +838,8 @@ main {
 		display: inline;
 	}
 
-	#topinfo-mobile {
+	#topinfo-mobile,
+	#topinfo-mobile-status {
 		display: inline;
 	}
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -823,6 +823,11 @@ main {
 	.ai-panel {
 		grid-row: 2;
 		min-height: 0;
+		/* Reset desktop flex-row sizing: the row is `display: grid` here, so
+		   `flex: 1 1 0; width: 0` from the desktop block would otherwise
+		   collapse panels to zero width inside their grid cells. */
+		flex: initial;
+		width: auto;
 	}
 
 	.ai-panel .panel-meta {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -268,6 +268,13 @@ main {
 	content: " ]──";
 }
 
+/* Panel label normally lives on the bottom edge; the top-edge copy is
+   hidden by default and only shown for strip cards in the bento layout
+   (see the <=720px media query). */
+.brow-top .panel-name {
+	display: none;
+}
+
 .ai-panel.panel--addressed .brow-label::before {
 	content: "══[ ";
 }
@@ -899,6 +906,16 @@ main {
 		text-overflow: ellipsis;
 	}
 
+	/* Strip-card panels surface the daemon name on the TOP edge so the
+	   label is visible above the bottom-anchored transcript preview. */
+	.ai-panel .brow-top .panel-name {
+		display: inline-block;
+	}
+
+	.ai-panel .brow-bot .panel-name {
+		display: none;
+	}
+
 	.ai-panel.panel--addressed,
 	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child {
 		grid-row: 1;
@@ -930,6 +947,23 @@ main {
 		white-space: pre-wrap;
 		overflow: visible;
 		text-overflow: clip;
+	}
+
+	/* Main panel keeps its label on the bottom edge. */
+	.ai-panel.panel--addressed .brow-top .panel-name,
+	#panels:not(:has(.panel--addressed))
+		> .ai-panel:first-child
+		.brow-top
+		.panel-name {
+		display: none;
+	}
+
+	.ai-panel.panel--addressed .brow-bot .panel-name,
+	#panels:not(:has(.panel--addressed))
+		> .ai-panel:first-child
+		.brow-bot
+		.panel-name {
+		display: inline-block;
 	}
 
 	.cmd {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -389,6 +389,13 @@ main {
 	word-break: break-word;
 }
 
+/* Each transcript line is wrapped in a .msg-line block so strip-card mode
+   can apply per-line nowrap + ellipsis. Desktop inherits pre-wrap from
+   .transcript and behaves identically to the pre-wrapper rendering. */
+.msg-line {
+	display: block;
+}
+
 .transcript .msg-you {
 	color: var(--you);
 	text-shadow: 0 0 6px rgba(255, 245, 224, 0.5);
@@ -835,9 +842,28 @@ main {
 	}
 
 	.ai-panel .scroll {
+		position: relative;
 		overflow: hidden;
 		font-size: 11px;
 		padding: 4px 6px;
+	}
+
+	/* Strip-card preview: bottom-anchor the transcript so the most recent
+	   messages stay in view. Position absolute lets the transcript grow
+	   above its container; overflow:hidden on .scroll clips the older
+	   lines off the top. */
+	.ai-panel .transcript {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		margin-top: 0;
+	}
+
+	.ai-panel .msg-line {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.ai-panel.panel--addressed,
@@ -853,9 +879,24 @@ main {
 
 	.ai-panel.panel--addressed .scroll,
 	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child .scroll {
+		position: static;
 		overflow-y: auto;
 		font-size: inherit;
 		padding: 2px 10px 12px;
+	}
+
+	/* Main panel reverts to the scrollable, in-flow transcript. */
+	.ai-panel.panel--addressed .transcript,
+	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child .transcript {
+		position: static;
+		margin-top: auto;
+	}
+
+	.ai-panel.panel--addressed .msg-line,
+	#panels:not(:has(.panel--addressed)) > .ai-panel:first-child .msg-line {
+		white-space: pre-wrap;
+		overflow: visible;
+		text-overflow: clip;
 	}
 
 	.cmd {


### PR DESCRIPTION
## Summary

Diagnose and fix the broken `<=720px` bento layout, then polish the mobile preview UX based on iterative review.

- **Root-cause fix**: `.ai-panel { flex: 1 1 0; width: 0 }` from the desktop flex row leaked into the bento grid context, collapsing every panel to 0px wide. Override `flex: initial; width: auto` inside the `<=720px` block.
- **Strip-card previews bottom-anchored**: `.transcript` is now `position: absolute; bottom: 0` inside `position: relative` `.scroll`, so the latest messages stay visible and older lines clip off the top — no JS scrolling needed.
- **Per-line ellipsis**: each transcript line is wrapped in a `<div class="msg-line">`. Strip-card mode applies `nowrap + overflow:hidden + text-overflow:ellipsis`; main panel keeps `pre-wrap` for multi-line wrap.
- **One line per message**: `appendToTranscript` split into `appendAiTokens` (always extends the current AI line, ignoring embedded `\n`s) and `appendStandaloneLine` (phase separator, lockout/error brackets — own msg-line). `renderRestoredTranscript` mirrors this by treating orphan amber lines as continuations of the preceding AI msg-line, so live and restored DOM shapes match.
- **Mobile chrome**: hide the desktop ASCII banner, surface a `HI-BLUE` title in the header (BLUE in `--blue`) opposite the cog, shorten the topinfo to `0xBCE6 · 01/03 · TRN 1`, and re-add a green ` ● stable` indicator on the right.
- **Panel labels on top edge** for strip cards (preview boxes only); main panel keeps the bottom label.
- **Wider row gap** (14px) between main and previews while keeping the column gap (6px) tight between the two strip cards.

## Test plan

Six new Playwright tests in `e2e/responsive-bento.spec.ts` cover every behavior above:

- [x] `bento layout: panels have non-zero geometry inside their grid cells`
- [x] `strip-card label: panel-name renders on the TOP edge, not the bottom`
- [x] `strip-card preview: latest line visible + per-line ellipsis`
- [x] `strip-card preview: restored multi-line AI message stays in one msg-line`
- [x] `strip-card preview: streamed AI tokens with embedded \n stay in one msg-line`
- [x] `mobile header: HI-BLUE title visible left, cog right; compact topinfo`
- [x] Full e2e suite (22 stubbed tests) and 832 unit tests pass; typecheck and lint clean.

https://claude.ai/code/session_01GLxjCrbHBpSvq8BaUTEygv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLxjCrbHBpSvq8BaUTEygv)_