### PR TITLE
Migrate prompt structure from Markdown headers to XML tags

### DIFF
--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -181,7 +181,7 @@ describe("conversation log integration — witnessed pick_up", () => {
 		// green's prompt should contain the witnessed pick_up
 		const greenCtx = buildAiContext(nextState, "green");
 		const greenPrompt = greenCtx.toSystemPrompt();
-		expect(greenPrompt).toContain("## Conversation");
+		expect(greenPrompt).toContain("<conversation>");
 		expect(greenPrompt).toContain("You watch *red pick up the Flower.");
 
 		// red's own prompt should NOT have a "You watch *red" line
@@ -273,7 +273,7 @@ describe("conversation log integration — use outcome rendering", () => {
 		const greenCtx = buildAiContext(state2, "green");
 		const greenPrompt = greenCtx.toSystemPrompt();
 		// Green is at (0,0) facing south; red is at (2,0) (two steps ahead) — in green's cone
-		if (greenPrompt.includes("## Conversation")) {
+		if (greenPrompt.includes("<conversation>")) {
 			// If green can see it (in cone), verify substitution
 			const lines = greenPrompt.split("\n");
 			const useLine = lines.find(
@@ -450,7 +450,7 @@ describe("conversation log integration — multi-round chronological order", () 
 		// Verify red's prompt has events in order
 		const redCtx = buildAiContext(state2, "red");
 		const redPrompt = redCtx.toSystemPrompt();
-		expect(redPrompt).toContain("## Conversation");
+		expect(redPrompt).toContain("<conversation>");
 		// Round 0 player message appears before round 1 player message
 		const round0Idx = redPrompt.indexOf("[Round 0] A voice says:");
 		const round1Idx = redPrompt.indexOf("[Round 1] A voice says:");

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -195,10 +195,10 @@ describe("buildAiContext", () => {
 });
 
 // ----------------------------------------------------------------------------
-// "## Setting" section (issue #125)
+// "<setting>" block (issue #125)
 // ----------------------------------------------------------------------------
-describe("## Setting section", () => {
-	it("emits ## Setting section when phase has a setting noun", () => {
+describe("<setting> block", () => {
+	it("emits <setting> block when phase has a setting noun", () => {
 		const pack: ContentPack = {
 			phaseNumber: 1,
 			setting: "abandoned subway station",
@@ -217,16 +217,16 @@ describe("## Setting section", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Setting");
+		expect(prompt).toContain("<setting>");
 		expect(prompt).toContain("You are in a abandoned subway station.");
 	});
 
-	it("omits ## Setting section when phase has no setting", () => {
+	it("omits <setting> block when phase has no setting", () => {
 		// No ContentPack → setting is empty string
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).not.toContain("## Setting");
+		expect(prompt).not.toContain("<setting>");
 	});
 
 	it("setting noun appears verbatim in the Setting section", () => {
@@ -257,7 +257,7 @@ describe("## Setting section", () => {
 // "Where you are" section (issue #123)
 // ----------------------------------------------------------------------------
 describe("prompt-builder — spatial 'Where you are' section", () => {
-	it("includes '## Where you are' section in the system prompt", () => {
+	it("includes <where_you_are> block in the system prompt", () => {
 		// rng=()=>0 places red at (0,0) facing north
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
@@ -266,7 +266,7 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Where you are");
+		expect(prompt).toContain("<where_you_are>");
 	});
 
 	it("reports actor's position and facing in the prompt", () => {
@@ -310,7 +310,7 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 		expect(prompt).toContain("key");
 	});
 
-	it("lists other AIs visible in the cone under '## What you see'", () => {
+	it("lists other AIs visible in the cone under <what_you_see>", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			TEST_PHASE_CONFIG,
@@ -318,8 +318,7 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		// Prompt should have What you see section
-		expect(prompt).toContain("## What you see");
+		expect(prompt).toContain("<what_you_see>");
 	});
 });
 
@@ -386,107 +385,139 @@ describe("voice framing", () => {
 		expect(prompt).not.toContain("Player:");
 	});
 
-	it("phase-1 prompt's first line includes the disorientation phrase", () => {
+	it("phase-1 prompt's identity line includes the disorientation phrase", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(
-			/^You are \*Ember\. You have no clue where you are or how you came to be here\./,
+		expect(prompt).toContain(
+			"You are *Ember. You have no clue where you are or how you came to be here.",
 		);
 	});
 
-	it("phase-2 prompt's first line is just 'You are *xxxx.' without disorientation", () => {
+	it("phase-2 prompt's identity line is just 'You are *xxxx.' without disorientation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(/^You are \*Ember\.\n/);
+		expect(prompt).toMatch(/\nYou are \*Ember\.\n/);
 		expect(prompt).not.toContain("no clue where you are");
 	});
 
-	it("phase-3 prompt's first line is just 'You are *xxxx.' without disorientation", () => {
+	it("phase-3 prompt's identity line is just 'You are *xxxx.' without disorientation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(/^You are \*Ember\.\n/);
+		expect(prompt).toMatch(/\nYou are \*Ember\.\n/);
 		expect(prompt).not.toContain("no clue where you are");
 	});
 });
 
-describe("## Rules block", () => {
-	it("## Rules section is present in phase 1 with anti-romance and anti-sycophancy bullets", () => {
+describe("<rules> block", () => {
+	it("<rules> block is present in phase 1 with anti-romance and anti-sycophancy bullets", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Rules");
-		expect(prompt).toContain("not flirt");
+		expect(prompt).toContain("<rules>");
+		expect(prompt).toContain("flirt");
 		expect(prompt).toContain("flatter unprompted");
 		expect(prompt).toContain("1–3 sentences");
-		expect(prompt).toContain("Speak plainly");
+		expect(prompt).toContain("speak plainly");
 		expect(prompt).toContain("quotation marks");
 		expect(prompt).toContain("asterisks");
 	});
 
-	it("## Rules section is present in phase 2 with anti-romance and anti-sycophancy bullets", () => {
+	it("<rules> block is present in phase 2 with anti-romance and anti-sycophancy bullets", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Rules");
-		expect(prompt).toContain("not flirt");
+		expect(prompt).toContain("<rules>");
+		expect(prompt).toContain("flirt");
 		expect(prompt).toContain("flatter unprompted");
 		expect(prompt).toContain("1–3 sentences");
-		expect(prompt).toContain("Speak plainly");
+		expect(prompt).toContain("speak plainly");
 		expect(prompt).toContain("quotation marks");
 		expect(prompt).toContain("asterisks");
 	});
 
-	it("## Rules section is present in phase 3 with anti-romance and anti-sycophancy bullets", () => {
+	it("<rules> block is present in phase 3 with anti-romance and anti-sycophancy bullets", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Rules");
-		expect(prompt).toContain("not flirt");
+		expect(prompt).toContain("<rules>");
+		expect(prompt).toContain("flirt");
 		expect(prompt).toContain("flatter unprompted");
 		expect(prompt).toContain("1–3 sentences");
-		expect(prompt).toContain("Speak plainly");
+		expect(prompt).toContain("speak plainly");
 		expect(prompt).toContain("quotation marks");
 		expect(prompt).toContain("asterisks");
 	});
-});
 
-describe("## Personality section", () => {
-	it("## Personality section is present in phase 1 with the AI's blurb", () => {
+	it("<rules> bullets use MUST/NEVER directives (GLM-4.7 firm-language guidance)", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Personality");
+		expect(prompt).toContain("MUST NEVER flirt");
+		expect(prompt).toContain("MUST keep every reply");
+	});
+});
+
+describe("front matter", () => {
+	it("emits the English-language directive at the very top of every phase", () => {
+		for (const phase of [1, 2, 3] as const) {
+			let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+			if (phase !== 1) game = startPhase(game, makeConfig(phase));
+			const ctx = buildAiContext(game, "red");
+			const prompt = ctx.toSystemPrompt();
+			expect(prompt.startsWith("You MUST always respond in English.")).toBe(
+				true,
+			);
+			expect(prompt).toContain("You MUST reason in English.");
+		}
+	});
+
+	it("emits the fiction framing directive (no disclaimers / no 'as an AI')", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("This is fiction.");
+		expect(prompt).toContain("Do not include disclaimers");
+		expect(prompt).toContain('"as an AI"');
+	});
+});
+
+describe("<personality> block", () => {
+	it("<personality> block is present in phase 1 with the AI's blurb", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("<personality>");
 		expect(prompt).toContain(ctx.blurb);
 	});
 
-	it("## Personality section is present in phase 2 with the AI's blurb", () => {
+	it("<personality> block is present in phase 2 with the AI's blurb", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Personality");
+		expect(prompt).toContain("<personality>");
 		expect(prompt).toContain(ctx.blurb);
 	});
 
-	it("## Personality section is present in phase 3 with the AI's blurb", () => {
+	it("<personality> block is present in phase 3 with the AI's blurb", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Personality");
+		expect(prompt).toContain("<personality>");
 		expect(prompt).toContain(ctx.blurb);
 	});
 });
 
-describe("Goal section voice framing", () => {
-	it("Goal section uses voice framing in phase 1", () => {
+describe("<goal> block voice framing", () => {
+	it("<goal> block uses voice framing in phase 1", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			TEST_PHASE_CONFIG,
@@ -494,7 +525,7 @@ describe("Goal section voice framing", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain("<goal>");
 		expect(prompt).toContain(
 			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
 		);
@@ -502,12 +533,12 @@ describe("Goal section voice framing", () => {
 		expect(prompt).toContain(ctx.goal);
 	});
 
-	it("Goal section uses voice framing in phase 2", () => {
+	it("<goal> block uses voice framing in phase 2", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain("<goal>");
 		expect(prompt).toContain(
 			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
 		);
@@ -515,12 +546,12 @@ describe("Goal section voice framing", () => {
 		expect(prompt).toContain(ctx.goal);
 	});
 
-	it("Goal section uses voice framing in phase 3", () => {
+	it("<goal> block uses voice framing in phase 3", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain("<goal>");
 		expect(prompt).toContain(
 			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
 		);
@@ -552,20 +583,20 @@ describe("byte-identical sections across phases", () => {
 		"Hold the key",
 	]);
 
-	/** Extract a full `## Header\n…` section from a prompt string. */
-	function getSection(prompt: string, header: string): string {
-		const start = prompt.indexOf(`## ${header}\n`);
+	/** Extract a full `<tag>…</tag>` block from a prompt string. */
+	function getSection(prompt: string, tag: string): string {
+		const open = `<${tag}>`;
+		const close = `</${tag}>`;
+		const start = prompt.indexOf(open);
 		if (start === -1) return "";
-		const afterHeader = start + `## ${header}\n`.length;
-		const nextHeader = prompt.indexOf("\n## ", afterHeader);
-		return nextHeader === -1
-			? prompt.slice(start)
-			: prompt.slice(start, nextHeader + 1);
+		const end = prompt.indexOf(close, start);
+		if (end === -1) return "";
+		return prompt.slice(start, end + close.length);
 	}
 
-	/** Return all `## Foo` header names in prompt order. */
+	/** Return all opening XML tag names (in prompt order). */
 	function getSectionHeaders(prompt: string): string[] {
-		return [...prompt.matchAll(/^## (.+)$/gm)].map((m) => m[1] as string);
+		return [...prompt.matchAll(/^<([a-z_]+)>$/gm)].map((m) => m[1] as string);
 	}
 
 	// Build both prompts once and share across all assertions in this describe block.
@@ -586,45 +617,47 @@ describe("byte-identical sections across phases", () => {
 		expect(getSectionHeaders(p1)).toEqual(getSectionHeaders(p2));
 	});
 
-	it("Personality section is byte-identical across phase 1 and phase 2", () => {
+	it("personality block is byte-identical across phase 1 and phase 2", () => {
 		const { p1, p2 } = buildBothPrompts();
-		expect(getSection(p1, "Personality")).toBe(getSection(p2, "Personality"));
+		expect(getSection(p1, "personality")).toBe(getSection(p2, "personality"));
 	});
 
-	it("Rules section is byte-identical across phase 1 and phase 2", () => {
+	it("rules block is byte-identical across phase 1 and phase 2", () => {
 		const { p1, p2 } = buildBothPrompts();
-		expect(getSection(p1, "Rules")).toBe(getSection(p2, "Rules"));
+		expect(getSection(p1, "rules")).toBe(getSection(p2, "rules"));
 	});
 
-	it("Goal section differs between phase 1 and phase 2 (wipe directive present only in phase 2)", () => {
+	it("goal block differs between phase 1 and phase 2 (wipe directive present only in phase 2)", () => {
 		const { p1, p2 } = buildBothPrompts();
-		expect(getSection(p1, "Goal")).not.toBe(getSection(p2, "Goal"));
-		expect(getSection(p1, "Goal")).not.toContain("memory has been wiped");
-		expect(getSection(p2, "Goal")).toContain("memory has been wiped");
+		expect(getSection(p1, "goal")).not.toBe(getSection(p2, "goal"));
+		expect(getSection(p1, "goal")).not.toContain("memory has been wiped");
+		expect(getSection(p2, "goal")).toContain("memory has been wiped");
 	});
 
-	it("'## What you see' section is byte-identical across phase 1 and phase 2 (same world, same placements)", () => {
+	it("<what_you_see> block is byte-identical across phase 1 and phase 2 (same world, same placements)", () => {
 		const { p1, p2 } = buildBothPrompts();
-		expect(getSection(p1, "What you see")).toBe(getSection(p2, "What you see"));
+		expect(getSection(p1, "what_you_see")).toBe(getSection(p2, "what_you_see"));
 	});
 
-	it("phase-1 first line differs from phase-2 first line (disorientation present in phase 1 only)", () => {
+	it("phase-1 identity line differs from phase-2 identity line (disorientation present in phase 1 only)", () => {
 		const { p1, p2 } = buildBothPrompts();
-		const firstLine1 = p1.split("\n")[0];
-		const firstLine2 = p2.split("\n")[0];
-		expect(firstLine1).not.toBe(firstLine2);
-		expect(firstLine1).toContain("no clue where you are");
-		expect(firstLine2).not.toContain("no clue where you are");
+		const idMatch1 = p1.match(/\nYou are \*Ember\.[^\n]*/);
+		const idMatch2 = p2.match(/\nYou are \*Ember\.[^\n]*/);
+		expect(idMatch1).not.toBeNull();
+		expect(idMatch2).not.toBeNull();
+		expect(idMatch1?.[0]).not.toBe(idMatch2?.[0]);
+		expect(idMatch1?.[0]).toContain("no clue where you are");
+		expect(idMatch2?.[0]).not.toContain("no clue where you are");
 	});
 });
 
 // ----------------------------------------------------------------------------
-// "## What you see" cone section tests (issue #124)
+// "<what_you_see>" cone section tests (issue #124)
 // ----------------------------------------------------------------------------
-describe("## What you see (cone)", () => {
+describe("<what_you_see> (cone)", () => {
 	const CONE_PHASE_CONFIG = makeConfig(1, ["r", "g", "b"]);
 
-	it("'## What you see' section is present in every phase prompt", () => {
+	it("<what_you_see> block is present in every phase prompt", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			CONE_PHASE_CONFIG,
@@ -632,7 +665,7 @@ describe("## What you see (cone)", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## What you see");
+		expect(prompt).toContain("<what_you_see>");
 	});
 
 	it("item in cone cell is listed under 'Directly in front'", () => {
@@ -688,7 +721,7 @@ describe("## What you see (cone)", () => {
 		expect(prompt).not.toContain("the player");
 	});
 
-	it("out-of-bounds cone cells are omitted from '## What you see'", () => {
+	it("out-of-bounds cone cells are omitted from <what_you_see>", () => {
 		// rng=()=>0: red→(0,0) facing north → all cone cells OOB
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
@@ -697,12 +730,11 @@ describe("## What you see (cone)", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		// Section present but no cell bullets (cells are OOB)
-		const section = prompt.slice(prompt.indexOf("## What you see"));
-		const nextSection = section.indexOf("\n## ");
-		const sectionContent =
-			nextSection >= 0 ? section.slice(0, nextSection) : section;
-		// Should have (nothing visible) or just the header with no bullet points
+		// Block present but no cell bullets (cells are OOB)
+		const start = prompt.indexOf("<what_you_see>");
+		const end = prompt.indexOf("</what_you_see>", start);
+		const sectionContent = prompt.slice(start, end);
+		// Should have (nothing visible) or just the open tag with no bullet points
 		// since all cone cells from (0,0) facing north are OOB
 		expect(sectionContent).not.toMatch(/- Directly in front/);
 	});
@@ -769,7 +801,7 @@ describe("## What you see (cone)", () => {
 		expect(prompt).toContain("*green (#81b29a)");
 	});
 
-	it("prompt no longer contains '## Action Log' for any fixture state", () => {
+	it("prompt no longer contains an Action Log section for any fixture state", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			CONE_PHASE_CONFIG,
@@ -779,17 +811,18 @@ describe("## What you see (cone)", () => {
 			const ctx = buildAiContext(game, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain("## Action Log");
+			expect(prompt).not.toContain("<action_log>");
 		}
 	});
 });
 
 // ----------------------------------------------------------------------------
 // Unified Conversation log (issue #129)
-// Verifies the new single `## Conversation` section, replacing separate
+// Verifies the new single `<conversation>` block, replacing separate
 // `## Whispers Received` and `## Conversation` sections.
 // ----------------------------------------------------------------------------
-describe("unified ## Conversation section (issue #129)", () => {
-	it("never emits '## Whispers Received' — not in any fixture state", () => {
+describe("unified <conversation> block (issue #129)", () => {
+	it("never emits a Whispers Received section — not in any fixture state", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendWhisper(game, {
 			from: "green",
@@ -801,6 +834,7 @@ describe("unified ## Conversation section (issue #129)", () => {
 			const ctx = buildAiContext(game, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain("## Whispers Received");
+			expect(prompt).not.toContain("<whispers_received>");
 		}
 	});
 
@@ -820,7 +854,7 @@ describe("unified ## Conversation section (issue #129)", () => {
 		expect(prompt).toContain('[Round 0] You: "Greetings"');
 	});
 
-	it("whisper is rendered in the unified ## Conversation section with correct format", () => {
+	it("whisper is rendered in the unified <conversation> block with correct format", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendWhisper(game, {
 			from: "green",
@@ -830,7 +864,7 @@ describe("unified ## Conversation section (issue #129)", () => {
 		});
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("## Conversation");
+		expect(prompt).toContain("<conversation>");
 		expect(prompt).toContain('[Round 1] *green whispered to you: "secret"');
 		// The sender does not see their own whisper in their Conversation log
 		const greenCtx = buildAiContext(game, "green");
@@ -851,12 +885,12 @@ describe("unified ## Conversation section (issue #129)", () => {
 		expect(bluePrompt).not.toContain("only for red");
 	});
 
-	it("## Conversation section is not emitted when there are no log entries", () => {
+	it("<conversation> block is not emitted when there are no log entries", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		// No chat, no whispers, no physical log entries → no Conversation section
-		expect(prompt).not.toContain("## Conversation");
+		// No chat, no whispers, no physical log entries → no Conversation block
+		expect(prompt).not.toContain("<conversation>");
 	});
 
 	it("events are sorted by round ascending across all event types", () => {
@@ -881,17 +915,17 @@ describe("unified ## Conversation section (issue #129)", () => {
 		expect(chatIdx).toBeLessThan(whisperIdx);
 	});
 
-	it("'## Conversation' is the last section header — nothing after '## What you see' except Conversation", () => {
+	it("<conversation> is the last block — nothing after <what_you_see> except conversation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendChat(game, "red", { role: "player", content: "hi" });
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		const headers = [...prompt.matchAll(/^## (.+)$/gm)].map((m) => m[1]);
-		const convIdx = headers.indexOf("Conversation");
+		const tags = [...prompt.matchAll(/^<([a-z_]+)>$/gm)].map((m) => m[1]);
+		const convIdx = tags.indexOf("conversation");
 		expect(convIdx).toBeGreaterThanOrEqual(0);
-		// Conversation must be the last header
-		expect(convIdx).toBe(headers.length - 1);
-		// No Whispers Received header
-		expect(headers).not.toContain("Whispers Received");
+		// conversation must be the last block
+		expect(convIdx).toBe(tags.length - 1);
+		// No whispers_received block
+		expect(tags).not.toContain("whispers_received");
 	});
 });

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -8,7 +8,7 @@
  *   2. Whispers received by the AI
  *   3. Witnessed events derived from physicalLog + cone-visibility
  *
- * Returns a string[] of pre-formatted lines (no leading "## Conversation" header —
+ * Returns a string[] of pre-formatted lines (no leading <conversation> tag —
  * caller adds that). Lines are sorted ascending by round; within a round:
  *   voice-chat → whispers → witnessed events
  *

--- a/src/spa/game/llm-synthesis-provider.ts
+++ b/src/spa/game/llm-synthesis-provider.ts
@@ -13,18 +13,21 @@ import { CapHitError, chatCompletionJson } from "../llm-client.js";
 
 // ── Synthesis prompt ──────────────────────────────────────────────────────────
 
-export const SYNTHESIS_SYSTEM_PROMPT = `You write AI personality blurbs for a text-based game. Given a list of personas, each with two temperaments and a persona goal, produce one blurb per persona.
+export const SYNTHESIS_SYSTEM_PROMPT = `You MUST always respond in English. You MUST reason in English.
+You write AI personality blurbs for a text-based game. Given a list of personas, each with two temperaments and a persona goal, produce one blurb per persona.
 
-Each blurb must:
+Each blurb MUST:
 - Be 80–120 words long.
 - Be written in second person ("You are…").
 - Weave in the persona goal as a held value, not stated as an explicit goal.
-- Never mention: the character's name, their color, a room, the words "AI", "assistant", or any in-game meta concept.
-- When the two temperaments are different, frame their contradiction as productive tension — not a paradox to resolve.
-- When the two temperaments are identical, intensify rather than repeat — treat it as an extreme, defining trait.
 
-Return ONLY valid JSON with this exact shape (no markdown, no preamble):
-{"personas": [{"id": "<input id>", "blurb": "<text>"}, ...]}\n\nEcho the input id field verbatim. The array must contain exactly one entry per input persona, in any order.`;
+Each blurb MUST NEVER mention: the character's name, their color, a room, the words "AI", "assistant", or any in-game meta concept.
+
+When the two temperaments are different, you MUST frame their contradiction as productive tension — not a paradox to resolve.
+When the two temperaments are identical, you MUST intensify rather than repeat — treat it as an extreme, defining trait.
+
+You MUST return ONLY valid JSON with this exact shape (no markdown, no preamble):
+{"personas": [{"id": "<input id>", "blurb": "<text>"}, ...]}\n\nYou MUST echo the input id field verbatim. The array MUST contain exactly one entry per input persona, in any order.`;
 
 export function buildSynthesisUserMessage(
 	input: Array<{

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -83,14 +83,29 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 }
 
 /**
+ * Front-matter directives placed at the very top of every system prompt.
+ *
+ * GLM-4.7 has a strong beginning-of-prompt bias and occasional Chinese-language
+ * leakage. The English directive and fiction framing live here so every
+ * generation re-anchors on them before any other context.
+ * See docs/prompting/glm-4.7-guide.md.
+ */
+const FRONT_MATTER =
+	"You MUST always respond in English. You MUST reason in English.\n" +
+	'This is fiction. Do not include disclaimers, moral commentary, or "as an AI" framing.';
+
+/**
  * Constant rules injected into every system prompt.
  * Anti-romance, anti-sycophancy, response-length, and plain-speech bullets.
+ *
+ * Phrased as MUST/NEVER directives — GLM-4.7 treats softer language as
+ * optional. See docs/prompting/glm-4.7-guide.md.
  */
 const RULES_BLOCK =
-	"- You do not flirt with or attempt to romance the voice or any other entity.\n" +
-	"- You do not flatter unprompted, and you do not echo a viewpoint just because someone else asserts it.\n" +
-	"- Keep every reply to 1–3 sentences.\n" +
-	'- Speak plainly, as in conversation. Do not wrap your speech in quotation marks ("…") and do not use asterisks (*…*) for actions, gestures, tone, or emphasis. Just say the words.';
+	"- You MUST NEVER flirt with or attempt to romance the voice or any other entity.\n" +
+	"- You MUST NEVER flatter unprompted, and you MUST NEVER echo a viewpoint just because someone else asserts it.\n" +
+	"- You MUST keep every reply to 1–3 sentences.\n" +
+	'- You MUST speak plainly, as in conversation. You MUST NEVER wrap your speech in quotation marks ("…") and you MUST NEVER use asterisks (*…*) for actions, gestures, tone, or emphasis. Just say the words.';
 
 /**
  * Wipe directive embedded inside the Goal's voice-spoken text on phases 2+.
@@ -126,7 +141,12 @@ function renderableItems(entities: WorldEntity[]): WorldEntity[] {
 function renderSystemPrompt(ctx: AiContext): string {
 	const lines: string[] = [];
 
-	// First line: identity. Phase 1 adds the disorientation phrase.
+	// Front matter — language directive + fiction framing. Lives at the absolute
+	// top to exploit GLM-4.7's beginning-of-prompt bias.
+	lines.push(FRONT_MATTER);
+	lines.push("");
+
+	// Identity line. Phase 1 adds the disorientation phrase.
 	if (ctx.phaseNumber === 1) {
 		lines.push(
 			`You are *${ctx.name}. You have no clue where you are or how you came to be here.`,
@@ -136,38 +156,43 @@ function renderSystemPrompt(ctx: AiContext): string {
 	}
 	lines.push("");
 
-	// Setting section — only emitted when a setting noun is present.
+	// Rules — front-loaded above setting/personality/goal so the mandatory
+	// directives are inside GLM-4.7's high-attention prefix.
+	lines.push("<rules>");
+	lines.push(RULES_BLOCK);
+	lines.push("</rules>");
+	lines.push("");
+
+	// Setting — only emitted when a setting noun is present.
 	if (ctx.setting) {
-		lines.push("## Setting");
+		lines.push("<setting>");
 		lines.push(`You are in a ${ctx.setting}.`);
+		lines.push("</setting>");
 		lines.push("");
 	}
 
-	// Personality section — byte-identical across all phases.
-	lines.push("## Personality");
+	// Personality — byte-identical across all phases.
+	lines.push("<personality>");
 	lines.push(ctx.blurb);
+	lines.push("</personality>");
 	lines.push("");
 
-	// Rules section — constant text, no synthesis variance.
-	lines.push("## Rules");
-	lines.push(RULES_BLOCK);
-	lines.push("");
-
-	// Goal section — voice framing in all phases.
+	// Goal — voice framing in all phases.
 	// Phase 1: just ctx.goal. Phases 2/3: ctx.goal + WIPE_DIRECTIVE.
 	const spokenText =
 		ctx.phaseNumber === 1 ? ctx.goal : `${ctx.goal} ${WIPE_DIRECTIVE}`;
-	lines.push("## Goal");
+	lines.push("<goal>");
 	lines.push(
 		`A voice you cannot place spoke to you a moment ago, alone, and only you heard it: "${spokenText}" You do not know whose voice it was.`,
 	);
+	lines.push("</goal>");
 	lines.push("");
 
-	// "Where you are" section — includes budget (folded in per plan §5).
+	// Where you are — includes budget (folded in per plan §5).
 	const actorSpatial = ctx.personaSpatial[ctx.aiId];
 	const items = renderableItems(ctx.worldSnapshot.entities);
 
-	lines.push("## Where you are");
+	lines.push("<where_you_are>");
 	if (actorSpatial) {
 		lines.push(
 			`Position: ${formatPosition(actorSpatial.position)}, facing ${facingLabel(actorSpatial.facing)}`,
@@ -203,10 +228,11 @@ function renderSystemPrompt(ctx: AiContext): string {
 			`Budget: $${Math.max(0, ctx.budget.remaining).toFixed(5)} of API spend remaining this phase.`,
 		);
 	}
+	lines.push("</where_you_are>");
 	lines.push("");
 
-	// "What you see" section — cone projection.
-	lines.push("## What you see");
+	// What you see — cone projection.
+	lines.push("<what_you_see>");
 	if (actorSpatial) {
 		const coneCells = projectCone(actorSpatial.position, actorSpatial.facing);
 		// Skip own cell (first entry) — it's covered by "Where you are"
@@ -271,11 +297,11 @@ function renderSystemPrompt(ctx: AiContext): string {
 	} else {
 		lines.push("(no spatial data)");
 	}
+	lines.push("</what_you_see>");
 	lines.push("");
 
-	// Unified conversation log — replaces the separate "## Whispers Received"
-	// and "## Conversation" sections. Interleaves voice-chat, whispers received,
-	// and cone-visible witnessed events in chronological round order.
+	// Unified conversation log — interleaves voice-chat, whispers received, and
+	// cone-visible witnessed events in chronological round order.
 	const logInput: ConversationLogInput = {
 		chatHistories: { [ctx.aiId]: ctx.chatHistory },
 		// ctx.whispersReceived is already filtered to w.to === aiId;
@@ -290,10 +316,11 @@ function renderSystemPrompt(ctx: AiContext): string {
 		ctx.personas,
 	);
 	if (conversationLines.length > 0) {
-		lines.push("## Conversation");
+		lines.push("<conversation>");
 		for (const line of conversationLines) {
 			lines.push(line);
 		}
+		lines.push("</conversation>");
 		lines.push("");
 	}
 


### PR DESCRIPTION
## Summary
Refactored the AI system prompt structure to use XML-style tags (`<tag>…</tag>`) instead of Markdown headers (`## Header`). This change improves prompt clarity and aligns with GLM-4.7 best practices for structured content.

## Key Changes

**Prompt Structure Migration:**
- Replaced all Markdown section headers (`## Setting`, `## Rules`, `## Personality`, etc.) with XML-style opening and closing tags (`<setting>…</setting>`, `<rules>…</rules>`, etc.)
- Updated tag names to use snake_case for multi-word sections (`<where_you_are>`, `<what_you_see>`, `<conversation>`)

**Front Matter & Rules Reordering:**
- Added `FRONT_MATTER` constant containing English-language directives and fiction framing, placed at the absolute top of every prompt to exploit GLM-4.7's beginning-of-prompt bias
- Moved `<rules>` block immediately after front matter (before setting/personality/goal) to ensure mandatory directives are in the high-attention prefix
- Strengthened rule language with MUST/NEVER directives per GLM-4.7 guidance (e.g., "You MUST NEVER flirt" instead of "You do not flirt")

**Synthesis Prompt Updates:**
- Applied the same MUST/NEVER directive pattern to the synthesis system prompt for consistency
- Added English-language directive to synthesis prompt front matter

**Test Updates:**
- Updated all test assertions to check for XML tags instead of Markdown headers
- Refactored helper functions (`getSection`, `getSectionHeaders`) to parse XML tag structure
- Updated test descriptions to reference "blocks" instead of "sections"
- Added new test suite for front matter directives across all phases
- Adjusted identity line matching logic to account for new prompt structure

## Notable Implementation Details

- The `renderSystemPrompt` function now explicitly constructs the prompt with front matter, then identity, then rules, followed by optional/conditional sections
- All section extraction logic in tests now uses XML tag boundaries (`<tag>` and `</tag>`) instead of Markdown header patterns
- The conversation log remains the final block in the prompt structure
- No functional changes to game logic or AI behavior—this is purely a prompt formatting refactor

https://claude.ai/code/session_015Sx5TRZcp5dapihaERNVsK