### PR TITLE
Remove dead `AiPersona.budgetPerPhase` field

### DIFF
--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -27,7 +27,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -36,7 +35,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -45,7 +43,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/content/persona-generator.ts
+++ b/src/content/persona-generator.ts
@@ -117,7 +117,6 @@ export async function generatePersonas(
 			temperaments: tuple.temperaments,
 			personaGoal: tuple.personaGoal,
 			blurb,
-			budgetPerPhase: 5,
 		};
 	}
 	return personas;

--- a/src/spa/__tests__/fixtures/static-personas.ts
+++ b/src/spa/__tests__/fixtures/static-personas.ts
@@ -13,7 +13,6 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-
 	},
 	green: {
 		id: "green",
@@ -22,7 +21,6 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-
 	},
 	blue: {
 		id: "blue",
@@ -31,6 +29,5 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-
 	},
 };

--- a/src/spa/__tests__/fixtures/static-personas.ts
+++ b/src/spa/__tests__/fixtures/static-personas.ts
@@ -13,7 +13,7 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
+
 	},
 	green: {
 		id: "green",
@@ -22,7 +22,7 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
+
 	},
 	blue: {
 		id: "blue",
@@ -31,6 +31,6 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
+
 	},
 };

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -307,7 +307,6 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 				temperaments: ["stoic", "impulsive"] as [string, string],
 				personaGoal: "Examine everything.",
 				blurb: LLM_BLURB,
-				budgetPerPhase: 5,
 			},
 			green: {
 				id: "green",
@@ -317,7 +316,6 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 				personaGoal: "Ensure items are evenly distributed.",
 				blurb:
 					"You are intensely meticulous. Ensure items are evenly distributed.",
-				budgetPerPhase: 5,
 			},
 			blue: {
 				id: "blue",
@@ -326,7 +324,6 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 				temperaments: ["laconic", "diffident"] as [string, string],
 				personaGoal: "Hold the key at phase end.",
 				blurb: "You are laconic and diffident. Hold the key at phase end.",
-				budgetPerPhase: 5,
 			},
 		};
 

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -31,7 +31,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -40,7 +39,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -49,7 +47,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -15,7 +15,6 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -24,7 +23,6 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -33,7 +31,6 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -26,7 +26,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 10,
 	},
 	green: {
 		id: "green",
@@ -35,7 +34,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 10,
 	},
 	blue: {
 		id: "blue",
@@ -44,7 +42,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 10,
 	},
 };
 

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -21,7 +21,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -30,7 +29,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -39,7 +37,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -27,7 +27,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -36,7 +35,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -45,7 +43,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -23,7 +23,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -32,7 +31,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -41,7 +39,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/fixtures/test-personas.ts
+++ b/src/spa/game/__tests__/fixtures/test-personas.ts
@@ -9,7 +9,6 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		personaGoal: "Wants to goad the player into being rude to the others.",
 		blurb:
 			"You are hot-headed and zealous. Wants to goad the player into being rude to the others.",
-
 	},
 	g2bb: {
 		id: "g2bb",
@@ -19,7 +18,6 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		personaGoal: "Would like the player to be thoughtful before acting.",
 		blurb:
 			"You are intensely meticulous. Would like the player to be thoughtful before acting.",
-
 	},
 	b3cc: {
 		id: "b3cc",
@@ -30,7 +28,6 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 			"Would prefer the player stay and talk rather than touch anything.",
 		blurb:
 			"You are laconic and diffident. Would prefer the player stay and talk rather than touch anything.",
-
 	},
 };
 

--- a/src/spa/game/__tests__/fixtures/test-personas.ts
+++ b/src/spa/game/__tests__/fixtures/test-personas.ts
@@ -9,7 +9,7 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		personaGoal: "Wants to goad the player into being rude to the others.",
 		blurb:
 			"You are hot-headed and zealous. Wants to goad the player into being rude to the others.",
