### PR TITLE
Fix banner-blue color specificity in login contexts

### DIFF
--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -134,6 +134,14 @@ header {
 		0 0 6px rgba(127, 182, 255, 0.5);
 }
 
+/* `.login-tag b` and `.login-sysinfo b` set color: var(--amber) at
+   specificity (0,1,1), which beats the single-class `.banner-blue` rule
+   above. Re-apply the blue color in those contexts. */
+.login-tag b.banner-blue,
+.login-sysinfo b.banner-blue {
+	color: var(--blue);
+}
+
 /* Top-info row */
 .topinfo {
 	display: flex;


### PR DESCRIPTION
## Summary
Fixed a CSS specificity issue where the `.banner-blue` color styling was being overridden in login tag and system info contexts.

## Changes
- Added CSS rules for `.login-tag b.banner-blue` and `.login-sysinfo b.banner-blue` to explicitly re-apply the blue color
- The fix addresses a specificity conflict where more specific selectors (`.login-tag b` and `.login-sysinfo b`) with `color: var(--amber)` at specificity (0,1,1) were beating the single-class `.banner-blue` rule
- Included explanatory comment documenting the specificity issue and solution

## Implementation Details
The solution maintains the intended styling hierarchy by using the same specificity level (0,2,1) as the overriding rules, ensuring `.banner-blue` elements within login contexts display in blue as intended.

https://claude.ai/code/session_01WudPa8Rv7xSTw8gVhXNM1m