### PR TITLE
ADR + ConversationEntry type for per-Daemon conversation logs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,8 +77,12 @@ The wedge-shaped region of cells an AI can see each turn: 1 cell directly in fro
 The cardinal direction (N/S/E/W) an AI is currently looking. Part of the AI's state alongside `(row, col)`. Updated by `go(direction)` (move and face) and `look(direction)` (face without moving).
 
 **Conversation log**:
-The single chronological per-AI per-phase section of the system prompt that interleaves voice-chat, whispers received, and **Witnessed event**s — all tagged by round. The AI's complete phase memory: nothing the AI has experienced this phase exists outside this log. Replaces both the broadcast action log of an earlier design and the once-considered separate "events in your cone" section.
+The single chronological per-AI per-phase section of the system prompt that interleaves voice-chat, whispers received, and **Witnessed event**s — all tagged by round. The AI's complete phase memory: nothing the AI has experienced this phase exists outside this log. Now also the per-Daemon storage shape — see **ConversationEntry**. Replaces both the broadcast action log of an earlier design and the once-considered separate "events in your cone" section.
 _Avoid_: Action log (deprecated; do not reintroduce), event delta, transcript.
+
+**ConversationEntry**:
+A single tagged item inside a Daemon's **Conversation log**. Discriminated union of three kinds — `chat`, `whisper`, `witnessed-event` — each carrying a `round` and the smallest payload needed to render its line. The shape that a player sees when they open a `*xxxx.txt` file in devtools.
+_Avoid_: Log entry (ambiguous), event (use **Witnessed event** for the specific witness-cone case).
 
 **Witnessed event**:
 A single line in the **Conversation log** describing something an AI saw happen inside their **Cone**. Rendered second-person: `You watch *xxxx [verb]…` for movement / pick-up / put-down / give, and the `{actor}`-substituted use-outcome flavor string for `use`. `examine` produces no Witnessed event (it is a private query, not an observable physical act).

