### PR TITLE
fix(start): keep panels hidden on mobile start screen

### DIFF
--- a/e2e/start-screen.spec.ts
+++ b/e2e/start-screen.spec.ts
@@ -59,6 +59,30 @@ test("new visitor sees start screen with disabled [ BEGIN ] button initially", a
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });
 
+test.describe("mobile viewport", () => {
+	test.use({ viewport: { width: 375, height: 667 } });
+
+	test("start screen keeps panels and composer hidden on mobile", async ({
+		page,
+	}) => {
+		const pageErrors: Error[] = [];
+		page.on("pageerror", (err) => pageErrors.push(err));
+
+		await stubChatCompletions(page, ["stub reply"]);
+
+		await page.goto("/");
+
+		await expect(page.locator("#start-screen")).toBeVisible();
+		// The mobile media query sets `#panels.row { display: grid }`. That id+class
+		// selector outranked `[hidden] { display: none }` and leaked the chat
+		// boxes onto the start screen on small viewports.
+		await expect(page.locator("#panels")).toBeHidden();
+		await expect(page.locator("#composer")).toBeHidden();
+
+		expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	});
+});
+
 test("[ BEGIN ] is enabled after persona synthesis and content-pack generation complete", async ({
 	page,
 }) => {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1158,7 +1158,7 @@ main {
 		display: none;
 	}
 
-	#panels.row {
+	#panels.row:not([hidden]) {
 		display: grid;
 		grid-template-rows: minmax(0, 1fr) 88px;
 		grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
The mobile media query's `#panels.row { display: grid }` rule (id+class
specificity, 0,1,1,0) overrode `[hidden] { display: none }` (single attribute,
0,0,1,0), so the chat panels remained visible on the start screen on viewports
≤720px even though start.ts sets `panelsEl.hidden = true`. Other route
sections (#start-screen, #endgame, #sessions-screen) already use `:not([hidden])`
to avoid this — #panels.row was the outlier.

Add the same `:not([hidden])` qualifier and a regression test exercising the
mobile viewport against the start route.

https://claude.ai/code/session_01VjW9x3KpBoJebCV6QiiCBD