### PR TITLE
e2e: responsive-bento expects restored multi-line AI message in single msg-line; got zero lines

### DIFF
--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -245,17 +245,29 @@ test("strip-card preview: restored multi-line AI message stays in one msg-line",
 	await page.locator("#send").click();
 	const transcript0 = page.locator(`[data-transcript="${handles.ids[0]}"]`);
 	await expect(transcript0).toContainText("third");
-	// Wait for the save to land in localStorage.
-	// Post-#172: poll for engine.dat commit signal (written last in strict order).
+	// Wait for the round-end save to land in localStorage. engine.dat already
+	// exists from the initial start-save (round=0, empty chatHistories), so
+	// polling for its mere presence races the round-end save. Instead, poll
+	// the addressed AI's daemon file until phase-1 chatHistory has at least
+	// one entry — that pins the AI response into the persisted shape.
 	await page.waitForFunction(
-		() => {
+		(addressedAiId) => {
 			const sessionId = localStorage.getItem("hi-blue:active-session");
 			if (!sessionId) return false;
-			return (
-				localStorage.getItem(`hi-blue:sessions/${sessionId}/engine.dat`) !==
-				null
+			const daemonRaw = localStorage.getItem(
+				`hi-blue:sessions/${sessionId}/${addressedAiId}.txt`,
 			);
+			if (!daemonRaw) return false;
+			try {
+				const daemon = JSON.parse(daemonRaw) as {
+					phases?: { "1"?: { chatHistory?: unknown[] } };
+				};
+				return (daemon.phases?.["1"]?.chatHistory?.length ?? 0) > 0;
+			} catch {
+				return false;
+			}
 		},
+		handles.ids[0],
 		{ timeout: 15_000 },
 	);
 


### PR DESCRIPTION
## What this fixes

`e2e/responsive-bento.spec.ts` — `strip-card preview: restored multi-line AI message stays in one msg-line` was failing with `aiLineCount` `0` (expected `1`) after a reload.

**Root cause: test-side bug, not a SPA regression.**

The test polled localStorage for the mere presence of `engine.dat` as its "save landed" gate. But `engine.dat` is also written on game start (`round: 0`, empty `chatHistories`) by `start.ts:saveActiveSession(session.getState())`. The gate therefore flipped to `true` the instant the player landed on `#/game`, well before the round-end save in `routes/game.ts:1137` had a chance to persist the AI's response.

Verified by dumping localStorage before the reload: every daemon `.txt` had `phases."1".chatHistory: []`. With nothing in `chatHistories[aiId]`, the restore branch in `routes/game.ts` (`if ((restoredPhase.chatHistories[aiId]?.length ?? 0) > 0)`) skipped the panel entirely, so no `.msg-line` was ever appended — hence `aiLineCount === 0`.

## Fix

Poll the **addressed AI's daemon `.txt`** for a non-empty phase-1 `chatHistory` instead of checking that `engine.dat` exists. That file only gains a chat entry once the round-end save commits — pinning the AI response into the persisted shape before reload.

## QA steps for the human

- `pnpm typecheck` — clean
- `pnpm smoke -- e2e/responsive-bento.spec.ts -g "restored multi-line AI message"` — passes (was failing on `main`)
- `pnpm smoke -- e2e/responsive-bento.spec.ts` — full file 6/6 passing
- The sibling streamed-tokens test (`:312`) was already passing and is unaffected — it covers the live-render path; this fix repairs the reload-render path's harness.

## Automated coverage

The Playwright integration test itself is now the regression pin (its previous gate was a false positive that masked any later regression in the round-end save path). No new unit test was added: the SPA persistence and `renderRestoredTranscript` paths are not changed; existing Vitest coverage for `loadActiveSession` / `saveActiveSession` / `chatHistories` round-trip already pins those contracts (`src/spa/persistence/__tests__/session-storage.test.ts`, `session-codec.test.ts`, `game-storage.test.ts`).

Closes #185

---
_Generated by [Claude Code](https://claude.ai/code/session_015a8i9c7TbQnABFz6nrjpuT)_