### PR TITLE
Add persona mention highlighting and refactor budget display

### DIFF
--- a/e2e/cents-live-smoke.spec.ts
+++ b/e2e/cents-live-smoke.spec.ts
@@ -11,7 +11,7 @@ test.use({ ignoreHTTPSErrors: true });
  *
  * Runs against real OpenRouter via BYOK (key set in localStorage so the SPA
  * bypasses the proxy). Verifies:
- *   1. Initial UI label is "cents" with value $0.05000
+ *   1. Initial UI value is $0.05000
  *   2. After one round of 3 AI replies, each panel's budget has decremented
  *      by a small but non-zero USD amount (the actual usage.cost from the
  *      final SSE chunk).
@@ -41,9 +41,8 @@ test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", 
 	// Wait for the three AI panels to be ready (synthesis complete).
 	const { ids, names } = await getAiHandles(page);
 
-	// 1. Initial state: label "cents", value "$0.05000".
+	// 1. Initial state: value "$0.05000".
 	const firstPanel = page.locator(`.ai-panel[data-ai="${ids[0]}"]`);
-	await expect(firstPanel.locator(".panel-meta")).toContainText("cents");
 	await expect(firstPanel.locator(".panel-budget")).toHaveText("$0.05000", {
 		timeout: 30_000,
 	});

--- a/e2e/cents-live-smoke.spec.ts
+++ b/e2e/cents-live-smoke.spec.ts
@@ -11,7 +11,7 @@ test.use({ ignoreHTTPSErrors: true });
  *
  * Runs against real OpenRouter via BYOK (key set in localStorage so the SPA
  * bypasses the proxy). Verifies:
- *   1. Initial UI value is $0.05000
+ *   1. Initial UI value is 5.000¢
  *   2. After one round of 3 AI replies, each panel's budget has decremented
  *      by a small but non-zero USD amount (the actual usage.cost from the
  *      final SSE chunk).
@@ -41,17 +41,17 @@ test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", 
 	// Wait for the three AI panels to be ready (synthesis complete).
 	const { ids, names } = await getAiHandles(page);
 
-	// 1. Initial state: value "$0.05000".
+	// 1. Initial state: value "5.000¢".
 	const firstPanel = page.locator(`.ai-panel[data-ai="${ids[0]}"]`);
-	await expect(firstPanel.locator(".panel-budget")).toHaveText("$0.05000", {
+	await expect(firstPanel.locator(".panel-budget")).toHaveText("5.000¢", {
 		timeout: 30_000,
 	});
 
-	// All three panels start at $0.05000.
+	// All three panels start at 5.000¢.
 	for (const id of ids) {
 		await expect(
 			page.locator(`.ai-panel[data-ai="${id}"] .panel-budget`),
-		).toHaveText("$0.05000");
+		).toHaveText("5.000¢");
 	}
 
 	// 2. Send a short message addressed to all three AIs. Keep it minimal to
@@ -60,7 +60,7 @@ test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", 
 	await page.fill("#prompt", message);
 	await page.click("#send");
 
-	// 3. Wait for all three panels to drop below $0.05000 (i.e. cost was
+	// 3. Wait for all three panels to drop below 5.000¢ (i.e. cost was
 	//    deducted). Real OpenRouter calls take a few seconds.
 	await page.waitForFunction(
 		(aiIds: string[]) => {
@@ -69,25 +69,25 @@ test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", 
 					`.ai-panel[data-ai="${id}"] .panel-budget`,
 				);
 				const text = el?.textContent ?? "";
-				const match = /^\$(\d+\.\d{5})$/.exec(text);
+				const match = /^(\d+\.\d{3})¢$/.exec(text);
 				if (!match) return false;
-				const value = Number(match[1]);
-				return Number.isFinite(value) && value < 0.05;
+				const cents = Number(match[1]);
+				return Number.isFinite(cents) && cents < 5;
 			});
 		},
 		ids,
 		{ timeout: 120_000 },
 	);
 
