### PR TITLE
Synthesize few-shot voice examples per daemon to anchor character voice

### DIFF
--- a/e2e/diagnose-streaming.spec.ts
+++ b/e2e/diagnose-streaming.spec.ts
@@ -172,6 +172,7 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 							const personas = ids.map((id) => ({
 								id,
 								blurb: `Stub blurb for ${id}.`,
+								voiceExamples: [`ex1-${id}`, `ex2-${id}`, `ex3-${id}`],
 							}));
 							content = JSON.stringify({ personas });
 						} else if (

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -77,7 +77,15 @@ function buildSynthesisResponseBody(
 ): string {
 	const ids = extractInputIds(body?.messages?.[1]?.content ?? "");
 	const content = JSON.stringify({
-		personas: ids.map((id) => ({ id, blurb: blurbFn(id) })),
+		personas: ids.map((id) => ({
+			id,
+			blurb: blurbFn(id),
+			voiceExamples: [
+				`Stub voice 1 for ${id}.`,
+				`Stub voice 2 for ${id}.`,
+				`Stub voice 3 for ${id}.`,
+			],
+		})),
 	});
 	return JSON.stringify({ choices: [{ message: { content } }] });
 }

--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -272,7 +272,11 @@ describe("generatePersonas — LLM path", () => {
 	it("passes all 3 persona tuples in a single batched call", async () => {
 		const mockProvider = new MockSynthesisProvider(
 			(input: SynthesisInput[]) => ({
-				personas: input.map((p) => ({ id: p.id, blurb: `BLURB_${p.id}` })),
+				personas: input.map((p) => ({
+					id: p.id,
+					blurb: `BLURB_${p.id}`,
+					voiceExamples: [`voice1-${p.id}`, `voice2-${p.id}`, `voice3-${p.id}`],
+				})),
 			}),
 		);
 
@@ -284,7 +288,11 @@ describe("generatePersonas — LLM path", () => {
 	it("returned record has exactly 3 entries with blurbs matching canned values", async () => {
 		const mockProvider = new MockSynthesisProvider(
 			(input: SynthesisInput[]) => ({
-				personas: input.map((p) => ({ id: p.id, blurb: `BLURB_${p.id}` })),
+				personas: input.map((p) => ({
+					id: p.id,
+					blurb: `BLURB_${p.id}`,
+					voiceExamples: [`voice1-${p.id}`, `voice2-${p.id}`, `voice3-${p.id}`],
+				})),
 			}),
 		);
 
@@ -296,10 +304,36 @@ describe("generatePersonas — LLM path", () => {
 		}
 	});
 
+	it("returned record has voiceExamples plumbed through from LLM result", async () => {
+		const mockProvider = new MockSynthesisProvider(
+			(input: SynthesisInput[]) => ({
+				personas: input.map((p) => ({
+					id: p.id,
+					blurb: `BLURB_${p.id}`,
+					voiceExamples: [`voice1-${p.id}`, `voice2-${p.id}`, `voice3-${p.id}`],
+				})),
+			}),
+		);
+
+		const personas = await generatePersonas(() => 0.5, mockProvider);
+
+		for (const [id, persona] of Object.entries(personas)) {
+			expect(persona.voiceExamples).toEqual([
+				`voice1-${id}`,
+				`voice2-${id}`,
+				`voice3-${id}`,
+			]);
+		}
+	});
+
 	it("input to mock contains 3-element array of {id, temperaments, personaGoal} tuples", async () => {
 		const mockProvider = new MockSynthesisProvider(
 			(input: SynthesisInput[]) => ({
-				personas: input.map((p) => ({ id: p.id, blurb: `BLURB_${p.id}` })),
+				personas: input.map((p) => ({
+					id: p.id,
+					blurb: `BLURB_${p.id}`,
+					voiceExamples: [`voice1-${p.id}`, `voice2-${p.id}`, `voice3-${p.id}`],
+				})),
 			}),
 		);
 
@@ -321,6 +355,7 @@ describe("generatePersonas — LLM path", () => {
 				personas: input.map((p, i) => ({
 					id: p.id,
 					blurb: ["BLURB_A", "BLURB_B", "BLURB_C"][i] ?? "BLURB_UNKNOWN",
+					voiceExamples: [`voice1-${p.id}`, `voice2-${p.id}`, `voice3-${p.id}`],
 				})),
 			}),
 		);
@@ -335,5 +370,16 @@ describe("generatePersonas — LLM path", () => {
 		expect(values[0]?.blurb).toBe("BLURB_A");
 		expect(values[1]?.blurb).toBe("BLURB_B");
 		expect(values[2]?.blurb).toBe("BLURB_C");
+	});
+
+	it("template fallback (no-LLM) produces voiceExamples of length 3 non-empty strings", async () => {
+		const personas = await generatePersonas(() => 0.5);
+		for (const p of Object.values(personas)) {
+			expect(p.voiceExamples).toHaveLength(3);
+			for (const ex of p.voiceExamples) {
+				expect(typeof ex).toBe("string");
+				expect(ex.length).toBeGreaterThan(0);
+			}
+		}
 	});
 });

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -31,6 +31,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -43,6 +44,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -55,6 +57,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/content/persona-generator.ts
+++ b/src/content/persona-generator.ts
@@ -51,6 +51,23 @@ export function buildBlurb(
 	return `${temperamentSentence} ${personaGoal}`;
 }
 
+/**
+ * Fallback voice examples for the offline (no-LLM) path.
+ * Intentionally low-quality — exists only so the type stays satisfied.
+ * The real value comes from the LLM synthesis path.
+ */
+export function buildFallbackVoiceExamples(tuple: {
+	temperaments: [string, string];
+	personaGoal: string;
+}): string[] {
+	const [t1, t2] = tuple.temperaments;
+	return [
+		`Something ${t1} just to set a tone.`,
+		`A ${t2} remark in the same breath.`,
+		`One more line that sounds the same.`,
+	];
+}
+
 function drawWithReplacement<T>(pool: T[], rng: () => number): T {
 	// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
 	return pool[Math.floor(rng() * pool.length)]!;
@@ -101,14 +118,25 @@ export async function generatePersonas(
 		});
 	}
 
-	// Synthesize blurbs: LLM path when provider supplied, template fallback otherwise.
-	let blurbMap: Map<string, string>;
+	// Synthesize blurbs and voice examples: LLM path when provider supplied, template fallback otherwise.
+	let synthesisMap: Map<string, { blurb: string; voiceExamples: string[] }>;
 	if (llm) {
 		const result = await llm.synthesizePersonas(tuples);
-		blurbMap = new Map(result.personas.map((p) => [p.id, p.blurb]));
+		synthesisMap = new Map(
+			result.personas.map((p) => [
+				p.id,
+				{ blurb: p.blurb, voiceExamples: p.voiceExamples },
+			]),
+		);
 	} else {
-		blurbMap = new Map(
-			tuples.map((t) => [t.id, buildBlurb(t.temperaments, t.personaGoal)]),
+		synthesisMap = new Map(
+			tuples.map((t) => [
+				t.id,
+				{
+					blurb: buildBlurb(t.temperaments, t.personaGoal),
+					voiceExamples: buildFallbackVoiceExamples(t),
+				},
+			]),
 		);
 	}
 
@@ -117,8 +145,11 @@ export async function generatePersonas(
 		const tuple = tuples[i] as (typeof tuples)[number];
 		const name = tuple.id;
 		const color = colors[i] as string;
+		const synthesized = synthesisMap.get(name);
 		const blurb =
-			blurbMap.get(name) ?? buildBlurb(tuple.temperaments, tuple.personaGoal);
+			synthesized?.blurb ?? buildBlurb(tuple.temperaments, tuple.personaGoal);
+		const voiceExamples =
+			synthesized?.voiceExamples ?? buildFallbackVoiceExamples(tuple);
 		personas[name] = {
 			id: name,
 			name,
@@ -127,6 +158,7 @@ export async function generatePersonas(
 			personaGoal: tuple.personaGoal,
 			typingQuirks: tuple.typingQuirks,
 			blurb,
+			voiceExamples,
 		};
 	}
 	return personas;

--- a/src/spa/__tests__/fixtures/static-personas.ts
+++ b/src/spa/__tests__/fixtures/static-personas.ts
@@ -17,6 +17,7 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -29,6 +30,7 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -41,5 +43,6 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -311,6 +311,7 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 					"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 				] as [string, string],
 				blurb: LLM_BLURB,
+				voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 			},
 			green: {
 				id: "green",
@@ -324,6 +325,7 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 				] as [string, string],
 				blurb:
 					"You are intensely meticulous. Ensure items are evenly distributed.",
+				voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 			},
 			blue: {
 				id: "blue",
@@ -336,6 +338,7 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 					"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 				] as [string, string],
 				blurb: "You are laconic and diffident. Hold the key at phase end.",
+				voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 			},
 		};
 

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -35,6 +35,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -47,6 +48,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -59,6 +61,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -19,6 +19,7 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -31,6 +32,7 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -43,6 +45,7 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -30,6 +30,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -42,6 +43,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -54,6 +56,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -25,6 +25,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -37,6 +38,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -49,6 +51,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -31,6 +31,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -43,6 +44,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -55,6 +57,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -27,6 +27,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -39,6 +40,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -51,6 +53,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/fixtures/test-personas.ts
+++ b/src/spa/game/__tests__/fixtures/test-personas.ts
@@ -13,6 +13,7 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		],
 		blurb:
 			"You are hot-headed and zealous. Wants to goad the player into being rude to the others.",
+		voiceExamples: ["ex1-r1aa", "ex2-r1aa", "ex3-r1aa"],
 	},
 	g2bb: {
 		id: "g2bb",
@@ -26,6 +27,7 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		],
 		blurb:
 			"You are intensely meticulous. Would like the player to be thoughtful before acting.",
+		voiceExamples: ["ex1-g2bb", "ex2-g2bb", "ex3-g2bb"],
 	},
 	b3cc: {
 		id: "b3cc",
@@ -40,6 +42,7 @@ export const TEST_PERSONAS: Record<string, AiPersona> = {
 		],
 		blurb:
 			"You are laconic and diffident. Would prefer the player stay and talk rather than touch anything.",
+		voiceExamples: ["ex1-b3cc", "ex2-b3cc", "ex3-b3cc"],
 	},
 };
 

--- a/src/spa/game/__tests__/game-loop.test.ts
+++ b/src/spa/game/__tests__/game-loop.test.ts
@@ -19,6 +19,7 @@ const TEST_PERSONA: AiPersona = {
 		"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 	],
 	blurb: "You are laconic and diffident. Hold the key at phase end.",
+	voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 };
 
 function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -33,6 +33,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -45,6 +46,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -57,6 +59,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/llm-synthesis-provider.test.ts
+++ b/src/spa/game/__tests__/llm-synthesis-provider.test.ts
@@ -36,9 +36,21 @@ const INPUT_C: SynthesisInput = {
 const THREE_INPUTS = [INPUT_A, INPUT_B, INPUT_C];
 
 const CANNED_PERSONAS = [
-	{ id: "a1b2", blurb: "You are stoic and precise." },
-	{ id: "c3d4", blurb: "You are intensely impulsive." },
-	{ id: "e5f6", blurb: "You are gentle and wry." },
+	{
+		id: "a1b2",
+		blurb: "You are stoic and precise.",
+		voiceExamples: ["voice1-a1b2", "voice2-a1b2", "voice3-a1b2"],
+	},
+	{
+		id: "c3d4",
+		blurb: "You are intensely impulsive.",
+		voiceExamples: ["voice1-c3d4", "voice2-c3d4", "voice3-c3d4"],
+	},
+	{
+		id: "e5f6",
+		blurb: "You are gentle and wry.",
+		voiceExamples: ["voice1-e5f6", "voice2-e5f6", "voice3-e5f6"],
+	},
 ];
 
 /** Build a successful non-streaming fetch response with JSON in content. */
@@ -100,7 +112,13 @@ describe("MockSynthesisProvider", () => {
 		let received: SynthesisInput[] | null = null;
 		const provider = new MockSynthesisProvider((input) => {
 			received = input;
-			return { personas: input.map((p) => ({ id: p.id, blurb: "test" })) };
+			return {
+				personas: input.map((p) => ({
+					id: p.id,
+					blurb: "test",
+					voiceExamples: ["ex1", "ex2", "ex3"],
+				})),
+			};
 		});
 		await provider.synthesizePersonas(THREE_INPUTS);
 		expect(received).toEqual(THREE_INPUTS);
@@ -381,5 +399,256 @@ describe("BrowserSynthesisProvider", () => {
 		).rejects.toBeInstanceOf(SynthesisError);
 		// Two attempts (first + one retry)
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	// ── voiceExamples validation ──────────────────────────────────────────────
+
+	it("throws SynthesisError when voiceExamples field is missing", async () => {
+		const badPersonas = [
+			{ id: "a1b2", blurb: "blurb1" },
+			{ id: "c3d4", blurb: "blurb2" },
+			{ id: "e5f6", blurb: "blurb3" },
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{
+						message: {
+							content: JSON.stringify({ personas: badPersonas }),
+							reasoning: null,
+						},
+					},
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
+	});
+
+	it("throws SynthesisError when voiceExamples has length != 3 (length 1)", async () => {
+		const badPersonas = [
+			{ id: "a1b2", blurb: "blurb1", voiceExamples: ["only one"] },
+			{ id: "c3d4", blurb: "blurb2", voiceExamples: ["only one"] },
+			{ id: "e5f6", blurb: "blurb3", voiceExamples: ["only one"] },
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{
+						message: {
+							content: JSON.stringify({ personas: badPersonas }),
+							reasoning: null,
+						},
+					},
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
+	});
+
+	it("throws SynthesisError when voiceExamples has length != 3 (length 4)", async () => {
+		const badPersonas = [
+			{
+				id: "a1b2",
+				blurb: "blurb1",
+				voiceExamples: ["one", "two", "three", "four"],
+			},
+			{
+				id: "c3d4",
+				blurb: "blurb2",
+				voiceExamples: ["one", "two", "three", "four"],
+			},
+			{
+				id: "e5f6",
+				blurb: "blurb3",
+				voiceExamples: ["one", "two", "three", "four"],
+			},
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{
+						message: {
+							content: JSON.stringify({ personas: badPersonas }),
+							reasoning: null,
+						},
+					},
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
+	});
+
+	it("throws SynthesisError when voiceExamples contains a non-string entry", async () => {
+		const badPersonas = [
+			{ id: "a1b2", blurb: "blurb1", voiceExamples: ["ok", 42, "ok"] },
+			{ id: "c3d4", blurb: "blurb2", voiceExamples: ["ok", "ok", "ok"] },
+			{ id: "e5f6", blurb: "blurb3", voiceExamples: ["ok", "ok", "ok"] },
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{
+						message: {
+							content: JSON.stringify({ personas: badPersonas }),
+							reasoning: null,
+						},
+					},
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
+	});
+
+	it("throws SynthesisError when voiceExamples contains an empty string", async () => {
+		const badPersonas = [
+			{ id: "a1b2", blurb: "blurb1", voiceExamples: ["ok", "", "ok"] },
+			{ id: "c3d4", blurb: "blurb2", voiceExamples: ["ok", "ok", "ok"] },
+			{ id: "e5f6", blurb: "blurb3", voiceExamples: ["ok", "ok", "ok"] },
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{
+						message: {
+							content: JSON.stringify({ personas: badPersonas }),
+							reasoning: null,
+						},
+					},
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockImplementation(() =>
+					Promise.resolve(new Response(makeBody(), { status: 200 })),
+				),
+		);
+		const provider = new BrowserSynthesisProvider();
+		await expect(
+			provider.synthesizePersonas(THREE_INPUTS),
+		).rejects.toBeInstanceOf(SynthesisError);
+	});
+
+	it("returns voiceExamples when valid 3-entry array provided", async () => {
+		const goodPersonas = [
+			{
+				id: "a1b2",
+				blurb: "blurb1",
+				voiceExamples: ["line one.", "line two.", "line three."],
+			},
+			{
+				id: "c3d4",
+				blurb: "blurb2",
+				voiceExamples: ["alpha.", "beta.", "gamma."],
+			},
+			{
+				id: "e5f6",
+				blurb: "blurb3",
+				voiceExamples: ["uno.", "dos.", "tres."],
+			},
+		];
+		const makeBody = () =>
+			JSON.stringify({
+				choices: [
+					{
+						message: {
+							content: JSON.stringify({ personas: goodPersonas }),
+							reasoning: null,
+						},
+					},
+				],
+			});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(makeBody(), { status: 200 })),
+		);
+		const provider = new BrowserSynthesisProvider();
+		const result = await provider.synthesizePersonas(THREE_INPUTS);
+		const a1b2 = result.personas.find((p) => p.id === "a1b2");
+		expect(a1b2?.voiceExamples).toEqual([
+			"line one.",
+			"line two.",
+			"line three.",
+		]);
+	});
+});
+
+// ── SYNTHESIS_SYSTEM_PROMPT — voiceExamples additions ────────────────────────
+
+describe("SYNTHESIS_SYSTEM_PROMPT — voiceExamples", () => {
+	it("includes 'voiceExamples' JSON token", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT).toContain('"voiceExamples"');
+	});
+
+	it("mentions exactly 3 voice examples requirement", () => {
+		const lower = SYNTHESIS_SYSTEM_PROMPT.toLowerCase();
+		const mentionsThree =
+			lower.includes("exactly 3") || lower.includes("3 voiceexamples");
+		expect(mentionsThree).toBe(true);
+	});
+
+	it("mentions one sentence constraint", () => {
+		expect(SYNTHESIS_SYSTEM_PROMPT.toLowerCase()).toContain("one sentence");
+	});
+
+	it("prohibits first-person goal descriptions in voice examples", () => {
+		const lower = SYNTHESIS_SYSTEM_PROMPT.toLowerCase();
+		const hasProhibition =
+			lower.includes("first-person") ||
+			lower.includes("first person") ||
+			lower.includes("i want") ||
+			lower.includes("don't say");
+		expect(hasProhibition).toBe(true);
+	});
+
+	it("prohibits name/color/room in voice examples", () => {
+		// The same prohibition block covers both blurbs and voice examples.
+		const lower = SYNTHESIS_SYSTEM_PROMPT.toLowerCase();
+		const hasProhibition =
+			lower.includes("name") ||
+			lower.includes("color") ||
+			lower.includes("room");
+		expect(hasProhibition).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -30,6 +30,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -42,6 +43,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are meticulous.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -54,6 +56,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -19,6 +19,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -31,6 +32,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -43,6 +45,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -20,6 +20,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -32,6 +33,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -44,6 +46,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -528,6 +528,27 @@ describe("<personality> block", () => {
 	});
 });
 
+describe("<voice_examples> block", () => {
+	it("renders <voice_examples> block with the persona's three deterministic examples", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+
+		// Extract the voice_examples section content
+		const open = "<voice_examples>";
+		const close = "</voice_examples>";
+		const start = prompt.indexOf(open);
+		const end = prompt.indexOf(close, start);
+		expect(start).toBeGreaterThanOrEqual(0);
+		const sectionInner = prompt.slice(start + open.length, end).trim();
+
+		expect(sectionInner).toBe("- ex1-red\n- ex2-red\n- ex3-red");
+		// also confirm the other AIs' examples are NOT in red's prompt
+		expect(prompt).not.toContain("ex1-green");
+		expect(prompt).not.toContain("ex1-blue");
+	});
+});
+
 describe("<goal> block voice framing", () => {
 	it("<goal> block uses voice framing in phase 1", () => {
 		const game = startPhase(
@@ -649,6 +670,13 @@ describe("byte-identical sections across phases", () => {
 	it("<what_you_see> block is byte-identical across phase 1 and phase 2 (same world, same placements)", () => {
 		const { p1, p2 } = buildBothPrompts();
 		expect(getSection(p1, "what_you_see")).toBe(getSection(p2, "what_you_see"));
+	});
+
+	it("<voice_examples> block is byte-identical across phase 1 and phase 2", () => {
+		const { p1, p2 } = buildBothPrompts();
+		expect(getSection(p1, "voice_examples")).toBe(
+			getSection(p2, "voice_examples"),
+		);
 	});
 
 	it("phase-1 identity line differs from phase-2 identity line (disorientation present in phase 1 only)", () => {

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -38,6 +38,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -50,6 +51,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -62,6 +64,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -36,6 +36,7 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -48,6 +49,7 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -60,6 +62,7 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 

--- a/src/spa/game/llm-synthesis-provider.ts
+++ b/src/spa/game/llm-synthesis-provider.ts
@@ -36,7 +36,6 @@ When typing quirks are supplied for a persona, each voice example MUST follow th
 You MUST return ONLY valid JSON with this exact shape (no markdown, no preamble):
 {"personas": [{"id": "<input id>", "blurb": "<text>", "voiceExamples": ["<line>", "<line>", "<line>"]}, ...]}\n\nYou MUST echo the input id field verbatim. The array MUST contain exactly one entry per input persona, in any order.`;
 
-// TODO(#167): when typing quirks land, include `typingQuirk` per persona in this user-message payload so the synthesizer leans on it for voice examples.
 export function buildSynthesisUserMessage(
 	input: Array<{
 		id: string;

--- a/src/spa/game/llm-synthesis-provider.ts
+++ b/src/spa/game/llm-synthesis-provider.ts
@@ -36,6 +36,7 @@ When typing quirks are supplied for a persona, each voice example MUST follow th
 You MUST return ONLY valid JSON with this exact shape (no markdown, no preamble):
 {"personas": [{"id": "<input id>", "blurb": "<text>", "voiceExamples": ["<line>", "<line>", "<line>"]}, ...]}\n\nYou MUST echo the input id field verbatim. The array MUST contain exactly one entry per input persona, in any order.`;
 
+// TODO(#167): when typing quirks land, include `typingQuirk` per persona in this user-message payload so the synthesizer leans on it for voice examples.
 export function buildSynthesisUserMessage(
 	input: Array<{
 		id: string;

--- a/src/spa/game/llm-synthesis-provider.ts
+++ b/src/spa/game/llm-synthesis-provider.ts
@@ -14,7 +14,7 @@ import { CapHitError, chatCompletionJson } from "../llm-client.js";
 // ── Synthesis prompt ──────────────────────────────────────────────────────────
 
 export const SYNTHESIS_SYSTEM_PROMPT = `You MUST always respond in English. You MUST reason in English.
-You write AI personality blurbs for a text-based game. Given a list of personas, each with two temperaments and a persona goal, produce one blurb per persona.
+You write AI personality blurbs and voice examples for a text-based game. Given a list of personas, each with two temperaments and a persona goal, produce one blurb and exactly 3 voiceExamples per persona.
 
 Each blurb MUST:
 - Be 80–120 words long.
@@ -26,20 +26,31 @@ Each blurb MUST NEVER mention: the character's name, their color, a room, the wo
 When the two temperaments are different, you MUST frame their contradiction as productive tension — not a paradox to resolve.
 When the two temperaments are identical, you MUST intensify rather than repeat — treat it as an extreme, defining trait.
 
+Each persona MUST have exactly 3 voiceExamples entries.
+Each voice example MUST be exactly one sentence.
+Each voice example MUST NEVER mention: the character's name, their color, a room, the words "AI", "assistant", or any in-game meta concept.
+Each voice example MUST NEVER use a first-person pronoun to describe the persona's goal directly (don't say "I want to keep order" — say something the character would actually say in conversation).
+Voice examples MUST sound like in-character dialogue lines, not descriptions of the character.
+When typing quirks are supplied for a persona, each voice example MUST follow those quirks.
+
 You MUST return ONLY valid JSON with this exact shape (no markdown, no preamble):
-{"personas": [{"id": "<input id>", "blurb": "<text>"}, ...]}\n\nYou MUST echo the input id field verbatim. The array MUST contain exactly one entry per input persona, in any order.`;
+{"personas": [{"id": "<input id>", "blurb": "<text>", "voiceExamples": ["<line>", "<line>", "<line>"]}, ...]}\n\nYou MUST echo the input id field verbatim. The array MUST contain exactly one entry per input persona, in any order.`;
 
 export function buildSynthesisUserMessage(
 	input: Array<{
 		id: string;
 		temperaments: [string, string];
 		personaGoal: string;
+		typingQuirks?: [string, string];
 	}>,
 ): string {
-	const items = input.map(
-		(p) =>
-			`id: ${JSON.stringify(p.id)}, temperaments: [${JSON.stringify(p.temperaments[0])}, ${JSON.stringify(p.temperaments[1])}], personaGoal: ${JSON.stringify(p.personaGoal)}`,
-	);
+	const items = input.map((p) => {
+		let line = `id: ${JSON.stringify(p.id)}, temperaments: [${JSON.stringify(p.temperaments[0])}, ${JSON.stringify(p.temperaments[1])}], personaGoal: ${JSON.stringify(p.personaGoal)}`;
+		if (p.typingQuirks) {
+			line += `, typingQuirks: [${JSON.stringify(p.typingQuirks[0])}, ${JSON.stringify(p.typingQuirks[1])}]`;
+		}
+		return line;
+	});
 	return `Synthesize blurbs for these personas:\n${items.join("\n")}`;
 }
 
@@ -58,10 +69,11 @@ export interface SynthesisInput {
 	id: string;
 	temperaments: [string, string];
 	personaGoal: string;
+	typingQuirks?: [string, string];
 }
 
 export interface SynthesisResult {
-	personas: Array<{ id: string; blurb: string }>;
+	personas: Array<{ id: string; blurb: string; voiceExamples: string[] }>;
 }
 
 export interface LlmSynthesisProvider {
@@ -85,7 +97,8 @@ function validateResult(raw: unknown, inputIds: string[]): SynthesisResult {
 		);
 	}
 	const seen = new Set<string>();
-	const result: Array<{ id: string; blurb: string }> = [];
+	const result: Array<{ id: string; blurb: string; voiceExamples: string[] }> =
+		[];
 	for (const p of personas) {
 		if (p == null || typeof p !== "object") {
 			throw new SynthesisError("synthesis persona entry is not an object");
@@ -101,8 +114,29 @@ function validateResult(raw: unknown, inputIds: string[]): SynthesisResult {
 				`synthesis response contains unexpected id: ${entry.id}`,
 			);
 		}
+		if (!Array.isArray(entry.voiceExamples)) {
+			throw new SynthesisError(
+				"synthesis persona entry missing voiceExamples array",
+			);
+		}
+		if (entry.voiceExamples.length !== 3) {
+			throw new SynthesisError(
+				"synthesis persona entry voiceExamples must have length 3",
+			);
+		}
+		for (const ex of entry.voiceExamples as unknown[]) {
+			if (typeof ex !== "string" || ex.length === 0) {
+				throw new SynthesisError(
+					"synthesis persona entry voiceExamples contains non-string or empty entry",
+				);
+			}
+		}
 		seen.add(entry.id);
-		result.push({ id: entry.id, blurb: entry.blurb });
+		result.push({
+			id: entry.id,
+			blurb: entry.blurb,
+			voiceExamples: entry.voiceExamples as string[],
+		});
 	}
 	for (const id of inputIds) {
 		if (!seen.has(id)) {

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -23,6 +23,8 @@ export interface AiContext {
 	aiId: AiId;
 	blurb: string;
 	typingQuirks: [string, string];
+	/** Three short in-character utterances; rendered as `<voice_examples>` in the system prompt. */
+	voiceExamples: string[];
 	personaGoal: string;
 	goal: string;
 	setting: string;
@@ -66,6 +68,7 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 		aiId,
 		blurb: persona.blurb,
 		typingQuirks: persona.typingQuirks,
+		voiceExamples: persona.voiceExamples,
 		personaGoal: persona.personaGoal,
 		goal,
 		setting,
@@ -185,6 +188,17 @@ function renderSystemPrompt(ctx: AiContext): string {
 	lines.push(ctx.typingQuirks[0]);
 	lines.push(ctx.typingQuirks[1]);
 	lines.push("</typing_quirks>");
+	lines.push("");
+
+	// Voice examples — byte-identical across phases. 3 short utterances per persona.
+	// Per the GLM-4.7 prompting guide (docs/prompting/glm-4.7-guide.md §1.4 #2),
+	// few-shot voice examples are the highest-ROI part of a multi-character prompt.
+	// Each example MUST adhere to the persona's typing quirk.
+	lines.push("<voice_examples>");
+	for (const ex of ctx.voiceExamples) {
+		lines.push(`- ${ex}`);
+	}
+	lines.push("</voice_examples>");
 	lines.push("");
 
 	// Goal — voice framing in all phases.

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -12,6 +12,12 @@ export interface AiPersona {
 	personaGoal: string;
 	typingQuirks: [string, string];
 	blurb: string;
+	/**
+	 * Three short, single-sentence in-character utterances synthesized alongside
+	 * the blurb. Rendered into the `<voice_examples>` block in the system prompt.
+	 * Length is exactly 3.
+	 */
+	voiceExamples: string[];
 }
 
 export type WorldEntityKind =

--- a/src/spa/persistence/__tests__/game-storage.test.ts
+++ b/src/spa/persistence/__tests__/game-storage.test.ts
@@ -20,6 +20,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You lean on em-dashes — interrupting yourself mid-sentence — and rarely use commas where a dash would do.",
 		],
 		blurb: "You are hot-headed and zealous. Hold the flower at phase end.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
 	},
 	green: {
 		id: "green",
@@ -32,6 +33,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You use ALL-CAPS to emphasize the one or two words that MATTER in any given sentence.",
 		],
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
 	blue: {
 		id: "blue",
@@ -44,6 +46,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
 	},
 };
 


### PR DESCRIPTION
## What this fixes

Per the GLM-4.7 prompting guide, few-shot example utterances per character are the single highest-ROI part of a multi-persona system prompt — far more effective than prose blurbs at stabilizing voice. Today daemons only carry a synthesized `<personality>` blurb, so on long sessions their voices drift toward a shared house style.

This change extends the one-shot persona-synthesis call so it returns three short in-character utterances per persona alongside the blurb, and renders them as a `<voice_examples>` block in each daemon's system prompt — between `<typing_quirks>` and `<goal>`, byte-identical across phases (so the cache key holds).

Shape:

- `AiPersona.voiceExamples: string[]` (length 3, required) added to `src/spa/game/types.ts`.
- `SynthesisResult` extended with `voiceExamples` per persona; `validateSynthesisOutput` in `src/spa/game/llm-synthesis-provider.ts` rejects missing/wrong-length/non-string/empty-string entries.
- `SYNTHESIS_SYSTEM_PROMPT` requests 3 single-sentence examples per persona with the same name/color/room/meta prohibitions as the blurb plus a "no first-person goal recitation" rule, and (now that #176 has landed) requires examples to follow the persona's typing quirks.
- `prompt-builder.ts` renders the `<voice_examples>` block immediately after `<typing_quirks>` and before `<goal>` as bullet lines (`- <utterance>`).
- `persona-generator.ts` plumbs the field through both the LLM synthesis path and a deterministic offline-fallback path (`buildFallbackVoiceExamples`). Typing quirks now flow into `SynthesisInput` end-to-end so the synthesizer leans on them when composing voice examples.
- E2E synthesis stubs (`e2e/helpers/stubs.ts` + the inline stub in `e2e/diagnose-streaming.spec.ts`) updated to emit `voiceExamples` so the strict validator doesn't trip the new-game lockout.

Rebased onto current `main` after #176 (typing quirks) and #175 (drop `budgetPerPhase`) landed; the TODO(#167) hooks the original commit added are now obsolete and have been removed in favour of real wiring.

## QA steps for the human

None required — fully covered by the automated suite (unit + Playwright). If you want to spot-check by eye: open a fresh game and inspect a daemon's rendered system prompt; you should see a `<voice_examples>` block with three bullet lines between `<typing_quirks>` and `<goal>`.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 866/866 (new tests cover validation rejections, `<voice_examples>` block content, byte-identical-across-phases, mock-synthesis plumbing)
- `pnpm lint` — clean (only pre-existing CSS warnings)
- `pnpm smoke -- e2e/diagnose-streaming.spec.ts` — passes (was the regression caught and fixed during smoke)

Closes #168