### PR TITLE
Display dynamic build uptime on login screen

### DIFF
--- a/scripts/build-spa.mjs
+++ b/scripts/build-spa.mjs
@@ -20,8 +20,22 @@ const COMMIT_SHA = (() => {
 	}
 })();
 
+const COMMIT_TIMESTAMP_MS = (() => {
+	try {
+		const seconds = Number.parseInt(
+			execSync("git log -1 --format=%ct HEAD", { cwd: root })
+				.toString()
+				.trim(),
+			10,
+		);
+		return Number.isFinite(seconds) ? seconds * 1000 : 0;
+	} catch {
+		return 0;
+	}
+})();
+
 console.log(
-	`Building SPA with WORKER_BASE_URL=${WORKER_BASE_URL} COMMIT_SHA=${COMMIT_SHA}`,
+	`Building SPA with WORKER_BASE_URL=${WORKER_BASE_URL} COMMIT_SHA=${COMMIT_SHA} COMMIT_TIMESTAMP_MS=${COMMIT_TIMESTAMP_MS}`,
 );
 
 // Ensure dist/ and dist/assets/ exist
@@ -56,6 +70,7 @@ const ctx = await esbuild.context({
 	define: {
 		__WORKER_BASE_URL__: JSON.stringify(WORKER_BASE_URL),
 		__COMMIT_SHA__: JSON.stringify(COMMIT_SHA),
+		__COMMIT_TIMESTAMP_MS__: JSON.stringify(COMMIT_TIMESTAMP_MS),
 	},
 	plugins: [copyHtmlPlugin],
 });

--- a/scripts/build-spa.mjs
+++ b/scripts/build-spa.mjs
@@ -23,9 +23,7 @@ const COMMIT_SHA = (() => {
 const COMMIT_TIMESTAMP_MS = (() => {
 	try {
 		const seconds = Number.parseInt(
-			execSync("git log -1 --format=%ct HEAD", { cwd: root })
-				.toString()
-				.trim(),
+			execSync("git log -1 --format=%ct HEAD", { cwd: root }).toString().trim(),
 			10,
 		);
 		return Number.isFinite(seconds) ? seconds * 1000 : 0;

--- a/src/spa/env.d.ts
+++ b/src/spa/env.d.ts
@@ -1,5 +1,6 @@
 declare const __WORKER_BASE_URL__: string;
 declare const __COMMIT_SHA__: string;
+declare const __COMMIT_TIMESTAMP_MS__: number;
 
 // Allow CSS side-effect imports processed by esbuild
 declare module "*.css" {

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -45,7 +45,7 @@
 							<div class="row"><span class="k">sysop</span> <b class="banner-blue">blue</b></div>
 							<div class="row"><span class="k">node</span> <span>01/01</span></div>
 							<div class="row"><span class="k">location</span> <span>cold storage</span></div>
-							<div class="row"><span class="k">uptime</span> <span>11d 04h 22m</span></div>
+							<div class="row"><span class="k">uptime</span> <span id="login-uptime">--d --h --m</span></div>
 						</div>
 						<div class="login-rule" aria-hidden="true">─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</div>
 						<div class="login-frame">

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -238,6 +238,22 @@ export function _setTestOverrides(
 let _beginClickPending = false;
 /** The resize listener installed on the most recent render — removed on next call. */
 let _activeResizeHandler: (() => void) | undefined;
+/** The uptime ticker installed on the most recent render — cleared on next call. */
+let _activeUptimeInterval: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Format the elapsed time since the build's commit as `Dd HHh MMm`. Mirrors
+ * the look of the placeholder text the design system uses for the BBS uptime
+ * line (e.g. `11d 04h 22m`). Negative or zero spans render as `0d 00h 00m`.
+ */
+export function formatUptime(elapsedMs: number): string {
+	const safe = Math.max(0, Math.floor(elapsedMs / 1000));
+	const days = Math.floor(safe / 86400);
+	const hours = Math.floor((safe % 86400) / 3600);
+	const minutes = Math.floor((safe % 3600) / 60);
+	const pad = (n: number) => n.toString().padStart(2, "0");
+	return `${days}d ${pad(hours)}h ${pad(minutes)}m`;
+}
 
 export function renderStart(
 	root: HTMLElement,
@@ -314,6 +330,12 @@ export function renderStart(
 		_activeResizeHandler = undefined;
 	}
 
+	// Drop the previous render's uptime ticker if it's still running.
+	if (_activeUptimeInterval !== undefined) {
+		clearInterval(_activeUptimeInterval);
+		_activeUptimeInterval = undefined;
+	}
+
 	// Merge hash-query-string params with location.search so ?winImmediately=1 etc. work
 	const effectiveParams = new URLSearchParams(
 		typeof location !== "undefined" ? location.search : "",
@@ -331,6 +353,16 @@ export function renderStart(
 		// asset readiness. Generation continues in the background while the
 		// player types, and the game route renders progressive loading.
 		beginBtn.disabled = false;
+		const uptimeEl = doc.querySelector<HTMLElement>("#login-uptime");
+		if (uptimeEl && __COMMIT_TIMESTAMP_MS__ > 0) {
+			const tick = () => {
+				uptimeEl.textContent = formatUptime(
+					Date.now() - __COMMIT_TIMESTAMP_MS__,
+				);
+			};
+			tick();
+			_activeUptimeInterval = setInterval(tick, 60_000);
+		}
 		if (keyartEl) {
 			paintLandscape(keyartEl);
 			const handler = () => paintLandscape(keyartEl);


### PR DESCRIPTION
## Summary
This PR adds dynamic uptime display to the login screen that shows how long the current build has been running since its commit timestamp.

## Key Changes
- **New `formatUptime()` function** in `src/spa/routes/start.ts` that formats elapsed milliseconds as `Dd HHh MMm` (e.g., `11d 04h 22m`)
- **Uptime ticker** that updates the `#login-uptime` element every 60 seconds with the elapsed time since the build's commit
- **Build-time commit timestamp capture** in `scripts/build-spa.mjs` using `git log` to extract the commit timestamp in milliseconds
- **Environment variable** `__COMMIT_TIMESTAMP_MS__` injected into the SPA build via esbuild's `define` option
- **HTML update** to replace the static placeholder text with a dynamic element (`id="login-uptime"`)
- **Proper cleanup** of the uptime interval when the start route re-renders

## Implementation Details
- The uptime calculation uses `Date.now() - __COMMIT_TIMESTAMP_MS__` to determine elapsed time
- The interval is stored in `_activeUptimeInterval` and cleared on subsequent renders to prevent memory leaks
- The ticker only activates if `__COMMIT_TIMESTAMP_MS__ > 0` (gracefully handles build environments where git is unavailable)
- Initial tick is called immediately, then updates every 60 seconds (60,000ms)
- Negative or zero elapsed time safely renders as `0d 00h 00m`

https://claude.ai/code/session_01P3vtGybq3JXVoCzmuCY7yN