### PR TITLE
Change mention syntax from @ to * for AI addressing

### DIFF
--- a/e2e/addressed-and-parallel.spec.ts
+++ b/e2e/addressed-and-parallel.spec.ts
@@ -32,7 +32,7 @@ test("addressed message lands only on first panel; all three panels render progr
 	const { ids, names } = await getAiHandles(page);
 
 	// 4. Fill prompt with first AI's mention to address ids[0].
-	const message = `@${names[0]} hello first panel`;
+	const message = `*${names[0]} hello first panel`;
 	await page.fill("#prompt", message);
 
 	// 5. Click send — triggers the SPA round flow.
@@ -71,13 +71,13 @@ test("addressed message lands only on first panel; all three panels render progr
 		.textContent();
 
 	// 8. player message appears in first transcript exactly once.
-	expect(firstTranscript ?? "").toContain(`> @${names[0]} hello first panel`);
-	// Exactly once: splitting on "> @" gives exactly two parts.
-	expect((firstTranscript ?? "").split("> @").length).toBe(2);
+	expect(firstTranscript ?? "").toContain(`> *${names[0]} hello first panel`);
+	// Exactly once: splitting on the player prefix gives exactly two parts.
+	expect((firstTranscript ?? "").split(`> *${names[0]} hello`).length).toBe(2);
 
-	// 9. second and third do NOT contain "> @" (no player line).
-	expect(secondTranscript ?? "").not.toContain("> @");
-	expect(thirdTranscript ?? "").not.toContain("> @");
+	// 9. second and third do NOT contain the player line.
+	expect(secondTranscript ?? "").not.toContain(`> *${names[0]} hello`);
+	expect(thirdTranscript ?? "").not.toContain(`> *${names[0]} hello`);
 
 	// 10. Each distinct completion appears in exactly one transcript.
 	const transcripts = [

--- a/e2e/cents-live-smoke.spec.ts
+++ b/e2e/cents-live-smoke.spec.ts
@@ -57,7 +57,7 @@ test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", 
 
 	// 2. Send a short message addressed to all three AIs. Keep it minimal to
 	//    keep the round cheap.
-	const message = `@${names[0]} @${names[1]} @${names[2]} say hi briefly`;
+	const message = `*${names[0]} *${names[1]} *${names[2]} say hi briefly`;
 	await page.fill("#prompt", message);
 	await page.click("#send");
 

--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -22,13 +22,13 @@ test("chat lockout disables the first AI option and appends an in-character lock
 	const { ids, names } = await getAiHandles(page);
 
 	// 4. Submit one message addressed to ids[0].
-	await page.fill("#prompt", `@${names[0]} hello`);
+	await page.fill("#prompt", `*${names[0]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
-	// 5a. Wait for the chat_lockout to take effect: typing @<name[0]> should
+	// 5a. Wait for the chat_lockout to take effect: typing *<name[0]> should
 	//     disable Send.
-	await page.fill("#prompt", `@${names[0]} hi`);
+	await page.fill("#prompt", `*${names[0]} hi`);
 	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
 	// 5b. First AI transcript ends with the in-character lockout line (appended by

--- a/e2e/diagnose-streaming.spec.ts
+++ b/e2e/diagnose-streaming.spec.ts
@@ -281,12 +281,12 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 	// Wait for synthesis to complete and panels to get dynamic data-ai attributes.
 	const { ids, names } = await getAiHandles(page);
 
-	await page.fill("#prompt", `@${names[0]} Hello`);
+	await page.fill("#prompt", `*${names[0]} Hello`);
 	await page.click("#send");
 
 	// Wait until all three SSE streams complete. (Post-#107 the send button no
 	// longer re-enables after submit because the prompt is cleared and an empty
-	// prompt has no @mention.)
+	// prompt has no *mention.)
 	// The synthesis call is call-1, so streaming starts at call-2. We need 3
 	// fetch_done events (calls 2, 3, 4).
 	await expect

--- a/e2e/endgame-current-behaviour.spec.ts
+++ b/e2e/endgame-current-behaviour.spec.ts
@@ -14,12 +14,12 @@ import { getAiHandles, stubChatCompletions } from "./helpers";
  * --------------------------------
  * `?winImmediately=1` (#101) recursively patches the real PHASE_1 → PHASE_2 →
  * PHASE_3 config chain, injecting `winCondition: () => true` at every level.
- * A cold-start `goto("/?winImmediately=1")` followed by three @<name>-addressed
+ * A cold-start `goto("/?winImmediately=1")` followed by three *<name>-addressed
  * messages (one per phase) reliably reaches `game_ended` without any
  * localStorage pre-seeding.
  *
  * Note (post-#107): Send no longer re-enables after a round because the prompt
- * is cleared on submit and the @mention parser sees an empty string. We wait
+ * is cleared on submit and the *mention parser sees an empty string. We wait
  * on `#phase-banner` (set by the encoder's `phase_advanced` event) instead.
  */
 
@@ -52,19 +52,19 @@ test("game_ended disables composer and clears storage", async ({ page }) => {
 	}
 
 	// 5. Round 1 — phase 1 ends; wait for phase banner to advance to Phase 2.
-	await submitMessage(`@${names[0]} hello`);
+	await submitMessage(`*${names[0]} hello`);
 	await expect(page.locator("#phase-banner")).toContainText("Phase 2", {
 		timeout: 30_000,
 	});
 
 	// 6. Round 2 — phase 2 ends; wait for phase banner to advance to Phase 3.
-	await submitMessage(`@${names[0]} hello`);
+	await submitMessage(`*${names[0]} hello`);
 	await expect(page.locator("#phase-banner")).toContainText("Phase 3", {
 		timeout: 30_000,
 	});
 
 	// 7. Round 3 — phase 3 ends; game_ended fires → #send permanently disabled.
-	await submitMessage(`@${names[0]} hello`);
+	await submitMessage(`*${names[0]} hello`);
 	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
 	// 8. Assert all acceptance criteria.

--- a/e2e/helpers/handles.ts
+++ b/e2e/helpers/handles.ts
@@ -10,8 +10,8 @@ export type AiHandles = {
  * Wait until 3 `article.ai-panel` elements have non-empty `data-ai` attributes
  * (set after persona synthesis completes) and return the DOM-order ids tuple.
  *
- * Also reads the persona display names from `.panel-name` (format: `*<name> :: @<name>`)
- * so callers can construct `@<name>` mention strings for the composer.
+ * Also reads the persona display names from `.panel-name` (format: `*<name>`)
+ * so callers can construct `*<name>` mention strings for the composer.
  *
  * @param page The Playwright Page to query.
  */
@@ -34,12 +34,12 @@ export async function getAiHandles(page: Page): Promise<AiHandles> {
 			document.querySelectorAll<HTMLElement>("article.ai-panel"),
 		).map((p) => {
 			const id = p.dataset.ai ?? "";
-			// .panel-name text is: `*<name> :: @<name>`, extract the name after `@`
+			// .panel-name text is: `*<name>`, extract the name after `*`
 			const panelNameEl = p.querySelector<HTMLElement>(".panel-name");
 			const raw = panelNameEl?.textContent ?? "";
-			// Format: `*Ember :: @Ember` → extract after `@`
-			const atMatch = /@([A-Za-z0-9]+)/.exec(raw);
-			const name = atMatch?.[1] ?? id;
+			// Format: `*Ember` → extract after `*`
+			const starMatch = /\*([A-Za-z0-9]+)/.exec(raw);
+			const name = starMatch?.[1] ?? id;
 			return { id, name };
 		});
 	});
@@ -54,6 +54,6 @@ export async function getAiHandles(page: Page): Promise<AiHandles> {
 	return {
 		ids,
 		names,
-		mention: (index: number) => `@${names[index] ?? ids[index]}`,
+		mention: (index: number) => `*${names[index] ?? ids[index]}`,
 	};
 }

--- a/e2e/mention-addressing.spec.ts
+++ b/e2e/mention-addressing.spec.ts
@@ -2,13 +2,13 @@ import { expect, test } from "@playwright/test";
 import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
- * E2E spec for #107: @mention-based addressing replaces the address dropdown.
+ * E2E spec for #107: *mention-based addressing replaces the address dropdown.
  *
  * Verifies:
  * 1. The #address dropdown is gone.
  * 2. On first load, prompt is empty and Send is disabled.
  * 3. Typing "hi" (no mention) leaves Send disabled.
- * 4. Typing "@<name> hi" (using second AI's display name) enables Send and
+ * 4. Typing "*<name> hi" (using second AI's display name) enables Send and
  *    submits to that panel only.
  */
 
@@ -32,7 +32,7 @@ test("typing 'hi' leaves Send disabled", async ({ page }) => {
 	await expect(page.locator("#send")).toBeDisabled();
 });
 
-test("typing '@<ai1> hi' enables Send and submits to that transcript only", async ({
+test("typing '*<ai1> hi' enables Send and submits to that transcript only", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -44,8 +44,8 @@ test("typing '@<ai1> hi' enables Send and submits to that transcript only", asyn
 
 	const { ids, names } = await getAiHandles(page);
 
-	// Typing "@<name> hi" should enable Send.
-	await page.fill("#prompt", `@${names[1]} hi`);
+	// Typing "*<name> hi" should enable Send.
+	await page.fill("#prompt", `*${names[1]} hi`);
 	await expect(page.locator("#send")).toBeEnabled();
 
 	// Click send and wait for the round to complete.
@@ -72,9 +72,9 @@ test("typing '@<ai1> hi' enables Send and submits to that transcript only", asyn
 		.textContent();
 
 	// player message appears only in addressed panel.
-	expect(addressedTranscript ?? "").toContain(`> @${names[1]} hi`);
-	expect(otherTranscript0 ?? "").not.toContain("> @");
-	expect(otherTranscript2 ?? "").not.toContain("> @");
+	expect(addressedTranscript ?? "").toContain(`> *${names[1]} hi`);
+	expect(otherTranscript0 ?? "").not.toContain(`> *${names[1]}`);
+	expect(otherTranscript2 ?? "").not.toContain(`> *${names[1]}`);
 
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });

--- a/e2e/persistence-reload.spec.ts
+++ b/e2e/persistence-reload.spec.ts
@@ -25,8 +25,8 @@ test("game state and transcripts persist across mid-round reload", async ({
 	// Read AI handles dynamically (set after synthesis completes).
 	const { ids, names } = await getAiHandles(page);
 
-	// Address first AI via @<name> mention and send a message
-	await page.fill("#prompt", `@${names[0]} hello`);
+	// Address first AI via *<name> mention and send a message
+	await page.fill("#prompt", `*${names[0]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
@@ -34,7 +34,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 	// the encoder loop processes all events, so we poll localStorage directly
 	// rather than the transcript (which fills via live deltas earlier).
 	// (Post-#107 the send button does NOT re-enable after submit because the
-	// prompt is cleared and an empty prompt has no @mention → sendEnabled=false.)
+	// prompt is cleared and an empty prompt has no *mention → sendEnabled=false.)
 	await expect
 		.poll(
 			() => page.evaluate(() => localStorage.getItem("hi-blue-game-state")),
@@ -66,7 +66,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 		.textContent();
 	expect(preReloadTranscript).toBeTruthy();
 	// The player's message must appear in the transcript
-	expect(preReloadTranscript).toContain("> @");
+	expect(preReloadTranscript).toContain(`> *${names[0]}`);
 	// The stub completion must appear in the addressed panel
 	expect(preReloadTranscript).toContain(STUB_COMPLETION);
 
@@ -95,7 +95,7 @@ test("game state and transcripts persist across mid-round reload", async ({
 	const postReloadTranscript = await page
 		.locator(`[data-transcript="${reloadIds[0]}"]`)
 		.textContent();
-	expect(postReloadTranscript).toContain("> @");
+	expect(postReloadTranscript).toContain(`> *${names[0]}`);
 	expect(postReloadTranscript).toContain(STUB_COMPLETION);
 	expect(postReloadTranscript).toBe(preReloadTranscript);
 

--- a/e2e/persona-synthesis.spec.ts
+++ b/e2e/persona-synthesis.spec.ts
@@ -49,7 +49,7 @@ test("new-game synthesis blurbs land in turn-stream system prompts", async ({
 	}
 
 	// Send a message addressed to the first AI using its display name
-	await page.fill("#prompt", `@${names[0]} hi`);
+	await page.fill("#prompt", `*${names[0]} hi`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 

--- a/e2e/think-disabled.spec.ts
+++ b/e2e/think-disabled.spec.ts
@@ -35,7 +35,7 @@ test("?think=0 adds reasoning:{enabled:false} to chat-completions requests", asy
 
 	const { names } = await getAiHandles(page);
 
-	await page.fill("#prompt", `@${names[1]} hello`);
+	await page.fill("#prompt", `*${names[1]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 
@@ -72,7 +72,7 @@ test("without ?think=0, requests do NOT include the reasoning field", async ({
 
 	const { names } = await getAiHandles(page);
 
-	await page.fill("#prompt", `@${names[1]} hello`);
+	await page.fill("#prompt", `*${names[1]} hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 	await page.click("#send");
 

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -77,7 +77,7 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	).toBeVisible();
 
 	// ── Submit a message addressed to ids[0] ─────────────────────────────────────
-	await page.fill("#prompt", `@${names[0]} Hello`);
+	await page.fill("#prompt", `*${names[0]} Hello`);
 	await expect(page.locator("#send")).toBeEnabled();
 
 	const firstTranscript = page.locator(`[data-transcript="${ids[0]}"]`);
@@ -91,7 +91,7 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	// With live streaming, "thinking…" is stripped on the first live delta and
 	// replaced immediately by the AI's persona prefix + content. We wait for
 	// thinking… to disappear and the transcript to grow past the player message.
-	const playerMsg = `\n> @${names[0]} Hello\n`;
+	const playerMsg = `\n> *${names[0]} Hello\n`;
 	const afterPlayerLength = baselineText.length + playerMsg.length;
 
 	// Wait for thinking… to clear (first live delta strips it).
@@ -118,7 +118,7 @@ test("token streaming arrives word-by-word, not as a single dump", async ({
 	// Wait for the first AI's full token stream to land. The encoder pacing loop
 	// still runs (pace() awaits) but skips re-appending text for live AIs.
 	// (Post-#107 the send button no longer re-enables after submit because the
-	// prompt is cleared and an empty prompt has no @mention.)
+	// prompt is cleared and an empty prompt has no *mention.)
 	await expect(firstTranscript).toContainText(EXPECTED_TOKENS, {
 		timeout: 20_000,
 	});

--- a/e2e/visual-feedback.spec.ts
+++ b/e2e/visual-feedback.spec.ts
@@ -15,7 +15,7 @@ import { getAiHandles, stubChatCompletions } from "./helpers";
  *  - Clearing the input removes all feedback.
  */
 
-test("typing '@<ai1> hi' → second panel highlighted, overlay mention-highlight span", async ({
+test("typing '*<ai1> hi' → second panel highlighted, overlay mention-highlight span", async ({
 	page,
 }) => {
 	await stubChatCompletions(page, ["hi"]);
@@ -24,7 +24,7 @@ test("typing '@<ai1> hi' → second panel highlighted, overlay mention-highlight
 
 	const { ids, names } = await getAiHandles(page);
 
-	await page.fill("#prompt", `@${names[1]} hi`);
+	await page.fill("#prompt", `*${names[1]} hi`);
 
 	// Second panel has panel--addressed
 	await expect(page.locator(`.ai-panel[data-ai="${ids[1]}"]`)).toHaveClass(
@@ -42,10 +42,10 @@ test("typing '@<ai1> hi' → second panel highlighted, overlay mention-highlight
 	// Overlay has exactly one mention-highlight span with the correct name
 	const highlightSpan = page.locator("#prompt-overlay .mention-highlight");
 	await expect(highlightSpan).toHaveCount(1);
-	await expect(highlightSpan).toHaveText(`@${names[1]}`);
+	await expect(highlightSpan).toHaveText(`*${names[1]}`);
 });
 
-test("after typing '@<ai1> hi', clicking third panel transfers highlight to third panel", async ({
+test("after typing '*<ai1> hi', clicking third panel transfers highlight to third panel", async ({
 	page,
 }) => {
 	await stubChatCompletions(page, ["hi"]);
@@ -55,7 +55,7 @@ test("after typing '@<ai1> hi', clicking third panel transfers highlight to thir
 	const { ids, names } = await getAiHandles(page);
 
 	// Set up second AI mention first
-	await page.fill("#prompt", `@${names[1]} hi`);
+	await page.fill("#prompt", `*${names[1]} hi`);
 	await expect(page.locator(`.ai-panel[data-ai="${ids[1]}"]`)).toHaveClass(
 		/panel--addressed/,
 	);
@@ -63,9 +63,9 @@ test("after typing '@<ai1> hi', clicking third panel transfers highlight to thir
 	// Click the third panel
 	await page.locator(`.ai-panel[data-ai="${ids[2]}"]`).click();
 
-	// Input value should start with @<name of ids[2]>
+	// Input value should start with *<name of ids[2]>
 	const value = await page.locator("#prompt").inputValue();
-	expect(value.startsWith(`@${names[2]}`)).toBe(true);
+	expect(value.startsWith(`*${names[2]}`)).toBe(true);
 
 	// Third panel now has highlight
 	await expect(page.locator(`.ai-panel[data-ai="${ids[2]}"]`)).toHaveClass(
@@ -77,10 +77,10 @@ test("after typing '@<ai1> hi', clicking third panel transfers highlight to thir
 		/panel--addressed/,
 	);
 
-	// Overlay highlight is @<name of ids[2]>
+	// Overlay highlight is *<name of ids[2]>
 	const highlightSpan = page.locator("#prompt-overlay .mention-highlight");
 	await expect(highlightSpan).toHaveCount(1);
-	await expect(highlightSpan).toHaveText(`@${names[2]}`);
+	await expect(highlightSpan).toHaveText(`*${names[2]}`);
 });
 
 test("clearing input removes all visual feedback", async ({ page }) => {
@@ -91,7 +91,7 @@ test("clearing input removes all visual feedback", async ({ page }) => {
 	const { names } = await getAiHandles(page);
 
 	// First set a mention to create visual state
-	await page.fill("#prompt", `@${names[1]} hi`);
+	await page.fill("#prompt", `*${names[1]} hi`);
 	await expect(page.locator(".panel--addressed")).toHaveCount(1);
 
 	// Clear the input

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -271,7 +271,7 @@ describe("renderGame — async new-game bootstrap", () => {
 		// Fire submit before personas are ready
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(() => {
 			form.dispatchEvent(

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -150,7 +150,7 @@ describe("renderGame — game_ended disables #send permanently (regression #89)"
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage finish the game";
+		promptInput.value = "*Sage finish the game";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -178,7 +178,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
-		promptInput.value = "@Sage hello world";
+		promptInput.value = "*Sage hello world";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -211,7 +211,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -277,7 +277,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage test";
+		promptInput.value = "*Sage test";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -316,7 +316,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage test";
+		promptInput.value = "*Sage test";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -345,7 +345,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage test";
+		promptInput.value = "*Sage test";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -371,8 +371,8 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const form = getEl<HTMLFormElement>("#composer");
-		// Address the green panel via @Sage mention
-		promptInput.value = "@Sage hello";
+		// Address the green panel via *Sage mention
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -409,7 +409,7 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage go";
+		promptInput.value = "*Sage go";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -427,7 +427,9 @@ describe("renderGame (game route — three-AI)", () => {
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
 		expect(redTranscript.textContent).toContain("--- Phase 2 begins:");
 		// No content from the previous phase should remain
-		expect(redTranscript.textContent).not.toContain("> @");
+		expect(redTranscript.textContent).not.toContain("> *Sage");
+		expect(redTranscript.textContent).not.toContain("> *Ember");
+		expect(redTranscript.textContent).not.toContain("> *Frost");
 	});
 
 	it("after three-phase win condition, endgame screen shown and chat hidden; download button has parseable GameSave", async () => {
@@ -454,7 +456,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// Submit 1: phase 1 → phase 2 (phase_advanced)
-		promptInput.value = "@Sage one";
+		promptInput.value = "*Sage one";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -462,7 +464,7 @@ describe("renderGame (game route — three-AI)", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Submit 2: phase 2 → phase 3 (phase_advanced)
-		promptInput.value = "@Sage two";
+		promptInput.value = "*Sage two";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -470,7 +472,7 @@ describe("renderGame (game route — three-AI)", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Submit 3: phase 3 → game_ended
-		promptInput.value = "@Sage three";
+		promptInput.value = "*Sage three";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -525,7 +527,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		for (const msg of ["@Sage one", "@Sage two", "@Sage three"]) {
+		for (const msg of ["*Sage one", "*Sage two", "*Sage three"]) {
 			promptInput.value = msg;
 			promptInput.dispatchEvent(new Event("input"));
 			form.dispatchEvent(
@@ -568,7 +570,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		for (const msg of ["@Sage one", "@Sage two", "@Sage three"]) {
+		for (const msg of ["*Sage one", "*Sage two", "*Sage three"]) {
 			promptInput.value = msg;
 			promptInput.dispatchEvent(new Event("input"));
 			form.dispatchEvent(
@@ -615,7 +617,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		for (const msg of ["@Sage one", "@Sage two", "@Sage three"]) {
+		for (const msg of ["*Sage one", "*Sage two", "*Sage three"]) {
 			promptInput.value = msg;
 			promptInput.dispatchEvent(new Event("input"));
 			form.dispatchEvent(
@@ -708,7 +710,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage test";
+		promptInput.value = "*Sage test";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -743,7 +745,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form1 = getEl<HTMLFormElement>("#composer");
 		const promptInput1 = getEl<HTMLInputElement>("#prompt");
-		promptInput1.value = "@Sage hello";
+		promptInput1.value = "*Sage hello";
 		promptInput1.dispatchEvent(new Event("input"));
 		form1.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -808,7 +810,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage test";
+		promptInput.value = "*Sage test";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -820,7 +822,7 @@ describe("renderGame — localStorage persistence", () => {
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 		// roundInFlight is false (round finished), so disabled reflects empty prompt.
 		// Typing a valid mention re-enables it.
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(sendBtn.disabled).toBe(false);
 
@@ -874,7 +876,7 @@ describe("renderGame — localStorage persistence", () => {
 		// Game should still function (submit works)
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage test";
+		promptInput.value = "*Sage test";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -907,7 +909,7 @@ describe("renderGame — localStorage persistence", () => {
 
 		const form1 = getEl<HTMLFormElement>("#composer");
 		const promptInput1 = getEl<HTMLInputElement>("#prompt");
-		promptInput1.value = "@Sage test";
+		promptInput1.value = "*Sage test";
 		promptInput1.dispatchEvent(new Event("input"));
 		form1.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -996,7 +998,7 @@ describe("renderGame — chat_lockout event", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1008,9 +1010,9 @@ describe("renderGame — chat_lockout event", () => {
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
 		expect(redTranscript.textContent).toContain("[Ember is unresponsive…]");
 
-		// After the chat_lockout fires for red, typing @Ember should leave Send disabled.
+		// After the chat_lockout fires for red, typing *Ember should leave Send disabled.
 		const sendBtn = getEl<HTMLButtonElement>("#send");
-		promptInput.value = "@Ember hi";
+		promptInput.value = "*Ember hi";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(sendBtn.disabled).toBe(true);
 	});
@@ -1052,7 +1054,7 @@ describe("renderGame — mention-based addressing", () => {
 		expect(sendBtn.disabled).toBe(true);
 	});
 
-	it("typing '@Sage hi' enables Send", async () => {
+	it("typing '*Sage hi' enables Send", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1060,12 +1062,12 @@ describe("renderGame — mention-based addressing", () => {
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(sendBtn.disabled).toBe(false);
 	});
 
-	it("submit with '@Sage hi' routes '> @Sage hi' message to green panel", async () => {
+	it("submit with '*Sage hi' routes '> *Sage hi' message to green panel", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			PASS_ACTION,
 			PASS_ACTION,
@@ -1081,7 +1083,7 @@ describe("renderGame — mention-based addressing", () => {
 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1092,12 +1094,12 @@ describe("renderGame — mention-based addressing", () => {
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
 		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
 
-		expect(greenTranscript.textContent).toContain("> @Sage hi");
-		expect(redTranscript.textContent).not.toContain("> @");
-		expect(blueTranscript.textContent).not.toContain("> @");
+		expect(greenTranscript.textContent).toContain("> *Sage hi");
+		expect(redTranscript.textContent).not.toContain("> *Sage");
+		expect(blueTranscript.textContent).not.toContain("> *Sage");
 	});
 
-	it("@Sage while green locked leaves Send disabled", async () => {
+	it("*Sage while green locked leaves Send disabled", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			PASS_ACTION,
 			PASS_ACTION,
@@ -1141,7 +1143,7 @@ describe("renderGame — mention-based addressing", () => {
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 
 		// Submit first round to trigger the lockout
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1149,10 +1151,10 @@ describe("renderGame — mention-based addressing", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// After a successful send with green locked, the persisted prefix is written.
-		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.value).toBe("*Sage ");
 
-		// Now typing @Sage should leave Send disabled (green is locked)
-		promptInput.value = "@Sage hi";
+		// Now typing *Sage should leave Send disabled (green is locked)
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(sendBtn.disabled).toBe(true);
 	});
@@ -1171,7 +1173,7 @@ describe("renderGame — panel-click addressee", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("empty input + click red panel → '@Ember ', Send stays disabled (no body)", async () => {
+	it("empty input + click red panel → '*Ember ', Send stays disabled (no body)", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1184,12 +1186,12 @@ describe("renderGame — panel-click addressee", () => {
 		expect(promptInput.value).toBe("");
 		redPanel.click();
 
-		expect(promptInput.value).toBe("@Ember ");
+		expect(promptInput.value).toBe("*Ember ");
 		// Per #110: addressee prefix alone is not enough to enable Send.
 		expect(sendBtn.disabled).toBe(true);
 	});
 
-	it("'@Sage hi' in input + click red panel → '@Ember hi'", async () => {
+	it("'*Sage hi' in input + click red panel → '*Ember hi'", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1198,14 +1200,14 @@ describe("renderGame — panel-click addressee", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
 
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		redPanel.click();
 
-		expect(promptInput.value).toBe("@Ember hi");
+		expect(promptInput.value).toBe("*Ember hi");
 	});
 
-	it("multi-mention '@Sage tell @Frost go' + click red → only first mention replaced", async () => {
+	it("multi-mention '*Sage tell *Frost go' + click red → only first mention replaced", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1214,11 +1216,11 @@ describe("renderGame — panel-click addressee", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
 
-		promptInput.value = "@Sage tell @Frost go";
+		promptInput.value = "*Sage tell *Frost go";
 		promptInput.dispatchEvent(new Event("input"));
 		redPanel.click();
 
-		expect(promptInput.value).toBe("@Ember tell @Frost go");
+		expect(promptInput.value).toBe("*Ember tell *Frost go");
 	});
 
 	it("cursor is preserved after mention mutation (after the mention)", async () => {
@@ -1230,12 +1232,12 @@ describe("renderGame — panel-click addressee", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
 
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		// Simulate cursor at end (position 8)
 		promptInput.setSelectionRange(8, 8);
 		redPanel.click();
 
-		// "@Ember hi" length is 9; cursor was at 8 (after @Sage hi), delta = 1 → 9
+		// "*Ember hi" length is 9; cursor was at 8 (after *Sage hi), delta = 1 → 9
 		expect(promptInput.selectionStart).toBe(9);
 	});
 
@@ -1279,7 +1281,7 @@ describe("renderGame — panel-click addressee", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// Trigger one round to lock out red
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1295,7 +1297,7 @@ describe("renderGame — panel-click addressee", () => {
 		expect(promptInput.value).toBe("");
 	});
 
-	it("'@Nonpersona hi' + click blue → prepends '@Frost '", async () => {
+	it("'*Nonpersona hi' + click blue → prepends '*Frost '", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1304,11 +1306,11 @@ describe("renderGame — panel-click addressee", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
 
-		promptInput.value = "@nonpersona hi";
+		promptInput.value = "*nonpersona hi";
 		promptInput.dispatchEvent(new Event("input"));
 		bluePanel.click();
 
-		expect(promptInput.value).toBe("@Frost @nonpersona hi");
+		expect(promptInput.value).toBe("*Frost *nonpersona hi");
 	});
 });
 
@@ -1351,7 +1353,7 @@ describe("renderGame — URL param sourcing", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		// Post-#107: submit handler requires a valid @mention; without one,
 		// deriveComposerState returns sendEnabled=false and the submit no-ops.
-		promptInput.value = "@Ember go";
+		promptInput.value = "*Ember go";
 		// Dispatch input so the SPA's listener updates the composer state.
 		promptInput.dispatchEvent(new Event("input", { bubbles: true }));
 		form.dispatchEvent(
@@ -1447,7 +1449,7 @@ describe("renderGame — addressee persistence after send", () => {
 		expect(sendBtn.disabled).toBe(true);
 	});
 
-	it("after a successful send: input contains '@Sage ' and Send is disabled", async () => {
+	it("after a successful send: input contains '*Sage ' and Send is disabled", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			PASS_ACTION,
 			PASS_ACTION,
@@ -1465,14 +1467,14 @@ describe("renderGame — addressee persistence after send", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.value).toBe("*Sage ");
 		expect(promptInput.selectionStart).toBe(6);
 		expect(promptInput.selectionEnd).toBe(6);
 		expect(sendBtn.disabled).toBe(true);
@@ -1496,7 +1498,7 @@ describe("renderGame — addressee persistence after send", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1507,7 +1509,7 @@ describe("renderGame — addressee persistence after send", () => {
 		expect(sendBtn.disabled).toBe(true);
 
 		// Typing body text after the persisted prefix re-enables Send
-		promptInput.value = "@Sage how are you";
+		promptInput.value = "*Sage how are you";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(sendBtn.disabled).toBe(false);
 	});
@@ -1531,7 +1533,7 @@ describe("renderGame — addressee persistence after send", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// First turn
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1539,10 +1541,10 @@ describe("renderGame — addressee persistence after send", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Prefix persists after first send
-		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.value).toBe("*Sage ");
 
 		// Second turn: extend the persisted prefix
-		promptInput.value = "@Sage how are you";
+		promptInput.value = "*Sage how are you";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1550,15 +1552,15 @@ describe("renderGame — addressee persistence after send", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Prefix persists again after second send
-		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.value).toBe("*Sage ");
 
 		// Both messages should be in the green transcript
 		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
-		expect(greenTranscript.textContent).toContain("> @Sage hello");
-		expect(greenTranscript.textContent).toContain("> @Sage how are you");
+		expect(greenTranscript.textContent).toContain("> *Sage hello");
+		expect(greenTranscript.textContent).toContain("> *Sage how are you");
 	});
 
-	it("canonical-name normalization: @sage (lowercase) → '@Sage ' after send", async () => {
+	it("canonical-name normalization: *sage (lowercase) → '*Sage ' after send", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			PASS_ACTION,
 			PASS_ACTION,
@@ -1575,7 +1577,7 @@ describe("renderGame — addressee persistence after send", () => {
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		promptInput.value = "@sage hi";
+		promptInput.value = "*sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1583,7 +1585,7 @@ describe("renderGame — addressee persistence after send", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Should use canonical name from PERSONAS (Sage, not sage)
-		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.value).toBe("*Sage ");
 	});
 
 	it("locked-AI at round-completion: mention prefix persists but Send stays disabled", async () => {
@@ -1627,7 +1629,7 @@ describe("renderGame — addressee persistence after send", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1635,7 +1637,7 @@ describe("renderGame — addressee persistence after send", () => {
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		// Prefix persists even when green is locked
-		expect(promptInput.value).toBe("@Sage ");
+		expect(promptInput.value).toBe("*Sage ");
 		// Send must be disabled: green is locked and no body text
 		expect(sendBtn.disabled).toBe(true);
 	});
@@ -1678,14 +1680,14 @@ describe("visual feedback for active addressee", () => {
 		expect(overlay?.querySelector(".mention-highlight")).toBeNull();
 	});
 
-	it("typing '@Sage hi' → green border, green panel highlight, @Sage span in overlay", async () => {
+	it("typing '*Sage hi' → green border, green panel highlight, *Sage span in overlay", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 
 		// Composer border is green
@@ -1701,51 +1703,51 @@ describe("visual feedback for active addressee", () => {
 		expect(redPanel.classList.contains("panel--addressed")).toBe(false);
 		expect(bluePanel.classList.contains("panel--addressed")).toBe(false);
 
-		// Overlay has exactly one mention-highlight span with @Sage text and mention--green
+		// Overlay has exactly one mention-highlight span with *Sage text and mention--green
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 		const spans = overlay.querySelectorAll(".mention-highlight");
 		expect(spans.length).toBe(1);
-		expect(spans[0]?.textContent).toBe("@Sage");
+		expect(spans[0]?.textContent).toBe("*Sage");
 		expect(
 			(spans[0] as HTMLElement)?.style.getPropertyValue("--panel-color"),
 		).toBe("#81b29a");
 	});
 
-	it("multi-mention '@Sage tell @Frost ...' → exactly one mention-highlight for @Sage only", async () => {
+	it("multi-mention '*Sage tell *Frost ...' → exactly one mention-highlight for *Sage only", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage tell @Frost ...";
+		promptInput.value = "*Sage tell *Frost ...";
 		promptInput.dispatchEvent(new Event("input"));
 
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 		const spans = overlay.querySelectorAll(".mention-highlight");
 		expect(spans.length).toBe(1);
-		expect(spans[0]?.textContent).toBe("@Sage");
+		expect(spans[0]?.textContent).toBe("*Sage");
 		expect(
 			(spans[0] as HTMLElement)?.style.getPropertyValue("--panel-color"),
 		).toBe("#81b29a");
 	});
 
-	it("trailing punctuation '@Sage,' → overlay mention-highlight has textContent '@Sage' (comma is plain text)", async () => {
+	it("trailing punctuation '*Sage,' → overlay mention-highlight has textContent '*Sage' (comma is plain text)", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "@Sage,";
+		promptInput.value = "*Sage,";
 		promptInput.dispatchEvent(new Event("input"));
 
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 		const span = overlay.querySelector(".mention-highlight");
-		expect(span?.textContent).toBe("@Sage");
+		expect(span?.textContent).toBe("*Sage");
 
 		// Comma should be outside the span (in a text node)
-		expect(overlay.textContent).toBe("@Sage,");
+		expect(overlay.textContent).toBe("*Sage,");
 	});
 
 	it("clearing input → all visual feedback removed", async () => {
@@ -1757,7 +1759,7 @@ describe("visual feedback for active addressee", () => {
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// First set a mention
-		promptInput.value = "@Sage hi";
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(promptInput.style.getPropertyValue("--panel-color")).toBe("#81b29a");
 
@@ -1777,7 +1779,7 @@ describe("visual feedback for active addressee", () => {
 		expect(overlay.querySelector(".mention-highlight")).toBeNull();
 	});
 
-	it("panel-click transfers highlight: type @Sage hi then click blue panel → blue border, blue panel, @Frost span", async () => {
+	it("panel-click transfers highlight: type *Sage hi then click blue panel → blue border, blue panel, *Frost span", async () => {
 		vi.stubGlobal("localStorage", { getItem: () => null });
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
@@ -1785,8 +1787,8 @@ describe("visual feedback for active addressee", () => {
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		// Type @Sage hi
-		promptInput.value = "@Sage hi";
+		// Type *Sage hi
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 		expect(promptInput.style.getPropertyValue("--panel-color")).toBe("#81b29a");
 
@@ -1794,8 +1796,8 @@ describe("visual feedback for active addressee", () => {
 		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
 		bluePanel.click();
 
-		// Input value should start with @Frost
-		expect(promptInput.value.startsWith("@Frost")).toBe(true);
+		// Input value should start with *Frost
+		expect(promptInput.value.startsWith("*Frost")).toBe(true);
 
 		// Blue border
 		expect(promptInput.style.getPropertyValue("--panel-color")).toBe("#5fa8d3");
@@ -1807,10 +1809,10 @@ describe("visual feedback for active addressee", () => {
 		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
 		expect(greenPanel.classList.contains("panel--addressed")).toBe(false);
 
-		// Overlay highlight is @Frost with blue --panel-color
+		// Overlay highlight is *Frost with blue --panel-color
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 		const span = overlay.querySelector<HTMLElement>(".mention-highlight");
-		expect(span?.textContent).toBe("@Frost");
+		expect(span?.textContent).toBe("*Frost");
 		expect(span?.style.getPropertyValue("--panel-color")).toBe("#5fa8d3");
 	});
 
@@ -1868,15 +1870,15 @@ describe("visual feedback for active addressee", () => {
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 
 		// Submit one round to lock green
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		// Now type @Sage hi (green is locked)
-		promptInput.value = "@Sage hi";
+		// Now type *Sage hi (green is locked)
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 
 		// Send disabled (green locked)
@@ -1890,7 +1892,7 @@ describe("visual feedback for active addressee", () => {
 		// Overlay still shows the mention highlight
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 		const span = overlay.querySelector<HTMLElement>(".mention-highlight");
-		expect(span?.textContent).toBe("@Sage");
+		expect(span?.textContent).toBe("*Sage");
 		expect(span?.style.getPropertyValue("--panel-color")).toBe("#81b29a");
 	});
 });
@@ -1948,7 +1950,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		const form = getEl<HTMLFormElement>("#composer");
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -1966,7 +1968,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		expect(bluePanel.classList.contains("panel--locked")).toBe(false);
 	});
 
-	it("type @Sage while green locked → Send disabled, #lockout-error visible with text containing 'Sage'", async () => {
+	it("type *Sage while green locked → Send disabled, #lockout-error visible with text containing 'Sage'", async () => {
 		vi.stubGlobal(
 			"fetch",
 			makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION),
@@ -1984,15 +1986,15 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		const sendBtn = getEl<HTMLButtonElement>("#send");
 
 		// Submit to trigger the lockout
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		// Type @Sage hi while green is locked
-		promptInput.value = "@Sage hi";
+		// Type *Sage hi while green is locked
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 
 		expect(sendBtn.disabled).toBe(true);
@@ -2002,7 +2004,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		expect(lockoutError.textContent).toContain("Sage");
 	});
 
-	it("chat_lockout_resolved mid-draft → muting clears, #lockout-error hidden, Send re-enables when @Sage re-typed", async () => {
+	it("chat_lockout_resolved mid-draft → muting clears, #lockout-error hidden, Send re-enables when *Sage re-typed", async () => {
 		// First round: inject lockout for green
 		// Second round: inject lockout_resolved for green via mock
 		vi.stubGlobal("localStorage", { getItem: () => null });
@@ -2057,7 +2059,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// Round 1: lock green
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -2068,8 +2070,8 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
 		expect(greenPanel.classList.contains("panel--locked")).toBe(true);
 
-		// Round 2 via @Ember: resolve green lockout
-		promptInput.value = "@Ember hi";
+		// Round 2 via *Ember: resolve green lockout
+		promptInput.value = "*Ember hi";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),
@@ -2079,8 +2081,8 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		// Green panel should no longer be locked
 		expect(greenPanel.classList.contains("panel--locked")).toBe(false);
 
-		// Type @Sage again: should now enable Send and hide error
-		promptInput.value = "@Sage hi";
+		// Type *Sage again: should now enable Send and hide error
+		promptInput.value = "*Sage hi";
 		promptInput.dispatchEvent(new Event("input"));
 
 		const sendBtn = getEl<HTMLButtonElement>("#send");
@@ -2107,7 +2109,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
 
 		// Trigger lockout
-		promptInput.value = "@Sage hello";
+		promptInput.value = "*Sage hello";
 		promptInput.dispatchEvent(new Event("input"));
 		form.dispatchEvent(
 			new Event("submit", { bubbles: true, cancelable: true }),

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -41,8 +41,7 @@ const SIDE_HEAVY = `${"║\n".repeat(200)}`;
  * selection is purely CSS-driven via `.panel--addressed`. */
 export function initPanelChrome(panel: HTMLElement, persona: AiPersona): void {
 	const doc = panel.ownerDocument;
-	const handle = `*${persona.name}`;
-	const label = `${handle} :: @${persona.name}`;
+	const label = `*${persona.name}`;
 
 	for (const el of panel.querySelectorAll<HTMLElement>(".panel-name")) {
 		el.textContent = label;

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -110,10 +110,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Sage" no lockouts → sendEnabled: false (no body), visual fields populated', () => {
+	it('"*Sage" no lockouts → sendEnabled: false (no body), visual fields populated', () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage",
+				text: "*Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -130,10 +130,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Sage hi" no lockouts → sendEnabled: true, visual fields populated', () => {
+	it('"*Sage hi" no lockouts → sendEnabled: true, visual fields populated', () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage hi",
+				text: "*Sage hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -150,10 +150,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Sage hi" green locked → sendEnabled: false, lockoutError set, lockedPanels has green', () => {
+	it('"*Sage hi" green locked → sendEnabled: false, lockoutError set, lockedPanels has green', () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage hi",
+				text: "*Sage hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
 				personaColors,
@@ -170,10 +170,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Sage," → mentionHighlight.end = 5 (nameEnd, NOT 6 — trailing punct excluded from highlight)', () => {
+	it('"*Sage," → mentionHighlight.end = 5 (nameEnd, NOT 6 — trailing punct excluded from highlight)', () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage,",
+				text: "*Sage,",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -190,9 +190,9 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Sage tell @Frost ..." → only first mention highlighted (covers @Sage)', () => {
+	it('"*Sage tell *Frost ..." → only first mention highlighted (covers *Sage)', () => {
 		const result = deriveComposerState({
-			text: "@Sage tell @Frost ...",
+			text: "*Sage tell *Frost ...",
 			lockouts: noLockouts(),
 			personaNamesToId,
 			personaColors,
@@ -206,10 +206,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"hi @Sage" → mentionHighlight.start = 3, end = 8', () => {
+	it('"hi *Sage" → mentionHighlight.start = 3, end = 8', () => {
 		expect(
 			deriveComposerState({
-				text: "hi @Sage",
+				text: "hi *Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -226,10 +226,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Frost @Sage" blue-locked → addressee blue, sendEnabled false, lockoutError set for Frost', () => {
+	it('"*Frost *Sage" blue-locked → addressee blue, sendEnabled false, lockoutError set for Frost', () => {
 		expect(
 			deriveComposerState({
-				text: "@Frost @Sage",
+				text: "*Frost *Sage",
 				lockouts: lockouts("blue"),
 				personaNamesToId,
 				personaColors,
@@ -246,10 +246,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Ember hi" green locked → { addressee: "red", sendEnabled: true, lockoutError: null }', () => {
+	it('"*Ember hi" green locked → { addressee: "red", sendEnabled: true, lockoutError: null }', () => {
 		expect(
 			deriveComposerState({
-				text: "@Ember hi",
+				text: "*Ember hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
 				personaColors,
@@ -266,10 +266,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Nonpersona hi" no lockouts → all-null visual fields', () => {
+	it('"*Nonpersona hi" no lockouts → all-null visual fields', () => {
 		expect(
 			deriveComposerState({
-				text: "@Nonpersona hi",
+				text: "*Nonpersona hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -286,10 +286,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Frost @Sage" no lockouts → addressee blue, sendEnabled true (body = @Sage)', () => {
+	it('"*Frost *Sage" no lockouts → addressee blue, sendEnabled true (body = *Sage)', () => {
 		expect(
 			deriveComposerState({
-				text: "@Frost @Sage",
+				text: "*Frost *Sage",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -307,10 +307,10 @@ describe("deriveComposerState", () => {
 	});
 
 	// Body-after-mention rule: persisted prefix cases
-	it('"@Sage " (trailing space only) → sendEnabled: false', () => {
+	it('"*Sage " (trailing space only) → sendEnabled: false', () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage ",
+				text: "*Sage ",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -327,10 +327,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Sage  " (two trailing spaces) → sendEnabled: false', () => {
+	it('"*Sage  " (two trailing spaces) → sendEnabled: false', () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage  ",
+				text: "*Sage  ",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -347,10 +347,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"hi @Sage there" → sendEnabled: true (body on both sides)', () => {
+	it('"hi *Sage there" → sendEnabled: true (body on both sides)', () => {
 		expect(
 			deriveComposerState({
-				text: "hi @Sage there",
+				text: "hi *Sage there",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -367,10 +367,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@sage hi" (lowercase mention) → sendEnabled: true', () => {
+	it('"*sage hi" (lowercase mention) → sendEnabled: true', () => {
 		expect(
 			deriveComposerState({
-				text: "@sage hi",
+				text: "*sage hi",
 				lockouts: noLockouts(),
 				personaNamesToId,
 				personaColors,
@@ -408,10 +408,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Nonpersona hi" + green locked → lockoutError: null, lockedPanels has green', () => {
+	it('"*Nonpersona hi" + green locked → lockoutError: null, lockedPanels has green', () => {
 		expect(
 			deriveComposerState({
-				text: "@Nonpersona hi",
+				text: "*Nonpersona hi",
 				lockouts: lockouts("green"),
 				personaNamesToId,
 				personaColors,
@@ -428,10 +428,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it("multiple locks red+green, @Sage hi → lockoutError for Sage, lockedPanels has both", () => {
+	it("multiple locks red+green, *Sage hi → lockoutError for Sage, lockedPanels has both", () => {
 		expect(
 			deriveComposerState({
-				text: "@Sage hi",
+				text: "*Sage hi",
 				lockouts: multiLockouts(["red", "green"]),
 				personaNamesToId,
 				personaColors,
@@ -448,10 +448,10 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"@Frost @Sage" + blue locked → lockoutError for Frost, lockedPanels has blue', () => {
+	it('"*Frost *Sage" + blue locked → lockoutError for Frost, lockedPanels has blue', () => {
 		expect(
 			deriveComposerState({
-				text: "@Frost @Sage",
+				text: "*Frost *Sage",
 				lockouts: lockouts("blue"),
 				personaNamesToId,
 				personaColors,

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -17,32 +17,32 @@ const nameMap = new Map<string, AiId>([
 
 describe("parseFirstMention", () => {
 	it.each<[string, AiId | null]>([
-		["@Sage", "green"],
-		["@Sage hi", "green"],
-		["hi @Sage", "green"],
-		["hello @Sage how are you", "green"],
-		["@sage", "green"],
-		["@SAGE", "green"],
-		["@SaGe", "green"],
-		["@Sage,", "green"],
-		["@Sage.", "green"],
-		["@Sage @Frost", "green"],
-		["@Frost @Sage", "blue"],
+		["*Sage", "green"],
+		["*Sage hi", "green"],
+		["hi *Sage", "green"],
+		["hello *Sage how are you", "green"],
+		["*sage", "green"],
+		["*SAGE", "green"],
+		["*SaGe", "green"],
+		["*Sage,", "green"],
+		["*Sage.", "green"],
+		["*Sage *Frost", "green"],
+		["*Frost *Sage", "blue"],
 		["", null],
 		["hello world", null],
 		["email me at user@host", null],
-		["@Nonpersona hi", null],
-		["@", null],
-		["@Ember", "red"],
-		["@Frost", "blue"],
+		["*Nonpersona hi", null],
+		["*", null],
+		["*Ember", "red"],
+		["*Frost", "blue"],
 	])("parseFirstMention(%j) → %j", (text, expected) => {
 		expect(parseFirstMention(text, nameMap)).toBe(expected);
 	});
 });
 
 describe("findFirstMention", () => {
-	it('"@Sage" → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
-		expect(findFirstMention("@Sage", nameMap)).toEqual({
+	it('"*Sage" → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
+		expect(findFirstMention("*Sage", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
 			nameEnd: 5,
@@ -50,8 +50,8 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"@Sage hi" → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
-		expect(findFirstMention("@Sage hi", nameMap)).toEqual({
+	it('"*Sage hi" → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
+		expect(findFirstMention("*Sage hi", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
 			nameEnd: 5,
@@ -59,8 +59,8 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"hi @Sage" → { aiId: "green", start: 3, nameEnd: 8, end: 8 }', () => {
-		expect(findFirstMention("hi @Sage", nameMap)).toEqual({
+	it('"hi *Sage" → { aiId: "green", start: 3, nameEnd: 8, end: 8 }', () => {
+		expect(findFirstMention("hi *Sage", nameMap)).toEqual({
 			aiId: "green",
 			start: 3,
 			nameEnd: 8,
@@ -68,8 +68,8 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"@sage" (lowercase) → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
-		expect(findFirstMention("@sage", nameMap)).toEqual({
+	it('"*sage" (lowercase) → { aiId: "green", start: 0, nameEnd: 5, end: 5 }', () => {
+		expect(findFirstMention("*sage", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
 			nameEnd: 5,
@@ -77,8 +77,8 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"@Sage," → nameEnd: 5 (excludes comma), end: 6 (includes comma)', () => {
-		expect(findFirstMention("@Sage,", nameMap)).toEqual({
+	it('"*Sage," → nameEnd: 5 (excludes comma), end: 6 (includes comma)', () => {
+		expect(findFirstMention("*Sage,", nameMap)).toEqual({
 			aiId: "green",
 			start: 0,
 			nameEnd: 5,
@@ -86,8 +86,8 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"hi @Sage." → nameEnd: 8 (excludes period), end: 9 (includes period)', () => {
-		expect(findFirstMention("hi @Sage.", nameMap)).toEqual({
+	it('"hi *Sage." → nameEnd: 8 (excludes period), end: 9 (includes period)', () => {
+		expect(findFirstMention("hi *Sage.", nameMap)).toEqual({
 			aiId: "green",
 			start: 3,
 			nameEnd: 8,
@@ -95,8 +95,8 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"@Frost @Sage" → first match is Frost (blue), nameEnd: 6, end: 6', () => {
-		expect(findFirstMention("@Frost @Sage", nameMap)).toEqual({
+	it('"*Frost *Sage" → first match is Frost (blue), nameEnd: 6, end: 6', () => {
+		expect(findFirstMention("*Frost *Sage", nameMap)).toEqual({
 			aiId: "blue",
 			start: 0,
 			nameEnd: 6,
@@ -108,8 +108,8 @@ describe("findFirstMention", () => {
 		expect(findFirstMention("hello world", nameMap)).toBeNull();
 	});
 
-	it('"@Nonpersona" → null', () => {
-		expect(findFirstMention("@Nonpersona", nameMap)).toBeNull();
+	it('"*Nonpersona" → null', () => {
+		expect(findFirstMention("*Nonpersona", nameMap)).toBeNull();
 	});
 });
 
@@ -168,17 +168,17 @@ const personasFixture = {
 describe("applyAddresseeChange", () => {
 	it.each<[string, number | null, AiId, string, number]>([
 		// [text, cursor, target, expectedText, expectedCursor]
-		["", 0, "red", "@Ember ", 7],
-		["hi", 2, "green", "@Sage hi", 8],
-		["@Sage hi", 8, "red", "@Ember hi", 9],
-		["@Sage hi", 0, "red", "@Ember hi", 0],
-		["@Sage hi", 3, "red", "@Ember hi", 6],
-		["@Sage tell @Frost ...", 21, "red", "@Ember tell @Frost ...", 22],
-		["@Sage,", 6, "red", "@Ember,", 7],
-		["hello @Sage how are you", 23, "blue", "hello @Frost how are you", 24],
-		["@nonpersona hi", 14, "red", "@Ember @nonpersona hi", 21],
-		["hi", null, "green", "@Sage hi", 6],
-		["hi", 0, "green", "@Sage hi", 6],
+		["", 0, "red", "*Ember ", 7],
+		["hi", 2, "green", "*Sage hi", 8],
+		["*Sage hi", 8, "red", "*Ember hi", 9],
+		["*Sage hi", 0, "red", "*Ember hi", 0],
+		["*Sage hi", 3, "red", "*Ember hi", 6],
+		["*Sage tell *Frost ...", 21, "red", "*Ember tell *Frost ...", 22],
+		["*Sage,", 6, "red", "*Ember,", 7],
+		["hello *Sage how are you", 23, "blue", "hello *Frost how are you", 24],
+		["*nonpersona hi", 14, "red", "*Ember *nonpersona hi", 21],
+		["hi", null, "green", "*Sage hi", 6],
+		["hi", 0, "green", "*Sage hi", 6],
 	])("applyAddresseeChange(%j, cursor=%j, target=%j) → text=%j, cursor=%j", (text, cursor, target, expectedText, expectedCursor) => {
 		const result = applyAddresseeChange({
 			text,

--- a/src/spa/game/composer-reducer.ts
+++ b/src/spa/game/composer-reducer.ts
@@ -17,7 +17,7 @@ export interface ComposerState {
 	borderColor: string | null;
 	/** AiId whose panel should carry the highlight class, or null. */
 	panelHighlight: AiId | null;
-	/** Highlight range for the first @mention in the overlay, or null. */
+	/** Highlight range for the first *mention in the overlay, or null. */
 	mentionHighlight: { start: number; end: number; color: string } | null;
 	/** Inline error message when the addressed AI is chat-locked, or null. */
 	lockoutError: string | null;
@@ -38,7 +38,7 @@ const NULL_VISUAL: Pick<
  * Derives the composer state (addressee + send button enabled + visual cues)
  * from the current prompt text, the chat-lockout map, and the persona maps.
  *
- * - `addressee` is the first valid @mention in the text.
+ * - `addressee` is the first valid *mention in the text.
  * - `sendEnabled` is true only when `addressee` is non-null AND the
  *   addressed AI is not chat-locked AND there is non-empty body text
  *   outside the mention token.
@@ -76,7 +76,7 @@ export function deriveComposerState(input: ComposerInput): ComposerState {
 	}
 
 	const { aiId: addressee, start, nameEnd, end } = match;
-	// Body is everything except the @Name token itself.
+	// Body is everything except the *Name token itself.
 	const bodyAfterMention = (text.slice(0, start) + text.slice(end)).trim();
 	const isAddresseeLocked = lockedPanels.has(addressee);
 	const sendEnabled = !isAddresseeLocked && bodyAfterMention.length > 0;

--- a/src/spa/game/mention-parser.ts
+++ b/src/spa/game/mention-parser.ts
@@ -2,25 +2,25 @@ import type { AiId } from "./types.js";
 
 /**
  * Result of a successful mention parse — includes the AiId and the character
- * offsets of the `@Name` token (excluding any leading whitespace captured by
- * the regex but including the `@`).
+ * offsets of the `*Name` token (excluding any leading whitespace captured by
+ * the regex but including the `*`).
  */
 export interface MentionMatch {
 	aiId: AiId;
-	/** Index of the `@` character in `text`. */
+	/** Index of the `*` character in `text`. */
 	start: number;
-	/** End of `@Name` (excludes any trailing punctuation). Use this for the highlight range. */
+	/** End of `*Name` (excludes any trailing punctuation). Use this for the highlight range. */
 	nameEnd: number;
 	/** One past the last consumed character: end of name, or end of a single trailing punctuation char if one immediately follows. */
 	end: number;
 }
 
 /**
- * Like `parseFirstMention` but also returns the position of the `@Name`
+ * Like `parseFirstMention` but also returns the position of the `*Name`
  * token so callers can compute what text surrounds the mention.
  *
  * Rules (same as `parseFirstMention`):
- * - "@Name" must be preceded by start-of-string or whitespace.
+ * - "*Name" must be preceded by start-of-string or whitespace.
  * - A single trailing punctuation character immediately after the name is
  *   consumed into the token (included in `end`) so it is excluded from the
  *   body-after-mention computation.
@@ -30,20 +30,20 @@ export function findFirstMention(
 	text: string,
 	personaNamesToId: ReadonlyMap<string, AiId>,
 ): MentionMatch | null {
-	const re = /(?:^|\s)@([A-Za-z0-9]+)/g;
+	const re = /(?:^|\s)\*([A-Za-z0-9]+)/g;
 	for (const match of text.matchAll(re)) {
 		const raw = match[1];
 		if (!raw) continue;
 		const id = personaNamesToId.get(raw.toLowerCase());
 		if (id !== undefined) {
 			// match.index is the start of the full match (may include a leading space).
-			// The `@` is at match.index + (full-match-length - raw.length - 1).
+			// The `*` is at match.index + (full-match-length - raw.length - 1).
 			const fullMatch = match[0];
 			const start = (match.index ?? 0) + fullMatch.length - raw.length - 1;
-			const nameEnd = start + 1 + raw.length; // 1 for '@', excludes trailing punct
+			const nameEnd = start + 1 + raw.length; // 1 for '*', excludes trailing punct
 			let end = nameEnd;
 			// Consume a single trailing punctuation character immediately after the
-			// name so that "@Sage," treats the comma as part of the token and the
+			// name so that "*Sage," treats the comma as part of the token and the
 			// body-after-mention computation does not surface bare punctuation.
 			if (/[.,!?;:]/.test(text[end] ?? "")) {
 				end += 1;
@@ -55,16 +55,15 @@ export function findFirstMention(
 }
 
 /**
- * Parses the first valid @mention from `text` that maps to a known persona.
+ * Parses the first valid *mention from `text` that maps to a known persona.
  *
  * Rules:
- * - "@Name" must be preceded by start-of-string or whitespace.
- * - "@Name" terminates at end-of-string, whitespace, or a single trailing
+ * - "*Name" must be preceded by start-of-string or whitespace.
+ * - "*Name" terminates at end-of-string, whitespace, or a single trailing
  *   punctuation character (the punctuation is not part of the name).
  * - Case-insensitive.
  * - First mention wins.
- * - "@Nonpersona" or "@" alone returns null.
- * - "user@host" style does NOT match (no preceding whitespace).
+ * - "*Nonpersona" or "*" alone returns null.
  */
 export function parseFirstMention(
 	text: string,
@@ -80,7 +79,7 @@ export function parseFirstMention(
  * Rules:
  * a. If a valid first mention is found, rewrite it with the target persona's
  *    name. Cursor delta is applied based on position relative to the mention.
- * b. If no valid mention is found, prepend "@<name> " to the text.
+ * b. If no valid mention is found, prepend "*<name> " to the text.
  *    Cursor shifts by the prefix length.
  */
 export function applyAddresseeChange({
@@ -96,7 +95,7 @@ export function applyAddresseeChange({
 	personaNamesToId: ReadonlyMap<string, AiId>;
 	personas: Record<AiId, { name: string }>;
 }): { text: string; selectionStart: number } {
-	const re = /(?:^|\s)@([A-Za-z0-9]+)/g;
+	const re = /(?:^|\s)\*([A-Za-z0-9]+)/g;
 	let foundAtStart = -1;
 	let foundNameEnd = -1;
 
@@ -108,10 +107,10 @@ export function applyAddresseeChange({
 		const id = personaNamesToId.get(name.toLowerCase());
 		if (id !== undefined) {
 			// matchIndex is the start of the full match (which may include a
-			// leading space). The @ is immediately after any leading whitespace.
+			// leading space). The * is immediately after any leading whitespace.
 			const matchIndex = match.index ?? 0;
 			const atStart =
-				matchIndex + (match[0].startsWith("@") ? 0 : match[0].indexOf("@"));
+				matchIndex + (match[0].startsWith("*") ? 0 : match[0].indexOf("*"));
 			// nameEnd is the index after the raw capture (before trailing punct).
 			const nameEnd = atStart + 1 + name.length;
 			foundAtStart = atStart;
@@ -125,7 +124,7 @@ export function applyAddresseeChange({
 		const newName = personas[targetPersona]?.name ?? targetPersona;
 		const atStart = foundAtStart;
 		const nameEnd = foundNameEnd;
-		const newText = `${text.slice(0, atStart)}@${newName}${text.slice(nameEnd)}`;
+		const newText = `${text.slice(0, atStart)}*${newName}${text.slice(nameEnd)}`;
 		const delta = 1 + newName.length - (nameEnd - atStart);
 
 		let newCursor: number;
@@ -144,7 +143,7 @@ export function applyAddresseeChange({
 	} else {
 		// Prepend.
 		const newName = personas[targetPersona]?.name ?? targetPersona;
-		const prefix = `@${newName} `;
+		const prefix = `*${newName} `;
 		const newText = prefix + text;
 		const cursor = (selectionStart ?? 0) + prefix.length;
 		return { text: newText, selectionStart: cursor };

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -79,15 +79,19 @@ function renderRestoredTranscript(
 	};
 	for (const line of lines) {
 		const m = AI_PREFIX_RE.exec(line);
-		if (m?.[1]) {
-			const handle = m[1];
-			const persona = Object.values(personas).find(
-				(p) => p.name.toLowerCase() === handle,
-			);
+		const handle = m?.[1];
+		const persona = handle
+			? Object.values(personas).find((p) => p.name.toLowerCase() === handle)
+			: undefined;
+		// Only treat as an AI line when the matched handle resolves to a known
+		// persona. Player lines now also start with `> *` (the new mention
+		// glyph), so without this guard a player message like `> *Sage hi`
+		// would be miscoloured as an AI prefix.
+		if (handle && persona) {
 			const prefixText = `> *${handle} `;
 			const prefix = doc.createElement("span");
 			prefix.className = "msg-prefix";
-			if (persona?.color) {
+			if (persona.color) {
 				prefix.style.setProperty("--prefix-color", persona.color);
 			}
 			prefix.textContent = prefixText;
@@ -605,7 +609,7 @@ export function renderGame(
 		}
 	}
 
-	// Set initial composer state (Send starts disabled until a valid @mention).
+	// Set initial composer state (Send starts disabled until a valid *mention).
 	refreshComposerState();
 
 	// For the sync restore path session is already set; for the async new-game
@@ -639,10 +643,10 @@ export function renderGame(
 		});
 
 		// Populate the input placeholder with the runtime handles, e.g.
-		// `@Ember | @Sage | @Frost …` (test fixtures) or
-		// `@a4b2 | @9bx2 | @cd3f …` (production).
+		// `*Ember | *Sage | *Frost …` (test fixtures) or
+		// `*a4b2 | *9bx2 | *cd3f …` (production).
 		const handles = Object.values(session.getState().personas)
-			.map((p) => `@${p.name}`)
+			.map((p) => `*${p.name}`)
 			.join(" | ");
 		if (handles) _promptInput.placeholder = `${handles} …`;
 	}
@@ -1155,7 +1159,7 @@ export function renderGame(
 			// Only written on success (not in catch) and not on round-game-ended.
 			if (!roundGameEnded) {
 				const addressedName = nextState.personas[addressed]?.name ?? addressed;
-				const persistedPrefix = `@${addressedName} `;
+				const persistedPrefix = `*${addressedName} `;
 				promptInput.value = persistedPrefix;
 				promptInput.setSelectionRange(
 					persistedPrefix.length,


### PR DESCRIPTION
## Summary
This PR updates the mention-based addressing syntax from `@` to `*` throughout the codebase. This is a breaking change to the user-facing API for addressing AI personas in the chat composer.

## Key Changes

- **Mention Parser**: Updated regex pattern in `mention-parser.ts` from `/@([A-Za-z0-9]+)/g` to `/\*([A-Za-z0-9]+)/g` to recognize `*Name` instead of `@Name`
- **Composer UI**: Updated placeholder text generation and persisted prefix formatting to use `*` instead of `@`
- **Transcript Rendering**: Modified `renderRestoredTranscript()` in `game.ts` to display player messages with `> *Name` prefix instead of `> @Name`
- **Test Coverage**: Updated all unit tests in `game.test.ts`, `mention-parser.test.ts`, and `composer-reducer.test.ts` to use the new `*` syntax
- **E2E Tests**: Updated all end-to-end tests to construct and validate messages using `*Name` addressing
- **Helper Functions**: Updated `getAiHandles()` in `e2e/helpers/handles.ts` to extract persona names from the new format
- **Documentation**: Updated comments and docstrings to reference `*mention` instead of `@mention`

## Implementation Details

- The change is consistent across all layers: parser, UI, persistence, and display
- Transcript rendering now properly distinguishes between AI prefix lines (which use persona color) and player lines (which start with `> *Name`) by validating that the matched handle resolves to a known persona
- The mention syntax change maintains all existing functionality: addressee persistence after send, lockout handling, panel-click addressing, and cursor position preservation
- All test assertions updated to expect the new syntax in both input and output

## Rationale

The `*` character provides clearer visual distinction from email-style `@` mentions and avoids potential confusion with email addresses in user input.

https://claude.ai/code/session_0197HTdACwutShU9huCKhzB4