### PR TITLE
feat(start): progressive-loading flow on the main screen

### DIFF
--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -173,23 +173,23 @@ describe("renderStart — BEGIN button state", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("BEGIN is disabled at mount while generation is in flight", async () => {
+	it("BEGIN is enabled as soon as the login form reveals — generation runs in the background", async () => {
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
 		const { renderStart } = await import("../routes/start.js");
 
-		// renderStart kicks off generation and returns a promise. Before the
-		// promise settles, BEGIN must be disabled. We check the synchronous
-		// post-mount state by starting the render but not awaiting it yet.
+		// renderStart kicks off generation and returns a promise. With skipDialup,
+		// the login form reveals synchronously; BEGIN should be available
+		// immediately so the player can click through to the progressive-loading
+		// game route while content packs are still resolving.
 		const renderPromise = renderStart(
 			getMain(),
 			new URLSearchParams("skipDialup=1"),
 		);
 
-		// Immediately after mount (generation promise is in flight), BEGIN is disabled
 		const beginBtn = document.querySelector<HTMLButtonElement>("#begin");
-		expect(beginBtn?.disabled).toBe(true);
+		expect(beginBtn?.disabled).toBe(false);
 
 		// Clean up — let generation finish
 		try {
@@ -199,7 +199,7 @@ describe("renderStart — BEGIN button state", () => {
 		}
 	});
 
-	it("BEGIN becomes enabled after generation resolves successfully", async () => {
+	it("BEGIN remains enabled after generation resolves successfully", async () => {
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
@@ -306,24 +306,32 @@ describe("renderStart — CapHitError handling", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("shows #cap-hit and hides #start-screen when generateNewGameAssets throws CapHitError", async () => {
+	it("shows #cap-hit and hides #start-screen when generation throws CapHitError", async () => {
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
 
-		// Override the bootstrap module so generateNewGameAssets throws CapHitError
+		// Override the bootstrap module so the split generation rejects with
+		// CapHitError on both promises. Pending-bootstrap subscribes to each
+		// promise; surfacing CapHitError on either is enough to trigger the
+		// start route's #cap-hit fallback.
 		vi.doMock("../game/bootstrap.js", async (importOriginal) => {
 			const actual =
 				await importOriginal<typeof import("../game/bootstrap.js")>();
 			const { CapHitError } = await import("../llm-client.js");
+			const err = new CapHitError({
+				message: "rate limit",
+				reason: "per-ip-daily",
+				retryAfterSec: 86400,
+			});
 			return {
 				...actual,
+				generateNewGameAssetsSplit: () => ({
+					personasPromise: Promise.reject(err),
+					contentPacksPromise: Promise.reject(err),
+				}),
 				generateNewGameAssets: async () => {
-					throw new CapHitError({
-						message: "rate limit",
-						reason: "per-ip-daily",
-						retryAfterSec: 86400,
-					});
+					throw err;
 				},
 			};
 		});

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -112,6 +112,45 @@ export function formatTopInfoRight(i: TopInfoInputs): string {
 }
 
 export const TOPINFO_RIGHT_OK_TEXT = "● connection stable";
+export const TOPINFO_RIGHT_LOADING_TEXT = "● loading daemons";
+export const TOPINFO_RIGHT_GENERATING_TEXT = "● generating room";
+
+export const TOPINFO_MOBILE_OK_TEXT = "● stable";
+export const TOPINFO_MOBILE_LOADING_TEXT = "● loading";
+export const TOPINFO_MOBILE_GENERATING_TEXT = "● generating";
+
+/** Three-phase load state used by the start → game progressive loading flow. */
+export type LoadState = "loading-daemons" | "generating-room" | "stable";
+
+export interface LoadStateStatus {
+	desktop: string;
+	mobile: string;
+	cls: "err" | "warn" | "ok";
+}
+
+/** Map a `LoadState` to the right-cell text + the CSS class that colors it. */
+export function topInfoStatus(state: LoadState): LoadStateStatus {
+	switch (state) {
+		case "loading-daemons":
+			return {
+				desktop: TOPINFO_RIGHT_LOADING_TEXT,
+				mobile: TOPINFO_MOBILE_LOADING_TEXT,
+				cls: "err",
+			};
+		case "generating-room":
+			return {
+				desktop: TOPINFO_RIGHT_GENERATING_TEXT,
+				mobile: TOPINFO_MOBILE_GENERATING_TEXT,
+				cls: "warn",
+			};
+		case "stable":
+			return {
+				desktop: TOPINFO_RIGHT_OK_TEXT,
+				mobile: TOPINFO_MOBILE_OK_TEXT,
+				cls: "ok",
+			};
+	}
+}
 
 /** Idempotent: inject the ASCII banner into `#banner` if not already there. */
 export function paintBanner(doc: Document): void {

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -30,46 +30,71 @@ export interface NewGameAssets {
 	contentPacks: ContentPack[];
 }
 
+export interface SplitNewGameAssets {
+	personasPromise: Promise<Record<AiId, AiPersona>>;
+	contentPacksPromise: Promise<ContentPack[]>;
+}
+
+export interface BootstrapOpts {
+	synthesis?: LlmSynthesisProvider;
+	packProvider?: ContentPackProvider;
+	rng?: () => number;
+}
+
 // Re-export provider types for use in start.ts without creating circular deps
 export type { ContentPackProvider, LlmSynthesisProvider as SynthesisProvider };
 
 /**
- * Run the full async generation pipeline and return the resulting personas
- * and content packs.
- *
- * Default opts use the browser providers and Math.random.
- * Tests can inject deterministic alternatives via opts.
- *
- * Does NOT create a GameSession or touch localStorage.
+ * Kick off persona + content-pack generation and expose them as separate
+ * promises. Personas resolve seconds before content packs, which lets the
+ * UI react to each stage independently (drive a multi-phase loading screen).
  */
-export async function generateNewGameAssets(opts?: {
-	synthesis?: LlmSynthesisProvider;
-	packProvider?: ContentPackProvider;
-	rng?: () => number;
-}): Promise<NewGameAssets> {
+export function generateNewGameAssetsSplit(
+	opts?: BootstrapOpts,
+): SplitNewGameAssets {
 	const rng = opts?.rng ?? Math.random;
 	const synth = opts?.synthesis ?? new BrowserSynthesisProvider();
 	const packLLM = opts?.packProvider ?? new BrowserContentPackProvider();
 
-	const personasPromise = generatePersonas(rng, synth);
+	const personasPromise = generatePersonas(rng, synth) as Promise<
+		Record<AiId, AiPersona>
+	>;
+	// Silence unhandled-rejection on derived promises if a downstream consumer
+	// chooses not to await one of them.
+	personasPromise.catch(() => {});
 	const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
-	// Silence derived-promise unhandled rejection when personasPromise rejects
-	// but packs path returns before awaiting aiIdsPromise.
 	aiIdsPromise.catch(() => {});
-	const packsPromise = generateContentPacks(
+
+	const contentPacksPromise = generateContentPacks(
 		rng,
 		SETTING_POOL,
 		[PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG],
 		packLLM,
 		aiIdsPromise,
 	);
+	contentPacksPromise.catch(() => {});
 
+	return { personasPromise, contentPacksPromise };
+}
+
+/**
+ * Run the full async generation pipeline and return the resulting personas
+ * and content packs as a single resolved bundle.
+ *
+ * Thin wrapper around `generateNewGameAssetsSplit` for callers (mostly tests)
+ * that don't care about the per-stage timing. Does NOT create a GameSession
+ * or touch localStorage.
+ */
+export async function generateNewGameAssets(
+	opts?: BootstrapOpts,
+): Promise<NewGameAssets> {
+	const { personasPromise, contentPacksPromise } =
+		generateNewGameAssetsSplit(opts);
 	const [personas, contentPacks] = await Promise.all([
 		personasPromise,
-		packsPromise,
+		contentPacksPromise,
 	]);
-
-	return { personas: personas as Record<AiId, AiPersona>, contentPacks };
+	return { personas, contentPacks };
 }
 
 /**

--- a/src/spa/game/pending-bootstrap.ts
+++ b/src/spa/game/pending-bootstrap.ts
@@ -1,0 +1,91 @@
+/**
+ * pending-bootstrap.ts
+ *
+ * In-memory holder for an in-flight asset generation bootstrap that needs to
+ * outlive the start → game route transition. Personas resolve quickly,
+ * content packs slowly; the game route observes both stages to drive its
+ * loading UI.
+ *
+ * NEVER persisted to localStorage — a session can't be built (or saved) until
+ * content packs land. Cleared once the session is built and saved, or on
+ * failure.
+ */
+
+import {
+	type BootstrapOpts,
+	generateNewGameAssetsSplit,
+	type SplitNewGameAssets,
+} from "./bootstrap.js";
+import type { AiId, AiPersona, ContentPack } from "./types.js";
+
+export type PendingBootstrapStatus =
+	| "pending"
+	| "personas-ready"
+	| "ready"
+	| "failed";
+
+export interface PendingBootstrap {
+	personasPromise: Promise<Record<AiId, AiPersona>>;
+	contentPacksPromise: Promise<ContentPack[]>;
+	status: PendingBootstrapStatus;
+	error?: unknown;
+}
+
+let _current: PendingBootstrap | undefined;
+
+/**
+ * Kick off (or reuse) a bootstrap and stash it in module scope so the game
+ * route can observe its progress. Idempotent: subsequent calls return the
+ * existing in-flight bootstrap unless the previous one failed.
+ */
+export function startBootstrap(opts?: BootstrapOpts): PendingBootstrap {
+	if (_current && _current.status !== "failed") return _current;
+
+	const split: SplitNewGameAssets = generateNewGameAssetsSplit(opts);
+	const entry: PendingBootstrap = {
+		personasPromise: split.personasPromise,
+		contentPacksPromise: split.contentPacksPromise,
+		status: "pending",
+	};
+
+	split.personasPromise.then(
+		() => {
+			if (entry.status === "pending") entry.status = "personas-ready";
+		},
+		(err: unknown) => {
+			entry.status = "failed";
+			entry.error = err;
+		},
+	);
+	split.contentPacksPromise.then(
+		() => {
+			entry.status = "ready";
+		},
+		(err: unknown) => {
+			entry.status = "failed";
+			entry.error = err;
+		},
+	);
+
+	_current = entry;
+	return entry;
+}
+
+/**
+ * Return the current in-flight bootstrap, or undefined if none is pending.
+ *
+ * The game route uses this on entry to decide whether to render the
+ * progressive-loading UI vs. the normal restore path.
+ */
+export function getPendingBootstrap(): PendingBootstrap | undefined {
+	return _current;
+}
+
+/**
+ * Clear the pending bootstrap. Called once the game route has built the
+ * session from the resolved assets and persisted it to localStorage —
+ * subsequent route entries will use the normal restore path.
+ */
+export function clearPendingBootstrap(): void {
+	_current = undefined;
+}

--- a/src/spa/main.ts
+++ b/src/spa/main.ts
@@ -13,6 +13,7 @@
 
 import "./styles.css";
 import { initByokModal } from "./byok-modal.js";
+import { getPendingBootstrap } from "./game/pending-bootstrap.js";
 import { dispatchActiveSession } from "./persistence/active-session-dispatcher.js";
 import {
 	deleteLegacySaveKey,
@@ -105,8 +106,13 @@ function withDispatcher(
 		}
 
 		// targetHash === "#/game"
-		// Only render when the session is populated; otherwise redirect appropriately.
+		// Render when the session is populated, OR when a fresh bootstrap is
+		// in flight (the player just submitted CONNECT but content packs
+		// haven't landed yet — the game route owns the progressive-loading UI).
 		if (verdict.reason !== "populated") {
+			if (getPendingBootstrap() !== undefined) {
+				return renderer(root, params);
+			}
 			if (
 				verdict.reason === "broken" ||
 				verdict.reason === "version-mismatch"

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -555,10 +555,10 @@ export function renderGame(
 			if (!stageEl) return;
 			const startTs =
 				typeof performance !== "undefined" ? performance.now() : Date.now();
-			// τ chosen so the bright band reaches ~95% at ~60s (target pack
-			// load time) and ~99% at ~90s, asymptotically capped at 99% so
-			// the panel never visually completes until packs actually resolve.
-			const TAU_MS = 20_000;
+			// τ chosen so the bright band reaches ~95% at ~3 min (target pack
+			// load time) and ~99% at ~4.5 min, asymptotically capped at 99%
+			// so the panel never visually completes until packs actually resolve.
+			const TAU_MS = 60_000;
 			const tick = (): void => {
 				const now =
 					typeof performance !== "undefined" ? performance.now() : Date.now();

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -5,9 +5,11 @@ import {
 	formatTopInfoMobile,
 	formatTopInfoRight,
 	initPanelChrome,
+	type LoadState,
 	renderTopInfoLeft,
-	TOPINFO_RIGHT_OK_TEXT,
+	topInfoStatus,
 } from "../bbs-chrome.js";
+import { buildSessionFromAssets } from "../game/bootstrap.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
 import { getActivePhase, updateActivePhase } from "../game/engine.js";
@@ -19,8 +21,12 @@ import {
 	buildPersonaNameMap,
 	findFirstMention,
 } from "../game/mention-parser.js";
+import {
+	clearPendingBootstrap,
+	getPendingBootstrap,
+} from "../game/pending-bootstrap.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
-import type { AiId, PhaseConfig } from "../game/types";
+import type { AiId, AiPersona, PhaseConfig } from "../game/types";
 import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";
 import { CapHitError } from "../llm-client.js";
 import {
@@ -397,9 +403,273 @@ export function renderGame(
 		persistenceWarningEl.removeAttribute("hidden");
 	}
 
+	/** Apply the three-phase load state on `#stage` so CSS can drive panel +
+	 * status visuals. Removing the attribute (state="stable") restores the
+	 * fully-bright "live" look. */
+	function setStageLoadState(state: LoadState): void {
+		const stageEl = doc.querySelector<HTMLElement>("#stage");
+		if (!stageEl) return;
+		if (state === "stable") {
+			stageEl.removeAttribute("data-load-state");
+			stageEl.style.removeProperty("--fill-pct");
+		} else {
+			stageEl.setAttribute("data-load-state", state);
+		}
+	}
+
+	/** Paint the right-hand topinfo cell for one of the three load states.
+	 * Used during progressive loading; the normal `refreshTopInfo` (session
+	 * required) takes over once we transition to stable. */
+	function renderLoadingTopInfo(state: LoadState, daemonsOnline: number): void {
+		const topinfoLeftEl = doc.querySelector<HTMLElement>("#topinfo-left");
+		const topinfoRightEl = doc.querySelector<HTMLElement>("#topinfo-right");
+		const topinfoMobileEl = doc.querySelector<HTMLElement>("#topinfo-mobile");
+		const topinfoMobileStatusEl = doc.querySelector<HTMLElement>(
+			"#topinfo-mobile-status",
+		);
+		const status = topInfoStatus(state);
+		const sessionIdLocal = getActiveSessionId() ?? "0x????";
+		// Walk the phase chain to count total phases (matches refreshTopInfo).
+		let total = 1;
+		let cursor: PhaseConfig | undefined = PHASE_1_CONFIG.nextPhaseConfig;
+		while (cursor) {
+			total += 1;
+			cursor = cursor.nextPhaseConfig;
+		}
+		const inputs = {
+			sessionId: sessionIdLocal,
+			phaseNumber: 1,
+			totalPhases: total,
+			turn: 0,
+			daemonsOnline,
+		};
+		if (topinfoLeftEl) renderTopInfoLeft(topinfoLeftEl, inputs);
+		if (topinfoRightEl) {
+			topinfoRightEl.textContent = formatTopInfoRight(inputs);
+			const span = doc.createElement("span");
+			span.className = status.cls;
+			span.textContent = status.desktop;
+			topinfoRightEl.appendChild(span);
+		}
+		if (topinfoMobileEl) {
+			topinfoMobileEl.textContent = formatTopInfoMobile(inputs);
+		}
+		if (topinfoMobileStatusEl) {
+			topinfoMobileStatusEl.textContent = "";
+			const span = doc.createElement("span");
+			span.className = status.cls;
+			span.textContent = ` ${status.mobile}`;
+			topinfoMobileStatusEl.appendChild(span);
+		}
+	}
+
+	/** Async loading flow: render an empty "loading daemons" screen
+	 * immediately, populate panels with names + braille spinners when
+	 * personas resolve, run a fake-progress brightness wipe while waiting
+	 * for content packs, then build + persist the session and recurse into
+	 * the normal restore path. */
+	function renderBootstrapLoadingFlow(
+		pending: ReturnType<typeof getPendingBootstrap> & object,
+	): Promise<void> {
+		// Show route chrome + global header now (start route hides them).
+		const startScreenEl = doc.querySelector<HTMLElement>("#start-screen");
+		const sessionsScreenEl = doc.querySelector<HTMLElement>("#sessions-screen");
+		const panelsEl = doc.querySelector<HTMLElement>("#panels");
+		const composerEl = doc.querySelector<HTMLElement>("#composer");
+		if (startScreenEl) startScreenEl.setAttribute("hidden", "");
+		if (sessionsScreenEl) sessionsScreenEl.setAttribute("hidden", "");
+		if (panelsEl) panelsEl.removeAttribute("hidden");
+		if (composerEl) composerEl.removeAttribute("hidden");
+		const headerEl = doc.querySelector<HTMLElement>("#stage > header");
+		const topinfoEl = doc.querySelector<HTMLElement>("#topinfo");
+		const bannerWrapEl = doc.querySelector<HTMLElement>("#banner");
+		if (headerEl) headerEl.removeAttribute("hidden");
+		if (topinfoEl) topinfoEl.removeAttribute("hidden");
+		if (bannerWrapEl) bannerWrapEl.removeAttribute("hidden");
+		const bannerEl = doc.querySelector<HTMLElement>("#banner");
+		if (bannerEl && !bannerEl.innerHTML) bannerEl.innerHTML = BANNER;
+
+		// Reset panels: clear any stale data-ai/persona-name from a previous
+		// session so the loading frames render as empty shells.
+		const panelEls = doc.querySelectorAll<HTMLElement>(".ai-panel");
+		for (const panel of panelEls) {
+			panel.removeAttribute("data-ai");
+			panel.style.removeProperty("--panel-color");
+			for (const lbl of panel.querySelectorAll<HTMLElement>(".panel-name")) {
+				lbl.textContent = "";
+			}
+			const transcript = panel.querySelector<HTMLElement>(".transcript");
+			if (transcript) {
+				transcript.dataset.transcript = "";
+				transcript.textContent = "";
+			}
+			const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
+			if (budgetEl) {
+				budgetEl.dataset.budget = "";
+				budgetEl.textContent = "";
+			}
+		}
+
+		// Composer: visible but disabled with a "loading…" placeholder.
+		_promptInput.disabled = true;
+		_sendBtn.disabled = true;
+		_promptInput.placeholder = "loading…";
+
+		setStageLoadState("loading-daemons");
+		renderLoadingTopInfo("loading-daemons", 0);
+
+		// Braille spinner machinery — duplicated from the round-submit path so
+		// we can ride spinners on the panel-name labels while content packs
+		// load (no session yet, so we can't share that closure).
+		const BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+		const SPINNER_INTERVAL_MS = 80;
+		let spinnerInterval: ReturnType<typeof setInterval> | undefined;
+		let wipeRaf: ReturnType<typeof requestAnimationFrame> | undefined;
+
+		const cleanupLoadingTimers = (): void => {
+			if (spinnerInterval) {
+				clearInterval(spinnerInterval);
+				spinnerInterval = undefined;
+			}
+			if (wipeRaf !== undefined) {
+				cancelAnimationFrame(wipeRaf);
+				wipeRaf = undefined;
+			}
+		};
+
+		const startSpinners = (): void => {
+			let frame = 0;
+			spinnerInterval = setInterval(() => {
+				frame = (frame + 1) % BRAILLE_FRAMES.length;
+				const text = ` ${BRAILLE_FRAMES[frame] ?? ""}`;
+				for (const sp of doc.querySelectorAll<HTMLElement>(
+					".panel-name .panel-spinner",
+				)) {
+					sp.textContent = text;
+				}
+			}, SPINNER_INTERVAL_MS);
+		};
+
+		const startBrightnessWipe = (): void => {
+			const stageEl = doc.querySelector<HTMLElement>("#stage");
+			if (!stageEl) return;
+			const startTs =
+				typeof performance !== "undefined" ? performance.now() : Date.now();
+			// τ chosen so the bright band reaches ~95% at ~60s (target pack
+			// load time) and ~99% at ~90s, asymptotically capped at 99% so
+			// the panel never visually completes until packs actually resolve.
+			const TAU_MS = 20_000;
+			const tick = (): void => {
+				const now =
+					typeof performance !== "undefined" ? performance.now() : Date.now();
+				const elapsed = now - startTs;
+				const eased = 1 - Math.exp(-elapsed / TAU_MS);
+				const pct = Math.min(99, Math.max(0, eased * 100));
+				stageEl.style.setProperty("--fill-pct", `${pct.toFixed(2)}%`);
+				wipeRaf = requestAnimationFrame(tick);
+			};
+			wipeRaf = requestAnimationFrame(tick);
+		};
+
+		const buildLoadingPersonaShape = (
+			personas: Record<AiId, AiPersona>,
+		): void => {
+			const ids = Object.keys(personas);
+			panelEls.forEach((panel, idx) => {
+				const aiId = ids[idx];
+				if (!aiId) return;
+				const persona = personas[aiId];
+				if (!persona) return;
+				panel.dataset.ai = aiId;
+				panel.style.setProperty("--panel-color", persona.color);
+				initPanelChrome(panel, persona);
+				// Append a braille spinner span next to each persona name label.
+				for (const labelEl of panel.querySelectorAll<HTMLElement>(
+					".panel-name",
+				)) {
+					const sp = doc.createElement("span");
+					sp.className = "panel-spinner";
+					sp.textContent = ` ${BRAILLE_FRAMES[0] ?? ""}`;
+					labelEl.appendChild(sp);
+				}
+			});
+		};
+
+		return pending.personasPromise
+			.then((personas) => {
+				buildLoadingPersonaShape(personas);
+				setStageLoadState("generating-room");
+				renderLoadingTopInfo("generating-room", Object.keys(personas).length);
+				startSpinners();
+				startBrightnessWipe();
+				return pending.contentPacksPromise.then((packs) => ({
+					personas,
+					contentPacks: packs,
+				}));
+			})
+			.then((assets) => {
+				cleanupLoadingTimers();
+				let built = buildSessionFromAssets(assets);
+				built = applyTestAffordances(built, effectiveParams);
+
+				const saveResult = saveActiveSession(built.getState());
+				if (!saveResult.ok) {
+					showPersistenceWarning(saveResult.reason);
+				}
+				clearPendingBootstrap();
+
+				// Strip braille spinners — initPanelChrome below will overwrite
+				// .panel-name text content but spinners are appended children,
+				// so clear them explicitly first.
+				for (const sp of doc.querySelectorAll<HTMLElement>(
+					".panel-name .panel-spinner",
+				)) {
+					sp.remove();
+				}
+
+				setStageLoadState("stable");
+
+				// Re-enable composer; the recursive renderGame call below will
+				// run refreshComposerState which re-derives sendBtn.disabled from
+				// the current text + lockouts (start state: send disabled until
+				// a valid mention is typed).
+				_promptInput.disabled = false;
+				_promptInput.placeholder = "";
+
+				// Hand off to the normal populated path. Setting the module-scope
+				// session var lets the recursive call skip both the loading branch
+				// and the localStorage restore path.
+				session = built;
+				return renderGame(root, params);
+			})
+			.catch((err: unknown) => {
+				cleanupLoadingTimers();
+				clearPendingBootstrap();
+				if (err instanceof CapHitError && capHitEl) {
+					capHitEl.removeAttribute("hidden");
+					if (panelsEl) panelsEl.setAttribute("hidden", "");
+					if (composerEl) composerEl.setAttribute("hidden", "");
+					return;
+				}
+				// Anything else: bounce to start with a generic broken reason.
+				clearActiveSession();
+				if (typeof location !== "undefined") {
+					location.hash = "#/start?reason=broken";
+				}
+			});
+	}
+
 	// Session restore path: load from active session pointer.
 	// If no valid session → redirect to #/start.
 	if (!session) {
+		// Bootstrap-loading branch: the player just submitted CONNECT, the
+		// session can't be built until content packs land, but we want them on
+		// the main screen with progressive loading rather than stuck on dial-up.
+		const pendingBootstrap = getPendingBootstrap();
+		if (pendingBootstrap) {
+			return renderBootstrapLoadingFlow(pendingBootstrap);
+		}
+
 		// Feature-detect localStorage availability (SecurityError in privacy mode).
 		let storageAvailable = true;
 		try {
@@ -621,12 +891,26 @@ export function renderGame(
 		};
 		renderTopInfoLeft(topinfoLeftEl, inputs);
 		topinfoRightEl.textContent = formatTopInfoRight(inputs);
+		const stableStatus = topInfoStatus("stable");
 		const okSpan = doc.createElement("span");
-		okSpan.className = "ok";
-		okSpan.textContent = TOPINFO_RIGHT_OK_TEXT;
+		okSpan.className = stableStatus.cls;
+		okSpan.textContent = stableStatus.desktop;
 		topinfoRightEl.appendChild(okSpan);
 		if (topinfoMobileEl) {
 			topinfoMobileEl.textContent = formatTopInfoMobile(inputs);
+		}
+		// Reset the mobile status pill to "stable" — during progressive
+		// loading we put loading/generating in #topinfo-mobile-status; this
+		// brings it back to its normal green appearance once a session is live.
+		const topinfoMobileStatusEl = doc.querySelector<HTMLElement>(
+			"#topinfo-mobile-status",
+		);
+		if (topinfoMobileStatusEl) {
+			topinfoMobileStatusEl.textContent = "";
+			const sp = doc.createElement("span");
+			sp.className = stableStatus.cls;
+			sp.textContent = ` ${stableStatus.mobile}`;
+			topinfoMobileStatusEl.appendChild(sp);
 		}
 	}
 

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -10,26 +10,25 @@
  *     legacy-save-discarded is present.
  *   - Type out the dial-up handshake into #dial, then reveal the login form.
  *     Skip the animation under prefers-reduced-motion or ?skipDialup=1.
- *   - Kick off generateNewGameAssets() on mount; CONNECT starts disabled.
- *   - On generation success → enable CONNECT and hold assets in module scope.
- *   - On failure (CapHitError or any error) → show #cap-hit, hide #start-screen.
- *   - CONNECT click → password === "password" gate. On match: buildSessionFromAssets,
- *     applyTestAffordances, saveActiveSession, then location.hash = "#/game".
- *     On mismatch: show inline error, keep CONNECT enabled. Idempotent against
- *     double-click while a successful connect is mid-flight.
- *
- * Issue #173 (parent #155).
+ *   - Kick off persona + content-pack generation on mount via the shared
+ *     pending-bootstrap module. CONNECT becomes available as soon as the
+ *     login form is revealed — generation continues in the background and
+ *     the game route observes it for progressive loading.
+ *   - On generation failure (CapHitError or any error) → show #cap-hit and
+ *     hide #start-screen.
+ *   - CONNECT click → password === "password" gate. On match, navigate to
+ *     #/game; the game route handles the loading UI and only persists the
+ *     session once content packs resolve. On mismatch: show inline error.
  */
 
-import {
-	buildSessionFromAssets,
-	type ContentPackProvider,
-	generateNewGameAssets,
-	type NewGameAssets,
-	type SynthesisProvider,
+import type {
+	ContentPackProvider,
+	SynthesisProvider,
 } from "../game/bootstrap.js";
-import { saveActiveSession } from "../persistence/session-storage.js";
-import { applyTestAffordances } from "./game.js";
+import {
+	getPendingBootstrap,
+	startBootstrap,
+} from "../game/pending-bootstrap.js";
 
 /** Warning reason strings shown in the persistence warning banner. */
 export const PERSISTENCE_WARNING_MESSAGES: Record<string, string> = {
@@ -235,8 +234,7 @@ export function _setTestOverrides(
 	_testOverrides = overrides;
 }
 
-/** Module-level pending assets holder. Cleared on each render call. */
-let _pendingAssets: NewGameAssets | undefined;
+/** Set once a successful CONNECT submit is mid-flight, to debounce double-clicks. */
 let _beginClickPending = false;
 /** The resize listener installed on the most recent render — removed on next call. */
 let _activeResizeHandler: (() => void) | undefined;
@@ -291,8 +289,9 @@ export function renderStart(
 	const formEl = doc.querySelector<HTMLFormElement>("#login-form");
 	const keyartEl = doc.querySelector<HTMLElement>("#login-keyart");
 
-	// Reset module-level state on each render call
-	_pendingAssets = undefined;
+	// Reset module-level state on each render call. CONNECT is disabled only
+	// while the dial-up animation is still typing out — it's re-enabled in
+	// revealLogin() once the login form appears.
 	_beginClickPending = false;
 	beginBtn.disabled = true;
 
@@ -328,6 +327,10 @@ export function renderStart(
 	const revealLogin = () => {
 		if (!revealEl) return;
 		revealEl.hidden = false;
+		// CONNECT is gated only on the dial-up animation completing — not on
+		// asset readiness. Generation continues in the background while the
+		// player types, and the game route renders progressive loading.
+		beginBtn.disabled = false;
 		if (keyartEl) {
 			paintLandscape(keyartEl);
 			const handler = () => paintLandscape(keyartEl);
@@ -368,29 +371,14 @@ export function renderStart(
 
 	const proceedConnect = () => {
 		if (_beginClickPending) return;
-		if (!_pendingAssets) return;
 		_beginClickPending = true;
 		beginBtn.disabled = true;
 		if (pwEl) pwEl.disabled = true;
 		clearError();
 
-		const assets = _pendingAssets;
-		let session = buildSessionFromAssets(assets);
-		session = applyTestAffordances(session, effectiveParams);
-
-		const saveResult = saveActiveSession(session.getState());
-		if (!saveResult.ok) {
-			const persistenceWarningEl = doc.querySelector<HTMLElement>(
-				"#persistence-warning",
-			);
-			if (persistenceWarningEl) {
-				persistenceWarningEl.textContent =
-					"Game progress cannot be saved: storage is full or disabled.";
-				persistenceWarningEl.removeAttribute("hidden");
-			}
-		}
-
-		// Navigate to game regardless of save result (game.ts will handle missing session)
+		// The game route reads the in-flight bootstrap from pending-bootstrap.ts
+		// and progressively renders the loading UI as personas, then content
+		// packs, resolve. The session is built and persisted there, not here.
 		location.hash = "#/game";
 	};
 
@@ -418,22 +406,31 @@ export function renderStart(
 	if (formEl) formEl.addEventListener("submit", handleSubmit);
 	beginBtn.addEventListener("click", handleSubmit);
 
-	// Kick off generation
+	// Kick off (or reuse) the in-flight bootstrap. If the user backed out to
+	// the start screen after a previous render, startBootstrap returns the
+	// existing entry rather than starting a fresh generation.
+	const existing = getPendingBootstrap();
+	const bootstrap = existing ?? startBootstrap(_testOverrides);
+	_testOverrides = undefined;
+
+	// If generation fails while the player is still on this screen, surface
+	// the same CapHitError UX we used to show when CONNECT was gated. Once
+	// they've navigated to #/game, the start screen is hidden — the game
+	// route's loading flow handles the failure there instead.
 	const generationPromise = (async () => {
 		try {
-			const assets = await generateNewGameAssets(_testOverrides);
-			_pendingAssets = assets;
-			beginBtn.disabled = false;
+			await Promise.all([
+				bootstrap.personasPromise,
+				bootstrap.contentPacksPromise,
+			]);
 		} catch (err) {
-			// Funnel failure to #cap-hit (same UX as game-route CapHitError)
-			const capHitEl = doc.querySelector<HTMLElement>("#cap-hit");
-			if (capHitEl) capHitEl.removeAttribute("hidden");
-			if (startScreenEl) startScreenEl.setAttribute("hidden", "");
-			// Re-throw so callers can observe the failure
+			const startVisible = startScreenEl ? !startScreenEl.hidden : false;
+			if (startVisible) {
+				const capHitEl = doc.querySelector<HTMLElement>("#cap-hit");
+				if (capHitEl) capHitEl.removeAttribute("hidden");
+				if (startScreenEl) startScreenEl.setAttribute("hidden", "");
+			}
 			throw err;
-		} finally {
-			// Clear test overrides after each render cycle
-			_testOverrides = undefined;
 		}
 	})();
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -239,6 +239,63 @@ main {
 	filter: grayscale(0.6);
 }
 
+/* ── Progressive-loading states (start → game transition) ─────────────────
+ * #stage carries a `data-load-state` attribute set by routes/game.ts:
+ *   loading-daemons   — empty panel frames; composer disabled; status red
+ *   generating-room   — names + braille spinners; bottom→top brightness
+ *                       wipe driven by --fill-pct; status yellow
+ *   stable (default)  — attribute removed; full-bright "live" appearance
+ * The wipe overlays a dull layer that retreats from the bottom; pixels
+ * BELOW --fill-pct (measured from the bottom edge) are fully bright.
+ */
+#stage[data-load-state="loading-daemons"] .ai-panel,
+#stage[data-load-state="generating-room"] .ai-panel {
+	pointer-events: none;
+	cursor: default;
+}
+
+#stage[data-load-state="loading-daemons"] .ai-panel {
+	opacity: 0.45;
+	filter: grayscale(0.55);
+}
+
+#stage[data-load-state="generating-room"] .ai-panel {
+	position: relative;
+}
+
+#stage[data-load-state="generating-room"] .ai-panel::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		to top,
+		transparent 0%,
+		transparent calc(var(--fill-pct, 0%) - 6%),
+		rgba(11, 7, 0, 0.55) var(--fill-pct, 0%),
+		rgba(11, 7, 0, 0.55) 100%
+	);
+	mix-blend-mode: multiply;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#stage[data-load-state="generating-room"] .ai-panel::after {
+		background: rgba(11, 7, 0, 0.35);
+	}
+}
+
+/* Topinfo right-cell status colors — green is .ok (existing), red is .err
+ * (loading daemons), yellow is .warn (generating room). */
+.topinfo .err {
+	color: var(--err);
+	text-shadow: 0 0 6px rgba(255, 123, 107, 0.5);
+}
+
+.topinfo .warn {
+	color: #ffe07a;
+	text-shadow: 0 0 6px rgba(255, 224, 122, 0.5);
+}
+
 /* Stretchable border row: [corner][label][stretch dashes][corner-r absolute] */
 .brow {
 	display: flex;


### PR DESCRIPTION
## Summary

Login no longer blocks on persona + content-pack generation. CONNECT is available the moment the dial-up animation reveals; the player lands on the main screen and watches a three-phase loading state on the "connection stable" indicator and the chat panels.

| Phase | Top-info (desktop) | Top-info (mobile) | Color | Panels | Composer |
|---|---|---|---|---|---|
| `loading-daemons` | `● loading daemons` | `● loading` | red | Empty full-height frames | Disabled |
| `generating-room` | `● generating room` | `● generating` | yellow | Names + braille spinner; bright band rises from the bottom over a dull base (asymptotic fake progress, ~3 min target) | Disabled |
| `stable` | `● connection stable` | `● stable` | green | Live | Enabled |

Brightness wipe uses `1 - exp(-t / 60s)` clamped to 99% so the panel never visually completes until content packs actually resolve, then snaps to fully-bright.

## Architecture

- New `src/spa/game/pending-bootstrap.ts` holds the in-flight generation across the start → game route transition. In-memory only — the session can't be persisted until packs land.
- `src/spa/game/bootstrap.ts` exposes `generateNewGameAssetsSplit` so personas + packs can be observed independently. The single-promise `generateNewGameAssets` stays as a thin wrapper for tests.
- `src/spa/routes/start.ts` ungates `#begin` (enabled at dial-up reveal, not on assets) and stashes the bootstrap. CONNECT just navigates — `buildSessionFromAssets` + `saveActiveSession` move to the game route.
- `src/spa/main.ts` dispatcher lets `#/game` render when a pending bootstrap exists (alongside the normal `populated` verdict).
- `src/spa/routes/game.ts` adds a loading branch: render empty chrome → await personas (populate names/colors + spinners, switch to `generating-room`, start the rAF wipe) → await packs (build session, save, clear pending bootstrap, recurse into the normal populated path which binds the form submit handler).
- `src/spa/bbs-chrome.ts` adds the three load-state constants + `topInfoStatus(state)` helper.
- `src/spa/styles.css` adds `.err`/`.warn` status colors, `[data-load-state]` panel rules, and the bottom→top brightness mask via a pseudo-element gradient driven by `--fill-pct`.

The localStorage restore path and dispatcher routing are otherwise unchanged — refreshing mid-session still lands directly at `stable` with no loading flicker.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm lint` — clean (10 pre-existing warnings, unchanged)
- `pnpm test` — 980/980 (updated 2 start-route tests for the new ungated CONNECT behavior; rest unchanged)

## Test plan

- [ ] Clear localStorage, submit password — confirm immediate navigation to `#/game` with red `loading daemons`, full-height empty panel frames, disabled input
- [ ] Within seconds (personas resolve, stubbed in dev): yellow `generating room`, panel names + braille spinners appear, brightness band starts rising from the bottom
- [ ] Wait for content packs (~3 min on real backend): green `connection stable`, spinners disappear, panels fully bright, input + send enabled
- [ ] Resize to mobile (≤720px) and repeat — confirm `loading` / `generating` / `stable` labels in `#topinfo-mobile-status`
- [ ] Refresh mid-session — confirm restore path lands at `stable` with no loading flicker
- [ ] `prefers-reduced-motion` — brightness wipe falls back to a static dim overlay (no rAF animation)

https://claude.ai/code/session_01AujSHAEaeRZ3BnuCjXAzda

---
_Generated by [Claude Code](https://claude.ai/code/session_01AujSHAEaeRZ3BnuCjXAzda)_