### PR TITLE
e2e: responsive-bento panel-name regex still references retired @ mention syntax

### DIFF
--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -100,7 +100,7 @@ test("strip-card label: panel-name renders on the TOP edge, not the bottom", asy
 		if (!l) throw new Error(`no label probe for index ${idx}`);
 		expect(l.addressed).toBe(false);
 		expect(l.topVisible).toBe(true);
-		expect(l.topText).toMatch(/^\*\S+ :: @\S+$/);
+		expect(l.topText).toMatch(/^\*\S+$/);
 		expect(l.botVisible).toBe(false);
 	}
 
@@ -110,7 +110,7 @@ test("strip-card label: panel-name renders on the TOP edge, not the bottom", asy
 	expect(main.addressed).toBe(true);
 	expect(main.topVisible).toBe(false);
 	expect(main.botVisible).toBe(true);
-	expect(main.botText).toMatch(/^\*\S+ :: @\S+$/);
+	expect(main.botText).toMatch(/^\*\S+$/);
 });
 
 test("strip-card preview: latest line visible + per-line ellipsis", async ({


### PR DESCRIPTION
## Summary

Fixes the two `panel-name` regex assertions in `e2e/responsive-bento.spec.ts` that still expected the pre-#161 `*Primary :: @Alias` display format. PR #161 ("Switch daemon mention syntax from @ to *") simplified the panel label to just `*<name>` — no addressee suffix is rendered.

## Root cause

`src/spa/bbs-chrome.ts#initPanelChrome` writes ``label = `*${persona.name}` `` into every `.panel-name` element and never appends a `:: ...` segment. The e2e regex `/^\*\S+ :: @\S+$/` therefore never matches; the test received `*` (truncated by the failing match attempt against actual content like `*Ember`).

## Fix

Drop the `:: @\S+` segment from both regexes:

- line 103: `expect(l.topText).toMatch(/^\*\S+$/)` (strip-card top label)
- line 113: `expect(main.botText).toMatch(/^\*\S+$/)` (main panel bottom label)

No SPA code changed.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm smoke -- e2e/responsive-bento.spec.ts -g "panel-name"` — target test "strip-card label: panel-name renders on the TOP edge, not the bottom" passes
- [x] `pnpm smoke -- e2e/responsive-bento.spec.ts` — 5 of 6 pass; only the unrelated `restored multi-line AI message stays in one msg-line` test still fails

## Out of scope / deferred

The test `strip-card preview: restored multi-line AI message stays in one msg-line` (line 232) still fails — that's tracked as **issue #185** and a sibling agent is held back from this file until this PR merges. Not addressed here.

## Note on base branch

Workflow spec named base as `claude/ralph-one-parallel-worktrees-8SuAW`, but that branch does not exist on the remote. `main` is at the same SHA (`8880a3a`) the worktree forked from, so PR is opened against `main`.

Closes #184

---
_Generated by [Claude Code](https://claude.ai/code/session_015a8i9c7TbQnABFz6nrjpuT)_