-	// 4. Each panel shows a strictly less-than-starting value, formatted as $X.XXXXX.
+	// 4. Each panel shows a strictly less-than-starting value, formatted as X.XXX¢.
 	for (const id of ids) {
 		const text = await page
 			.locator(`.ai-panel[data-ai="${id}"] .panel-budget`)
 			.textContent();
-		expect(text).toMatch(/^\$\d+\.\d{5}$/);
-		const value = Number((text ?? "").replace("$", ""));
-		expect(value).toBeLessThan(0.05);
-		expect(value).toBeGreaterThanOrEqual(0); // display clamps at zero
+		expect(text).toMatch(/^\d+\.\d{3}¢$/);
+		const cents = Number((text ?? "").replace("¢", ""));
+		expect(cents).toBeLessThan(5);
+		expect(cents).toBeGreaterThanOrEqual(0); // display clamps at zero
 	}
 
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);

--- a/src/content/color-palette.ts
+++ b/src/content/color-palette.ts
@@ -19,7 +19,6 @@ export const COLOR_PALETTE: string[] = [
 	"#fff03d", // lemon
 	"#ff9495", // coral
 	"#fa9d68", // apricot
-	"#e3ad4b", // honey
 	"#adc35e", // chartreuse
 	"#61d19a", // jade
 	"#17d0d8", // turquoise

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -765,11 +765,11 @@ describe("renderGame — localStorage persistence", () => {
 		const { renderGame: renderGame2 } = await import("../routes/game.js");
 		await renderGame2(getEl<HTMLElement>("main"));
 
-		// Budget should reflect round 1 complete: $0.05 - $0.01 cost = $0.04000
+		// Budget should reflect round 1 complete: 5¢ - 1¢ cost = 4.000¢
 		const redBudget = document.querySelector<HTMLSpanElement>(
 			'.ai-panel[data-ai="red"] .panel-budget',
 		);
-		expect(redBudget?.textContent).toBe("$0.04000");
+		expect(redBudget?.textContent).toBe("4.000¢");
 
 		// Transcripts must be restored verbatim (regression: AI responses were lost on reload)
 		const redTranscript = document.querySelector<HTMLElement>(

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -105,7 +105,7 @@
 					</article>
 				</div>
 				<form id="composer" class="cmd">
-					<span class="prompt-prefix"><span class="prompt-host"><b>guest</b><span class="at">@</span>hi-blue.bbs:</span><span class="prompt-target">/???</span><span class="at">&gt; </span></span>
+					<span class="prompt-prefix"><span class="prompt-host"><b>guest</b><span class="at">@</span>hi-blue.bbs:</span><span class="prompt-target">/?????</span><span class="at">&gt; </span></span>
 					<div class="prompt-wrap">
 						<div id="prompt-overlay" aria-hidden="true"></div>
 						<input id="prompt" type="text" placeholder="" autocomplete="off" spellcheck="false" />

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -37,7 +37,7 @@
 							<span class="side side-left side-thin"></span>
 							<span class="side side-left side-heavy"></span>
 							<div class="panel-content">
-								<div class="panel-meta dim">cents <span class="panel-budget" data-budget=""></span></div>
+								<div class="panel-meta dim"><span class="panel-budget" data-budget=""></span></div>
 								<div class="scroll"><div class="transcript" data-transcript=""></div></div>
 							</div>
 							<span class="side side-right side-thin"></span>
@@ -63,7 +63,7 @@
 							<span class="side side-left side-thin"></span>
 							<span class="side side-left side-heavy"></span>
 							<div class="panel-content">
-								<div class="panel-meta dim">cents <span class="panel-budget" data-budget=""></span></div>
+								<div class="panel-meta dim"><span class="panel-budget" data-budget=""></span></div>
 								<div class="scroll"><div class="transcript" data-transcript=""></div></div>
 							</div>
 							<span class="side side-right side-thin"></span>
@@ -89,7 +89,7 @@
 							<span class="side side-left side-thin"></span>
 							<span class="side side-left side-heavy"></span>
 							<div class="panel-content">
-								<div class="panel-meta dim">cents <span class="panel-budget" data-budget=""></span></div>
+								<div class="panel-meta dim"><span class="panel-budget" data-budget=""></span></div>
 								<div class="scroll"><div class="transcript" data-transcript=""></div></div>
 							</div>
 							<span class="side side-right side-thin"></span>

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -105,7 +105,7 @@
 					</article>
 				</div>
 				<form id="composer" class="cmd">
-					<span class="prompt-prefix"><b>guest</b><span class="at">@</span>hi-blue.bbs:<span class="prompt-target">/???</span><span class="at">&gt; </span></span>
+					<span class="prompt-prefix"><span class="prompt-host"><b>guest</b><span class="at">@</span>hi-blue.bbs:</span><span class="prompt-target">/???</span><span class="at">&gt; </span></span>
 					<div class="prompt-wrap">
 						<div id="prompt-overlay" aria-hidden="true"></div>
 						<input id="prompt" type="text" placeholder="" autocomplete="off" spellcheck="false" />

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -54,6 +54,70 @@ function formatBudget(remainingUsd: number): string {
  * non-whitespace). Capture group 1 is the lowercased handle. */
 const AI_PREFIX_RE = /^> \*(\S+) /;
 
+/** Build a regex that matches any persona handle (with an optional leading
+ * `*`) as a whole word, case-insensitive. Returns null when no personas
+ * are available so callers can short-circuit. */
+function buildMentionRegex(
+	personas: Record<string, { name: string }>,
+): RegExp | null {
+	const names = Object.values(personas)
+		.map((p) => p.name)
+		.filter((n) => n.length > 0);
+	if (names.length === 0) return null;
+	const escaped = names.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+	return new RegExp(`\\*?\\b(?:${escaped.join("|")})\\b`, "gi");
+}
+
+/** Append `text` to `parent`, splitting persona-name occurrences (with an
+ * optional leading `*`) into `.msg-mention` spans tinted with the persona's
+ * color. Non-matching chunks are wrapped in `defaultClass` when provided
+ * (e.g. `msg-you` for player lines), otherwise emitted as bare text nodes
+ * so they inherit the parent's amber color. */
+function appendMentionAwareText(
+	parent: HTMLElement,
+	text: string,
+	personas: Record<string, { name: string; color?: string }>,
+	defaultClass?: string,
+): void {
+	if (!text) return;
+	const doc = parent.ownerDocument;
+	const personaList = Object.values(personas);
+	const appendChunk = (chunk: string): void => {
+		if (!chunk) return;
+		if (defaultClass) {
+			const span = doc.createElement("span");
+			span.className = defaultClass;
+			span.textContent = chunk;
+			parent.appendChild(span);
+		} else {
+			parent.appendChild(doc.createTextNode(chunk));
+		}
+	};
+	const re = buildMentionRegex(personas);
+	if (!re) {
+		appendChunk(text);
+		return;
+	}
+	let lastIdx = 0;
+	for (let m = re.exec(text); m !== null; m = re.exec(text)) {
+		appendChunk(text.slice(lastIdx, m.index));
+		const matchText = m[0];
+		const baseName = matchText.startsWith("*") ? matchText.slice(1) : matchText;
+		const persona = personaList.find(
+			(p) => p.name.toLowerCase() === baseName.toLowerCase(),
+		);
+		const span = doc.createElement("span");
+		span.className = "msg-mention";
+		if (persona?.color) {
+			span.style.setProperty("--mention-color", persona.color);
+		}
+		span.textContent = matchText;
+		parent.appendChild(span);
+		lastIdx = m.index + matchText.length;
+	}
+	appendChunk(text.slice(lastIdx));
+}
+
 /** Render a saved transcript string into the given element by parsing
  * lines and wrapping each logical message in a `.msg-line` block. AI
  * prefix portions (`> *<handle> `) become `.msg-prefix` spans tinted
@@ -104,21 +168,18 @@ function renderRestoredTranscript(
 			const lineEl = startNewMsgLine();
 			lineEl.appendChild(prefix);
 			const rest = line.slice(prefixText.length);
-			if (rest) lineEl.appendChild(doc.createTextNode(rest));
+			if (rest) appendMentionAwareText(lineEl, rest, personas);
 			currentAiLine = lineEl;
 		} else if (line.startsWith("> ")) {
-			const span = doc.createElement("span");
-			span.className = "msg-you";
-			span.textContent = line;
-			startNewMsgLine().appendChild(span);
+			appendMentionAwareText(startNewMsgLine(), line, personas, "msg-you");
 			currentAiLine = null;
 		} else if (line.startsWith("[") || line.startsWith("--- ")) {
-			startNewMsgLine().appendChild(doc.createTextNode(line));
+			appendMentionAwareText(startNewMsgLine(), line, personas);
 			currentAiLine = null;
 		} else if (currentAiLine) {
-			currentAiLine.appendChild(doc.createTextNode(line));
+			appendMentionAwareText(currentAiLine, line, personas);
 		} else {
-			startNewMsgLine().appendChild(doc.createTextNode(line));
+			appendMentionAwareText(startNewMsgLine(), line, personas);
 		}
 	}
 }
@@ -463,10 +524,12 @@ export function renderGame(
 						const lineEl = doc.createElement("div");
 						lineEl.className = "msg-line";
 						if (msg.role === "player") {
-							const span = doc.createElement("span");
-							span.className = "msg-you";
-							span.textContent = `> ${msg.content}\n`;
-							lineEl.appendChild(span);
+							appendMentionAwareText(
+								lineEl,
+								`> ${msg.content}\n`,
+								restoredPersonas,
+								"msg-you",
+							);
 						} else {
 							const prefixSpan = doc.createElement("span");
 							prefixSpan.className = "msg-prefix";
@@ -475,7 +538,11 @@ export function renderGame(
 							}
 							prefixSpan.textContent = `> *${transcriptName(personaName)} `;
 							lineEl.appendChild(prefixSpan);
-							lineEl.appendChild(doc.createTextNode(`${msg.content}\n`));
+							appendMentionAwareText(
+								lineEl,
+								`${msg.content}\n`,
+								restoredPersonas,
+							);
 						}
 						transcript.appendChild(lineEl);
 					}
@@ -777,12 +844,20 @@ export function renderGame(
 	// AI message stays in one msg-line so strip-card preview can render it
 	// as a single ellipsis-truncated line. The line opened by appendAiPrefix
 	// is the target; if missing for any reason, a fallback line is opened.
+	// The accumulated body is stored on the line's dataset so each delta can
+	// re-render the body with mention-aware highlighting from the start.
 	function appendAiTokens(aiId: AiId, text: string): void {
 		const el = getTranscript(aiId);
 		if (!el) return;
 		const last = el.lastElementChild as HTMLElement | null;
 		const line = last?.classList.contains("msg-line") ? last : startMsgLine(el);
-		line.appendChild(doc.createTextNode(text));
+		line.dataset.body = (line.dataset.body ?? "") + text;
+		const personas = session?.getState().personas ?? {};
+		const prefix = line.querySelector<HTMLElement>(":scope > .msg-prefix");
+		while (line.lastChild && line.lastChild !== prefix) {
+			line.removeChild(line.lastChild);
+		}
+		appendMentionAwareText(line, line.dataset.body, personas);
 		scrollToBottom(el);
 	}
 
@@ -793,20 +868,21 @@ export function renderGame(
 		const el = getTranscript(aiId);
 		if (!el) return;
 		const line = startMsgLine(el);
-		line.appendChild(doc.createTextNode(text));
+		const personas = session?.getState().personas ?? {};
+		appendMentionAwareText(line, text, personas);
 		scrollToBottom(el);
 	}
 
 	// Helper: append a player line wrapped in a .msg-you span (warm white)
-	// inside its own .msg-line block.
+	// inside its own .msg-line block. Persona-name mentions inside the
+	// message body are split into .msg-mention spans so they pick up the
+	// addressed daemon's color instead of warm white.
 	function appendPlayerLine(aiId: AiId, text: string): void {
 		const el = getTranscript(aiId);
 		if (!el) return;
 		const line = startMsgLine(el);
-		const span = doc.createElement("span");
-		span.className = "msg-you";
-		span.textContent = text;
-		line.appendChild(span);
+		const personas = session?.getState().personas ?? {};
+		appendMentionAwareText(line, text, personas, "msg-you");
 		scrollToBottom(el);
 	}
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -44,6 +44,12 @@ function transcriptName(name: string): string {
 	return name.toLowerCase();
 }
 
+/** Format a USD remaining amount as cents for the panel budget display
+ * (e.g. 0.05 → "5.000¢"). Clamps negatives to zero. */
+function formatBudget(remainingUsd: number): string {
+	return `${(Math.max(0, remainingUsd) * 100).toFixed(3)}¢`;
+}
+
 /** Match an AI prefix at the start of a line: `> *<handle> ` (handle is
  * non-whitespace). Capture group 1 is the lowercased handle. */
 const AI_PREFIX_RE = /^> \*(\S+) /;
@@ -552,7 +558,7 @@ export function renderGame(
 							const budget = phase.budgets[aiId];
 							if (budget) {
 								budgetEl.dataset.budget = String(budget.remaining);
-								budgetEl.textContent = `$${Math.max(0, budget.remaining).toFixed(5)}`;
+								budgetEl.textContent = formatBudget(budget.remaining);
 							}
 						}
 					});
@@ -637,7 +643,7 @@ export function renderGame(
 				const budget = phase.budgets[aiId];
 				if (budget) {
 					budgetEl.dataset.budget = String(budget.remaining);
-					budgetEl.textContent = `$${Math.max(0, budget.remaining).toFixed(5)}`;
+					budgetEl.textContent = formatBudget(budget.remaining);
 				}
 			}
 		});
