### PR TITLE
Disable reasoning for routine daemon turns

### DIFF
--- a/e2e/think-disabled.spec.ts
+++ b/e2e/think-disabled.spec.ts
@@ -2,17 +2,22 @@ import { expect, test } from "@playwright/test";
 import { getAiHandles, stubChatCompletions } from "./helpers";
 
 /**
- * `?think=0` is a wrangler-dev-only affordance that adds
- * `reasoning: { enabled: false }` to every `/v1/chat/completions` request body
- * the SPA POSTs, so the model skips its thinking step entirely.
+ * Routine daemon turns disable reasoning by default — `BrowserLLMProvider`
+ * passes `disableReasoning: true` to `streamCompletion`, which adds
+ * `reasoning: { enabled: false }` to every `/v1/chat/completions` body the
+ * SPA POSTs so GLM-4.7 skips its thinking step entirely.
  *
- * The unit tests in `src/spa/__tests__/llm-client.test.ts` lock the body shape
+ * `?think=1` is a wrangler-dev-only affordance that opts thinking back on
+ * for prompt-tuning.
+ *
+ * The unit tests in `src/spa/__tests__/llm-client.test.ts` and
+ * `src/spa/game/__tests__/browser-llm-provider.test.ts` lock the body shape
  * directly. This e2e spec confirms the wiring all the way through:
- * `?think=0` URL param → `isDevHost()` gate → `BrowserLLMProvider` →
- * `streamCompletion` → request body on the wire.
+ * URL → `isDevHost()` gate → `BrowserLLMProvider` → `streamCompletion` →
+ * request body on the wire.
  */
 
