### PR TITLE
e2e: mention-addressing asserts player line preserves leading mention, but SPA strips it

### DIFF
--- a/e2e/mention-addressing.spec.ts
+++ b/e2e/mention-addressing.spec.ts
@@ -69,10 +69,12 @@ test("typing '*<ai1> hi' enables Send and submits to that transcript only", asyn
 		.locator(`[data-transcript="${ids[2]}"]`)
 		.textContent();
 
-	// player message appears only in addressed panel.
-	expect(addressedTranscript ?? "").toContain(`> *${names[1]} hi`);
-	expect(otherTranscript0 ?? "").not.toContain(`> *${names[1]}`);
-	expect(otherTranscript2 ?? "").not.toContain(`> *${names[1]}`);
+	// player message appears only in addressed panel. The SPA strips the
+	// leading `*<name>` mention from the rendered player line (see
+	// src/spa/routes/game.ts), so the displayed form is `> hi`.
+	expect(addressedTranscript ?? "").toContain("> hi");
+	expect(otherTranscript0 ?? "").not.toContain("> hi");
+	expect(otherTranscript2 ?? "").not.toContain("> hi");
 
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });


### PR DESCRIPTION
## What this fixes

`e2e/mention-addressing.spec.ts:73` was asserting that the rendered
player line preserves the leading `*<name>` mention:

```ts
expect(addressedTranscript ?? "").toContain(`> *${names[1]} hi`);
```

The SPA (`src/spa/routes/game.ts`, see the comment around line 794
"Strip a leading *DaemonName mention…") strips the leading mention
before appending the player line, so the rendered form is `> hi`.
The assertion never matched and the test failed with
`Received: "> hi"` followed by the AI's reply.

This PR is test-only — it does not modify the SPA. Specifically:

- Change the addressed-transcript assertion to `toContain("> hi")`
  (the stripped form the SPA actually renders).
- Update the sibling `not.toContain` checks for the other two
  transcripts to use the same stripped form, preserving the
  cross-panel isolation guarantee (the player line still appears in
  exactly one panel — the addressed one).
- Add a short comment explaining why the assertion uses the stripped
  form so future readers don't reintroduce the bug.

The `*${names[1]}` mention is still typed into the composer at line 46
to drive addressing, so the test still exercises the mention parser;
only the post-strip rendered form changes.

Note: the workflow instructions specified a base branch of
`claude/ralph-one-parallel-worktrees-8SuAW`, but that branch does not
exist on the remote. `main` is at the same commit SHA
(`8880a3acafb5905c1c42af29699c9f954cf86ee6`) as the documented parent,
so this PR targets `main` instead — same approach as sibling PR #187.

## QA steps for the human

- `pnpm install --frozen-lockfile`
- `pnpm typecheck` (passes)
- `pnpm smoke -- e2e/mention-addressing.spec.ts` — all 4 tests pass
  locally (~5s); previously test 4 failed at line 73.

## Automated coverage

The updated assertions still validate:
1. Send is enabled when typing `*<name> hi`.
2. The addressed panel receives a player line containing `> hi`.
3. The two non-addressed panels do **not** receive `> hi`,
   confirming addressing isolation.
4. No page errors during the round.

## Scope

Strictly scoped to `e2e/mention-addressing.spec.ts`. Does **not**
touch `e2e/addressed-and-parallel.spec.ts` (sibling agent's territory
for #182, PR #187) or `src/spa/routes/game.ts`.

Closes #183

---
_Generated by [Claude Code](https://claude.ai/code/session_015a8i9c7TbQnABFz6nrjpuT)_