### PR TITLE
Fix stale message tail for non-addressed AIs in multi-turn conversations

### DIFF
--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression: a non-addressed daemon must not see a stale user/assistant pair
+ * as the tail of its OpenAI messages array.
+ *
+ * Without the fix, when daemon X was addressed in round N-1 and not in round N,
+ * X's round-N call ended with `[..., user "<prev msg>", assistant "<X's reply>"]`.
+ * The model treated that prior user message as the freshest stimulus and
+ * re-responded to it (player symptom: "the other AI acts like I just sent them
+ * the last message I sent them again").
+ *
+ * Fix: append a synthetic `user: "The voice is silent."` turn for any
+ * non-addressed daemon, anchoring the current round.
+ */
+import { describe, expect, it } from "vitest";
+import { createGame, startPhase } from "../engine";
+import { SILENT_VOICE_TURN } from "../openai-message-builder";
+import { runRound } from "../round-coordinator";
+import { MockRoundLLMProvider } from "../round-llm-provider";
+import type { AiId, AiPersona, ContentPack, PhaseConfig } from "../types";
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "Hold the flower at phase end.",
+		blurb: "You are hot-headed and zealous.",
+		budgetPerPhase: 5,
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "#81b29a",
+		temperaments: ["meticulous", "meticulous"],
+		personaGoal: "Ensure items are evenly distributed.",
+		blurb: "You are meticulous.",
+		budgetPerPhase: 5,
+	},
+	blue: {
+		id: "blue",
+		name: "Frost",
+		color: "#5fa8d3",
+		temperaments: ["laconic", "diffident"],
+		personaGoal: "Hold the key at phase end.",
+		blurb: "You are laconic.",
+		budgetPerPhase: 5,
+	},
+};
+
+const TEST_PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	kRange: [1, 1],
+	nRange: [1, 1],
+	mRange: [0, 0],
+	aiGoalPool: ["g1", "g2", "g3"],
+	budgetPerAi: 5,
+};
+
+const TEST_CONTENT_PACK: ContentPack = {
+	phaseNumber: 1,
+	setting: "",
+	objectivePairs: [
+		{
+			object: {
+				id: "flower",
+				kind: "objective_object",
+				name: "flower",
+				examineDescription: "A flower",
+				holder: { row: 0, col: 0 },
+				pairsWithSpaceId: "flower_space",
+			},
+			space: {
+				id: "flower_space",
+				kind: "objective_space",
+				name: "flower space",
+				examineDescription: "A space",
+				holder: { row: 4, col: 4 },
+			},
+		},
+	],
+	interestingObjects: [
+		{
+			id: "key",
+			kind: "interesting_object",
+			name: "key",
+			examineDescription: "A key",
+			holder: { row: 0, col: 1 },
+		},
+	],
+	obstacles: [],
+	aiStarts: {
+		red: { position: { row: 0, col: 0 }, facing: "north" },
+		green: { position: { row: 0, col: 1 }, facing: "north" },
+		blue: { position: { row: 0, col: 2 }, facing: "north" },
+	},
+};
+
+function makeGame() {
+	return startPhase(
+		createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]),
+		TEST_PHASE_CONFIG,
+	);
+}
+
+describe("non-addressed daemon never sees a stale user message as its last turn", () => {
+	it("after addressing red then blue, red's round-2 messages end with the silent-voice anchor (not the prior user/assistant)", async () => {
+		const initiative: AiId[] = ["red", "green", "blue"];
+		const game = makeGame();
+
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "Hi, I am Ember.", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "<red round 2>", toolCalls: [] },
+			{ assistantText: "<green round 2>", toolCalls: [] },
+			{ assistantText: "<blue round 2>", toolCalls: [] },
+		]);
+
+		const r1 = await runRound(
+			game,
+			"red",
+			"are you alive?",
+			provider,
+			undefined,
+			initiative,
+		);
+
+		await runRound(
+			r1.nextState,
+			"blue",
+			"different question for blue",
+			provider,
+			undefined,
+			initiative,
+			r1.toolRoundtrip,
+		);
+
+		expect(provider.calls).toHaveLength(6);
+
+		const redRound2 = provider.calls[3];
+		expect(redRound2).toBeDefined();
+		const msgs = redRound2!.messages;
+
+		// Last message anchors the current round.
+		const last = msgs[msgs.length - 1];
+		expect(last?.role).toBe("user");
+		expect((last as { content: string }).content).toBe(SILENT_VOICE_TURN);
+
+		// And the prior round's user/assistant are still in history but no longer
+		// at the tail.
+		const lastUser = [...msgs].reverse().find((m) => m.role === "user");
+		expect((lastUser as { content: string }).content).toBe(SILENT_VOICE_TURN);
+		const priorUser = msgs.find(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "are you alive?",
+		);
+		expect(priorUser).toBeDefined();
+
+		// Blue (the addressee this round) must NOT receive the silent-voice
+		// anchor — its tail is the actual player message.
+		const blueRound2 = provider.calls[5];
+		const blueMsgs = blueRound2!.messages;
+		const blueLastUser = [...blueMsgs].reverse().find((m) => m.role === "user");
+		expect((blueLastUser as { content: string }).content).toBe(
+			"different question for blue",
+		);
+		expect(
+			blueMsgs.some(
+				(m) =>
+					m.role === "user" &&
+					(m as { content: string }).content === SILENT_VOICE_TURN,
+			),
+		).toBe(false);
+	});
+
+	it("an AI that has never been addressed still gets the silent-voice anchor", async () => {
+		const initiative: AiId[] = ["red", "green", "blue"];
+		const game = makeGame();
+
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "<red>", toolCalls: [] },
+			{ assistantText: "<green>", toolCalls: [] },
+			{ assistantText: "<blue>", toolCalls: [] },
+		]);
+
+		await runRound(game, "red", "hello red", provider, undefined, initiative);
+
+		// Green was never addressed; green's call (index 1) must end with the anchor.
+		const greenCall = provider.calls[1];
+		const greenMsgs = greenCall!.messages;
+		const last = greenMsgs[greenMsgs.length - 1];
+		expect(last?.role).toBe("user");
+		expect((last as { content: string }).content).toBe(SILENT_VOICE_TURN);
+	});
+});

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { appendChat, createGame, startPhase } from "../engine";
-import { buildOpenAiMessages } from "../openai-message-builder";
+import {
+	buildOpenAiMessages,
+	SILENT_VOICE_TURN,
+} from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import type { AiPersona, PhaseConfig, ToolRoundtripMessage } from "../types";
 
