### PR TITLE
feat(start): CRT dial-up login screen with password gate

### DIFF
--- a/e2e/cents-live-smoke.spec.ts
+++ b/e2e/cents-live-smoke.spec.ts
@@ -46,12 +46,13 @@ test("live: per-AI budget decrements in cents from real OpenRouter usage.cost", 
 	// Navigate to the root — the start screen will appear first since there
 	// is no active session. Real LLM calls (synthesis + content-pack) will run
 	// using the injected BYOK key.
-	await page.goto("/");
+	await page.goto("/?skipDialup=1");
 
 	// Wait for the start screen's generation to complete (real synthesis call).
 	await expect(page.locator("#begin")).toBeEnabled({ timeout: 120_000 });
 
-	// Click BEGIN to proceed to the game.
+	// Enter the password and click CONNECT to proceed to the game.
+	await page.locator("#password").fill("password");
 	await page.locator("#begin").click();
 	await page.waitForURL(/.*#\/game/, { timeout: 30_000 });
 

--- a/e2e/diagnose-streaming.spec.ts
+++ b/e2e/diagnose-streaming.spec.ts
@@ -277,12 +277,13 @@ test("DIAGNOSTIC: observe wire vs DOM timeline during streaming", async ({
 		{ chunkSets: CHUNKS_PER_AI, intervalMs: CHUNK_INTERVAL_MS },
 	);
 
-	await page.goto("/");
+	await page.goto("/?skipDialup=1");
 
-	// Wait for the start screen's generation to complete, then click BEGIN.
+	// Wait for the start screen's generation to complete, then click CONNECT.
 	// The addInitScript monkey-patch handles synthesis and content-pack JSON-mode
-	// calls, so generation should complete and enable the BEGIN button.
+	// calls, so generation should complete and enable the CONNECT button.
 	await expect(page.locator("#begin")).toBeEnabled({ timeout: 30_000 });
+	await page.locator("#password").fill("password");
 	await page.locator("#begin").click();
 	await page.waitForURL(/.*#\/game/, { timeout: 10_000 });
 

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -368,11 +368,13 @@ export type GoToGameOptions = {
  *
  * Steps:
  *  a. Stubs all new-game LLM calls (synthesis, content-pack, SSE) via `stubNewGameLLM`.
- *  b. `await page.goto(opts.url ?? "/")`
- *  c. Waits for `#begin` to be enabled (generation complete).
- *  d. Clicks `#begin`.
- *  e. Waits for `#/game` URL and `#composer` visibility.
- *  f. Returns AiHandles from `getAiHandles(page)`.
+ *  b. `await page.goto(opts.url ?? "/?skipDialup=1")` — the default skips the
+ *     dial-up animation so the login form appears immediately.
+ *  c. Waits for `#begin` (CONNECT) to be enabled (generation complete).
+ *  d. Fills `#password` with the accepted password.
+ *  e. Clicks `#begin`.
+ *  f. Waits for `#/game` URL and `#composer` visibility.
+ *  g. Returns AiHandles from `getAiHandles(page)`.
  *
  * Specs that test the start-screen path itself should NOT use this helper —
  * they should navigate to `"/"` directly and exercise start-screen behaviour.
@@ -383,10 +385,18 @@ export async function goToGame(
 ): Promise<AiHandles> {
 	const sse = opts?.sse ?? ["stub reply"];
 	await stubNewGameLLM(page, { sse, synthesis: opts?.synthesis });
-	await page.goto(opts?.url ?? "/");
+	await page.goto(withSkipDialup(opts?.url ?? "/"));
 	await expect(page.locator("#begin")).toBeEnabled({ timeout: 30_000 });
+	await page.locator("#password").fill("password");
 	await page.locator("#begin").click();
 	await page.waitForURL(/.*#\/game/, { timeout: 10_000 });
 	await expect(page.locator("#composer")).toBeVisible();
 	return getAiHandles(page);
+}
+
+/** Append `skipDialup=1` to the URL's query string if it's not already present. */
+function withSkipDialup(url: string): string {
+	if (/[?&]skipDialup=/.test(url)) return url;
+	const sep = url.includes("?") ? "&" : "?";
+	return `${url}${sep}skipDialup=1`;
 }

--- a/e2e/start-screen.spec.ts
+++ b/e2e/start-screen.spec.ts
@@ -86,13 +86,14 @@ test("clicking [ BEGIN ] navigates to #/game and shows panels", async ({
 	// Stub both generation and subsequent gameplay LLM calls
 	await stubNewGameLLM(page, { sse: ["stub reply"] });
 
-	await page.goto("/");
+	await page.goto("/?skipDialup=1");
 
-	// Wait for [ BEGIN ] to be enabled
+	// Wait for [ CONNECT ] to be enabled
 	const beginBtn = page.locator("#begin");
 	await expect(beginBtn).toBeEnabled({ timeout: 30_000 });
 
-	// Click BEGIN
+	// Enter the password and click CONNECT
+	await page.locator("#password").fill("password");
 	await beginBtn.click();
 
 	// Should navigate to #/game
@@ -119,11 +120,12 @@ test("refreshing on #/game with an active session stays on #/game (no redirect t
 	// Stub all LLM calls
 	await stubNewGameLLM(page, { sse: ["stub reply"] });
 
-	await page.goto("/");
+	await page.goto("/?skipDialup=1");
 
-	// Complete the new-game flow: wait for BEGIN and click it
+	// Complete the new-game flow: wait for CONNECT, fill password, click
 	const beginBtn = page.locator("#begin");
 	await expect(beginBtn).toBeEnabled({ timeout: 30_000 });
+	await page.locator("#password").fill("password");
 	await beginBtn.click();
 	await page.waitForURL(/.*#\/game/, { timeout: 10_000 });
 

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -37,8 +37,19 @@ vi.mock("../../content/content-pack-generator", () => ({
 const INDEX_BODY_HTML = `
 <main>
   <section id="start-screen" hidden>
-    <p class="start-placeholder">initialising daemon mesh&hellip;</p>
-    <button id="begin" type="button" disabled>[ BEGIN ]</button>
+    <pre id="dial" class="dial"></pre>
+    <div id="login-reveal" class="login-reveal" hidden>
+      <pre id="login-keyart" class="login-keyart"></pre>
+      <form id="login-form" autocomplete="off">
+        <div class="login-field">
+          <label for="password">password:</label>
+          <input id="password" type="text" autocomplete="off" data-real="" />
+          <button id="begin" class="login-connect" type="submit" disabled>[ CONNECT ]</button>
+        </div>
+        <output id="login-error" hidden></output>
+      </form>
+      <pre id="login-postlog" class="dial"></pre>
+    </div>
   </section>
   <div id="panels" class="row">
     <article class="ai-panel" data-ai="red">
@@ -133,7 +144,7 @@ describe("renderStart — screen visibility", () => {
 		const { renderStart } = await import("../routes/start.js");
 
 		try {
-			await renderStart(getMain(), new URLSearchParams());
+			await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
 		} catch {
 			// generation may reject in test environment — ok
 		}
@@ -171,7 +182,10 @@ describe("renderStart — BEGIN button state", () => {
 		// renderStart kicks off generation and returns a promise. Before the
 		// promise settles, BEGIN must be disabled. We check the synchronous
 		// post-mount state by starting the render but not awaiting it yet.
-		const renderPromise = renderStart(getMain(), new URLSearchParams());
+		const renderPromise = renderStart(
+			getMain(),
+			new URLSearchParams("skipDialup=1"),
+		);
 
 		// Immediately after mount (generation promise is in flight), BEGIN is disabled
 		const beginBtn = document.querySelector<HTMLButtonElement>("#begin");
@@ -191,7 +205,7 @@ describe("renderStart — BEGIN button state", () => {
 		vi.resetModules();
 		const { renderStart } = await import("../routes/start.js");
 
-		await renderStart(getMain(), new URLSearchParams());
+		await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
 
 		const beginBtn = document.querySelector<HTMLButtonElement>("#begin");
 		expect(beginBtn?.disabled).toBe(false);
@@ -218,10 +232,13 @@ describe("renderStart — BEGIN click saves session and navigates", () => {
 		vi.resetModules();
 		const { renderStart } = await import("../routes/start.js");
 
-		await renderStart(getMain(), new URLSearchParams());
+		await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
 
 		const beginBtn = document.querySelector<HTMLButtonElement>("#begin");
 		expect(beginBtn?.disabled).toBe(false);
+
+		const pwEl = document.querySelector<HTMLInputElement>("#password");
+		if (pwEl) pwEl.dataset.real = "password";
 
 		// Click BEGIN — start.ts will call saveActiveSession then set location.hash
 		beginBtn?.click();
@@ -235,14 +252,43 @@ describe("renderStart — BEGIN click saves session and navigates", () => {
 		vi.resetModules();
 		const { renderStart } = await import("../routes/start.js");
 
-		await renderStart(getMain(), new URLSearchParams());
+		await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
 
 		const beginBtn = document.querySelector<HTMLButtonElement>("#begin");
+		const pwEl = document.querySelector<HTMLInputElement>("#password");
+		if (pwEl) pwEl.dataset.real = "password";
 		beginBtn?.click();
 		beginBtn?.click();
 
 		// After first click, _beginClickPending=true and btn.disabled=true; second is no-op.
 		expect(beginBtn?.disabled).toBe(true);
+	});
+
+	it("CONNECT click with wrong password shows inline error and does not navigate", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderStart } = await import("../routes/start.js");
+
+		await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
+
+		const beginBtn = document.querySelector<HTMLButtonElement>("#begin");
+		const pwEl = document.querySelector<HTMLInputElement>("#password");
+		const errorEl = document.querySelector<HTMLElement>("#login-error");
+
+		// Wrong password — directly setting dataset.real bypasses the masking listener,
+		// which is fine because the gate reads dataset.real.
+		if (pwEl) pwEl.dataset.real = "wrong";
+
+		const hashBefore = location.hash;
+		beginBtn?.click();
+
+		// Hash didn't change → did not navigate.
+		expect(location.hash).toBe(hashBefore);
+		// Error revealed and CONNECT remains enabled for retry.
+		expect(errorEl?.hasAttribute("hidden")).toBe(false);
+		expect(errorEl?.textContent).toContain("access denied");
+		expect(beginBtn?.disabled).toBe(false);
 	});
 });
 
@@ -286,7 +332,7 @@ describe("renderStart — CapHitError handling", () => {
 		const { renderStart } = await import("../routes/start.js");
 
 		try {
-			await renderStart(getMain(), new URLSearchParams());
+			await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
 		} catch {
 			// renderStart re-throws generation errors — expected
 		}
@@ -319,7 +365,10 @@ describe("renderStart — persistence warning banners", () => {
 		const { renderStart } = await import("../routes/start.js");
 
 		try {
-			await renderStart(getMain(), new URLSearchParams("reason=broken"));
+			await renderStart(
+				getMain(),
+				new URLSearchParams("reason=broken&skipDialup=1"),
+			);
 		} catch {
 			// ok
 		}
@@ -341,7 +390,7 @@ describe("renderStart — persistence warning banners", () => {
 		try {
 			await renderStart(
 				getMain(),
-				new URLSearchParams("reason=version-mismatch"),
+				new URLSearchParams("reason=version-mismatch&skipDialup=1"),
 			);
 		} catch {
 			// ok
@@ -364,7 +413,7 @@ describe("renderStart — persistence warning banners", () => {
 		try {
 			await renderStart(
 				getMain(),
-				new URLSearchParams("reason=legacy-save-discarded"),
+				new URLSearchParams("reason=legacy-save-discarded&skipDialup=1"),
 			);
 		} catch {
 			// ok
@@ -385,7 +434,7 @@ describe("renderStart — persistence warning banners", () => {
 		const { renderStart } = await import("../routes/start.js");
 
 		try {
-			await renderStart(getMain(), new URLSearchParams());
+			await renderStart(getMain(), new URLSearchParams("skipDialup=1"));
 		} catch {
 			// ok
 		}
@@ -404,7 +453,7 @@ describe("renderStart — persistence warning banners", () => {
 		try {
 			await renderStart(
 				getMain(),
-				new URLSearchParams("reason=totally-unknown"),
+				new URLSearchParams("reason=totally-unknown&skipDialup=1"),
 			);
 		} catch {
 			// ok

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -25,8 +25,55 @@
 			</div>
 			<main>
 				<section id="start-screen" hidden>
-					<p class="start-placeholder">initialising daemon mesh&hellip;</p>
-					<button id="begin" type="button" disabled>[ BEGIN ]</button>
+					<pre id="dial" class="dial" aria-hidden="true"></pre>
+					<div id="login-reveal" class="login-reveal" hidden>
+						<pre class="banner-login banner-login-full" aria-hidden="true">   ██╗  ██╗██╗      <span class="banner-blue">██████╗ ██╗     ██╗   ██╗███████╗</span>
+   ██║  ██║██║      <span class="banner-blue">██╔══██╗██║     ██║   ██║██╔════╝</span>
+   ███████║██║█████╗<span class="banner-blue">██████╔╝██║     ██║   ██║█████╗  </span>
+   ██╔══██║██║╚════╝<span class="banner-blue">██╔══██╗██║     ██║   ██║██╔══╝  </span>
+   ██║  ██║██║      <span class="banner-blue">██████╔╝███████╗╚██████╔╝███████╗</span>
+   ╚═╝  ╚═╝╚═╝      <span class="banner-blue">╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝</span></pre>
+						<pre class="banner-login banner-login-mini" aria-hidden="true"> ██╗  ██╗██╗ ▄▄ <span class="banner-blue">██████╗ ██╗    ██╗   ██╗███████╗</span>
+ ██║  ██║██║    <span class="banner-blue">██╔══██╗██║    ██║   ██║██╔════╝</span>
+ ███████║██║▄▄▄▄<span class="banner-blue">██████╔╝██║    ██║   ██║█████╗  </span>
+ ██╔══██║██║    <span class="banner-blue">██╔══██╗██║    ██║   ██║██╔══╝  </span>
+ ██║  ██║██║    <span class="banner-blue">██████╔╝███████╗╚█████╔╝███████╗</span>
+ ╚═╝  ╚═╝╚═╝    <span class="banner-blue">╚═════╝ ╚══════╝ ╚════╝ ╚══════╝</span></pre>
+						<div class="login-tag">// <b class="banner-blue">blue</b>'s personal bbs · est <b>1996</b> · running on a <b>486</b> in a closet</div>
+						<div class="login-rule" aria-hidden="true">─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</div>
+						<div class="login-sysinfo">
+							<div class="row"><span class="k">sysop</span> <b class="banner-blue">blue</b></div>
+							<div class="row"><span class="k">node</span> <span>01/01</span></div>
+							<div class="row"><span class="k">visits</span> <span>1,247</span></div>
+							<div class="row"><span class="k">in chat</span> <span>3 daemons</span></div>
+							<div class="row"><span class="k">location</span> <span>cold storage</span></div>
+							<div class="row"><span class="k">uptime</span> <span>11d 04h 22m</span></div>
+						</div>
+						<div class="login-rule" aria-hidden="true">─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</div>
+						<div class="login-frame">
+							<div class="login-frame-brow"><span>┌──[ </span><span>last visit</span><span> ]──</span><span class="fill">─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</span><span class="corner-r">┐</span></div>
+							<div class="login-frame-body">
+								<span class="side">│
+│
+│</span>
+								<div class="inner"><span class="who">02:14</span> prior · <span class="banner-blue">&gt; @blue</span> <span class="dim">well, what do we have here?</span></div>
+								<span class="side">│
+│
+│</span>
+							</div>
+							<div class="login-frame-brow"><span>└</span><span class="fill">──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</span><span class="corner-r">┘</span></div>
+						</div>
+						<pre id="login-keyart" class="login-keyart" aria-hidden="true"></pre>
+						<form id="login-form" class="login-form" autocomplete="off">
+							<div class="login-field">
+								<label class="lbl" for="password">password:</label>
+								<input id="password" type="text" maxlength="32" autocomplete="off" spellcheck="false" data-real="" />
+								<button id="begin" class="login-connect" type="submit" disabled>[ CONNECT ]</button>
+							</div>
+							<output id="login-error" class="login-error" role="status" aria-live="polite" hidden></output>
+						</form>
+						<pre id="login-postlog" class="dial dial-postlog" aria-hidden="true"></pre>
+					</div>
 				</section>
 				<section id="sessions-screen" hidden>
 					<aside id="sessions-banner" hidden role="status" aria-live="polite"></aside>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -535,6 +535,13 @@ export function renderGame(
 	if (sessionsScreenEl) sessionsScreenEl.setAttribute("hidden", "");
 	if (panelsEl) panelsEl.removeAttribute("hidden");
 	if (composerEl) composerEl.removeAttribute("hidden");
+	// Restore the global chrome that the start route hides during the login takeover.
+	const headerEl = doc.querySelector<HTMLElement>("#stage > header");
+	const topinfoEl = doc.querySelector<HTMLElement>("#topinfo");
+	const bannerWrapEl = doc.querySelector<HTMLElement>("#banner");
+	if (headerEl) headerEl.removeAttribute("hidden");
+	if (topinfoEl) topinfoEl.removeAttribute("hidden");
+	if (bannerWrapEl) bannerWrapEl.removeAttribute("hidden");
 
 	// Set initial composer state (Send starts disabled until a valid *mention).
 	refreshComposerState();

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -92,6 +92,13 @@ export function renderSessions(
 
 	// Route-entry visibility
 	showOnly(doc, "#sessions-screen");
+	// Restore the global chrome that the start route hides during the login takeover.
+	const headerEl = doc.querySelector<HTMLElement>("#stage > header");
+	const topinfoEl = doc.querySelector<HTMLElement>("#topinfo");
+	const bannerWrapEl = doc.querySelector<HTMLElement>("#banner");
+	if (headerEl) headerEl.removeAttribute("hidden");
+	if (topinfoEl) topinfoEl.removeAttribute("hidden");
+	if (bannerWrapEl) bannerWrapEl.removeAttribute("hidden");
 
 	// Persistent chrome (visible on every route): ASCII banner + topinfo.
 	// Direct-load on #/sessions otherwise leaves them empty.

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -4,14 +4,19 @@
  * Route renderer for #/start.
  *
  * Responsibilities:
- *   - Show #start-screen, hide #panels and #composer.
+ *   - Show #start-screen (CRT dial-up login), hide #panels and #composer.
+ *   - Hide global header/topinfo/banner so the login screen takes over.
  *   - Show a persistence-warning banner when ?reason=broken|version-mismatch|
  *     legacy-save-discarded is present.
- *   - Kick off generateNewGameAssets() on mount; BEGIN starts disabled.
- *   - On success → enable BEGIN and hold assets in module scope.
+ *   - Type out the dial-up handshake into #dial, then reveal the login form.
+ *     Skip the animation under prefers-reduced-motion or ?skipDialup=1.
+ *   - Kick off generateNewGameAssets() on mount; CONNECT starts disabled.
+ *   - On generation success → enable CONNECT and hold assets in module scope.
  *   - On failure (CapHitError or any error) → show #cap-hit, hide #start-screen.
- *   - BEGIN click → buildSessionFromAssets, applyTestAffordances, saveActiveSession,
- *     then location.hash = "#/game". Idempotent against double-click.
+ *   - CONNECT click → password === "password" gate. On match: buildSessionFromAssets,
+ *     applyTestAffordances, saveActiveSession, then location.hash = "#/game".
+ *     On mismatch: show inline error, keep CONNECT enabled. Idempotent against
+ *     double-click while a successful connect is mid-flight.
  *
  * Issue #173 (parent #155).
  */
@@ -36,6 +41,180 @@ export const PERSISTENCE_WARNING_MESSAGES: Record<string, string> = {
 		"Saved game data from an older format has been discarded. Starting a new game.",
 };
 
+/** The password that gates entry. */
+const ACCEPTED_PASSWORD = "password";
+
+/** Dial-up handshake transcript — typed line-by-line into #dial. */
+const DIAL_LINES: ReadonlyArray<{ t: string; s: string }> = [
+	{
+		t: "> initializing modem ........................... ",
+		s: '<span class="ok">ok</span>',
+	},
+	{ t: "> ATZ\n  OK\n", s: "" },
+	{
+		t: "> ATDT 1-5555-HI-BLUE .......................... ",
+		s: '<span class="hot">dialing</span>',
+	},
+	{ t: "  ringing... ringing... ringing...\n", s: "" },
+	{ t: "  CONNECT 56000/ARQ/V90/LAPM/V42BIS\n", s: "" },
+	{
+		t: "> negotiating telnet IAC ....................... ",
+		s: '<span class="ok">ok</span>',
+	},
+	{
+		t: "> requesting ANSI/BBS terminal ................. ",
+		s: '<span class="ok">ok</span>',
+	},
+	{
+		t: "> hi-blue.bbs · node 01/01 ..................... ",
+		s: '<span class="ok">connected</span>\n\n',
+	},
+];
+
+/** Render the full handshake transcript synchronously (used when animation is skipped). */
+function renderDialFinalText(): string {
+	let out = "";
+	for (const ln of DIAL_LINES) {
+		out += ln.t;
+		if (ln.s) out += ln.s;
+		if (!ln.t.endsWith("\n") && !ln.s.includes("\n")) out += "\n";
+	}
+	return out;
+}
+
+/** Detect when motion should be suppressed. */
+function shouldSkipAnimation(params: URLSearchParams): boolean {
+	if (params.get("skipDialup") === "1") return true;
+	if (
+		typeof window !== "undefined" &&
+		typeof window.matchMedia === "function"
+	) {
+		try {
+			if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+				return true;
+			}
+		} catch {
+			// matchMedia may throw in some test envs — treat as no preference
+		}
+	}
+	return false;
+}
+
+/** Type the dial-up handshake into `dialEl`, calling `onDone` when finished. */
+function typeDialUp(dialEl: HTMLElement, onDone: () => void): void {
+	let buffer = "";
+	let i = 0;
+
+	const next = () => {
+		if (i >= DIAL_LINES.length) {
+			dialEl.innerHTML = buffer;
+			onDone();
+			return;
+		}
+		const line = DIAL_LINES[i++];
+		if (!line) return;
+		const full = line.t;
+		let charIdx = 0;
+		let prefix = buffer;
+		const tick = () => {
+			if (charIdx < full.length) {
+				prefix += full.charAt(charIdx);
+				charIdx++;
+				dialEl.innerHTML = `${prefix}<span class="blinkonly">▍</span>`;
+				setTimeout(tick, full.startsWith("  ") ? 8 : 18);
+			} else {
+				buffer = prefix + (line.s || "");
+				if (!full.endsWith("\n") && !(line.s || "").includes("\n")) {
+					buffer += "\n";
+				}
+				dialEl.innerHTML = `${buffer}<span class="blinkonly">▍</span>`;
+				const pause = full.includes("ringing") ? 360 : 140;
+				setTimeout(next, pause);
+			}
+		};
+		tick();
+	};
+	setTimeout(next, 280);
+}
+
+/** Mountain variants for the ASCII landscape — each row is 18 chars wide. */
+const LANDSCAPE_VARIANTS: ReadonlyArray<readonly [string, string, string]> = [
+	["       ╱╲         ", "      ╱  ╲   ╱╲   ", "─────╱    ╲─╱  ╲──"],
+	["                  ", "   ╱╲      ╱╲     ", "──╱  ╲────╱  ╲────"],
+	["        ╱╲        ", "   ╱╲  ╱  ╲       ", "──╱  ╲╱    ╲──────"],
+	["     ╱╲           ", "    ╱  ╲  ╱╲   ╱╲ ", "───╱    ╲╱  ╲─╱  ╲"],
+	["                  ", "    ╱╲    ╱╲  ╱╲  ", "───╱  ╲──╱  ╲╱  ╲─"],
+	["        ╱╲        ", "       ╱  ╲       ", "──────╱    ╲──────"],
+];
+const LANDSCAPE_ORDER = [0, 3, 1, 5, 2, 4, 0, 2, 5, 1, 3, 4];
+
+/** Paint the ASCII landscape into #login-keyart, sized to the current viewport. */
+function paintLandscape(keyart: HTMLElement): void {
+	if (!keyart || keyart.offsetParent === null) return;
+	const doc = keyart.ownerDocument;
+	const probe = doc.createElement("span");
+	const cs = doc.defaultView?.getComputedStyle(keyart);
+	if (cs) {
+		probe.style.fontFamily = cs.fontFamily;
+		probe.style.fontSize = cs.fontSize;
+		probe.style.fontWeight = cs.fontWeight;
+	}
+	probe.style.position = "absolute";
+	probe.style.visibility = "hidden";
+	probe.style.whiteSpace = "pre";
+	probe.textContent = "─".repeat(200);
+	doc.body.appendChild(probe);
+	const charW = probe.getBoundingClientRect().width / 200 || 8;
+	doc.body.removeChild(probe);
+	const cols = Math.max(40, Math.floor(keyart.clientWidth / charW) - 1);
+
+	const buildLine = (rowIdx: 0 | 1 | 2): string => {
+		let s = "";
+		for (let i = 0; s.length < cols; i++) {
+			const variantIdx = LANDSCAPE_ORDER[i % LANDSCAPE_ORDER.length] ?? 0;
+			s += LANDSCAPE_VARIANTS[variantIdx]?.[rowIdx] ?? "";
+		}
+		return s.slice(0, cols);
+	};
+
+	const sky = Array<string>(cols).fill(" ");
+	sky[0] = "◯";
+	const glyphs = [".", "*", ".", "*", ".", "*", "."];
+	for (let i = 0; i < glyphs.length; i++) {
+		const pos = Math.floor(((i + 1) * cols) / (glyphs.length + 1));
+		const glyph = glyphs[i];
+		if (glyph !== undefined && pos > 2 && pos < cols - 1) sky[pos] = glyph;
+	}
+
+	keyart.textContent = [
+		"─".repeat(cols),
+		sky.join(""),
+		buildLine(0),
+		buildLine(1),
+		buildLine(2),
+	].join("\n");
+}
+
+/** Wire password masking: store real value in dataset.real, render asterisks. */
+function attachPasswordMask(pwEl: HTMLInputElement): void {
+	pwEl.addEventListener("input", () => {
+		const prev = pwEl.dataset.real || "";
+		const shown = pwEl.value;
+		let real = "";
+		for (let i = 0; i < shown.length; i++) {
+			real += shown[i] === "*" ? prev[i] || "" : shown[i];
+		}
+		pwEl.dataset.real = real;
+		const caret = pwEl.selectionStart;
+		pwEl.value = "*".repeat(real.length);
+		try {
+			if (caret !== null) pwEl.setSelectionRange(caret, caret);
+		} catch {
+			// some inputs/jsdom configurations don't support setSelectionRange
+		}
+	});
+}
+
 /**
  * Injection points for testing (not used in production).
  * Callers can provide alternative providers via the params sentinel trick:
@@ -59,6 +238,8 @@ export function _setTestOverrides(
 /** Module-level pending assets holder. Cleared on each render call. */
 let _pendingAssets: NewGameAssets | undefined;
 let _beginClickPending = false;
+/** The resize listener installed on the most recent render — removed on next call. */
+let _activeResizeHandler: (() => void) | undefined;
 
 export function renderStart(
 	root: HTMLElement,
@@ -76,6 +257,14 @@ export function renderStart(
 	if (composerEl) composerEl.hidden = true;
 	if (sessionsScreenEl) sessionsScreenEl.hidden = true;
 	if (startScreenEl) startScreenEl.hidden = false;
+
+	// Hide global chrome — the login screen owns the whole viewport.
+	const headerEl = doc.querySelector<HTMLElement>("#stage > header");
+	const topinfoEl = doc.querySelector<HTMLElement>("#topinfo");
+	const bannerEl = doc.querySelector<HTMLElement>("#banner");
+	if (headerEl) headerEl.hidden = true;
+	if (topinfoEl) topinfoEl.hidden = true;
+	if (bannerEl) bannerEl.hidden = true;
 
 	// Show persistence warning if reason param is present
 	const reason = params?.get("reason") ?? null;
@@ -95,10 +284,36 @@ export function renderStart(
 	const beginBtn = doc.querySelector<HTMLButtonElement>("#begin");
 	if (!beginBtn) return Promise.resolve();
 
+	const dialEl = doc.querySelector<HTMLElement>("#dial");
+	const revealEl = doc.querySelector<HTMLElement>("#login-reveal");
+	const pwEl = doc.querySelector<HTMLInputElement>("#password");
+	const errorEl = doc.querySelector<HTMLElement>("#login-error");
+	const formEl = doc.querySelector<HTMLFormElement>("#login-form");
+	const keyartEl = doc.querySelector<HTMLElement>("#login-keyart");
+
 	// Reset module-level state on each render call
 	_pendingAssets = undefined;
 	_beginClickPending = false;
 	beginBtn.disabled = true;
+
+	if (pwEl) {
+		pwEl.value = "";
+		pwEl.dataset.real = "";
+		pwEl.disabled = false;
+	}
+	if (errorEl) {
+		errorEl.textContent = "";
+		errorEl.setAttribute("hidden", "");
+	}
+	if (dialEl) dialEl.innerHTML = "";
+	const postlogEl = doc.querySelector<HTMLElement>("#login-postlog");
+	if (postlogEl) postlogEl.innerHTML = "";
+
+	// Drop the previous render's resize listener if it's still attached.
+	if (_activeResizeHandler && typeof window !== "undefined") {
+		window.removeEventListener("resize", _activeResizeHandler);
+		_activeResizeHandler = undefined;
+	}
 
 	// Merge hash-query-string params with location.search so ?winImmediately=1 etc. work
 	const effectiveParams = new URLSearchParams(
@@ -108,12 +323,56 @@ export function renderStart(
 		for (const [k, v] of params) effectiveParams.set(k, v);
 	}
 
-	// BEGIN click handler — idempotent, requires assets to be ready
-	beginBtn.addEventListener("click", () => {
+	const skipAnimation = shouldSkipAnimation(effectiveParams);
+
+	const revealLogin = () => {
+		if (!revealEl) return;
+		revealEl.hidden = false;
+		if (keyartEl) {
+			paintLandscape(keyartEl);
+			const handler = () => paintLandscape(keyartEl);
+			_activeResizeHandler = handler;
+			if (typeof window !== "undefined") {
+				window.addEventListener("resize", handler);
+			}
+		}
+		if (pwEl) {
+			attachPasswordMask(pwEl);
+			try {
+				pwEl.focus();
+			} catch {
+				// focus may fail in jsdom — non-fatal
+			}
+		}
+	};
+
+	if (skipAnimation) {
+		if (dialEl) dialEl.textContent = renderDialFinalText();
+		revealLogin();
+	} else if (dialEl) {
+		typeDialUp(dialEl, () => setTimeout(revealLogin, 220));
+	} else {
+		revealLogin();
+	}
+
+	const showError = (msg: string) => {
+		if (!errorEl) return;
+		errorEl.textContent = msg;
+		errorEl.removeAttribute("hidden");
+	};
+	const clearError = () => {
+		if (!errorEl) return;
+		errorEl.textContent = "";
+		errorEl.setAttribute("hidden", "");
+	};
+
+	const proceedConnect = () => {
 		if (_beginClickPending) return;
 		if (!_pendingAssets) return;
 		_beginClickPending = true;
 		beginBtn.disabled = true;
+		if (pwEl) pwEl.disabled = true;
+		clearError();
 
 		const assets = _pendingAssets;
 		let session = buildSessionFromAssets(assets);
@@ -121,7 +380,6 @@ export function renderStart(
 
 		const saveResult = saveActiveSession(session.getState());
 		if (!saveResult.ok) {
-			// Surface save failure via persistence warning but still navigate
 			const persistenceWarningEl = doc.querySelector<HTMLElement>(
 				"#persistence-warning",
 			);
@@ -134,7 +392,31 @@ export function renderStart(
 
 		// Navigate to game regardless of save result (game.ts will handle missing session)
 		location.hash = "#/game";
-	});
+	};
+
+	const handleSubmit = (e?: Event) => {
+		if (e) e.preventDefault();
+		if (beginBtn.disabled) return;
+		if (_beginClickPending) return;
+		const real = pwEl?.dataset.real ?? "";
+		if (real !== ACCEPTED_PASSWORD) {
+			showError("> access denied — invalid credentials");
+			if (pwEl) {
+				pwEl.value = "";
+				pwEl.dataset.real = "";
+				try {
+					pwEl.focus();
+				} catch {
+					// ignore
+				}
+			}
+			return;
+		}
+		proceedConnect();
+	};
+
+	if (formEl) formEl.addEventListener("submit", handleSubmit);
+	beginBtn.addEventListener("click", handleSubmit);
 
 	// Kick off generation
 	const generationPromise = (async () => {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -190,7 +190,9 @@ main {
 }
 
 @media (prefers-reduced-motion: reduce) {
-	#phase-banner {
+	#phase-banner,
+	.blinkonly,
+	.topinfo .blink {
 		animation: none;
 	}
 }
@@ -593,53 +595,291 @@ main {
 	margin-bottom: 2px;
 }
 
-/* Start screen */
+/* Start screen — CRT dial-up login */
+:root {
+	--amber-faint: #4a3618;
+}
+
 #start-screen:not([hidden]) {
 	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
+	align-items: stretch;
 	gap: 10px;
 	padding: 8px 0;
+	width: 100%;
+	max-width: 720px;
+	margin: 0 auto;
+	overflow-y: auto;
+	scrollbar-width: thin;
+	scrollbar-color: rgba(255, 180, 84, 0.3) transparent;
 }
 
-.start-placeholder {
+#start-screen::-webkit-scrollbar {
+	width: 6px;
+}
+
+#start-screen::-webkit-scrollbar-thumb {
+	background: rgba(255, 180, 84, 0.3);
+}
+
+#start-screen .dial {
 	margin: 0;
+	white-space: pre-wrap;
+	font-size: clamp(11px, 1.6vmin, 13px);
+	line-height: 1.35;
 	color: var(--amber-dim);
-	font-size: 12px;
-	letter-spacing: 0.06em;
+	letter-spacing: 0.02em;
+	text-shadow: none;
 }
 
-#begin {
-	background: transparent;
-	border: 1px solid var(--amber-dim);
-	color: var(--amber-dim);
-	font-family: inherit;
-	font-size: 13px;
-	letter-spacing: 0.18em;
-	padding: 5px 16px;
-	cursor: pointer;
-	text-shadow: inherit;
-	transition:
-		color 120ms,
-		border-color 120ms;
+#start-screen .dial .ok {
+	color: #8df27f;
+	text-shadow: 0 0 6px rgba(141, 242, 127, 0.5);
 }
 
-#begin:hover:not(:disabled) {
+#start-screen .dial .hot {
 	color: var(--amber);
-	border-color: var(--amber);
 	text-shadow:
 		0 0 1px var(--amber),
-		0 0 8px rgba(255, 180, 84, 0.5);
+		0 0 6px rgba(255, 180, 84, 0.4);
 }
 
-#begin:disabled {
+.blinkonly {
+	animation: blink 1.05s steps(2, end) infinite;
+}
+
+#start-screen .dial-postlog {
+	margin-top: 4px;
+}
+
+.login-reveal {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.banner-login {
+	margin: 6px 0 0;
+	white-space: pre;
+	line-height: 1;
+	font-size: clamp(7px, 1.5vmin, 12px);
+	color: var(--amber);
+	overflow: hidden;
+	text-align: center;
+}
+
+.banner-login-mini {
+	display: none;
+}
+
+.login-tag {
+	text-align: center;
+	color: var(--amber-dim);
+	letter-spacing: 0.18em;
+	font-size: clamp(9px, 1.3vmin, 11px);
+	text-transform: uppercase;
+}
+
+.login-tag b {
+	color: var(--amber);
+	font-weight: 500;
+}
+
+.login-rule {
+	margin: 2px 0;
+	line-height: 1;
+	font-size: clamp(10px, 1.4vmin, 13px);
+	color: var(--amber-dim);
+	overflow: hidden;
+	white-space: nowrap;
+	user-select: none;
+}
+
+.login-sysinfo {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 4px 22px;
+	font-size: clamp(10px, 1.4vmin, 12px);
+	color: var(--amber-dim);
+	padding: 4px 4px;
+	letter-spacing: 0.04em;
+}
+
+.login-sysinfo .k {
+	color: var(--amber-faint);
+}
+
+.login-sysinfo b {
+	color: var(--amber);
+	font-weight: 500;
+}
+
+.login-sysinfo .row {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.login-frame {
+	color: var(--amber-dim);
+	font-size: clamp(10px, 1.4vmin, 12px);
+	display: flex;
+	flex-direction: column;
+}
+
+.login-frame-brow {
+	display: flex;
+	white-space: pre;
+	line-height: 1;
+	user-select: none;
+	overflow: hidden;
+	position: relative;
+	color: var(--amber);
+}
+
+.login-frame-brow .fill {
+	flex: 1 1 0;
+	width: 0;
+	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	display: inline-block;
+}
+
+.login-frame-brow .corner-r {
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: 1;
+	background: var(--bg);
+}
+
+.login-frame-body {
+	display: flex;
+	align-items: stretch;
+}
+
+.login-frame-body .side {
+	white-space: pre;
+	line-height: 1;
+	width: 1ch;
+	flex: 0 0 auto;
+	user-select: none;
+	color: var(--amber);
+	overflow: hidden;
+}
+
+.login-frame-body .inner {
+	flex: 1;
+	min-width: 0;
+	padding: 6px 10px;
+}
+
+.login-frame-body .who {
+	color: var(--amber);
+}
+
+.login-keyart {
+	margin: 8px 0 0;
+	white-space: pre;
+	line-height: 1.15;
+	font-size: clamp(8px, 1.2vmin, 11px);
+	color: var(--blue);
+	text-shadow: 0 0 6px rgba(127, 182, 255, 0.4);
+	overflow: hidden;
+	user-select: none;
+	width: 100%;
+	text-align: left;
+}
+
+.login-form {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-top: 6px;
+}
+
+.login-field {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	font-size: clamp(11px, 1.6vmin, 13px);
+}
+
+.login-field .lbl {
+	color: var(--amber-dim);
+	width: 11ch;
+	flex: 0 0 auto;
+	text-align: right;
+	letter-spacing: 0.04em;
+}
+
+.login-field input {
+	flex: 1;
+	min-width: 0;
+	background: transparent;
+	border: 0;
+	border-bottom: 1px solid rgba(255, 180, 84, 0.45);
+	outline: 0;
+	color: var(--amber);
+	font-family: inherit;
+	font-size: inherit;
+	text-shadow: inherit;
+	caret-color: var(--amber);
+	padding: 2px 0 3px;
+}
+
+.login-field input:focus {
+	border-bottom-color: var(--amber);
+}
+
+.login-connect {
+	background: transparent;
+	border: 0;
+	color: var(--amber);
+	font-family: inherit;
+	font-size: clamp(11px, 1.5vmin, 13px);
+	letter-spacing: 0.06em;
+	padding: 2px 0 3px;
+	cursor: pointer;
+	text-shadow: inherit;
+	white-space: nowrap;
+}
+
+.login-connect:hover:not(:disabled) {
+	color: #fff5e0;
+	text-shadow: 0 0 6px rgba(255, 245, 224, 0.5);
+}
+
+.login-connect:disabled {
 	opacity: 0.4;
 	cursor: not-allowed;
 }
 
-#begin:not(:disabled) {
-	color: var(--amber);
-	border-color: var(--amber);
+.login-error {
+	color: var(--err);
+	font-size: clamp(10px, 1.3vmin, 11px);
+	letter-spacing: 0.04em;
+	text-shadow: 0 0 6px rgba(255, 123, 107, 0.4);
+	padding-left: calc(11ch + 10px);
+}
+
+@media (max-width: 520px) {
+	.banner-login-full {
+		display: none;
+	}
+	.banner-login-mini {
+		display: block;
+	}
+	.login-field .lbl {
+		width: 9ch;
+	}
+	.login-sysinfo {
+		grid-template-columns: 1fr;
+	}
+	.login-error {
+		padding-left: 0;
+	}
 }
 
 /* Cap-hit (rate limit) */


### PR DESCRIPTION
Replace the placeholder start screen with the hi-blue-login design from
Claude Design. The new screen types out a dial-up handshake into #dial,
then reveals the HI-BLUE banner, sysinfo grid, "last visit" framed quote,
ASCII landscape, and a password input that gates entry. CONNECT only
proceeds when the input matches "password"; wrong passwords surface an
inline "access denied" error.

The animation is bypassed under prefers-reduced-motion or ?skipDialup=1
(used by the e2e helper goToGame and unit tests). renderGame and
renderSessions now restore the global header/topinfo/banner that the
login takeover hides.

https://claude.ai/code/session_01BsHMMMh76MPcm7gnHCPbMK