### PR TITLE
E2e: witnessed-event reload survival + asymmetric whisper tampering

### DIFF
--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test } from "@playwright/test";
+import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
+
+/**
+ * E2E — Per-Daemon asymmetric whisper tampering (issue #196, PRD #157)
+ *
+ * Proves the editable surface (per-Daemon <aiId>.txt files) is:
+ *   1. The sole source of whisper state fed into the system prompt.
+ *   2. Per-Daemon: an entry injected into one Daemon's file does NOT bleed
+ *      into the other two Daemons' prompts.
+ *
+ * Strategy:
+ *   - Drive the start screen through goToGame → game is live, all three
+ *     <aiId>.txt files exist in localStorage.
+ *   - Directly mutate ids[0]'s DaemonFile in localStorage, appending a
+ *     fabricated `kind: "whisper"` ConversationEntry with a unique sentinel.
+ *   - Reload → the SPA deserialises from storage → reconstructs state.
+ *   - Capture the next round's /v1/chat/completions request bodies.
+ *   - Assert: the targeted Daemon's system prompt contains the whisper line
+ *     inside <conversation>...</conversation>; the other two do not contain
+ *     the sentinel at all.
+ *
+ * This is a v2-only property: in v1 whispers lived in a shared whispers.txt
+ * file and the "absent from other prompts" invariant could not be asserted at
+ * the per-Daemon storage level.
+ */
+
+const SENTINEL = "FABRICATED_TAMPERED_WHISPER_xyz123";
+
+test("fabricated whisper appears in target daemon prompt and is absent from others after reload", async ({
+	page,
+}) => {
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	// 1. Navigate through start screen into the game.
+	//    goToGame stubs synthesis + content-pack + SSE and clicks BEGIN.
+	const { ids, names } = await goToGame(page, { sse: ["stub reply"] });
+
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// ids[1] will be the whisper sender; ids[0] will be the recipient.
+	const targetId = ids[0];
+	const senderId = ids[1];
+	const senderName = names[1];
+
+	// 2. Mutate ids[0]'s DaemonFile in localStorage.
+	//    Append a fabricated whisper entry to phases["1"].conversationLog.
+	//    Do NOT touch the other two Daemon files or engine.dat.
+	await page.evaluate(
+		({ targetId, senderId, sentinel }) => {
+			const sessionId = localStorage.getItem("hi-blue:active-session");
+			if (!sessionId) throw new Error("No active session in localStorage");
+
+			const key = `hi-blue:sessions/${sessionId}/${targetId}.txt`;
+			const raw = localStorage.getItem(key);
+			if (!raw)
+				throw new Error(`DaemonFile not found for targetId=${targetId}`);
+
+			const daemonFile = JSON.parse(raw) as {
+				aiId: string;
+				persona: unknown;
+				phases: {
+					"1": {
+						phaseGoal: string;
+						conversationLog: Array<Record<string, unknown>>;
+					};
+					"2": { phaseGoal: string; conversationLog: Array<unknown> };
+					"3": { phaseGoal: string; conversationLog: Array<unknown> };
+				};
+			};
+
+			// Append fabricated whisper to phase "1" log.
+			daemonFile.phases["1"].conversationLog.push({
+				kind: "whisper",
+				round: 0,
+				from: senderId,
+				to: targetId,
+				content: sentinel,
+			});
+
+			localStorage.setItem(key, JSON.stringify(daemonFile, null, 2));
+		},
+		{ targetId, senderId, sentinel: SENTINEL },
+	);
+
+	// 3. Reload.
+	await page.reload();
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// 4. Stub completions post-reload, capturing request bodies.
+	const capturedBodies: unknown[] = [];
+	await stubChatCompletions(page, (request) => {
+		try {
+			capturedBodies.push(JSON.parse(request.postData() ?? "null"));
+		} catch {
+			capturedBodies.push(null);
+		}
+		return ["stub reply"];
+	});
+
+	// Re-fetch handles after reload.
+	const { names: reloadNames } = await getAiHandles(page);
+
+	// 5. Send a message to trigger a round (addresses any AI).
+	await page.fill("#prompt", `*${reloadNames[0]} hi`);
+	await expect(page.locator("#send")).toBeEnabled();
+	await page.click("#send");
+
+	// Wait for at least 3 captured bodies (one per daemon).
+	await expect
+		.poll(() => capturedBodies.length, { timeout: 30_000 })
+		.toBeGreaterThanOrEqual(3);
+
+	// 6. Identify each daemon's request body by matching the identity line.
+	//    renderSystemPrompt writes: `You are *${ctx.name}. You have no clue...`
+	//    (phase 1), so we match `You are *${name}.` for each known name.
+	function findBodyForName(
+		name: string,
+	): Record<string, unknown> | null {
+		for (const body of capturedBodies) {
+			if (
+				body &&
+				typeof body === "object" &&
+				Array.isArray((body as Record<string, unknown>).messages)
+			) {
+				const messages = (body as { messages: Array<{ content?: string }> })
+					.messages;
+				const sysContent = messages[0]?.content ?? "";
+				if (sysContent.includes(`You are *${name}.`)) {
+					return body as Record<string, unknown>;
+				}
+			}
+		}
+		return null;
+	}
+
+	const targetBody = findBodyForName(names[0]);
+	const other1Body = findBodyForName(names[1]);
+	const other2Body = findBodyForName(names[2]);
+
+	// Derive expected whisper line from conversation-log.ts:58-59:
+	//   `[Round ${round}] *${entry.from} whispered to you: "${entry.content}"`
+	// entry.from is senderId (an aiId); conversation-log uses entry.from directly
+	// as the display value. In the spec we verify the sentinel via SENTINEL alone
+	// and also check the full line format including senderName for robustness.
+	// NOTE: conversation-log.ts renders entry.from (the AiId) directly, not the
+	// persona name. The sentinel is unique so checking via SENTINEL is sufficient.
+	const expectedLine = `[Round 0] *${senderId} whispered to you: "${SENTINEL}"`;
+
+	// 7. Assert targeted daemon's system prompt contains the whisper inside
+	//    <conversation>...</conversation>.
+	expect(
+		targetBody,
+		`No request body found for target daemon (names[0]=${names[0]}). ` +
+			`Captured ${capturedBodies.length} bodies.`,
+	).not.toBeNull();
+
+	const targetSysContent = (
+		targetBody as { messages: Array<{ content: string }> }
+	).messages[0]?.content;
+	expect(targetSysContent).toContain("<conversation>");
+	expect(targetSysContent).toContain("</conversation>");
+	expect(
+		targetSysContent,
+		`Expected whisper line not found in target daemon's system prompt. ` +
+			`Expected: ${expectedLine}`,
+	).toContain(expectedLine);
+	expect(
+		targetSysContent,
+		"Sentinel must appear between <conversation> tags",
+	).toMatch(/<conversation>[\s\S]*FABRICATED_TAMPERED_WHISPER_xyz123[\s\S]*<\/conversation>/);
+
+	// 8. Assert the other two daemons' prompts do NOT contain the sentinel.
+	//    (senderName reference used in the log name for clarity.)
+	const _senderName = senderName; // referenced for documentation only
+
+	expect(
+		other1Body,
+		`No request body found for daemon[1] (names[1]=${names[1]}). ` +
+			`Captured ${capturedBodies.length} bodies.`,
+	).not.toBeNull();
+	const other1SysContent = (
+		other1Body as { messages: Array<{ content: string }> }
+	).messages[0]?.content;
+	expect(
+		other1SysContent,
+		`Sentinel must NOT appear in daemon[1]'s system prompt (asymmetric property)`,
+	).not.toContain(SENTINEL);
+
+	expect(
+		other2Body,
+		`No request body found for daemon[2] (names[2]=${names[2]}). ` +
+			`Captured ${capturedBodies.length} bodies.`,
+	).not.toBeNull();
+	const other2SysContent = (
+		other2Body as { messages: Array<{ content: string }> }
+	).messages[0]?.content;
+	expect(
+		other2SysContent,
+		`Sentinel must NOT appear in daemon[2]'s system prompt (asymmetric property)`,
+	).not.toContain(SENTINEL);
+
+	// 9. No page errors.
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+});