@@ -227,5 +230,47 @@ describe("buildOpenAiMessages", () => {
 		// No extra messages appended
 		expect(messages).toHaveLength(1); // only system
 		expect(messages.every((m) => m.role !== "tool")).toBe(true);
+	});
+
+	it("non-addressed AI gets a trailing 'The voice is silent.' user turn", () => {
+		let game = makeGame();
+		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
+		game = appendChat(game, "red", { role: "ai", content: "Hi player" });
+
+		const ctx = buildAiContext(game, "red");
+		// addressed = green: red is NOT the addressee this round.
+		const messages = buildOpenAiMessages(ctx, undefined, "green");
+
+		const last = messages[messages.length - 1];
+		expect(last?.role).toBe("user");
+		expect((last as { content: string }).content).toBe(SILENT_VOICE_TURN);
+	});
+
+	it("addressed AI does not get the silent-voice anchor", () => {
+		let game = makeGame();
+		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
+		const ctx = buildAiContext(game, "red");
+
+		const messages = buildOpenAiMessages(ctx, undefined, "red");
+		expect(
+			messages.some(
+				(m) =>
+					m.role === "user" &&
+					(m as { content: string }).content === SILENT_VOICE_TURN,
+			),
+		).toBe(false);
+	});
+
+	it("when `addressed` is omitted, no anchor is appended (back-compat)", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+		expect(
+			messages.some(
+				(m) =>
+					m.role === "user" &&
+					(m as { content: string }).content === SILENT_VOICE_TURN,
+			),
+		).toBe(false);
 	});
 });

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -10,6 +10,9 @@
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
  *      - { role: "tool", tool_call_id, content } for each result
+ *   4. If `addressed` is provided and is not this AI: a synthetic
+ *      { role: "user", content: SILENT_VOICE_TURN } anchoring the current
+ *      round so the model does not re-respond to its prior user turn.
  *
  * Note: the system prompt already encodes world state, action log, whispers etc.
  * The OpenAI `tools` field (not messages) teaches the model about available tools.