@@ -836,7 +842,7 @@ export function renderGame(
 		const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
 		if (!budgetEl) return;
 		budgetEl.dataset.budget = String(remaining);
-		budgetEl.textContent = `$${Math.max(0, remaining).toFixed(5)}`;
+		budgetEl.textContent = formatBudget(remaining);
 	}
 
 	// Helper: update chat lockout status in the lockouts map
@@ -1022,7 +1028,7 @@ export function renderGame(
 									const b = newPhase.budgets[aid];
 									if (b) {
 										budgetEl.dataset.budget = String(b.remaining);
-										budgetEl.textContent = `$${Math.max(0, b.remaining).toFixed(5)}`;
+										budgetEl.textContent = formatBudget(b.remaining);
 									}
 								}
 								// Re-enable chat-locked AIs that were carried over

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -281,12 +281,12 @@ export function renderGame(
 	// Prompt-target indicator inside the BBS-style command-line prefix.
 	const promptTargetEl = doc.querySelector<HTMLElement>(".prompt-target");
 
-	/** Update the `/<handle>` indicator beside `guest@hi-blue.bbs:` from the
-	 * current addressee. `null` resets to dim `/???`. */
+	/** Update the `/*<handle>` indicator beside `guest@hi-blue.bbs:` from the
+	 * current addressee. `null` resets to dim `/?????`. */
 	function refreshPromptTarget(addressee: AiId | null): void {
 		if (!promptTargetEl) return;
 		if (addressee == null) {
-			promptTargetEl.textContent = "/???";
+			promptTargetEl.textContent = "/?????";
 			promptTargetEl.classList.remove("is-set");
 			promptTargetEl.style.removeProperty("--target-color");
 			return;
@@ -294,7 +294,7 @@ export function renderGame(
 		const personas = session?.getState().personas ?? {};
 		const persona = personas[addressee];
 		const handle = persona?.name ?? addressee;
-		promptTargetEl.textContent = `/${handle}`;
+		promptTargetEl.textContent = `/*${handle}`;
 		promptTargetEl.classList.add("is-set");
 		if (persona?.color) {
 			promptTargetEl.style.setProperty("--target-color", persona.color);

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -54,6 +54,30 @@ function formatBudget(remainingUsd: number): string {
  * non-whitespace). Capture group 1 is the lowercased handle. */
 const AI_PREFIX_RE = /^> \*(\S+) /;
 
+/** Sentinel prepended to a serialized player line so the restore parser
+ * can route it to the player branch unambiguously. Necessary because
+ * player lines and AI prefixes are otherwise structurally identical
+ * (`> *<handle> …`) and persona names are lowercase in production, so
+ * the legacy "lowercase-vs-mixed-case" guard collapses there. */
+const PLAYER_LINE_SENTINEL = "​";
+
+/** Walk `transcript.children` and emit a textContent-equivalent string
+ * with a zero-width-space marker prepended to each player msg-line.
+ * AI prefix lines (those whose first child is a `.msg-prefix` span) and
+ * standalone system lines pass through unchanged. */
+function serializeTranscript(transcript: HTMLElement): string {
+	const out: string[] = [];
+	for (const child of Array.from(transcript.children)) {
+		if (!(child instanceof HTMLElement)) continue;
+		if (!child.classList.contains("msg-line")) continue;
+		const text = child.textContent ?? "";
+		const firstChild = child.firstElementChild;
+		const isPlayerLine = firstChild?.classList.contains("msg-you") === true;
+		out.push(isPlayerLine ? `${PLAYER_LINE_SENTINEL}${text}` : text);
+	}
+	return out.join("");
+}
+
 /** Build a regex that matches any persona handle (with an optional leading
  * `*`) as a whole word, case-insensitive. Returns null when no personas
  * are available so callers can short-circuit. */
@@ -147,16 +171,28 @@ function renderRestoredTranscript(
 		transcript.appendChild(el);
 		return el;
 	};
-	for (const line of lines) {
+	for (const rawLine of lines) {
+		// Player lines are persisted with a zero-width-space sentinel so the
+		// parser can disambiguate them from AI prefix lines, which would
+		// otherwise be structurally identical in production (lowercase
+		// persona names collide with the lowercased AI-prefix handle).
+		const isPlayerLine = rawLine.startsWith(PLAYER_LINE_SENTINEL);
+		const line = isPlayerLine ? rawLine.slice(1) : rawLine;
+		if (isPlayerLine) {
+			appendMentionAwareText(startNewMsgLine(), line, personas, "msg-you");
+			currentAiLine = null;
+			continue;
+		}
 		const m = AI_PREFIX_RE.exec(line);
 		const handle = m?.[1];
 		const persona = handle
 			? Object.values(personas).find((p) => p.name.toLowerCase() === handle)
 			: undefined;
-		// Only treat as an AI line when the matched handle resolves to a known
-		// persona. Player lines now also start with `> *` (the new mention
-		// glyph), so without this guard a player message like `> *Sage hi`
-		// would be miscoloured as an AI prefix.
+		// Legacy fallback (saves predating the player-line sentinel): only
+		// treat as an AI line when the matched handle resolves to a known
+		// persona. This guard works for capitalized names but collapses for
+		// production lowercase names — those legacy player lines will still
+		// be miscoloured. New saves use the sentinel above and avoid this.
 		if (handle && persona) {
 			const prefixText = `> *${handle} `;
 			const prefix = doc.createElement("span");
@@ -1228,7 +1264,7 @@ export function renderGame(
 				const transcripts: Partial<Record<AiId, string>> = {};
 				for (const aiId of Object.keys(nextState.personas)) {
 					const el = getTranscript(aiId);
-					if (el) transcripts[aiId] = el.textContent ?? "";
+					if (el) transcripts[aiId] = serializeTranscript(el);
 				}
 				const saveResult = saveGame(nextState, transcripts);
 				if (!saveResult.ok) {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -427,6 +427,12 @@ main {
 		color-mix(in srgb, var(--prefix-color, var(--amber)) 60%, transparent);
 }
 
+.transcript .msg-mention {
+	color: var(--mention-color, inherit);
+	text-shadow: 0 0 6px
+		color-mix(in srgb, var(--mention-color, var(--amber)) 60%, transparent);
+}
+
 .transcript .msg-placeholder {
 	color: var(--amber-dim);
 }

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -85,7 +85,6 @@ body::before {
 header {
 	display: flex;
 	justify-content: flex-end;
-	margin-top: -4px;
 }
 
 #byok-cog {
@@ -95,7 +94,7 @@ header {
 	font-family: inherit;
 	font-size: 13px;
 	letter-spacing: 0.18em;
-	padding: 2px 8px;
+	padding: 0;
 	cursor: pointer;
 	text-shadow: inherit;
 }

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -859,6 +859,10 @@ main {
 		padding-bottom: 4px;
 	}
 
+	.prompt-prefix .prompt-host {
+		display: none;
+	}
+
 	#panels.row {
 		display: grid;
 		grid-template-rows: minmax(0, 1fr) 88px;


### PR DESCRIPTION
## Summary
This PR enhances transcript rendering with persona-name mention highlighting and refactors budget display to show values in cents instead of dollars. It also improves transcript serialization to correctly handle player lines during save/restore cycles.

## Key Changes

- **Persona mention highlighting**: Added `appendMentionAwareText()` function that splits message text on persona name occurrences and wraps them in `.msg-mention` spans with the persona's color. This applies to both AI and player messages throughout the transcript.

- **Budget display format**: Changed from `$X.XXXXX` (dollars with 5 decimals) to `X.XXX¢` (cents with 3 decimals) via new `formatBudget()` helper. Updated all budget display locations and corresponding tests.

- **Transcript serialization**: 
  - Added `serializeTranscript()` to properly extract transcript content with a zero-width-space sentinel (`PLAYER_LINE_SENTINEL`) prepended to player lines
  - This disambiguates player lines from AI prefix lines during restore, fixing a bug where lowercase persona names in production would cause player messages to be miscolored as AI prefixes
  - Updated `renderRestoredTranscript()` to detect and handle the sentinel

- **AI token streaming**: Modified `appendAiTokens()` to accumulate message body in `line.dataset.body` and re-render with mention highlighting on each delta, ensuring mentions are highlighted as text streams in.

- **Prompt target indicator**: Updated from `/<handle>` to `/*<handle>` format to match the new mention glyph convention.

- **UI refinements**: 
  - Removed "cents" label from panel headers (now implicit in the ¢ symbol)
  - Removed header margin adjustment and adjusted button padding
  - Added CSS for `.msg-mention` styling with color and text-shadow
  - Hidden `.prompt-host` on mobile

## Implementation Details

- The `buildMentionRegex()` function creates a case-insensitive regex matching any persona name with optional leading `*`, returning null when no personas exist for short-circuiting
- Player line detection during restore uses the sentinel rather than relying on name casing, making the system robust to production lowercase persona names
- Mention highlighting preserves the default class (e.g., `msg-you` for player lines) for non-matching text chunks while splitting matches into colored spans

https://claude.ai/code/session_01GyQgZHVjXQAf6LATJie3xK