### PR TITLE
Fix session cache invalidation when loading different games

### DIFF
--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -235,6 +235,11 @@ const PERSISTENCE_WARNING_MESSAGES: Record<string, string> = {
 let gameEnded = false;
 
 let session: GameSession | null = null;
+/** The session id `session` was last hydrated from. When the active-session
+ * pointer moves (e.g. the user clicks Load on a different session in the
+ * picker), this drifts from `getActiveSessionId()` and the next renderGame
+ * drops the cache so the restore path runs against the new pointer. */
+let cachedSessionId: string | null = null;
 
 export function renderGame(
 	root: HTMLElement,
@@ -252,6 +257,20 @@ export function renderGame(
 	);
 
 	if (!form || !promptInput || !sendBtn) return Promise.resolve();
+
+	// Drop the in-memory session cache if the active-session pointer no longer
+	// matches what we hydrated from. This is what propagates a Load click in
+	// the picker without a page refresh: the click writes a new active id and
+	// re-enters this route, and the restore branch below picks up the new
+	// session instead of re-rendering the stale closure-held one.
+	if (session !== null && cachedSessionId !== getActiveSessionId()) {
+		session = null;
+		cachedSessionId = null;
+		gameEnded = false;
+		// Action log is live-only (no restore), so clear it for parity with
+		// a hard refresh — otherwise entries from the previous session linger.
+		if (actionLogList) actionLogList.textContent = "";
+	}
 
 	// Mention-based addressing state — built lazily after session init below,
 	// since persona handles are procedurally generated per session.
@@ -640,6 +659,7 @@ export function renderGame(
 				// session var lets the recursive call skip both the loading branch
 				// and the localStorage restore path.
 				session = built;
+				cachedSessionId = getActiveSessionId();
 				return renderGame(root, params);
 			})
 			.catch((err: unknown) => {
@@ -698,6 +718,7 @@ export function renderGame(
 			if (loadResult.kind === "ok") {
 				const restoredState = loadResult.state;
 				session = GameSession.restore(restoredState);
+				cachedSessionId = loadResult.sessionId;
 
 				// Re-render transcripts from restored state using conversationLogs.
 				// (The new format stores conversation logs in daemon .txt files, not as
@@ -1422,6 +1443,7 @@ export function renderGame(
 
 						// Reset session so a route re-entry produces a fresh game
 						session = null;
+						cachedSessionId = null;
 						break;
 					}
 				}


### PR DESCRIPTION
## Summary
This PR fixes a bug where switching between different game sessions using the Load picker without a page refresh would fail to properly load the new session. The in-memory session cache was not being invalidated when the active session pointer changed, causing stale session data to persist.

## Key Changes
- Added `cachedSessionId` variable to track which session ID the current in-memory `session` object was hydrated from
- Implemented cache invalidation logic at the start of `renderGame()` that detects when the active session ID has changed and clears the stale session state
- Updated session initialization paths to set `cachedSessionId` when a new session is loaded:
  - When creating a new session from scratch
  - When restoring a session from localStorage
- Clear `cachedSessionId` when resetting the session (e.g., on New Game)
- Clear the action log when invalidating the cache to maintain parity with a hard refresh

## Implementation Details
The fix works by comparing `cachedSessionId` (what we last hydrated from) against `getActiveSessionId()` (the current active pointer). When they diverge—which happens when a user clicks Load on a different session in the picker—the cache is dropped and the restore path runs against the new session pointer. The action log is also cleared since it's live-only and entries from the previous session would otherwise linger.

https://claude.ai/code/session_01THBGPAy3syEAKPDAd1XDcW