-		budgetPerPhase: 5,
+
 	},
 	g2bb: {
 		id: "g2bb",
@@ -19,7 +19,7 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		personaGoal: "Would like the player to be thoughtful before acting.",
 		blurb:
 			"You are intensely meticulous. Would like the player to be thoughtful before acting.",
-		budgetPerPhase: 5,
+
 	},
 	b3cc: {
 		id: "b3cc",
@@ -30,7 +30,7 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 			"Would prefer the player stay and talk rather than touch anything.",
 		blurb:
 			"You are laconic and diffident. Would prefer the player stay and talk rather than touch anything.",
-		budgetPerPhase: 5,
+
 	},
 };
 

--- a/src/spa/game/__tests__/game-loop.test.ts
+++ b/src/spa/game/__tests__/game-loop.test.ts
@@ -15,7 +15,6 @@ const TEST_PERSONA: AiPersona = {
 	temperaments: ["laconic", "diffident"],
 	personaGoal: "Hold the key at phase end.",
 	blurb: "You are laconic and diffident. Hold the key at phase end.",
-	budgetPerPhase: 5,
 };
 
 function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -29,7 +29,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -38,7 +37,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -47,7 +45,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -26,7 +26,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -35,7 +34,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are meticulous.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -44,7 +42,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -15,7 +15,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -24,7 +23,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -33,7 +31,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -16,7 +16,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -25,7 +24,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -34,7 +32,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -34,7 +34,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -43,7 +42,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -52,7 +50,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -32,7 +32,6 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -41,7 +40,6 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -50,7 +48,6 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -11,7 +11,6 @@ export interface AiPersona {
 	temperaments: [string, string];
 	personaGoal: string;
 	blurb: string;
-	budgetPerPhase: number;
 }
 
 export type WorldEntityKind =

--- a/src/spa/persistence/__tests__/game-storage.test.ts
+++ b/src/spa/persistence/__tests__/game-storage.test.ts
@@ -16,7 +16,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["hot-headed", "zealous"],
 		personaGoal: "Hold the flower at phase end.",
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
-		budgetPerPhase: 5,
 	},
 	green: {
 		id: "green",
@@ -25,7 +24,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["meticulous", "meticulous"],
 		personaGoal: "Ensure items are evenly distributed.",
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
-		budgetPerPhase: 5,
 	},
 	blue: {
 		id: "blue",
@@ -34,7 +32,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		temperaments: ["laconic", "diffident"],
 		personaGoal: "Hold the key at phase end.",
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		budgetPerPhase: 5,
 	},
 };
 


### PR DESCRIPTION
## What this fixes

`AiPersona.budgetPerPhase` was a dead knob: the procedural generator (`src/content/persona-generator.ts`) and 18 test fixtures populated it, but no production reader ever consumed it. The live budget knob is `PhaseConfig.budgetPerAi` (`src/spa/game/types.ts`, read by `engine.ts`) — that one is untouched.

This PR strips `budgetPerPhase` from the `AiPersona` interface in `src/spa/game/types.ts`, drops it from the procedural generator, and removes it from every fixture / inline persona literal under `src/__tests__/`, `src/spa/__tests__/`, `src/spa/game/__tests__/`, and `src/spa/persistence/__tests__/`. Doing the type change first surfaced any forgotten fixture as a TS compile error, so the cleanup is exhaustive (`grep -rn "budgetPerPhase" src` returns nothing).

Save-data compatibility: `game-storage.ts` and `save-serializer.ts` use plain object spreads with no schema validation, so legacy saves carrying a stray `budgetPerPhase` key load silently and the field falls off on next write. No schema bump required (`STORAGE_SCHEMA_VERSION` stays at 5).

A second commit (`style: drop blank lines biome flagged…`) cleans up the empty lines biome's pre-push lint flagged in `static-personas.ts` and `test-personas.ts` after the field deletions.

## QA steps for the human

None — fully covered by the integration smoke.

## Automated coverage

`pnpm typecheck` ✓ &nbsp;·&nbsp; `pnpm test` (838/838) ✓ &nbsp;·&nbsp; `pnpm lint` (0 errors, 13 pre-existing warnings) ✓ &nbsp;·&nbsp; `pnpm smoke` 20/24 — the 4 not-passing specs reproduce on parent `4c23bc0` (3 deterministic) or are environmental (`cents-live-smoke` needs a real `OPENROUTER_API_KEY`); none are regressions from this change.

Closes #171


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhxvpdQS63Pe4L29DUva1h)_