@@ -17,18 +20,19 @@
 
 import type { AiContext } from "./prompt-builder.js";
 import type { OpenAiMessage } from "./round-llm-provider.js";
-import type { ToolRoundtripMessage } from "./types.js";
+import type { AiId, ToolRoundtripMessage } from "./types.js";
+
+export const SILENT_VOICE_TURN = "The voice is silent.";
 
 export function buildOpenAiMessages(
 	ctx: AiContext,
 	priorToolRoundtrip?: ToolRoundtripMessage,
+	addressed?: AiId,
 ): OpenAiMessage[] {
 	const messages: OpenAiMessage[] = [];
 
-	// 1. System message (contains the full narrative context — world state, action log, etc.)
 	messages.push({ role: "system", content: ctx.toSystemPrompt() });
 
-	// 2. Chat history — alternating player (user) / AI (assistant) turns
 	for (const msg of ctx.chatHistory) {
 		if (msg.role === "player") {
 			messages.push({ role: "user", content: msg.content });
@@ -37,12 +41,7 @@ export function buildOpenAiMessages(
 		}
 	}
 
-	// 3. Prior-round tool roundtrip (assistant tool_calls + tool results)
-	//    This re-injects the protocol messages required by OpenAI's tool-use spec:
-	//    the assistant message that contained the tool_calls, followed by each
-	//    tool result message.
 	if (priorToolRoundtrip && priorToolRoundtrip.assistantToolCalls.length > 0) {
-		// Re-emit the assistant message with tool_calls
 		messages.push({
 			role: "assistant",
 			content: null,
@@ -53,7 +52,6 @@ export function buildOpenAiMessages(
 			})),
 		});
 
-		// Re-emit each tool result
 		for (const result of priorToolRoundtrip.toolResults) {
 			const content = result.success
 				? result.description
@@ -64,6 +62,13 @@ export function buildOpenAiMessages(
 				content,
 			});
 		}
+	}
+
+	// Anchor the current round for non-addressed AIs. Without this, the model's
+	// last user turn is the prior round's player message, and it tends to
+	// re-respond to it as if it had just been sent again.
+	if (addressed !== undefined && addressed !== ctx.aiId) {
+		messages.push({ role: "user", content: SILENT_VOICE_TURN });
 	}
 
 	return messages;

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -150,7 +150,7 @@ export async function runRound(
 		// Build OpenAI messages for this AI
 		const ctx = buildAiContext(state, aiId);
 		const priorRoundtrip = priorToolRoundtrip?.[aiId];
-		const messages = buildOpenAiMessages(ctx, priorRoundtrip);
+		const messages = buildOpenAiMessages(ctx, priorRoundtrip, addressed);
 
 		// Compute legal tools for this AI given current game state
 		const tools = availableTools(state, aiId);


### PR DESCRIPTION
## Summary
Fixes a regression where non-addressed AIs would re-respond to stale user messages from previous rounds. When an AI was addressed in round N-1 but not in round N, its message history would end with the prior round's user/assistant pair, causing the model to treat that old message as the current stimulus.

## Changes
- **Added `SILENT_VOICE_TURN` constant** (`"The voice is silent."`) to `openai-message-builder.ts` to serve as an anchor message for non-addressed AIs
- **Updated `buildOpenAiMessages()` function** to accept an optional `addressed` parameter (the AI ID being addressed this round) and append a synthetic user turn with `SILENT_VOICE_TURN` when the current AI is not the addressee
- **Updated `runRound()` call site** in `round-coordinator.ts` to pass the `addressed` parameter to `buildOpenAiMessages()`
- **Added comprehensive test coverage** in `non-addressed-anchor.test.ts` validating:
  - Non-addressed AIs receive the silent-voice anchor at the end of their message history
  - Addressed AIs do NOT receive the anchor (their tail is the actual player message)
  - AIs never previously addressed still get the anchor
- **Added unit tests** in `openai-message-builder.test.ts` covering the new anchor behavior and backward compatibility

## Implementation Details
The fix works by anchoring the current round with a synthetic user message for any AI that is not being directly addressed. This prevents the model from treating the prior round's user message as the most recent stimulus. The `addressed` parameter is optional for backward compatibility—when omitted, no anchor is appended.

https://claude.ai/code/session_014AT5XC8A7wFqYR5cH89kmi