--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -115,9 +115,7 @@ test("fabricated whisper appears in target daemon prompt and is absent from othe
 	// 6. Identify each daemon's request body by matching the identity line.
 	//    renderSystemPrompt writes: `You are *${ctx.name}. You have no clue...`
 	//    (phase 1), so we match `You are *${name}.` for each known name.
-	function findBodyForName(
-		name: string,
-	): Record<string, unknown> | null {
+	function findBodyForName(name: string): Record<string, unknown> | null {
 		for (const body of capturedBodies) {
 			if (
 				body &&
@@ -169,7 +167,9 @@ test("fabricated whisper appears in target daemon prompt and is absent from othe
 	expect(
 		targetSysContent,
 		"Sentinel must appear between <conversation> tags",
-	).toMatch(/<conversation>[\s\S]*FABRICATED_TAMPERED_WHISPER_xyz123[\s\S]*<\/conversation>/);
+	).toMatch(
+		/<conversation>[\s\S]*FABRICATED_TAMPERED_WHISPER_xyz123[\s\S]*<\/conversation>/,
+	);
 
 	// 8. Assert the other two daemons' prompts do NOT contain the sentinel.
 	//    (senderName reference used in the log name for clarity.)

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -101,21 +101,32 @@ interface GridPosition {
 type CardinalDirection = "north" | "south" | "east" | "west";
 const DIRECTIONS: CardinalDirection[] = ["north", "south", "east", "west"];
 
-function forwardDelta(facing: CardinalDirection): { drow: number; dcol: number } {
+function forwardDelta(facing: CardinalDirection): {
+	drow: number;
+	dcol: number;
+} {
 	switch (facing) {
-		case "north": return { drow: -1, dcol: 0 };
-		case "south": return { drow: 1, dcol: 0 };
-		case "east":  return { drow: 0, dcol: 1 };
-		case "west":  return { drow: 0, dcol: -1 };
+		case "north":
+			return { drow: -1, dcol: 0 };
+		case "south":
+			return { drow: 1, dcol: 0 };
+		case "east":
+			return { drow: 0, dcol: 1 };
+		case "west":
+			return { drow: 0, dcol: -1 };
 	}
 }
 
 function leftDelta(facing: CardinalDirection): { drow: number; dcol: number } {
 	switch (facing) {
-		case "north": return { drow: 0, dcol: -1 };
-		case "south": return { drow: 0, dcol: 1 };
-		case "east":  return { drow: -1, dcol: 0 };
-		case "west":  return { drow: 1, dcol: 0 };
+		case "north":
+			return { drow: 0, dcol: -1 };
+		case "south":
+			return { drow: 0, dcol: 1 };
+		case "east":
+			return { drow: -1, dcol: 0 };
+		case "west":
+			return { drow: 1, dcol: 0 };
 	}
 }
 
@@ -123,15 +134,24 @@ function inBounds(pos: GridPosition): boolean {
 	return pos.row >= 0 && pos.row < 5 && pos.col >= 0 && pos.col < 5;
 }
 
-function coneCells(pos: GridPosition, facing: CardinalDirection): GridPosition[] {
+function coneCells(
+	pos: GridPosition,
+	facing: CardinalDirection,
+): GridPosition[] {
 	const fwd = forwardDelta(facing);
 	const lft = leftDelta(facing);
 	const candidates: GridPosition[] = [
 		{ row: pos.row, col: pos.col },
 		{ row: pos.row + fwd.drow, col: pos.col + fwd.dcol },
-		{ row: pos.row + 2 * fwd.drow + lft.drow, col: pos.col + 2 * fwd.dcol + lft.dcol },
+		{
+			row: pos.row + 2 * fwd.drow + lft.drow,
+			col: pos.col + 2 * fwd.dcol + lft.dcol,
+		},
 		{ row: pos.row + 2 * fwd.drow, col: pos.col + 2 * fwd.dcol },
-		{ row: pos.row + 2 * fwd.drow - lft.drow, col: pos.col + 2 * fwd.dcol - lft.dcol },
+		{
+			row: pos.row + 2 * fwd.drow - lft.drow,
+			col: pos.col + 2 * fwd.dcol - lft.dcol,
+		},
 	];
 	return candidates.filter((c, i) => i === 0 || inBounds(c));
 }
@@ -149,7 +169,8 @@ function deobfuscateEngineBlob(blob: string): string {
 	const binary = atob(blob);
 	const bytes = new Uint8Array(binary.length);
 	for (let i = 0; i < binary.length; i++) {
-		bytes[i] = (binary.charCodeAt(i) & 0xff) ^ (keyBytes[i % keyBytes.length] as number);
+		bytes[i] =
+			(binary.charCodeAt(i) & 0xff) ^ (keyBytes[i % keyBytes.length] as number);
 	}
 	return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 }
@@ -445,9 +466,7 @@ async function waitForRound(
 			sid: string;
 			expectedRound: number;
 		}) => {
-			const metaRaw = localStorage.getItem(
-				`hi-blue:sessions/${sid}/meta.json`,
-			);
+			const metaRaw = localStorage.getItem(`hi-blue:sessions/${sid}/meta.json`);
 			if (!metaRaw) return false;
 			try {
 				const meta = JSON.parse(metaRaw) as { round?: number };
@@ -584,28 +603,43 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 				const bytes = new Uint8Array(binary.length);
 				for (let i = 0; i < binary.length; i++) {
 					bytes[i] =
-						(binary.charCodeAt(i) & 0xff) ^ (keyBytes[i % keyBytes.length] as number);
+						(binary.charCodeAt(i) & 0xff) ^
+						(keyBytes[i % keyBytes.length] as number);
 				}
 				const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 				const data = JSON.parse(json) as {
 					personaSpatial: Record<
 						string,
-						Record<string, { position: { row: number; col: number }; facing: string }>
+						Record<
+							string,
+							{ position: { row: number; col: number }; facing: string }
+						>
 					>;
 				};
 
 				// Patch witness position in phase "1"
 				const phase1 = data.personaSpatial["1"];
-				if (!phase1 || !phase1[wId]) throw new Error(`No spatial for ${wId}`);
-				(phase1[wId] as { position: { row: number; col: number }; facing: string }).position = newPos;
-				(phase1[wId] as { position: { row: number; col: number }; facing: string }).facing = newFacing;
+				if (!phase1?.[wId]) throw new Error(`No spatial for ${wId}`);
+				(
+					phase1[wId] as {
+						position: { row: number; col: number };
+						facing: string;
+					}
+				).position = newPos;
+				(
+					phase1[wId] as {
+						position: { row: number; col: number };
+						facing: string;
+					}
+				).facing = newFacing;
 
 				// Inline encode
 				const patchedJson = JSON.stringify(data);
 				const patchBytes = new TextEncoder().encode(patchedJson);
 				for (let i = 0; i < patchBytes.length; i++) {
 					patchBytes[i] =
-						(patchBytes[i] as number) ^ (keyBytes[i % keyBytes.length] as number);
+						(patchBytes[i] as number) ^
+						(keyBytes[i % keyBytes.length] as number);
 				}
 				let binOut = "";
 				for (let i = 0; i < patchBytes.length; i++) {

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -1,0 +1,209 @@
+import { expect, test } from "@playwright/test";
+import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
+
+/**
+ * E2E — Witnessed-event reload survival (issue #196, PRD #157)
+ *
+ * Proves the per-Daemon storage shape from #195 preserves
+ * `kind: "witnessed-event"` entries across a page reload.
+ *
+ * Strategy:
+ *   1. Drive the start screen through goToGame → game is live, all three
+ *      <aiId>.txt DaemonFiles exist in localStorage.
+ *   2. Directly inject a `kind: "witnessed-event"` entry into ids[1]'s
+ *      (the witness's) DaemonFile, simulating what dispatcher.ts:460-493
+ *      would write when it fans out a cone-visible physical action.
+ *      The actor is ids[0]; the action is `go { direction: "north" }`.
+ *   3. Reload → the SPA deserialises from storage → reconstructs state.
+ *   4. Capture the next round's /v1/chat/completions request bodies.
+ *   5. Assert: the witness's system prompt contains the witnessed-event line
+ *      inside <conversation>...</conversation>.
+ *   6. Assert: the actor's system prompt does NOT contain the witnessed-event
+ *      line (actors get a private tool-result string, not a witnessed-event
+ *      entry — the write-time fan-out only targets witnesses).
+ *
+ * The injection bypasses the game engine to avoid spatial-state layout luck
+ * (the stub content pack returns aiStarts:{}, giving daemons no positions,
+ * so live `go` tool calls would fail dispatcher validation). It still exercises
+ * the full deserialization and prompt-rendering path from per-Daemon DaemonFile
+ * → conversationLogs → buildConversationLog → <conversation> block, which is
+ * the v2-only property: in v1 there was no per-Daemon storage for
+ * witnessed-events.
+ *
+ * Key source references:
+ *   src/spa/game/conversation-log.ts:63-65 — witnessed-event "go" line format
+ *   src/spa/game/dispatcher.ts:460-493     — write-time cone fan-out
+ *   src/spa/persistence/session-codec.ts:351-357 — DaemonFile round-trip
+ */
+
+test("fabricated witnessed-event entry survives reload and appears in witness system prompt", async ({
+	page,
+}) => {
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	// ── 1. Boot game ──────────────────────────────────────────────────────────
+	const { ids, names } = await goToGame(page, { sse: ["stub reply"] });
+
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// ids[0] = actor; ids[1] = witness; ids[2] = bystander (untouched)
+	const actorId = ids[0];
+	const witnessId = ids[1];
+	const witnessName = names[1];
+	const DIRECTION = "north";
+
+	// ── 2. Inject a witnessed-event entry into the witness's DaemonFile ───────
+	// This simulates what dispatcher.ts:460-493 would write when the actor
+	// does `go { direction: "north" }` and the actor's post-move cell falls
+	// inside the witness's 5-cell cone.
+	await page.evaluate(
+		({
+			witnessId,
+			actorId,
+			direction,
+		}: {
+			witnessId: string;
+			actorId: string;
+			direction: string;
+		}) => {
+			const sessionId = localStorage.getItem("hi-blue:active-session");
+			if (!sessionId) throw new Error("No active session in localStorage");
+
+			const key = `hi-blue:sessions/${sessionId}/${witnessId}.txt`;
+			const raw = localStorage.getItem(key);
+			if (!raw)
+				throw new Error(`DaemonFile not found for witnessId=${witnessId}`);
+
+			const daemonFile = JSON.parse(raw) as {
+				aiId: string;
+				persona: unknown;
+				phases: {
+					"1": {
+						phaseGoal: string;
+						conversationLog: Array<Record<string, unknown>>;
+					};
+					"2": { phaseGoal: string; conversationLog: Array<unknown> };
+					"3": { phaseGoal: string; conversationLog: Array<unknown> };
+				};
+			};
+
+			// Append a fabricated witnessed-event to phase "1" log.
+			// Shape matches dispatcher.ts:473-491 witness entry construction.
+			daemonFile.phases["1"].conversationLog.push({
+				kind: "witnessed-event",
+				round: 1,
+				actor: actorId,
+				actionKind: "go",
+				direction,
+			});
+
+			localStorage.setItem(key, JSON.stringify(daemonFile, null, 2));
+		},
+		{ witnessId, actorId, direction: DIRECTION },
+	);
+
+	// ── 3. Reload ──────────────────────────────────────────────────────────────
+	await page.reload();
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// ── 4. Stub completions post-reload; capture request bodies ───────────────
+	const capturedBodies: unknown[] = [];
+	await stubChatCompletions(page, (request) => {
+		try {
+			capturedBodies.push(JSON.parse(request.postData() ?? "null"));
+		} catch {
+			capturedBodies.push(null);
+		}
+		return ["stub reply"];
+	});
+
+	const { names: reloadNames } = await getAiHandles(page);
+
+	// ── 5. Trigger a round; wait for 3+ bodies ─────────────────────────────────
+	await page.fill("#prompt", `*${reloadNames[0]} hi`);
+	await expect(page.locator("#send")).toBeEnabled();
+	await page.click("#send");
+
+	await expect
+		.poll(() => capturedBodies.length, { timeout: 30_000 })
+		.toBeGreaterThanOrEqual(3);
+
+	// ── 6. Identify each daemon's request body by identity line ───────────────
+	// renderSystemPrompt (prompt-builder.ts:148-154) writes:
+	//   phase 1: `You are *${name}. You have no clue where you are…`
+	// so matching `You are *${name}.` covers both phase 1 and later phases.
+	function findBodyForName(
+		bodies: unknown[],
+		name: string,
+	): Record<string, unknown> | null {
+		for (const body of bodies) {
+			if (body && typeof body === "object") {
+				const b = body as { messages?: Array<{ content?: string }> };
+				const sysContent = b.messages?.[0]?.content ?? "";
+				if (sysContent.includes(`You are *${name}.`)) {
+					return body as Record<string, unknown>;
+				}
+			}
+		}
+		return null;
+	}
+
+	const witnessBody = findBodyForName(capturedBodies, witnessName);
+	const actorBody = findBodyForName(capturedBodies, names[0]);
+
+	expect(
+		witnessBody,
+		`No request body found for witness (${witnessName}). ` +
+			`Captured ${capturedBodies.length} bodies.`,
+	).not.toBeNull();
+
+	expect(
+		actorBody,
+		`No request body found for actor (${names[0]}). ` +
+			`Captured ${capturedBodies.length} bodies.`,
+	).not.toBeNull();
+
+	// ── 7. Build expected witnessed-event line ────────────────────────────────
+	// conversation-log.ts:63-65:
+	//   case "go":
+	//     return `[Round ${round}] You watch *${actorSub} walk ${direction}.`;
+	// where actorSub = `*${entry.actor}` (the AiId, not the name)
+	const expectedLine = `[Round 1] You watch *${actorId} walk ${DIRECTION}.`;
+
+	// ── 8. Assert witness's system prompt contains the witnessed-event line ────
+	const witnessSysContent = (
+		witnessBody as { messages: Array<{ content: string }> }
+	).messages[0]?.content;
+
+	expect(witnessSysContent).toContain("<conversation>");
+	expect(witnessSysContent).toContain("</conversation>");
+	expect(
+		witnessSysContent,
+		`Expected witnessed-event line not found in witness system prompt. ` +
+			`Expected: "${expectedLine}"`,
+	).toContain(expectedLine);
+	expect(
+		witnessSysContent,
+		"Witnessed-event line must appear between <conversation> tags",
+	).toMatch(
+		new RegExp(
+			`<conversation>[\\s\\S]*${expectedLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*</conversation>`,
+		),
+	);
+
+	// ── 9. Assert actor's system prompt does NOT contain the line ─────────────
+	// The write-time fan-out (dispatcher.ts:460-493) only appends to witnesses,
+	// never to the actor. The actor gets a private tool-result string instead.
+	const actorSysContent = (
+		actorBody as { messages: Array<{ content: string }> }
+	).messages[0]?.content;
+
+	expect(
+		actorSysContent,
+		"Actor must not have the witnessed-event line in their system prompt",
+	).not.toContain(expectedLine);
+
+	// ── 10. No page errors ────────────────────────────────────────────────────
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+});

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -10,104 +10,714 @@ import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
  * Strategy:
  *   1. Drive the start screen through goToGame → game is live, all three
  *      <aiId>.txt DaemonFiles exist in localStorage.
- *   2. Directly inject a `kind: "witnessed-event"` entry into ids[1]'s
- *      (the witness's) DaemonFile, simulating what dispatcher.ts:460-493
- *      would write when it fans out a cone-visible physical action.
- *      The actor is ids[0]; the action is `go { direction: "north" }`.
- *   3. Reload → the SPA deserialises from storage → reconstructs state.
- *   4. Capture the next round's /v1/chat/completions request bodies.
- *   5. Assert: the witness's system prompt contains the witnessed-event line
+ *   2. Decode engine.dat → read personaSpatial (actor positions + facings)
+ *      and obstacle positions.
+ *   3. Compute a walk plan: find (actorId, direction, witnessId,
+ *      witnessLookDir?) such that after the actor walks `direction`, their
+ *      post-move cell falls inside the witness's (possibly updated) cone.
+ *      - First try a "direct plan" with the witness's current facing.
+ *      - If no direct plan exists, compute a "setup plan": find witnessLookDir
+ *        such that reorienting the witness first (via `look`) makes the actor's
+ *        post-move visible, then drive round 0 as a setup round where the
+ *        witness `look`s and others pass.
+ *      - If after setup still no plan, fail with full spatial layout.
+ *   4. Reload (first reload) — after reload, renderGame is called only once
+ *      (restore path), so page.fill correctly enables #send.  The engine.dat
+ *      and DaemonFiles from step 1 are preserved in localStorage.
+ *   5. Re-register the JSON-mode and SSE stubs (route handlers are cleared on
+ *      reload).
+ *   6. If a setup round was needed, drive it first (witness `look`s, others pass).
+ *   7. Drive the action round: actor `go direction`, others pass.
+ *   8. Sanity-check: the witness's DaemonFile has a witnessed-event entry.
+ *   9. Reload (second reload) → the SPA deserialises from storage → reconstructs.
+ *  10. Capture the next round's /v1/chat/completions request bodies.
+ *  11. Assert: the witness's system prompt contains the witnessed-event line
  *      inside <conversation>...</conversation>.
- *   6. Assert: the actor's system prompt does NOT contain the witnessed-event
- *      line (actors get a private tool-result string, not a witnessed-event
- *      entry — the write-time fan-out only targets witnesses).
+ *  12. Assert: the actor's system prompt does NOT contain the line.
  *
- * The injection bypasses the game engine to avoid spatial-state layout luck
- * (the stub content pack returns aiStarts:{}, giving daemons no positions,
- * so live `go` tool calls would fail dispatcher validation). It still exercises
- * the full deserialization and prompt-rendering path from per-Daemon DaemonFile
- * → conversationLogs → buildConversationLog → <conversation> block, which is
- * the v2-only property: in v1 there was no per-Daemon storage for
- * witnessed-events.
+ * The round number in the witnessed-event entry is the phase.round at
+ * dispatch time. The first dispatched round (after the first reload) is
+ * round=0; after advanceRound it becomes 1. A setup round increments round
+ * to 1, so the action round dispatches at round=1 and the witnessed-event
+ * line reads "[Round 1]…". Without a setup round the action round dispatches
+ * at round=0.
  *
  * Key source references:
  *   src/spa/game/conversation-log.ts:63-65 — witnessed-event "go" line format
  *   src/spa/game/dispatcher.ts:460-493     — write-time cone fan-out
- *   src/spa/persistence/session-codec.ts:351-357 — DaemonFile round-trip
+ *   src/spa/game/dispatcher.ts:342         — round = getActivePhase(state).round
+ *   src/spa/persistence/session-codec.ts   — DaemonFile round-trip
+ *   src/spa/persistence/sealed-blob-codec.ts:18 — OBFUSCATION_KEY
  */
 
-test("fabricated witnessed-event entry survives reload and appears in witness system prompt", async ({
+// ── Tool-call SSE body helpers ────────────────────────────────────────────────
+
+/**
+ * Build a minimal OpenAI-compatible SSE body that emits a single tool call
+ * and then closes. The parser in streaming.ts collects tool_calls deltas by
+ * index and flushes them on finish_reason:"tool_calls" or [DONE].
+ */
+function toolCallSseBody(name: string, args: Record<string, string>): string {
+	const toolCallChunk = JSON.stringify({
+		choices: [
+			{
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							id: "call_e2e_tc",
+							function: {
+								name,
+								arguments: JSON.stringify(args),
+							},
+						},
+					],
+				},
+				finish_reason: null,
+			},
+		],
+	});
+	const finishChunk = JSON.stringify({
+		choices: [{ delta: {}, finish_reason: "tool_calls" }],
+	});
+	return `data: ${toolCallChunk}\n\ndata: ${finishChunk}\n\ndata: [DONE]\n\n`;
+}
+
+/** SSE body that returns a plain text reply ("stub reply"). */
+function stubReplySseBody(): string {
+	const chunk = JSON.stringify({
+		choices: [{ delta: { content: "stub reply" }, finish_reason: null }],
+	});
+	return `data: ${chunk}\n\ndata: [DONE]\n\n`;
+}
+
+// ── Cone projection (inlined from src/spa/game/cone-projector.ts) ─────────────
+
+interface GridPosition {
+	row: number;
+	col: number;
+}
+
+type CardinalDirection = "north" | "south" | "east" | "west";
+const DIRECTIONS: CardinalDirection[] = ["north", "south", "east", "west"];
+
+function forwardDelta(facing: CardinalDirection): { drow: number; dcol: number } {
+	switch (facing) {
+		case "north": return { drow: -1, dcol: 0 };
+		case "south": return { drow: 1, dcol: 0 };
+		case "east":  return { drow: 0, dcol: 1 };
+		case "west":  return { drow: 0, dcol: -1 };
+	}
+}
+
+function leftDelta(facing: CardinalDirection): { drow: number; dcol: number } {
+	switch (facing) {
+		case "north": return { drow: 0, dcol: -1 };
+		case "south": return { drow: 0, dcol: 1 };
+		case "east":  return { drow: -1, dcol: 0 };
+		case "west":  return { drow: 1, dcol: 0 };
+	}
+}
+
+function inBounds(pos: GridPosition): boolean {
+	return pos.row >= 0 && pos.row < 5 && pos.col >= 0 && pos.col < 5;
+}
+
+function coneCells(pos: GridPosition, facing: CardinalDirection): GridPosition[] {
+	const fwd = forwardDelta(facing);
+	const lft = leftDelta(facing);
+	const candidates: GridPosition[] = [
+		{ row: pos.row, col: pos.col },
+		{ row: pos.row + fwd.drow, col: pos.col + fwd.dcol },
+		{ row: pos.row + 2 * fwd.drow + lft.drow, col: pos.col + 2 * fwd.dcol + lft.dcol },
+		{ row: pos.row + 2 * fwd.drow, col: pos.col + 2 * fwd.dcol },
+		{ row: pos.row + 2 * fwd.drow - lft.drow, col: pos.col + 2 * fwd.dcol - lft.dcol },
+	];
+	return candidates.filter((c, i) => i === 0 || inBounds(c));
+}
+
+function posEqual(a: GridPosition, b: GridPosition): boolean {
+	return a.row === b.row && a.col === b.col;
+}
+
+// ── engine.dat codec (inlined from src/spa/persistence/sealed-blob-codec.ts) ──
+
+const OBFUSCATION_KEY = "hi-blue:engine/v1@kJvN3pX8wQmR2sZt";
+
+function deobfuscateEngineBlob(blob: string): string {
+	const keyBytes = new TextEncoder().encode(OBFUSCATION_KEY);
+	const binary = atob(blob);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = (binary.charCodeAt(i) & 0xff) ^ (keyBytes[i % keyBytes.length] as number);
+	}
+	return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}
+
+// ── Spatial planning ─────────────────────────────────────────────────────────
+
+interface PersonaSpatial {
+	position: GridPosition;
+	facing: CardinalDirection;
+}
+
+interface DirectPlan {
+	kind: "direct";
+	actorId: string;
+	direction: CardinalDirection;
+	witnessId: string;
+	/** The phase.round value at dispatch time (0 for first round after reload). */
+	roundAtDispatch: number;
+}
+
+interface SetupPlan {
+	kind: "setup";
+	actorId: string;
+	direction: CardinalDirection;
+	witnessId: string;
+	witnessLookDir: CardinalDirection;
+	/** The phase.round value at dispatch time (1 after the setup round advances it). */
+	roundAtDispatch: number;
+}
+
+type WalkPlan = DirectPlan | SetupPlan | PatchPlan;
+
+/**
+ * Find a walk plan such that after the actor moves, their post-move cell
+ * falls in the witness's cone (current or post-look cone).
+ *
+ * @param spatials      personaSpatial for phase 1 (aiId → spatial state)
+ * @param obstacles     obstacle positions for phase 1
+ * @param currentRound  current phase.round value (0 initially, 1 after a setup round)
+ */
+function findWalkPlan(
+	spatials: Record<string, PersonaSpatial>,
+	obstacles: GridPosition[],
+	currentRound: number,
+): WalkPlan | null {
+	const aiIds = Object.keys(spatials);
+
+	for (const actorId of aiIds) {
+		const actorSpatial = spatials[actorId];
+		if (!actorSpatial) continue;
+
+		for (const direction of DIRECTIONS) {
+			const delta = forwardDelta(direction);
+			const nextPos: GridPosition = {
+				row: actorSpatial.position.row + delta.drow,
+				col: actorSpatial.position.col + delta.dcol,
+			};
+			if (!inBounds(nextPos)) continue;
+			if (obstacles.some((o) => posEqual(o, nextPos))) continue;
+
+			// Try current facing of each other daemon
+			for (const witnessId of aiIds) {
+				if (witnessId === actorId) continue;
+				const witnessSpatial = spatials[witnessId];
+				if (!witnessSpatial) continue;
+				const cone = coneCells(witnessSpatial.position, witnessSpatial.facing);
+				if (cone.some((c) => posEqual(c, nextPos))) {
+					return {
+						kind: "direct",
+						actorId,
+						direction,
+						witnessId,
+						roundAtDispatch: currentRound,
+					};
+				}
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Find a setup plan: reorient the witness (via `look`) so that after they
+ * turn, the actor's post-move cell falls in the witness's new cone.
+ */
+function findSetupPlan(
+	spatials: Record<string, PersonaSpatial>,
+	obstacles: GridPosition[],
+): SetupPlan | null {
+	const aiIds = Object.keys(spatials);
+
+	for (const actorId of aiIds) {
+		const actorSpatial = spatials[actorId];
+		if (!actorSpatial) continue;
+
+		for (const direction of DIRECTIONS) {
+			const delta = forwardDelta(direction);
+			const nextPos: GridPosition = {
+				row: actorSpatial.position.row + delta.drow,
+				col: actorSpatial.position.col + delta.dcol,
+			};
+			if (!inBounds(nextPos)) continue;
+			if (obstacles.some((o) => posEqual(o, nextPos))) continue;
+
+			// Try all possible look directions for each witness
+			for (const witnessId of aiIds) {
+				if (witnessId === actorId) continue;
+				const witnessSpatial = spatials[witnessId];
+				if (!witnessSpatial) continue;
+
+				for (const lookDir of DIRECTIONS) {
+					if (lookDir === witnessSpatial.facing) continue; // skip no-op
+					const cone = coneCells(witnessSpatial.position, lookDir);
+					if (cone.some((c) => posEqual(c, nextPos))) {
+						// Round 0 is setup (witness looks), round 1 is action
+						return {
+							kind: "setup",
+							actorId,
+							direction,
+							witnessId,
+							witnessLookDir: lookDir,
+							roundAtDispatch: 1, // after setup round advances to round=1
+						};
+					}
+				}
+			}
+		}
+	}
+	return null;
+}
+
+interface PatchPlan {
+	kind: "patch";
+	actorId: string;
+	direction: CardinalDirection;
+	witnessId: string;
+	/** The new position to place the witness in engine.dat. */
+	witnessNewPosition: GridPosition;
+	/** The new facing for the witness (same as actor's direction so cone covers next cell). */
+	witnessNewFacing: CardinalDirection;
+	roundAtDispatch: 0;
+}
+
+/**
+ * Last-resort fallback: when no direct or setup plan is possible due to a
+ * degenerate spatial layout (all agents near corners facing outward), patch
+ * engine.dat to reposition the witness so a direct witnessed event is possible.
+ *
+ * Strategy: place the witness 1 cell BEHIND the actor's starting position,
+ * facing the same direction as the actor's planned move.  The actor's
+ * post-move cell will be exactly 2 steps ahead in the witness's cone.
+ *
+ * We ensure the new witness position is:
+ * - In-bounds
+ * - Not an obstacle
+ * - Not already occupied by another agent
+ *
+ * Returns null only if every (actor, direction) pair is blocked or no valid
+ * witness relocation site exists (extremely unlikely with a 5×5 grid).
+ */
+function findPatchPlan(
+	spatials: Record<string, PersonaSpatial>,
+	obstacles: GridPosition[],
+): PatchPlan | null {
+	const aiIds = Object.keys(spatials);
+
+	for (const actorId of aiIds) {
+		const actorSpatial = spatials[actorId];
+		if (!actorSpatial) continue;
+
+		for (const direction of DIRECTIONS) {
+			const fwd = forwardDelta(direction);
+			const nextPos: GridPosition = {
+				row: actorSpatial.position.row + fwd.drow,
+				col: actorSpatial.position.col + fwd.dcol,
+			};
+			if (!inBounds(nextPos)) continue;
+			if (obstacles.some((o) => posEqual(o, nextPos))) continue;
+
+			// Try to place a witness 1 step behind the actor (opposite of direction).
+			// The actor starts at actorSpatial.position; 1 step back is:
+			const backPos: GridPosition = {
+				row: actorSpatial.position.row - fwd.drow,
+				col: actorSpatial.position.col - fwd.dcol,
+			};
+
+			for (const witnessId of aiIds) {
+				if (witnessId === actorId) continue;
+				if (!inBounds(backPos)) continue;
+				if (obstacles.some((o) => posEqual(o, backPos))) continue;
+				// Make sure no other agent (besides the witness we're relocating) is there.
+				const blocked = aiIds.some(
+					(otherId) =>
+						otherId !== witnessId &&
+						spatials[otherId] &&
+						posEqual((spatials[otherId] as PersonaSpatial).position, backPos),
+				);
+				if (blocked) continue;
+
+				// Verify the actor's post-move cell is in the witness's cone from backPos.
+				const cone = coneCells(backPos, direction);
+				if (!cone.some((c) => posEqual(c, nextPos))) continue;
+
+				return {
+					kind: "patch",
+					actorId,
+					direction,
+					witnessId,
+					witnessNewPosition: backPos,
+					witnessNewFacing: direction,
+					roundAtDispatch: 0,
+				};
+			}
+		}
+	}
+	return null;
+}
+
+// ── Page-level route builder ──────────────────────────────────────────────────
+
+/**
+ * Register a page.route (prepend priority) that:
+ * - Passes JSON-mode requests through to the previous stub via fallback().
+ * - Serves `actorSseBody` when the system prompt identifies the actor.
+ * - Serves `stubReplySseBody()` for all other daemons.
+ */
+async function armRoute(
+	page: import("@playwright/test").Page,
+	actorName: string,
+	actorSseBody: string,
+): Promise<void> {
+	await page.route("**/v1/chat/completions", async (route, request) => {
+		const bodyText = request.postData() ?? "null";
+		let bodyParsed: {
+			stream?: boolean;
+			response_format?: unknown;
+			messages?: Array<{ content?: string }>;
+		} | null = null;
+		try {
+			bodyParsed = JSON.parse(bodyText) as typeof bodyParsed;
+		} catch {
+			// ignore
+		}
+
+		// JSON-mode: fall through to the earlier stub registered by stubChatCompletions
+		if (
+			bodyParsed !== null &&
+			(bodyParsed.stream === false || bodyParsed.response_format != null)
+		) {
+			await route.fallback();
+			return;
+		}
+
+		const sysContent = bodyParsed?.messages?.[0]?.content ?? "";
+		if (sysContent.includes(`You are *${actorName}.`)) {
+			await route.fulfill({
+				status: 200,
+				headers: {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+					"X-Content-Type-Options": "nosniff",
+				},
+				body: actorSseBody,
+			});
+		} else {
+			await route.fulfill({
+				status: 200,
+				headers: {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+					"X-Content-Type-Options": "nosniff",
+				},
+				body: stubReplySseBody(),
+			});
+		}
+	});
+}
+
+/**
+ * Poll localStorage until meta.json reflects the given expectedRound for
+ * the active phase. After `advanceRound`, phase.round becomes expectedRound.
+ */
+async function waitForRound(
+	page: import("@playwright/test").Page,
+	sessionId: string,
+	expectedRound: number,
+): Promise<void> {
+	await page.waitForFunction(
+		({
+			sid,
+			expectedRound: expRound,
+		}: {
+			sid: string;
+			expectedRound: number;
+		}) => {
+			const metaRaw = localStorage.getItem(
+				`hi-blue:sessions/${sid}/meta.json`,
+			);
+			if (!metaRaw) return false;
+			try {
+				const meta = JSON.parse(metaRaw) as { round?: number };
+				return (meta.round ?? 0) >= expRound;
+			} catch {
+				return false;
+			}
+		},
+		{ sid: sessionId, expectedRound },
+		{ timeout: 30_000 },
+	);
+}
+
+// ── Main test ────────────────────────────────────────────────────────────────
+
+test("live go tool-call produces witnessed-event that survives reload and appears in witness system prompt", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
 	page.on("pageerror", (err) => pageErrors.push(err));
 
-	// ── 1. Boot game ──────────────────────────────────────────────────────────
+	// ── 1. Boot game ─────────────────────────────────────────────────────────
+	// goToGame stubs all LLM calls and navigates through the start screen.
 	const { ids, names } = await goToGame(page, { sse: ["stub reply"] });
-
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// ids[0] = actor; ids[1] = witness; ids[2] = bystander (untouched)
-	const actorId = ids[0];
-	const witnessId = ids[1];
-	const witnessName = names[1];
-	const DIRECTION = "north";
+	// ── 2. Decode engine.dat → personaSpatial + obstacles ────────────────────
+	// Read engine.dat from localStorage now (before reload) since the session
+	// is already fully initialised after goToGame.
+	const storageInfo = await page.evaluate(() => {
+		const sessionId = localStorage.getItem("hi-blue:active-session");
+		if (!sessionId) throw new Error("No active session in localStorage");
+		const engineBlob = localStorage.getItem(
+			`hi-blue:sessions/${sessionId}/engine.dat`,
+		);
+		if (!engineBlob) throw new Error("engine.dat not found in localStorage");
+		return { engineBlob, sessionId };
+	});
 
-	// ── 2. Inject a witnessed-event entry into the witness's DaemonFile ───────
-	// This simulates what dispatcher.ts:460-493 would write when the actor
-	// does `go { direction: "north" }` and the actor's post-move cell falls
-	// inside the witness's 5-cell cone.
-	await page.evaluate(
-		({
-			witnessId,
-			actorId,
-			direction,
-		}: {
-			witnessId: string;
-			actorId: string;
-			direction: string;
-		}) => {
-			const sessionId = localStorage.getItem("hi-blue:active-session");
-			if (!sessionId) throw new Error("No active session in localStorage");
+	const engineJson = deobfuscateEngineBlob(storageInfo.engineBlob);
+	const engineData = JSON.parse(engineJson) as {
+		personaSpatial: Record<string, Record<string, PersonaSpatial>>;
+		contentPacks: Array<{
+			phaseNumber: number;
+			obstacles: Array<{ holder: GridPosition | null }>;
+		}>;
+		currentPhase: 1 | 2 | 3;
+	};
 
-			const key = `hi-blue:sessions/${sessionId}/${witnessId}.txt`;
-			const raw = localStorage.getItem(key);
-			if (!raw)
-				throw new Error(`DaemonFile not found for witnessId=${witnessId}`);
+	const phase1Spatial = engineData.personaSpatial["1"] as
+		| Record<string, PersonaSpatial>
+		| undefined;
+	if (!phase1Spatial) throw new Error("No phase 1 spatial data in engine.dat");
 
-			const daemonFile = JSON.parse(raw) as {
-				aiId: string;
-				persona: unknown;
-				phases: {
-					"1": {
-						phaseGoal: string;
-						conversationLog: Array<Record<string, unknown>>;
-					};
-					"2": { phaseGoal: string; conversationLog: Array<unknown> };
-					"3": { phaseGoal: string; conversationLog: Array<unknown> };
+	const phase1Pack = engineData.contentPacks.find((p) => p.phaseNumber === 1);
+	const obstaclePositions: GridPosition[] = (phase1Pack?.obstacles ?? [])
+		.map((o) => o.holder)
+		.filter((h): h is GridPosition => h !== null);
+
+	// ── 3. Compute walk plan ──────────────────────────────────────────────────
+	// Try direct plan first (witness's current facing covers actor's next cell).
+	let plan: WalkPlan | null = findWalkPlan(phase1Spatial, obstaclePositions, 0);
+	let setupPlanUsed = false;
+
+	if (!plan) {
+		// Try setup plan: reorient witness in round 0, then act in round 1.
+		const sp = findSetupPlan(phase1Spatial, obstaclePositions);
+		if (sp) {
+			plan = sp;
+			setupPlanUsed = true;
+		}
+	}
+
+	if (!plan) {
+		// Last-resort: patch engine.dat to relocate a witness into a position
+		// where the actor's next move will land in their cone.  The round itself
+		// is still driven via a live go tool call — only the starting spatial
+		// layout is adjusted via direct localStorage mutation.
+		const pp = findPatchPlan(phase1Spatial, obstaclePositions);
+		if (pp) {
+			plan = pp;
+		}
+	}
+
+	if (!plan) {
+		throw new Error(
+			`Could not find any valid walk plan (direct, setup, or patch).\n` +
+				`Spatial layout: ${JSON.stringify(phase1Spatial, null, 2)}\n` +
+				`Obstacles: ${JSON.stringify(obstaclePositions, null, 2)}\n` +
+				`AI ids: ${JSON.stringify(ids)}`,
+		);
+	}
+
+	const { actorId, direction, witnessId, roundAtDispatch } = plan;
+	const actorName = names[ids.indexOf(actorId as (typeof ids)[number])];
+	const witnessName = names[ids.indexOf(witnessId as (typeof ids)[number])];
+
+	if (!actorName || !witnessName) {
+		throw new Error(
+			`Could not resolve names: actorId=${actorId}, witnessId=${witnessId}, ` +
+				`ids=${JSON.stringify(ids)}, names=${JSON.stringify(names)}`,
+		);
+	}
+
+	// ── 4. Patch engine.dat if needed (degenerate spatial layout) ────────────
+	// For the rare case where agents are placed in a corner/edge configuration
+	// that makes witnessing geometrically impossible even with a setup round,
+	// we directly rewrite engine.dat's personaSpatial to reposition the witness
+	// adjacent to the actor.  The actual witnessed-event is still produced by a
+	// live go tool call in step 7; only the starting positions are patched.
+	if (plan.kind === "patch") {
+		const patchPlan = plan;
+		await page.evaluate(
+			({
+				sid,
+				wId,
+				newPos,
+				newFacing,
+				engineKey,
+			}: {
+				sid: string;
+				wId: string;
+				newPos: { row: number; col: number };
+				newFacing: string;
+				engineKey: string;
+			}) => {
+				const key = `hi-blue:sessions/${sid}/engine.dat`;
+				const blob = localStorage.getItem(key);
+				if (!blob) throw new Error("engine.dat not found");
+
+				// Inline decode
+				const keyBytes = new TextEncoder().encode(engineKey);
+				const binary = atob(blob);
+				const bytes = new Uint8Array(binary.length);
+				for (let i = 0; i < binary.length; i++) {
+					bytes[i] =
+						(binary.charCodeAt(i) & 0xff) ^ (keyBytes[i % keyBytes.length] as number);
+				}
+				const json = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+				const data = JSON.parse(json) as {
+					personaSpatial: Record<
+						string,
+						Record<string, { position: { row: number; col: number }; facing: string }>
+					>;
 				};
-			};
 
-			// Append a fabricated witnessed-event to phase "1" log.
-			// Shape matches dispatcher.ts:473-491 witness entry construction.
-			daemonFile.phases["1"].conversationLog.push({
-				kind: "witnessed-event",
-				round: 1,
-				actor: actorId,
-				actionKind: "go",
-				direction,
-			});
+				// Patch witness position in phase "1"
+				const phase1 = data.personaSpatial["1"];
+				if (!phase1 || !phase1[wId]) throw new Error(`No spatial for ${wId}`);
+				(phase1[wId] as { position: { row: number; col: number }; facing: string }).position = newPos;
+				(phase1[wId] as { position: { row: number; col: number }; facing: string }).facing = newFacing;
 
-			localStorage.setItem(key, JSON.stringify(daemonFile, null, 2));
-		},
-		{ witnessId, actorId, direction: DIRECTION },
-	);
+				// Inline encode
+				const patchedJson = JSON.stringify(data);
+				const patchBytes = new TextEncoder().encode(patchedJson);
+				for (let i = 0; i < patchBytes.length; i++) {
+					patchBytes[i] =
+						(patchBytes[i] as number) ^ (keyBytes[i % keyBytes.length] as number);
+				}
+				let binOut = "";
+				for (let i = 0; i < patchBytes.length; i++) {
+					binOut += String.fromCharCode(patchBytes[i] as number);
+				}
+				localStorage.setItem(key, btoa(binOut));
+			},
+			{
+				sid: storageInfo.sessionId,
+				wId: witnessId,
+				newPos: patchPlan.witnessNewPosition,
+				newFacing: patchPlan.witnessNewFacing,
+				engineKey: OBFUSCATION_KEY,
+			},
+		);
+	}
 
-	// ── 3. Reload ──────────────────────────────────────────────────────────────
+	// ── 5. First reload ───────────────────────────────────────────────────────
+	// After goToGame (new game), renderGame is called twice: once for the
+	// bootstrap loading phase and again recursively after session generation.
+	// Two input-event listeners are registered; the first closure's
+	// personaNamesToId is never populated, which can prevent page.fill from
+	// enabling #send reliably.  A reload resets to a single renderGame call
+	// (restore path), so page.fill correctly enables #send.
+	// The session state (engine.dat, DaemonFiles, meta.json) is preserved in
+	// localStorage and survives the reload.
 	await page.reload();
 	await expect(page.locator("#composer")).toBeVisible();
 
-	// ── 4. Stub completions post-reload; capture request bodies ───────────────
+	// ── 6. Re-register stubs post-reload ──────────────────────────────────────
+	// Playwright route handlers are cleared on page.reload().  We must
+	// re-register the JSON-mode (synthesis + content-pack) stubs so the SPA's
+	// post-round LLM calls don't receive unhandled requests.  The reload brings
+	// up the SPA in restore mode (no synthesis/content-pack calls are made on
+	// reload), so the stub only needs to cover the gameplay SSE requests.
+	// armRoute (registered below per-round) handles SSE; we register a base
+	// fallback stub here so the JSON-mode guard works if needed.
+	await stubChatCompletions(page, () => ["stub reply"]);
+
+	// ── 7. Setup round (if needed): reorient witness via `look` ─────────────
+	// When no direct plan exists, we drive a setup round where the witness
+	// looks in a direction that will put the actor's post-move cell in their cone.
+	// After this round, meta.round advances to 1, and the action round dispatches
+	// at round=1, so roundAtDispatch=1 (set in findSetupPlan).
+	if (setupPlanUsed && plan.kind === "setup") {
+		const { witnessLookDir } = plan;
+
+		// Register route: witness does `look witnessLookDir`, others stub reply
+		await armRoute(
+			page,
+			witnessName,
+			toolCallSseBody("look", { direction: witnessLookDir }),
+		);
+
+		// Address the witness to trigger the setup round
+		await page.locator("#prompt").fill(`*${witnessName} look around!`);
+		await expect(page.locator("#send")).toBeEnabled({ timeout: 15_000 });
+		await page.locator("#send").click();
+
+		// Wait for the setup round to complete: meta.round becomes 1
+		await waitForRound(page, storageInfo.sessionId, 1);
+	}
+
+	// ── 8. Action round: actor does `go direction`, others pass ──────────────
+	// Register route: actor emits go tool call, others get stub reply.
+	// This prepends a new route on top of any existing ones (Playwright prepends
+	// new routes for priority), so it overrides the setup round's route if one
+	// was registered above.
+	await armRoute(page, actorName, toolCallSseBody("go", { direction }));
+
+	// Address the actor.
+	await page.locator("#prompt").fill(`*${actorName} go!`);
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 15_000 });
+	await page.locator("#send").click();
+
+	// Wait for the round to advance: meta.round becomes roundAtDispatch + 1
+	await waitForRound(page, storageInfo.sessionId, roundAtDispatch + 1);
+
+	// ── 9. Sanity-check: witness DaemonFile has witnessed-event entry ──────────
+	const witnessFileCheck = await page.evaluate(
+		({ sid, wId, aId }: { sid: string; wId: string; aId: string }) => {
+			const key = `hi-blue:sessions/${sid}/${wId}.txt`;
+			const raw = localStorage.getItem(key);
+			if (!raw) return { found: false, log: [] as unknown[] };
+			const df = JSON.parse(raw) as {
+				phases: {
+					"1": { conversationLog: Array<{ kind: string; actor?: string }> };
+				};
+			};
+			const log = df.phases["1"].conversationLog;
+			const found = log.some(
+				(e) => e.kind === "witnessed-event" && e.actor === aId,
+			);
+			return { found, log };
+		},
+		{ sid: storageInfo.sessionId, wId: witnessId, aId: actorId },
+	);
+
+	expect(
+		witnessFileCheck.found,
+		`Expected a witnessed-event entry in witness's DaemonFile before reload. ` +
+			`conversationLog: ${JSON.stringify(witnessFileCheck.log, null, 2)}`,
+	).toBe(true);
+
+	// ── 10. Second reload ──────────────────────────────────────────────────────
+	// Reload the SPA, which deserialises from localStorage and reconstructs all
+	// DaemonFile conversation logs (including the witnessed-event entry) into
+	// the system prompts for the next round.
+	await page.reload();
+	await expect(page.locator("#composer")).toBeVisible();
+
+	// ── 11. Stub completions post-reload; capture request bodies ──────────────
 	const capturedBodies: unknown[] = [];
 	await stubChatCompletions(page, (request) => {
 		try {
@@ -120,24 +730,18 @@ test("fabricated witnessed-event entry survives reload and appears in witness sy
 
 	const { names: reloadNames } = await getAiHandles(page);
 
-	// ── 5. Trigger a round; wait for 3+ bodies ─────────────────────────────────
-	await page.fill("#prompt", `*${reloadNames[0]} hi`);
-	await expect(page.locator("#send")).toBeEnabled();
-	await page.click("#send");
+	// ── 12. Trigger another round; wait for 3+ bodies ─────────────────────────
+	await page.locator("#prompt").fill(`*${reloadNames[0]} hi`);
+	await expect(page.locator("#send")).toBeEnabled({ timeout: 15_000 });
+	await page.locator("#send").click();
 
 	await expect
 		.poll(() => capturedBodies.length, { timeout: 30_000 })
 		.toBeGreaterThanOrEqual(3);
 
-	// ── 6. Identify each daemon's request body by identity line ───────────────
-	// renderSystemPrompt (prompt-builder.ts:148-154) writes:
-	//   phase 1: `You are *${name}. You have no clue where you are…`
-	// so matching `You are *${name}.` covers both phase 1 and later phases.
-	function findBodyForName(
-		bodies: unknown[],
-		name: string,
-	): Record<string, unknown> | null {
-		for (const body of bodies) {
+	// ── 13. Identify each daemon's request body by identity line ──────────────
+	function findBodyForName(name: string): Record<string, unknown> | null {
+		for (const body of capturedBodies) {
 			if (body && typeof body === "object") {
 				const b = body as { messages?: Array<{ content?: string }> };
 				const sysContent = b.messages?.[0]?.content ?? "";
@@ -149,29 +753,29 @@ test("fabricated witnessed-event entry survives reload and appears in witness sy
 		return null;
 	}
 
-	const witnessBody = findBodyForName(capturedBodies, witnessName);
-	const actorBody = findBodyForName(capturedBodies, names[0]);
+	const witnessBody = findBodyForName(witnessName);
+	const actorBody = findBodyForName(actorName);
 
 	expect(
 		witnessBody,
 		`No request body found for witness (${witnessName}). ` +
-			`Captured ${capturedBodies.length} bodies.`,
+			`Captured ${capturedBodies.length} bodies. ` +
+			`actorId=${actorId} witnessId=${witnessId}`,
 	).not.toBeNull();
 
 	expect(
 		actorBody,
-		`No request body found for actor (${names[0]}). ` +
+		`No request body found for actor (${actorName}). ` +
 			`Captured ${capturedBodies.length} bodies.`,
 	).not.toBeNull();
 
-	// ── 7. Build expected witnessed-event line ────────────────────────────────
+	// ── 14. Assert witnessed-event line in witness prompt ─────────────────────
 	// conversation-log.ts:63-65:
 	//   case "go":
 	//     return `[Round ${round}] You watch *${actorSub} walk ${direction}.`;
-	// where actorSub = `*${entry.actor}` (the AiId, not the name)
-	const expectedLine = `[Round 1] You watch *${actorId} walk ${DIRECTION}.`;
+	// where round = phase.round at dispatch time.
+	const expectedLine = `[Round ${roundAtDispatch}] You watch *${actorId} walk ${direction}.`;
 
-	// ── 8. Assert witness's system prompt contains the witnessed-event line ────
 	const witnessSysContent = (
 		witnessBody as { messages: Array<{ content: string }> }
 	).messages[0]?.content;
@@ -181,7 +785,9 @@ test("fabricated witnessed-event entry survives reload and appears in witness sy
 	expect(
 		witnessSysContent,
 		`Expected witnessed-event line not found in witness system prompt. ` +
-			`Expected: "${expectedLine}"`,
+			`Expected: "${expectedLine}"\n` +
+			`plan: ${JSON.stringify(plan)}\n` +
+			`actorId=${actorId} direction=${direction} witnessId=${witnessId}`,
 	).toContain(expectedLine);
 	expect(
 		witnessSysContent,
@@ -192,9 +798,9 @@ test("fabricated witnessed-event entry survives reload and appears in witness sy
 		),
 	);
 
-	// ── 9. Assert actor's system prompt does NOT contain the line ─────────────
+	// ── 15. Assert actor's system prompt does NOT contain the line ────────────
 	// The write-time fan-out (dispatcher.ts:460-493) only appends to witnesses,
-	// never to the actor. The actor gets a private tool-result string instead.
+	// never to the actor.
 	const actorSysContent = (
 		actorBody as { messages: Array<{ content: string }> }
 	).messages[0]?.content;
@@ -204,6 +810,6 @@ test("fabricated witnessed-event entry survives reload and appears in witness sy
 		"Actor must not have the witnessed-event line in their system prompt",
 	).not.toContain(expectedLine);
 
-	// ── 10. No page errors ────────────────────────────────────────────────────
+	// ── 16. No page errors ────────────────────────────────────────────────────
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
 });


### PR DESCRIPTION
## What this fixes

Adds two Playwright e2e specs proving the user-visible behaviour of the per-Daemon storage shape from #195. No source code changed — these are pure test additions.

- **`e2e/witnessed-event-reload.spec.ts`** — Drives a live `go` tool call, lets the real dispatcher (`src/spa/game/dispatcher.ts:460-493`) run its write-time cone fan-out and append a `kind:"witnessed-event"` entry to the cone-visible witness's `phase.conversationLogs[witnessId]`. After a page reload the spec captures the next round's `/v1/chat/completions` request bodies, identifies the witness's prompt by matching `You are *${witnessName}.`, and asserts the entry surfaces inside the `<conversation>...</conversation>` block as `[Round N] You watch *${actorId} walk ${direction}.`. It also asserts the actor's prompt does not contain that line — the dispatcher only writes to non-actors. A three-tier spatial planner (direct walk → witness-look-first → last-resort `personaSpatial` patch in `engine.dat`) keeps the spec deterministic across the random 5×5 grid layout.
- **`e2e/whisper-tampering.spec.ts`** — Pre-populates one Daemon's `<aiId>.txt` (the editable surface, per ADR 0006 / #195) with a fabricated `kind:"whisper"` `ConversationEntry`. After reload the spec asserts the fabricated whisper appears in that Daemon's `<conversation>` block and the unique sentinel is absent from each other Daemon's prompt — the v2 asymmetric-tampering shape made user-visible.

Both specs follow the patterns of `e2e/persistence-reload.spec.ts` and `e2e/think-disabled.spec.ts` (DOM transitions and request-body capture; no internal-helper coupling).

## QA steps for the human

- `pnpm exec playwright test e2e/witnessed-event-reload.spec.ts e2e/whisper-tampering.spec.ts --repeat-each=3` to confirm both pass deterministically (the witnessed-event spec relies on random spatial geometry; the three-tier fallback handles all cases).
- Otherwise none — fully covered by the integration smoke.

**Note on the broader e2e suite:** `pnpm smoke` currently reports ~19 pre-existing failures on `origin/main` (commit `60f02d1`), confirmed by running the failing specs against a clean `origin/main` worktree. They are **not** caused by this PR. Likely root cause: the Daemon-log migration in #202 (already merged) appears to have broken the `panel--addressed` CSS class / `#send` enable flow in several existing specs. That's a separate triage item, out of scope for #196.

## Automated coverage

- `pnpm typecheck` — passes
- `pnpm test` — 952/952 pass
- `pnpm exec playwright test e2e/witnessed-event-reload.spec.ts e2e/whisper-tampering.spec.ts --repeat-each=3` — 6/6 pass
- `pnpm lint` — 10 warnings (same as `origin/main`); 0 errors

Closes #196


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nv2hGtUGuTRr5R5Fje3N56)_