-test("?think=0 adds reasoning:{enabled:false} to chat-completions requests", async ({
+test("default daemon turns add reasoning:{enabled:false} to chat-completions requests", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -31,7 +36,7 @@ test("?think=0 adds reasoning:{enabled:false} to chat-completions requests", asy
 		return ["greetings"];
 	});
 
-	await page.goto("/?think=0");
+	await page.goto("/");
 
 	const { names } = await getAiHandles(page);
 
@@ -50,7 +55,7 @@ test("?think=0 adds reasoning:{enabled:false} to chat-completions requests", asy
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });
 
-test("without ?think=0, requests do NOT include the reasoning field", async ({
+test("?think=1 opts back into thinking — requests do NOT include the reasoning field", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -68,7 +73,7 @@ test("without ?think=0, requests do NOT include the reasoning field", async ({
 		return ["greetings"];
 	});
 
-	await page.goto("/");
+	await page.goto("/?think=1");
 
 	const { names } = await getAiHandles(page);
 

--- a/src/spa/game/__tests__/browser-llm-provider.test.ts
+++ b/src/spa/game/__tests__/browser-llm-provider.test.ts
@@ -101,3 +101,57 @@ describe("BrowserLLMProvider.streamRound — onDelta callback", () => {
 		vi.restoreAllMocks();
 	});
 });
+
+describe("BrowserLLMProvider — reasoning default (issue #169)", () => {
+	function captureRequestBody(): { getBody: () => Record<string, unknown> } {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(makeSseBody(["ok"]), {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		return {
+			getBody: () => {
+				const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+				return JSON.parse(String(init?.body)) as Record<string, unknown>;
+			},
+		};
+	}
+
+	it("disables reasoning by default (no opts)", async () => {
+		const { getBody } = captureRequestBody();
+
+		await new BrowserLLMProvider().streamRound([], []);
+
+		expect(getBody().reasoning).toEqual({ enabled: false });
+
+		vi.restoreAllMocks();
+	});
+
+	it("disables reasoning when constructed with { disableReasoning: true }", async () => {
+		const { getBody } = captureRequestBody();
+
+		await new BrowserLLMProvider({ disableReasoning: true }).streamRound(
+			[],
+			[],
+		);
+
+		expect(getBody().reasoning).toEqual({ enabled: false });
+
+		vi.restoreAllMocks();
+	});
+
+	it("omits the reasoning field when constructed with { disableReasoning: false }", async () => {
+		const { getBody } = captureRequestBody();
+
+		await new BrowserLLMProvider({ disableReasoning: false }).streamRound(
+			[],
+			[],
+		);
+
+		expect(getBody()).not.toHaveProperty("reasoning");
+
+		vi.restoreAllMocks();
+	});
+});

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -6,6 +6,11 @@
  *
  * Collects the full assistant text and all tool calls from the SSE stream
  * and returns them together as a `RoundTurnResult`.
+ *
+ * Reasoning is disabled by default for routine daemon turns — GLM-4.7's
+ * thinking trace adds 1–4K tokens of latency per turn for little roleplay
+ * benefit (see `docs/prompting/glm-4.7-guide.md`). Construct with
+ * `{ disableReasoning: false }` to opt back into the thinking step.
  */
 
 import { streamCompletion } from "../llm-client.js";
@@ -20,7 +25,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 	private readonly disableReasoning: boolean;
 
 	constructor(opts: { disableReasoning?: boolean } = {}) {
-		this.disableReasoning = opts.disableReasoning ?? false;
+		this.disableReasoning = opts.disableReasoning ?? true;
 	}
 
 	async streamRound(
@@ -49,7 +54,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 			onUsage: (usage) => {
 				if (typeof usage.cost === "number") costUsd = usage.cost;
 			},
-			...(this.disableReasoning ? { disableReasoning: true } : {}),
+			disableReasoning: this.disableReasoning,
 		});
 
 		const assistantText = textParts.join("") || reasoningParts.join("");

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -160,7 +160,8 @@ export async function streamCompletion(opts: {
 
 	// OpenRouter Reasoning Tokens API: { enabled: false } skips the model's
 	// thinking step entirely (vs. { exclude: true } which still thinks but
-	// hides the trace). Used by the ?think=0 dev affordance.
+	// hides the trace). Daemon turns default to disabled (see
+	// BrowserLLMProvider); the `?think=1` dev affordance opts back in.
 	if (disableReasoning) {
 		bodyObj.reasoning = { enabled: false };
 	}

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -486,18 +486,19 @@ export function renderGame(
 		if (overlay) overlay.scrollLeft = _promptInput.scrollLeft;
 	});
 
-	// Dev-only: ?think=0 disables the model's thinking step (OpenRouter
-	// reasoning.enabled=false). Gated to wrangler-dev host (see isDevHost).
+	// Reasoning is disabled by default for routine daemon turns (see
+	// BrowserLLMProvider). Dev-only `?think=1` opts the model's thinking
+	// step back on for prompt-tuning. Gated to wrangler-dev (see isDevHost).
 	//
 	// Merge hash-query-string params (from the router) with location.search
-	// params so flags like ?think=0, ?lockout=1, ?winImmediately=1 work whether
+	// params so flags like ?think=1, ?lockout=1, ?winImmediately=1 work whether
 	// they appear in the search string (e.g. "/?lockout=1") or after the hash
 	// (e.g. "/#/?lockout=1"). Hash params win on conflict.
 	const effectiveParams = new URLSearchParams(location.search);
 	if (params) {
 		for (const [k, v] of params) effectiveParams.set(k, v);
 	}
-	const disableReasoning = isDevHost() && effectiveParams.get("think") === "0";
+	const enableReasoning = isDevHost() && effectiveParams.get("think") === "1";
 
 	/** Show the persistence warning banner once (idempotent). */
 	function showPersistenceWarning(reason: string): void {
@@ -606,8 +607,8 @@ export function renderGame(
 			// synthesis completes are silently dropped (safe).
 			asyncInitPromise = (async () => {
 				try {
-					const synth = new BrowserSynthesisProvider({ disableReasoning });
-					const packLLM = new BrowserContentPackProvider({ disableReasoning });
+					const synth = new BrowserSynthesisProvider();
+					const packLLM = new BrowserContentPackProvider();
 					const personasPromise = generatePersonas(Math.random, synth);
 					const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
 					// Silence derived-promise unhandled rejection when personasPromise
@@ -1089,7 +1090,9 @@ export function renderGame(
 		};
 
 		try {
-			const provider = new BrowserLLMProvider({ disableReasoning });
+			const provider = new BrowserLLMProvider({
+				disableReasoning: !enableReasoning,
+			});
 			const { result, completions, nextState } = await session.submitMessage(
 				addressed,
 				message,


### PR DESCRIPTION
## What this fixes

GLM-4.7 ships with thinking mode on, and every routine daemon turn was paying 1–4K tokens of reasoning latency for little roleplay benefit. Per `docs/prompting/glm-4.7-guide.md`, long thinking traces also tend to drift meta-narratively away from in-character pacing, so the guide explicitly recommends disabling reasoning on dialogue-heavy turns.

The plumbing was already in place — `src/spa/llm-client.ts` accepts `disableReasoning` and forwards `reasoning: { enabled: false }` to OpenRouter — but the daemon caller never set it. The actual caller is `BrowserLLMProvider` (not `RoundLLMProvider`, which is just an interface + Mock). This PR flips the default in `BrowserLLMProvider`'s constructor to `disableReasoning: true` and updates the dev affordance in `src/spa/routes/game.ts` from `?think=0` (disable) to `?think=1` (opt back into thinking for prompt-tuning). The synthesis and content-pack providers are one-shot startup calls, not routine daemon turns, so they keep their existing default (reasoning enabled).

Re-enabling reasoning on "moment of truth" turns (final accusation, escape attempt, etc.) is the follow-up the issue calls out.

## QA steps for the human

- Open the SPA in `wrangler dev`, send a daemon turn, and confirm in DevTools → Network that the `/v1/chat/completions` request body includes `"reasoning":{"enabled":false}`.
- Visit `/?think=1` (dev host only), send a daemon turn, and confirm the request body **omits** the `reasoning` field.
- Sanity check: daemons still reply normally (text deltas, not just reasoning chunks).

## Automated coverage

- `pnpm typecheck` — clean.
- `pnpm test` — 841/841 pass, including 3 new tests in `browser-llm-provider.test.ts` that lock the request-body shape (default disables, explicit `true` disables, explicit `false` omits the `reasoning` field).
- `pnpm smoke` — both `think-disabled.spec.ts` specs (default-off and `?think=1`-on) pass. The 3 unrelated failures (`addressed-and-parallel`, `mention-addressing`, `responsive-bento`) reproduce on `main` and are pre-existing.

Closes #169


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGqqjfknvGuWhAaDwsr6hW)_