### PR TITLE
Disable ligatures in password input to prevent visual misalignment

### DIFF
--- a/e2e/start-screen.spec.ts
+++ b/e2e/start-screen.spec.ts
@@ -83,6 +83,28 @@ test.describe("mobile viewport", () => {
 	});
 });
 
+test("password input disables ligatures so masked `***` doesn't shift mid-char", async ({
+	page,
+}) => {
+	// JetBrains Mono ligates `**` and `***` into a glyph that raises the middle
+	// asterisk. Since the password is masked to `*`s, three characters of input
+	// would visually misalign without `font-variant-ligatures: none`.
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	await stubChatCompletions(page, ["stub reply"]);
+
+	await page.goto("/?skipDialup=1");
+	await expect(page.locator("#password")).toBeVisible();
+
+	const liga = await page
+		.locator("#password")
+		.evaluate((el) => getComputedStyle(el).fontVariantLigatures);
+	expect(liga).toBe("none");
+
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+});
+
 test("[ BEGIN ] is enabled after persona synthesis and content-pack generation complete", async ({
 	page,
 }) => {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -884,6 +884,10 @@ main {
 	text-shadow: inherit;
 	caret-color: var(--amber);
 	padding: 2px 0 3px;
+	/* Password masking renders the user's input as `*` characters. JetBrains
+	   Mono ligates `**` and `***` into glyphs that shift the middle asterisk
+	   upward, so a 3-char password visually misaligns. */
+	font-variant-ligatures: none;
 }
 
 .login-field input:focus {


### PR DESCRIPTION
## Summary
Fixed a visual alignment issue in the password input field where certain fonts (like JetBrains Mono) apply ligatures to asterisk characters, causing the masked password display to shift unexpectedly.

## Changes
- **CSS**: Added `font-variant-ligatures: none` to the password input styling to prevent ligature rendering
  - Includes explanatory comment about why this is necessary
  - Addresses the specific issue where `**` and `***` ligatures raise the middle asterisk, misaligning a 3-character password display

- **Test**: Added e2e test to verify the fix
  - Confirms that `font-variant-ligatures` is set to `none` on the password input element
  - Ensures no page errors occur during the test
  - Documents the expected behavior for future regressions

## Implementation Details
The issue occurs because JetBrains Mono (and potentially other fonts) apply typographic ligatures to consecutive asterisks, which are used to mask password characters. When a user types 3 characters, the resulting `***` gets ligated into a single glyph with the middle asterisk raised, creating a visual misalignment. By explicitly disabling ligatures on the password input, the asterisks render as individual characters without any special glyph substitution.

https://claude.ai/code/session_01PSN9kCs3T1dx6VpKZYysjq