### PR TITLE
Fix transcript panels retaining stale chat when switching sessions

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1012,6 +1012,76 @@ describe("renderGame — localStorage persistence", () => {
 				?.textContent ?? "";
 		expect(redTextRestored).toContain("RED_RESPONSE_UNIQUE_TAG");
 	});
+
+	it("transcripts swap to the new session when the active pointer moves mid-SPA (no page refresh)", async () => {
+		// Regression for the [ load ] click path: PR #203 swapped the in-memory
+		// session when the active-pointer drifted, but the restore branch only
+		// cleared `transcript.textContent` when the new session had chat — so a
+		// load into a fresh-or-quieter session left the previous session's
+		// `> *ember …` lines in the panels.
+		const stub = makeLocalStorageStub();
+		await seedSessionInStub(stub);
+		vi.stubGlobal(
+			"fetch",
+			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, BLUE_ACTION),
+		);
+		vi.stubGlobal("localStorage", stub);
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		await renderGame(getEl<HTMLElement>("main"));
+
+		// Run a round so Session A's transcripts hold chat content.
+		const form = getEl<HTMLFormElement>("#composer");
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		promptInput.value = "*Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// Sanity: Session A chat is in the DOM.
+		expect(
+			document.querySelector<HTMLElement>('[data-transcript="red"]')
+				?.textContent ?? "",
+		).toContain("RED_RESPONSE_UNIQUE_TAG");
+
+		// Seed a brand-new Session B alongside Session A and point the active
+		// pointer at it. This mirrors the [ load ] click in #/sessions:
+		// `setActiveSessionId(B); location.hash = "#/game"`.
+		const { buildSessionFromAssets } = await import("../game/bootstrap.js");
+		const { setActiveSessionId, saveActiveSession } = await import(
+			"../persistence/session-storage.js"
+		);
+		setActiveSessionId("0xB000");
+		const sessionB = buildSessionFromAssets({
+			personas: STATIC_PERSONAS,
+			contentPacks: STATIC_CONTENT_PACKS,
+		});
+		saveActiveSession(sessionB.getState());
+
+		// Re-enter the route on the SAME module instance — the cached session
+		// id from Session A no longer matches the active pointer, so the route
+		// must drop its closure-held session and re-render against Session B.
+		await renderGame(getEl<HTMLElement>("main"));
+
+		// Session B has zero chat for any daemon, so all panel transcripts
+		// must be empty — Session A's chat lines must not linger.
+		expect(
+			document.querySelector<HTMLElement>('[data-transcript="red"]')
+				?.textContent ?? "",
+		).not.toContain("RED_RESPONSE_UNIQUE_TAG");
+		expect(
+			document.querySelector<HTMLElement>('[data-transcript="green"]')
+				?.textContent ?? "",
+		).not.toContain("GREEN_RESPONSE_UNIQUE_TAG");
+		expect(
+			document.querySelector<HTMLElement>('[data-transcript="blue"]')
+				?.textContent ?? "",
+		).not.toContain("BLUE_RESPONSE_UNIQUE_TAG");
+	});
 });
 
 describe("renderGame — chat_lockout event", () => {

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -731,12 +731,17 @@ export function renderGame(
 					if (!panel) return;
 					const transcript = panel.querySelector<HTMLElement>(".transcript");
 					if (!transcript) return;
+					// Always reset before re-populating: when the user clicks [load] on
+					// a different Session in the picker, the panels keep the previous
+					// session's transcript children. Clearing inside the entries-only
+					// branch left them stale whenever the new session had fewer (or
+					// zero) chat entries for this panel slot.
+					transcript.textContent = "";
 					const chatEntries = (
 						restoredPhase.conversationLogs[aiId] ?? []
 					).filter((e) => e.kind === "chat");
 					if (chatEntries.length > 0) {
 						// Synthesise from conversationLogs (stored in daemon .txt files).
-						transcript.textContent = "";
 						const persona = restoredPersonas[aiId];
 						const personaName = persona?.name ?? aiId;
 						for (const entry of chatEntries) {


### PR DESCRIPTION
## Summary
Fixes a regression where transcript panels would retain chat content from a previous session when the user navigates to a different session without a page refresh (e.g., clicking [load] in the session picker).

## Key Changes
- **Moved transcript clearing logic**: Moved `transcript.textContent = ""` outside the `if (chatEntries.length > 0)` conditional in `src/spa/routes/game.ts`. This ensures transcripts are always cleared before re-populating, even when the new session has fewer or zero chat entries for a given panel.
- **Added regression test**: Added comprehensive test case `"transcripts swap to the new session when the active pointer moves mid-SPA (no page refresh)"` that verifies:
  - Session A's chat content is properly rendered
  - Switching to a fresh Session B clears all transcript panels
  - Stale chat lines from Session A don't linger in the DOM

## Implementation Details
The bug occurred because the transcript clearing was conditional on having chat entries. When switching to a session with fewer chat entries than the previous session, the old entries would remain in the DOM since the clearing code was skipped. By unconditionally clearing `transcript.textContent` at the start of the restoration logic, we ensure a clean slate regardless of the new session's chat history.

https://claude.ai/code/session_017sBqUkR4diF7RQaMSkwoEH