### PR TITLE
Update BBS prompt prefix from guest to root user

### DIFF
--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -160,7 +160,7 @@
 					</article>
 				</div>
 				<form id="composer" class="cmd">
-					<span class="prompt-prefix"><span class="prompt-host"><b>guest</b><span class="at">@</span>hi-blue.bbs:</span><span class="prompt-target">/?????</span><span class="at">&gt; </span></span>
+					<span class="prompt-prefix"><span class="prompt-host"><b>root</b><span class="at">@</span>hi-blue:</span><span class="prompt-target">/?????</span><span class="at">&gt; </span></span>
 					<div class="prompt-wrap">
 						<div id="prompt-overlay" aria-hidden="true"></div>
 						<input id="prompt" type="text" placeholder="" autocomplete="off" spellcheck="false" />

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -290,7 +290,7 @@ export function renderGame(
 	// Prompt-target indicator inside the BBS-style command-line prefix.
 	const promptTargetEl = doc.querySelector<HTMLElement>(".prompt-target");
 
-	/** Update the `/*<handle>` indicator beside `guest@hi-blue.bbs:` from the
+	/** Update the `/*<handle>` indicator beside `root@hi-blue:` from the
 	 * current addressee. `null` resets to dim `/?????`. */
 	function refreshPromptTarget(addressee: AiId | null): void {
 		if (!promptTargetEl) return;


### PR DESCRIPTION
## Summary
Updated the BBS-style command-line prompt to reflect a root user instead of a guest user, along with corresponding documentation updates.

## Changes
- Changed the prompt prefix username from `guest` to `root` in the HTML markup
- Removed the `.bbs` domain suffix from the hostname (changed `hi-blue.bbs` to `hi-blue`)
- Updated the JSDoc comment in the game route to reflect the new prompt format

## Details
The prompt now displays `root@hi-blue:` instead of `guest@hi-blue.bbs:`, which better reflects the intended user context for the BBS-style interface. This is a cosmetic change to the UI that affects how the command-line prompt is presented to users.

https://claude.ai/code/session_011wSCDteRRYW8fSt4nipJGw