### PR TITLE
e2e: addressed-and-parallel asserts player line preserves leading mention, but SPA strips it

### DIFF
--- a/e2e/addressed-and-parallel.spec.ts
+++ b/e2e/addressed-and-parallel.spec.ts
@@ -68,14 +68,18 @@ test("addressed message lands only on first panel; all three panels render progr
 		.locator(`[data-transcript="${ids[2]}"]`)
 		.textContent();
 
-	// player message appears in first transcript exactly once.
-	expect(firstTranscript ?? "").toContain(`> *${names[0]} hello first panel`);
+	// Player message appears in the first transcript exactly once. The SPA's
+	// form-submit handler strips the leading `*<handle>` mention before
+	// rendering the player line (see `src/spa/routes/game.ts`: "Append the
+	// (mention-stripped) player message to the addressed panel."), so the
+	// assertion checks for the stripped body, not the original input.
+	expect(firstTranscript ?? "").toContain("> hello first panel");
 	// Exactly once: splitting on the player prefix gives exactly two parts.
-	expect((firstTranscript ?? "").split(`> *${names[0]} hello`).length).toBe(2);
+	expect((firstTranscript ?? "").split("> hello first panel").length).toBe(2);
 
 	// second and third do NOT contain the player line.
-	expect(secondTranscript ?? "").not.toContain(`> *${names[0]} hello`);
-	expect(thirdTranscript ?? "").not.toContain(`> *${names[0]} hello`);
+	expect(secondTranscript ?? "").not.toContain("> hello first panel");
+	expect(thirdTranscript ?? "").not.toContain("> hello first panel");
 
 	// Each distinct completion appears in exactly one transcript.
 	const transcripts = [


### PR DESCRIPTION
## What this fixes

`e2e/addressed-and-parallel.spec.ts` was asserting that the player line in
the addressed transcript preserves its leading `*<handle>` mention
(`> *${names[0]} hello first panel`). This contradicted the SPA's
intentional behaviour: the form-submit handler in `src/spa/routes/game.ts`
explicitly strips a leading mention before rendering the player line
(comment in source: "Append the (mention-stripped) player message to the
addressed panel.").

This PR applies Option 1 from the issue (the smaller fix matching SPA
intent): update the spec assertions to expect the stripped player line
(`> hello first panel`). The SPA itself is unchanged.

Changes are confined to four lines in
`e2e/addressed-and-parallel.spec.ts`:
- `toContain` now checks `"> hello first panel"`.
- The split-count assertion now splits on `"> hello first panel"`.
- The two negative `not.toContain` checks for the second/third panels now
  use `"> hello first panel"`.

A short comment was added explaining why the assertion uses the stripped
form so future readers don't reintroduce the original bug.

Note: the workflow instructions specified a base branch of
`claude/ralph-one-parallel-worktrees-8SuAW`, but that branch does not
exist on the remote. `main` is at the same commit SHA
(`8880a3acafb5905c1c42af29699c9f954cf86ee6`) as the documented parent of
this work, so this PR targets `main` instead.

## QA steps for the human

1. Check out this branch and `pnpm install --frozen-lockfile` if needed.
2. `pnpm typecheck` — should pass.
3. `pnpm smoke -- e2e/addressed-and-parallel.spec.ts` — should pass
   (verified: 1 passed in ~20s on this branch).
4. Optional sanity: `grep -n "hello first panel" e2e/` confirms the
   string only appears in this spec, so no other e2e specs are affected.

## Automated coverage

The fixed assertion is exercised by the existing test
`addressed message lands only on first panel; all three panels render
progressively` in `e2e/addressed-and-parallel.spec.ts:12`, which now
passes locally under `pnpm smoke`.

Closes #182

---
_Generated by [Claude Code](https://claude.ai/code/session_015a8i9c7TbQnABFz6nrjpuT)_