### PR TITLE
e2e: cents-live-smoke deliberately unstubbed; needs real OPENROUTER_API_KEY

### DIFF
--- a/e2e/cents-live-smoke.spec.ts
+++ b/e2e/cents-live-smoke.spec.ts
@@ -18,13 +18,20 @@ test.use({ ignoreHTTPSErrors: true });
  *   3. AI's own system prompt (server-rendered text) is not asserted here —
  *      we only smoke the user-visible flow.
  *
- * Skipped unless OPENROUTER_API_KEY is set in the environment.
+ * Skipped unless OPENROUTER_API_KEY is set in the environment to a real
+ * credential (the playwright webServer injects the placeholder "test-key" by
+ * default, which cannot reach OpenRouter and would only cause this test to
+ * time out).
  */
 test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", async ({
 	page,
 }) => {
 	const apiKey = process.env.OPENROUTER_API_KEY;
-	test.skip(!apiKey, "OPENROUTER_API_KEY not set — skipping live smoke");
+	const hasRealKey = !!apiKey && apiKey !== "test-key";
+	test.skip(
+		!hasRealKey,
+		"OPENROUTER_API_KEY not set (or is the placeholder 'test-key') — skipping live smoke; set a real OpenRouter key to run this test",
+	);
 
 	test.setTimeout(180_000);
 


### PR DESCRIPTION
## Summary

The `e2e/cents-live-smoke.spec.ts` test is a deliberately-unstubbed live smoke that exercises the real OpenRouter `usage.cost` flow. The Playwright webServer config injects `OPENROUTER_API_KEY=test-key`, which causes the synthesis call to fail, BEGIN never enables, and the test times out under the default `pnpm smoke`.

This PR (Option 1 from the issue — smallest change) tightens the existing `test.skip()` gate so the spec is also skipped when `OPENROUTER_API_KEY` is the placeholder string `"test-key"` (not just when unset). The skip message is human-readable so CI output makes the cause obvious.

The spec remains available for opt-in live runs: set a real (non-placeholder) `OPENROUTER_API_KEY` and re-run `pnpm smoke` (or target just this spec).

> Note: the requested PR base `claude/ralph-one-parallel-worktrees-8SuAW` does not exist on the remote, so this PR targets `main` instead. Retarget if needed.

Closes #186

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm smoke -- e2e/cents-live-smoke.spec.ts` reports `1 skipped` when `OPENROUTER_API_KEY=test-key` (the default test environment)
- [x] `pnpm smoke -- e2e/cents-live-smoke.spec.ts` reports `1 skipped` when `OPENROUTER_API_KEY` is unset
- [ ] QA: with a real (non-placeholder) `OPENROUTER_API_KEY` exported in the shell, `pnpm smoke -- e2e/cents-live-smoke.spec.ts` should actually run the test against OpenRouter (live BYOK flow). Out of scope for this PR's automated verification.

## Notes

Other `pnpm smoke` failures (issues #182/#183/#184/#185) are pre-existing and out of scope here; this change only stops `cents-live-smoke` from blocking the default smoke run.

---
_Generated by [Claude Code](https://claude.ai/code/session_015a8i9c7TbQnABFz6nrjpuT)_