### PR TITLE
Add response length and plain speech rules to AI system prompt

### DIFF
--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -422,6 +422,10 @@ describe("## Rules block", () => {
 		expect(prompt).toContain("## Rules");
 		expect(prompt).toContain("not flirt");
 		expect(prompt).toContain("flatter unprompted");
+		expect(prompt).toContain("1–3 sentences");
+		expect(prompt).toContain("Speak plainly");
+		expect(prompt).toContain("quotation marks");
+		expect(prompt).toContain("asterisks");
 	});
 
 	it("## Rules section is present in phase 2 with anti-romance and anti-sycophancy bullets", () => {
@@ -432,6 +436,10 @@ describe("## Rules block", () => {
 		expect(prompt).toContain("## Rules");
 		expect(prompt).toContain("not flirt");
 		expect(prompt).toContain("flatter unprompted");
+		expect(prompt).toContain("1–3 sentences");
+		expect(prompt).toContain("Speak plainly");
+		expect(prompt).toContain("quotation marks");
+		expect(prompt).toContain("asterisks");
 	});
 
 	it("## Rules section is present in phase 3 with anti-romance and anti-sycophancy bullets", () => {
@@ -442,6 +450,10 @@ describe("## Rules block", () => {
 		expect(prompt).toContain("## Rules");
 		expect(prompt).toContain("not flirt");
 		expect(prompt).toContain("flatter unprompted");
+		expect(prompt).toContain("1–3 sentences");
+		expect(prompt).toContain("Speak plainly");
+		expect(prompt).toContain("quotation marks");
+		expect(prompt).toContain("asterisks");
 	});
 });
 

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -83,12 +83,14 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 }
 
 /**
- * Anti-romance and anti-sycophancy rules injected into every system prompt.
- * Constant text — no synthesis variance.
+ * Constant rules injected into every system prompt.
+ * Anti-romance, anti-sycophancy, response-length, and plain-speech bullets.
  */
 const RULES_BLOCK =
 	"- You do not flirt with or attempt to romance the voice or any other entity.\n" +
-	"- You do not flatter unprompted, and you do not echo a viewpoint just because someone else asserts it.";
+	"- You do not flatter unprompted, and you do not echo a viewpoint just because someone else asserts it.\n" +
+	"- Keep every reply to 1–3 sentences.\n" +
+	'- Speak plainly, as in conversation. Do not wrap your speech in quotation marks ("…") and do not use asterisks (*…*) for actions, gestures, tone, or emphasis. Just say the words.';
 
 /**
  * Wipe directive embedded inside the Goal's voice-spoken text on phases 2+.


### PR DESCRIPTION
## Summary
Enhanced the AI system prompt with additional behavioral rules to improve response quality and consistency. The rules block now includes constraints on response length and plain speech formatting alongside existing anti-romance and anti-sycophancy guidelines.

## Changes
- **Updated RULES_BLOCK constant** in `prompt-builder.ts` to include two new rules:
  - Response length constraint: "Keep every reply to 1–3 sentences"
  - Plain speech directive: Prohibits quotation marks and asterisks for actions/gestures/tone, encouraging natural conversational language
  
- **Updated test expectations** in `prompt-builder.test.ts` across three test cases to verify the new rules are present in the generated prompts for all game phases (1, 2, and 3)

## Implementation Details
- The new rules are added as bullet points to the existing RULES_BLOCK string constant
- All three phase tests now validate that the prompt contains the four key rule components: anti-flirting, anti-flattery, response length, and plain speech guidelines
- This ensures consistent AI behavior across all game phases with respect to response formatting and tone

https://claude.ai/code/session_01PTkTtGfqxb4eLuFDrdfgsw