--- a/docs/adr/0006-per-daemon-conversation-logs.md
+++ b/docs/adr/0006-per-daemon-conversation-logs.md
@@ -1,0 +1,50 @@
+# ADR 0006 — Per-Daemon Conversation Logs
+
+**Status:** Accepted
+
+V2 continuation of [ADR 0004](./0004-editable-vs-sealed-save-surface.md), completing the editable-surface decision begun there for the in-flight issue PRD #155.
+
+## Context
+
+Today's storage shape for a phase holds:
+
+- `chatHistories: Record<AiId, ChatMessage[]>` — per-Daemon chat messages.
+- `whispers: WhisperMessage[]` — a flat **global** array for the whole phase, shared across all Daemons.
+- `physicalLog: PhysicalActionRecord[]` — a flat **global** append-only array, shared across all Daemons.
+
+Prompts are built in `prompt-builder.ts` via `buildConversationLog` (`src/spa/game/conversation-log.ts`), which **walks the entire `physicalLog` per prompt** and re-evaluates cone-visibility per record using a `witnessSpatial` snapshot stored on each `PhysicalActionRecord`.
+
+A comment at `game-storage.ts:168` reads:
+
+> `// physicalLog is not persisted (derived on-demand for prompts, safe to reset on reload)`
+
+This comment is misdirection. It implies the global `physicalLog` is a derived view that can be reconstructed, when in fact it is the **only** record of witnessed events. Resetting it on reload silently drops those events from every subsequent prompt — "derived on-demand" invites future contributors to treat write-time and read-time as interchangeable, which they are not. The comment is explicitly retired in issue #194 when `physicalLog` is either persisted or removed.
+
+This ADR also cross-references [ADR 0002](./0002-scrap-action-log.md) (the scrap-the-broadcast-log decision that introduced Witnessed events as per-cone lines).
+
+## Decision
+
+Four sub-decisions, each with a "why":
+
+1. **Per-Daemon ownership replaces the global arrays and read-time filter.** Each Daemon owns a `ConversationEntry[]` containing exactly the entries that Daemon would see in its prompt — chat addressed to or from it, whispers it sent or received, and witnessed events it saw. This makes the Daemon `.txt` file (per ADR 0004) the *complete* per-Daemon prompt-input record, not just a chat slice.
+
+2. **Cone visibility moves from read-time to write-time.** Today the dispatcher appends one `PhysicalActionRecord` to the shared `physicalLog` (carrying a `witnessSpatial` snapshot of every other AI's pose), and `buildConversationLog` re-walks that log per prompt, re-evaluating cone-visibility for every record. Going forward, the dispatcher computes cone-visibility **once** at append-time using the actor's `witnessSpatial` snapshot and writes a `witnessed-event` `ConversationEntry` directly into the conversation log of each witnessing Daemon. Read-time becomes a trivial sorted-by-round walk of one Daemon's own log.
+
+3. **Witnessed events become persisted as a side effect.** Because they now live inside per-Daemon logs rather than the in-memory global `physicalLog` that was reset on reload, they survive reload. This fixes the silent drop and removes the misleading "derived on-demand" framing.
+
+4. **The asymmetric-whisper-tampering vector is intentional emergent play, not a bug.** With per-Daemon ownership, a player can hand-edit one Daemon's `.txt` to alter the whisper *as that recipient remembers it* without touching the sender's record. The v1 model required editing one global `whispers.txt` symmetrically. This asymmetry is framed as a feature consistent with ADR 0004's editable-narrative-surface stance: it lets a player engineer a "what they said vs. what was heard" divergence — a productive tool for narrative manipulation, not data corruption. The engine state (`engine.dat`) remains sealed.
+
+## Considered Options
+
+**(a) Per-Daemon ownership with write-time cone resolution** — chosen. See Decision above.
+
+**(b) Keep global arrays, persist `physicalLog`** — fixes the reload-drop bug but keeps the per-prompt cone re-walk, and the asymmetric-edit surface remains a single-file affair (no productive divergence possible). Rejected.
+
+**(c) Derive everything from a shared event log per phase, materialise per-Daemon view at prompt time** — even more read-time work than today; the misleading "derived on-demand" comment was effectively this model in spirit. Rejected.
+
+## Consequences
+
+- `PhaseState` gains `conversationLogs: Record<AiId, ConversationEntry[]>`. Existing `chatHistories` / `whispers` / `physicalLog` are *retained for now* as the source of truth; this ADR's groundwork (issue #193) only adds the type and the empty map. Migration of writers (#194) and readers (#195) follows.
+- The retired comment at `game-storage.ts:168` is removed in #194 when `physicalLog` either persists or is removed.
+- Daemon `.txt` files (per ADR 0004) become the canonical per-Daemon prompt input, including witnessed events. Player hand-edits to a single Daemon's file produce that-Daemon-only effects — the asymmetric-tampering vector is now first-class.
+- The `witnessSpatial` snapshot field on `PhysicalActionRecord` becomes a dispatcher-local computation (consumed once, not stored) once #194 lands.

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -126,6 +126,7 @@ export function startPhase(
 		chatHistories,
 		whispers: [],
 		physicalLog: [],
+		conversationLogs: {},
 		lockedOut: new Set(),
 		chatLockouts: new Map(),
 		personaSpatial,

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -130,6 +130,48 @@ export interface WhisperMessage {
 	round: number;
 }
 
+/**
+ * A single tagged item inside a Daemon's conversation log.
+ *
+ * Discriminated union of three kinds — `chat`, `whisper`, `witnessed-event` — each carrying a
+ * `round` and the smallest payload needed to render its line in the system prompt. This is the
+ * per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's `Conversation log`
+ * glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt` file in devtools
+ * can tell entry kinds apart at a glance.
+ *
+ * - `chat`: projects ChatMessage — a voice/AI line addressed to or from this Daemon.
+ * - `whisper`: projects WhisperMessage — a whisper this Daemon sent or received.
+ * - `witnessed-event`: projects the render-relevant subset of PhysicalActionRecord for an action
+ *   this Daemon observed inside its cone. The cone-snapshot fields (`actorCellAtAction`,
+ *   `actorFacingAtAction`, `witnessSpatial`) are omitted — cone visibility is resolved at
+ *   write-time (ADR 0006), not re-evaluated at read-time.
+ */
+export type ConversationEntry =
+	| {
+			kind: "chat";
+			round: number;
+			role: "player" | "ai";
+			content: string;
+	  }
+	| {
+			kind: "whisper";
+			round: number;
+			from: AiId;
+			to: AiId;
+			content: string;
+	  }
+	| {
+			kind: "witnessed-event";
+			round: number;
+			actor: AiId;
+			actionKind: "go" | "pick_up" | "put_down" | "give" | "use";
+			item?: string;
+			to?: AiId;
+			direction?: CardinalDirection;
+			useOutcome?: string;
+			placementFlavorRaw?: string;
+	  };
+
 export interface AiBudget {
 	remaining: number;
 	total: number;
@@ -179,6 +221,8 @@ export interface PhaseState {
 	whispers: WhisperMessage[];
 	/** Append-only log of observable physical actions for the phase. Used for Witnessed event rendering. */
 	physicalLog: PhysicalActionRecord[];
+	/** Per-Daemon conversation log (storage + prompt-rendered shape). Populated by #194; read by #195. */
+	conversationLogs: Record<AiId, ConversationEntry[]>;
 	/** Budget-exhaustion lockout: prevents the AI from acting at all. */
 	lockedOut: Set<AiId>;
 	/**

--- a/src/spa/persistence/game-storage.ts
+++ b/src/spa/persistence/game-storage.ts
@@ -167,6 +167,7 @@ function deserializePhaseState(
 		whispers: [...persisted.whispers],
 		// physicalLog is not persisted (derived on-demand for prompts, safe to reset on reload)
 		physicalLog: [],
+		conversationLogs: {},
 		lockedOut: new Set<AiId>(persisted.lockedOut),
 		chatLockouts: new Map<AiId, number>(persisted.chatLockouts),
 		personaSpatial: structuredClone(persisted.personaSpatial ?? {}),

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -436,6 +436,7 @@ export function deserializeSession(
 				chatHistories,
 				whispers,
 				physicalLog: [],
+				conversationLogs: {},
 				lockedOut,
 				chatLockouts,
 				personaSpatial,


### PR DESCRIPTION
## What this fixes

Type + doc groundwork for the per-Daemon conversation-log refactor (PRD #157). Today, prompt input lives in three separately-stored shapes — `chatHistories: Record<AiId, ChatMessage[]>`, a flat global `whispers: WhisperMessage[]`, and a flat global `physicalLog: PhysicalActionRecord[]` that `buildConversationLog` (`src/spa/game/conversation-log.ts`) walks per prompt to re-evaluate cone-visibility. The persistence layer further muddles things with a comment at `game-storage.ts:168` claiming `physicalLog` is "derived on-demand for prompts, safe to reset on reload" — in fact it's the only record of witnessed events, and resetting silently drops them across reloads.

This change lays the type + doc shape for the v2 model without flipping any read or write paths:

- **`docs/adr/0006-per-daemon-conversation-logs.md`** — pins the v2 decision (per-Daemon ownership replacing global arrays + read-time filter; cone visibility moving from read-time to write-time; witnessed events becoming persisted as a side effect; retiring the misleading `game-storage.ts:168` comment; framing asymmetric whisper-tampering as intentional emergent play; positioning as v2 of ADR 0004 / PRD #155).
- **`ConversationEntry` discriminated union** (`src/spa/game/types.ts`) — three variants `chat | whisper | witnessed-event`, each carrying `round` and the smallest faithful payload from today's `ChatMessage` / `WhisperMessage` / `PhysicalActionRecord`. The `witnessed-event` variant deliberately drops the cone-snapshot fields (`actorCellAtAction`, `actorFacingAtAction`, `witnessSpatial`) since those exist solely to support read-time cone re-evaluation, which the ADR retires.
- **`PhaseState.conversationLogs: Record<AiId, ConversationEntry[]>`** — required (not optional), so every construction site is forced to initialise it now. Empty `{}` is wired in at `engine.ts startPhase`, `session-codec.ts deserializeSession`, and `game-storage.ts deserializePhase`; the literal is unconditional, so old saves without the field reload cleanly.
- **CONTEXT.md glossary** — new `ConversationEntry` entry; existing `Conversation log` entry extended to reaffirm dual storage + prompt-rendered role.

Nothing reads or writes `conversationLogs` yet — the writers come in #194 and the readers in #195. The misleading `game-storage.ts:168` comment is documented-as-retired in the ADR but stays in the code until #194 either persists or removes `physicalLog`.

## QA steps for the human

None — fully covered by automated coverage. The change is pure type + doc; no runtime path reads or writes the new field.

## Automated coverage

`pnpm typecheck` (root + proxy projects), `pnpm test` (50 files / 976 vitest tests), and Playwright e2e (smoke, persistence-reload, sessions-picker, cents-live — 13 specs) — all green on `9ee116e`.

Closes #193

---
_Generated by [Claude Code](https://claude.ai/code/session_017dAapTZMqpfZUTcLoscDVc)_