### PR TITLE
feat(assets): cache invalidation via content-hashed bundles

### DIFF
--- a/scripts/__tests__/build-spa.test.ts
+++ b/scripts/__tests__/build-spa.test.ts
@@ -9,7 +9,7 @@ const root = path.resolve(__dirname, "../..");
 const script = path.join(root, "scripts/build-spa.mjs");
 
 describe("build-spa.mjs (one-shot, no --watch)", () => {
-	it("exits with code 0 and creates dist/index.html, dist/assets/index.js, dist/assets/index.css", () => {
+	it("exits with code 0 and emits content-hashed assets referenced from index.html", () => {
 		const result = spawnSync("node", [script], {
 			cwd: root,
 			encoding: "utf-8",
@@ -21,13 +21,15 @@ describe("build-spa.mjs (one-shot, no --watch)", () => {
 			fs.existsSync(path.join(root, "dist/index.html")),
 			"dist/index.html should exist",
 		).toBe(true);
-		expect(
-			fs.existsSync(path.join(root, "dist/assets/index.js")),
-			"dist/assets/index.js should exist",
-		).toBe(true);
-		expect(
-			fs.existsSync(path.join(root, "dist/assets/index.css")),
-			"dist/assets/index.css should exist",
-		).toBe(true);
+
+		const assets = fs.readdirSync(path.join(root, "dist/assets"));
+		const jsName = assets.find((n) => /^index-[A-Z0-9]+\.js$/.test(n));
+		const cssName = assets.find((n) => /^index-[A-Z0-9]+\.css$/.test(n));
+		expect(jsName, "a content-hashed JS bundle should exist").toBeDefined();
+		expect(cssName, "a content-hashed CSS bundle should exist").toBeDefined();
+
+		const html = fs.readFileSync(path.join(root, "dist/index.html"), "utf8");
+		expect(html).toContain(`./assets/${jsName}`);
+		expect(html).toContain(`./assets/${cssName}`);
 	});
 });

--- a/scripts/build-spa.mjs
+++ b/scripts/build-spa.mjs
@@ -27,18 +27,59 @@ console.log(
 // Ensure dist/ and dist/assets/ exist
 await fs.mkdir(path.join(root, "dist", "assets"), { recursive: true });
 
-/** esbuild plugin: re-copy index.html after every (re)build. */
-const copyHtmlPlugin = {
-	name: "copy-html",
+// Drop any previously-built hashed assets so old hashes don't accumulate
+// across rebuilds (esbuild won't clean its outdir).
+async function cleanAssets() {
+	const assetsDir = path.join(root, "dist", "assets");
+	const entries = await fs.readdir(assetsDir).catch(() => []);
+	await Promise.all(
+		entries.map((name) =>
+			fs.rm(path.join(assetsDir, name), { force: true, recursive: true }),
+		),
+	);
+}
+await cleanAssets();
+
+/**
+ * esbuild plugin: after each (re)build, look up the content-hashed entry
+ * filenames from the metafile and rewrite dist/index.html to reference them.
+ * The source HTML keeps the un-hashed `./assets/index.{js,css}` paths so it
+ * stays valid as a template; the build is the only place hashes are wired in.
+ */
+const templateHtmlPlugin = {
+	name: "template-html",
 	setup(build) {
-		build.onEnd(async () => {
+		build.onEnd(async (result) => {
 			try {
-				await fs.copyFile(
+				if (!result.metafile) {
+					console.error("[template-html] missing metafile in build result");
+					return;
+				}
+				let jsName = null;
+				let cssName = null;
+				for (const outPath of Object.keys(result.metafile.outputs)) {
+					const base = path.basename(outPath);
+					if (base.endsWith(".map")) continue;
+					if (base.endsWith(".js")) jsName = base;
+					else if (base.endsWith(".css")) cssName = base;
+				}
+				if (!jsName || !cssName) {
+					console.error("[template-html] could not find hashed entry outputs", {
+						jsName,
+						cssName,
+					});
+					return;
+				}
+				const src = await fs.readFile(
 					path.join(root, "src/spa/index.html"),
-					path.join(root, "dist/index.html"),
+					"utf8",
 				);
+				const html = src
+					.replace("./assets/index.css", `./assets/${cssName}`)
+					.replace("./assets/index.js", `./assets/${jsName}`);
+				await fs.writeFile(path.join(root, "dist/index.html"), html);
 			} catch (err) {
-				console.error("[copy-html] failed to copy index.html:", err);
+				console.error("[template-html] failed:", err);
 			}
 		});
 	},
@@ -48,6 +89,11 @@ const ctx = await esbuild.context({
 	entryPoints: { index: path.join(root, "src/spa/main.ts") },
 	bundle: true,
 	outdir: path.join(root, "dist/assets"),
+	// Content-hashed entry filenames so new commits invalidate downstream
+	// caches automatically. Combined with long-lived Cache-Control headers on
+	// /assets/* in the Worker, this gives immutable-cacheable bundles.
+	entryNames: "[name]-[hash]",
+	metafile: true,
 	format: "esm",
 	target: ["es2022"],
 	sourcemap: true,
@@ -57,7 +103,7 @@ const ctx = await esbuild.context({
 		__WORKER_BASE_URL__: JSON.stringify(WORKER_BASE_URL),
 		__COMMIT_SHA__: JSON.stringify(COMMIT_SHA),
 	},
-	plugins: [copyHtmlPlugin],
+	plugins: [templateHtmlPlugin],
 });
 
 if (watchMode) {

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -107,7 +107,36 @@ export default {
 		// Delegate to the assets binding for any unmatched path. This allows
 		// the assets binding's not_found_handling: single-page-application to
 		// serve dist/index.html for SPA client-side routes (e.g. /endgame)
-		// instead of the Worker returning a hard 404.
-		return env.ASSETS.fetch(request);
+		// instead of the Worker returning a hard 404. Cache-Control is
+		// rewritten so content-hashed bundles can live in CDN/browser caches
+		// indefinitely while index.html is always revalidated.
+		return withAssetCacheHeaders(url, await env.ASSETS.fetch(request));
 	},
 } satisfies ExportedHandler<Env>;
+
+/**
+ * Rewrite Cache-Control on asset responses based on path:
+ *   /assets/*  → public, max-age=31536000, immutable  (filenames are
+ *                content-hashed by esbuild, so a new commit produces new URLs
+ *                and old URLs remain valid for clients that already hold them)
+ *   everything → no-cache, must-revalidate            (index.html and SPA
+ *                fallback responses; they must always reflect the latest
+ *                hashed bundle names)
+ *
+ * Only successful (2xx) responses are rewritten so error pages keep whatever
+ * caching the asset binding chose.
+ */
+function withAssetCacheHeaders(url: URL, response: Response): Response {
+	if (!response.ok) return response;
+	const headers = new Headers(response.headers);
+	if (url.pathname.startsWith("/assets/")) {
+		headers.set("Cache-Control", "public, max-age=31536000, immutable");
+	} else {
+		headers.set("Cache-Control", "no-cache, must-revalidate");
+	}
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+}

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -115,22 +115,23 @@ export default {
 } satisfies ExportedHandler<Env>;
 
 /**
- * Rewrite Cache-Control on asset responses based on path:
- *   /assets/*  → public, max-age=31536000, immutable  (filenames are
- *                content-hashed by esbuild, so a new commit produces new URLs
- *                and old URLs remain valid for clients that already hold them)
- *   everything → no-cache, must-revalidate            (index.html and SPA
- *                fallback responses; they must always reflect the latest
- *                hashed bundle names)
+ * Rewrite responses for static-asset routes:
+ *   /assets/*  with non-HTML body → public, max-age=31536000, immutable
+ *                (filenames are content-hashed by esbuild, so a new commit
+ *                produces new URLs and old URLs remain valid for clients
+ *                that already hold them)
+ *   /assets/*  with HTML body     → 404 Not Found
+ *                (the asset binding's single-page-application not_found_handling
+ *                returns index.html with status 200 for unmatched paths;
+ *                serving HTML for an asset URL would cause <script>/<link>
+ *                loads to fail with a cryptic SyntaxError as the parser tries
+ *                to execute HTML — fail fast with a real 404 instead)
+ *   everything → no-cache, must-revalidate
+ *                (index.html and SPA fallback responses; they must always
+ *                reflect the latest hashed bundle names)
  *
- * Two guard cases:
- *   1. Non-2xx responses pass through untouched so error pages keep whatever
- *      caching the asset binding chose.
- *   2. /assets/* requests that miss and fall back to index.html (the asset
- *      binding's single-page-application not_found_handling serves text/html
- *      with status 200 for any unmatched path) must NOT get the immutable
- *      header — otherwise a typo'd asset URL would pin an HTML body into
- *      browser/CDN caches under that URL forever.
+ * Non-2xx responses pass through untouched so error pages from the asset
+ * binding keep whatever caching it chose.
  */
 function withAssetCacheHeaders(url: URL, response: Response): Response {
 	if (!response.ok) return response;
@@ -138,8 +139,14 @@ function withAssetCacheHeaders(url: URL, response: Response): Response {
 	const isHtml = (response.headers.get("Content-Type") ?? "").includes(
 		"text/html",
 	);
+	if (isAssetPath && isHtml) {
+		return new Response("Asset not found", {
+			status: 404,
+			headers: { "Cache-Control": "no-cache, must-revalidate" },
+		});
+	}
 	const headers = new Headers(response.headers);
-	if (isAssetPath && !isHtml) {
+	if (isAssetPath) {
 		headers.set("Cache-Control", "public, max-age=31536000, immutable");
 	} else {
 		headers.set("Cache-Control", "no-cache, must-revalidate");

--- a/src/proxy/_smoke.ts
+++ b/src/proxy/_smoke.ts
@@ -123,13 +123,23 @@ export default {
  *                fallback responses; they must always reflect the latest
  *                hashed bundle names)
  *
- * Only successful (2xx) responses are rewritten so error pages keep whatever
- * caching the asset binding chose.
+ * Two guard cases:
+ *   1. Non-2xx responses pass through untouched so error pages keep whatever
+ *      caching the asset binding chose.
+ *   2. /assets/* requests that miss and fall back to index.html (the asset
+ *      binding's single-page-application not_found_handling serves text/html
+ *      with status 200 for any unmatched path) must NOT get the immutable
+ *      header — otherwise a typo'd asset URL would pin an HTML body into
+ *      browser/CDN caches under that URL forever.
  */
 function withAssetCacheHeaders(url: URL, response: Response): Response {
 	if (!response.ok) return response;
+	const isAssetPath = url.pathname.startsWith("/assets/");
+	const isHtml = (response.headers.get("Content-Type") ?? "").includes(
+		"text/html",
+	);
 	const headers = new Headers(response.headers);
-	if (url.pathname.startsWith("/assets/")) {
+	if (isAssetPath && !isHtml) {
 		headers.set("Cache-Control", "public, max-age=31536000, immutable");
 	} else {
 		headers.set("Cache-Control", "no-cache, must-revalidate");

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,8 +11,11 @@
 		"command": "pnpm build",
 		"watch_dir": "src/spa"
 	},
-	// Static assets (SPA). Wrangler serves matching paths from dist/ first;
-	// unmatched paths fall through to the Worker fetch handler (API routes).
+	// Static assets (SPA). The Worker fetch handler runs first for every
+	// request and either handles API routes itself or delegates to the
+	// ASSETS binding. Running the Worker first lets us attach Cache-Control
+	// headers to /assets/* (long, immutable — they're content-hashed) and to
+	// index.html (no-cache — it pins the current hashed bundle).
 	"assets": {
 		"directory": "./dist",
 		"not_found_handling": "single-page-application",
@@ -20,7 +23,8 @@
 		// unmatched paths via env.ASSETS.fetch(request) — required for the
 		// not_found_handling: single-page-application fallback to fire on
 		// client-side routes such as /endgame.
-		"binding": "ASSETS"
+		"binding": "ASSETS",
+		"run_worker_first": true
 	},
 	"kv_namespaces": [
 		{


### PR DESCRIPTION
## Summary

- esbuild emits `index-[hash].{js,css}`; the build templates the hashed names into `dist/index.html` so each commit produces fresh asset URLs.
- Worker runs first for every request (`assets.run_worker_first`) and sets `Cache-Control: public, max-age=31536000, immutable` on `/assets/*` and `Cache-Control: no-cache, must-revalidate` on `index.html` / SPA-fallback responses.
- `/assets/*` requests that fall through to the SPA fallback (typo, or stale hashed name from a cached old `index.html` after a deploy) now return a clean **404** instead of 200 + HTML — prevents `<script>` and `<link>` tags from trying to execute HTML and failing with a cryptic `SyntaxError`.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (953 tests) all green
- [x] `pnpm exec playwright test e2e/smoke.spec.ts` passes against the hashed bundle
- [x] curl probe against `wrangler dev` covers: real asset → 200 + immutable; missing asset → 404 + no-cache; stale hash → 404 + no-cache; `/` → 200 + no-cache; `/endgame` SPA fallback → 200 + no-cache; CORS preflight on `/v1/chat/completions` unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01GVLHDMV24QR8Gh5ftfYpfm)_