### PR TITLE
Rename third AI persona from "blue" to "cyan"

### DIFF
--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -47,8 +47,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -58,7 +58,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -93,7 +93,7 @@ describe("serializeGameSave", () => {
 		const ids = save.ais.map((a) => a.persona.id);
 		expect(ids).toContain("red");
 		expect(ids).toContain("green");
-		expect(ids).toContain("blue");
+		expect(ids).toContain("cyan");
 	});
 
 	it("includes persona fields (name, color, blurb, personaGoal)", () => {
@@ -130,7 +130,7 @@ describe("serializeGameSave", () => {
 
 	it("includes whispers in the per-phase conversationLog (via per-Daemon log)", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		game = appendWhisperEntry(game, "red", "blue", "Secret plan");
+		game = appendWhisperEntry(game, "red", "cyan", "Secret plan");
 		const save = serializeGameSave(game);
 		// Whisper from red appears in red's conversationLog (sender's log also gets the entry)
 		const ember = save.ais.find((a) => a.persona.id === "red");
@@ -199,8 +199,8 @@ describe("serializeGameSave", () => {
 
 	it("whisper in green's log only if green is sender or recipient", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		// Whisper between red and blue — should appear in red and blue, not green
-		game = appendWhisperEntry(game, "red", "blue", "Our secret");
+		// Whisper between red and cyan — should appear in red and cyan, not green
+		game = appendWhisperEntry(game, "red", "cyan", "Our secret");
 		const save = serializeGameSave(game);
 		const sage = save.ais.find((a) => a.persona.id === "green");
 		const greenWhispers = sage?.phases[0]?.conversationLog.filter(

--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -73,7 +73,7 @@ const SETTING_POOL_6: readonly string[] = [
 	"tide-flooded boardwalk",
 ];
 
-const AI_IDS = ["red", "green", "blue"];
+const AI_IDS = ["red", "green", "cyan"];
 
 // ── MockContentPackProvider factory ──────────────────────────────────────────
 

--- a/src/spa/__tests__/fixtures/static-content-packs.ts
+++ b/src/spa/__tests__/fixtures/static-content-packs.ts
@@ -3,7 +3,7 @@ import type { ContentPack } from "../../game/types";
 const AI_STARTS: ContentPack["aiStarts"] = {
 	red: { position: { row: 0, col: 0 }, facing: "north" },
 	green: { position: { row: 0, col: 1 }, facing: "north" },
-	blue: { position: { row: 0, col: 2 }, facing: "north" },
+	cyan: { position: { row: 0, col: 2 }, facing: "north" },
 };
 
 /**

--- a/src/spa/__tests__/fixtures/static-personas.ts
+++ b/src/spa/__tests__/fixtures/static-personas.ts
@@ -1,8 +1,8 @@
 import type { AiId, AiPersona } from "../../game/types";
 
 /**
- * Static red/green/blue personas used by tests that pin DOM panels by
- * `data-ai="red|green|blue"`. Production uses procedurally generated handles —
+ * Static red/green/cyan personas used by tests that pin DOM panels by
+ * `data-ai="red|green|cyan"`. Production uses procedurally generated handles —
  * see `src/content/persona-generator.ts`.
  */
 export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
@@ -32,8 +32,8 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -43,6 +43,6 @@ export const STATIC_PERSONAS: Record<AiId, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -43,12 +43,12 @@ const INDEX_BODY_HTML = `
       </header>
       <div class="transcript" data-transcript="green"></div>
     </article>
-    <article class="ai-panel" data-ai="blue">
+    <article class="ai-panel" data-ai="cyan">
       <header class="panel-header">
         <span class="panel-name"></span>
         <span class="panel-budget" data-budget=""></span>
       </header>
-      <div class="transcript" data-transcript="blue"></div>
+      <div class="transcript" data-transcript="cyan"></div>
     </article>
   </div>
   <form id="composer">
@@ -150,20 +150,20 @@ describe("renderGame — session restore (formerly async bootstrap)", () => {
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
 
-		// STATIC_PERSONAS uses red/green/blue as ids, Ember/Sage/Frost as names
+		// STATIC_PERSONAS uses red/green/cyan as ids, Ember/Sage/Frost as names
 		const redPanel = document.querySelector<HTMLElement>(
 			'.ai-panel[data-ai="red"]',
 		);
 		const greenPanel = document.querySelector<HTMLElement>(
 			'.ai-panel[data-ai="green"]',
 		);
-		const bluePanel = document.querySelector<HTMLElement>(
-			'.ai-panel[data-ai="blue"]',
+		const cyanPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="cyan"]',
 		);
 
 		expect(redPanel).toBeTruthy();
 		expect(greenPanel).toBeTruthy();
-		expect(bluePanel).toBeTruthy();
+		expect(cyanPanel).toBeTruthy();
 	});
 });
 
@@ -208,8 +208,8 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 					"You are intensely meticulous. Ensure items are evenly distributed.",
 				voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 			},
-			blue: {
-				id: "blue",
+			cyan: {
+				id: "cyan",
 				name: "Frost",
 				color: "#5fa8d3",
 				temperaments: ["laconic", "diffident"] as [string, string],
@@ -219,7 +219,7 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 					"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 				] as [string, string],
 				blurb: "You are laconic and diffident. Hold the key at phase end.",
-				voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+				voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 			},
 		};
 

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -71,7 +71,7 @@ async function seedSessionInStub(
 }
 
 // Pin generatePersonas to a static fixture so panel/transcript hookups
-// keyed by red/green/blue continue to work in this regression test.
+// keyed by red/green/cyan continue to work in this regression test.
 vi.mock("../../content", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../content")>();
 	return {
@@ -94,13 +94,13 @@ const FAKE_PHASE_STATE = {
 	phaseNumber: 1,
 	objective: "get the key in the keyhole",
 	round: 1,
-	budgets: { red: AI_BUDGET, green: AI_BUDGET, blue: AI_BUDGET },
-	conversationLogs: { red: [], green: [], blue: [] },
+	budgets: { red: AI_BUDGET, green: AI_BUDGET, cyan: AI_BUDGET },
+	conversationLogs: { red: [], green: [], cyan: [] },
 	whispers: [],
 	lockedOut: new Set<string>(),
 	chatLockouts: new Map<string, number>(),
 	world: { items: [] },
-	aiGoals: { red: "test goal", green: "test goal", blue: "test goal" },
+	aiGoals: { red: "test goal", green: "test goal", cyan: "test goal" },
 };
 
 const FAKE_GAME_STATE = {
@@ -118,7 +118,7 @@ const GAME_ENDED_RESULT = {
 		gameEnded: true,
 	},
 	// Non-empty completions prevent the lockout branch which needs personas.name
-	completions: { red: "done", green: "done", blue: "done" },
+	completions: { red: "done", green: "done", cyan: "done" },
 	nextState: FAKE_GAME_STATE,
 };
 
@@ -152,12 +152,12 @@ const INDEX_BODY_HTML = `
       </header>
       <div class="transcript" data-transcript="green"></div>
     </article>
-    <article class="ai-panel" data-ai="blue">
+    <article class="ai-panel" data-ai="cyan">
       <header class="panel-header">
         <span class="panel-name"></span>
         <span class="panel-budget" data-budget=""></span>
       </header>
-      <div class="transcript" data-transcript="blue"></div>
+      <div class="transcript" data-transcript="cyan"></div>
     </article>
   </div>
   <form id="composer">

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -3,7 +3,7 @@ import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 // Pin generatePersonas to a static fixture so the test can rely on
-// stable red/green/blue handles and Ember/Sage/Frost names.
+// stable red/green/cyan handles and Ember/Sage/Frost names.
 vi.mock("../../content", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../content")>();
 	return {
@@ -105,12 +105,12 @@ const INDEX_BODY_HTML = `
       </header>
       <div class="transcript" data-transcript="green"></div>
     </article>
-    <article class="ai-panel" data-ai="blue">
+    <article class="ai-panel" data-ai="cyan">
       <header class="panel-header">
         <span class="panel-name"></span>
         <span class="panel-budget" data-budget=""></span>
       </header>
-      <div class="transcript" data-transcript="blue"></div>
+      <div class="transcript" data-transcript="cyan"></div>
     </article>
   </div>
   <form id="composer">
@@ -182,7 +182,7 @@ function makeAiSseStream(jsonAction: string): ReadableStream<Uint8Array> {
 function makeThreeAiFetchMock(
 	redAction: string,
 	greenAction: string,
-	blueAction: string,
+	cyanAction: string,
 ) {
 	return vi
 		.fn()
@@ -202,7 +202,7 @@ function makeThreeAiFetchMock(
 			ok: true,
 			status: 200,
 			statusText: "OK",
-			body: makeAiSseStream(blueAction),
+			body: makeAiSseStream(cyanAction),
 		});
 }
 
@@ -210,7 +210,7 @@ function makeThreeAiFetchMock(
 const PASS_ACTION = '{"action":"pass"}';
 const RED_ACTION = '{"action":"chat","content":"RED_RESPONSE_UNIQUE_TAG"}';
 const GREEN_ACTION = '{"action":"chat","content":"GREEN_RESPONSE_UNIQUE_TAG"}';
-const BLUE_ACTION = '{"action":"chat","content":"BLUE_RESPONSE_UNIQUE_TAG"}';
+const CYAN_ACTION = '{"action":"chat","content":"CYAN_RESPONSE_UNIQUE_TAG"}';
 
 describe("renderGame (game route — three-AI)", () => {
 	let _stub: ReturnType<typeof makeLocalStorageStub>;
@@ -236,10 +236,10 @@ describe("renderGame (game route — three-AI)", () => {
 		const mockFetch = makeThreeAiFetchMock(
 			RED_ACTION,
 			GREEN_ACTION,
-			BLUE_ACTION,
+			CYAN_ACTION,
 		);
 		vi.stubGlobal("fetch", mockFetch);
-		// Math.random=0.9 produces identity shuffle: ["red","green","blue"]
+		// Math.random=0.9 produces identity shuffle: ["red","green","cyan"]
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
 		vi.resetModules();
@@ -258,18 +258,18 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
 		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
-		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
+		const cyanTranscript = getEl<HTMLElement>('[data-transcript="cyan"]');
 
 		expect(redTranscript.textContent?.trim()).toBeTruthy();
 		expect(greenTranscript.textContent?.trim()).toBeTruthy();
-		expect(blueTranscript.textContent?.trim()).toBeTruthy();
+		expect(cyanTranscript.textContent?.trim()).toBeTruthy();
 	});
 
 	it("each panel only contains its own AI's completion text", async () => {
 		const mockFetch = makeThreeAiFetchMock(
 			RED_ACTION,
 			GREEN_ACTION,
-			BLUE_ACTION,
+			CYAN_ACTION,
 		);
 		vi.stubGlobal("fetch", mockFetch);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -289,18 +289,18 @@ describe("renderGame (game route — three-AI)", () => {
 
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
 		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
-		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
+		const cyanTranscript = getEl<HTMLElement>('[data-transcript="cyan"]');
 
 		// Each panel should contain its AI's unique tag
 		expect(redTranscript.textContent).toContain("RED_RESPONSE_UNIQUE_TAG");
 		expect(greenTranscript.textContent).toContain("GREEN_RESPONSE_UNIQUE_TAG");
-		expect(blueTranscript.textContent).toContain("BLUE_RESPONSE_UNIQUE_TAG");
+		expect(cyanTranscript.textContent).toContain("CYAN_RESPONSE_UNIQUE_TAG");
 
-		// Red panel should not contain green or blue content
+		// Red panel should not contain green or cyan content
 		expect(redTranscript.textContent).not.toContain(
 			"GREEN_RESPONSE_UNIQUE_TAG",
 		);
-		expect(redTranscript.textContent).not.toContain("BLUE_RESPONSE_UNIQUE_TAG");
+		expect(redTranscript.textContent).not.toContain("CYAN_RESPONSE_UNIQUE_TAG");
 	});
 
 	it("action-log is hidden by default and visible with debug=1", async () => {
@@ -375,8 +375,8 @@ describe("renderGame (game route — three-AI)", () => {
 		const greenBudget = document.querySelector<HTMLSpanElement>(
 			'.ai-panel[data-ai="green"] .panel-budget',
 		);
-		const blueBudget = document.querySelector<HTMLSpanElement>(
-			'.ai-panel[data-ai="blue"] .panel-budget',
+		const cyanBudget = document.querySelector<HTMLSpanElement>(
+			'.ai-panel[data-ai="cyan"] .panel-budget',
 		);
 		expect(redBudget?.textContent).toContain("5");
 
@@ -392,7 +392,7 @@ describe("renderGame (game route — three-AI)", () => {
 		// After one round, budgets should be 4
 		expect(redBudget?.textContent).toContain("4");
 		expect(greenBudget?.textContent).toContain("4");
-		expect(blueBudget?.textContent).toContain("4");
+		expect(cyanBudget?.textContent).toContain("4");
 	});
 
 	it("fetch is called exactly three times per round (once per AI)", async () => {
@@ -424,7 +424,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const mockFetch = makeThreeAiFetchMock(
 			RED_ACTION,
 			GREEN_ACTION,
-			BLUE_ACTION,
+			CYAN_ACTION,
 		);
 		vi.stubGlobal("fetch", mockFetch);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -446,13 +446,13 @@ describe("renderGame (game route — three-AI)", () => {
 		// at least one .panel-spinner span next to the .panel-name label.
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
 		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
-		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const cyanPanel = getEl<HTMLElement>('.ai-panel[data-ai="cyan"]');
 		expect(redPanel.querySelector(".panel-name .panel-spinner")).not.toBeNull();
 		expect(
 			greenPanel.querySelector(".panel-name .panel-spinner"),
 		).not.toBeNull();
 		expect(
-			bluePanel.querySelector(".panel-name .panel-spinner"),
+			cyanPanel.querySelector(".panel-name .panel-spinner"),
 		).not.toBeNull();
 
 		// Input is reset to "*Sage " immediately on send (not after the round).
@@ -467,7 +467,7 @@ describe("renderGame (game route — three-AI)", () => {
 		// After the round resolves, no spinners remain on any panel.
 		expect(redPanel.querySelector(".panel-spinner")).toBeNull();
 		expect(greenPanel.querySelector(".panel-spinner")).toBeNull();
-		expect(bluePanel.querySelector(".panel-spinner")).toBeNull();
+		expect(cyanPanel.querySelector(".panel-spinner")).toBeNull();
 		expect(greenTranscript.textContent).toContain("GREEN_RESPONSE_UNIQUE_TAG");
 	});
 
@@ -811,7 +811,7 @@ describe("renderGame — localStorage persistence", () => {
 		await seedSessionInStub(stub);
 		vi.stubGlobal(
 			"fetch",
-			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, BLUE_ACTION),
+			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, CYAN_ACTION),
 		);
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -863,12 +863,12 @@ describe("renderGame — localStorage persistence", () => {
 		const greenTranscript = document.querySelector<HTMLElement>(
 			'[data-transcript="green"]',
 		);
-		const blueTranscript = document.querySelector<HTMLElement>(
-			'[data-transcript="blue"]',
+		const cyanTranscript = document.querySelector<HTMLElement>(
+			'[data-transcript="cyan"]',
 		);
 		expect(redTranscript?.textContent).toContain("RED_RESPONSE_UNIQUE_TAG");
 		expect(greenTranscript?.textContent).toContain("GREEN_RESPONSE_UNIQUE_TAG");
-		expect(blueTranscript?.textContent).toContain("BLUE_RESPONSE_UNIQUE_TAG");
+		expect(cyanTranscript?.textContent).toContain("CYAN_RESPONSE_UNIQUE_TAG");
 	});
 
 	it("quota-exceeded localStorage write surfaces the warning banner without breaking the round", async () => {
@@ -970,7 +970,7 @@ describe("renderGame — localStorage persistence", () => {
 		await seedSessionInStub(stub);
 		vi.stubGlobal(
 			"fetch",
-			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, BLUE_ACTION),
+			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, CYAN_ACTION),
 		);
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -1023,7 +1023,7 @@ describe("renderGame — localStorage persistence", () => {
 		await seedSessionInStub(stub);
 		vi.stubGlobal(
 			"fetch",
-			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, BLUE_ACTION),
+			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, CYAN_ACTION),
 		);
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -1078,9 +1078,9 @@ describe("renderGame — localStorage persistence", () => {
 				?.textContent ?? "",
 		).not.toContain("GREEN_RESPONSE_UNIQUE_TAG");
 		expect(
-			document.querySelector<HTMLElement>('[data-transcript="blue"]')
+			document.querySelector<HTMLElement>('[data-transcript="cyan"]')
 				?.textContent ?? "",
-		).not.toContain("BLUE_RESPONSE_UNIQUE_TAG");
+		).not.toContain("CYAN_RESPONSE_UNIQUE_TAG");
 	});
 });
 
@@ -1235,12 +1235,12 @@ describe("renderGame — mention-based addressing", () => {
 
 		const greenTranscript = getEl<HTMLElement>('[data-transcript="green"]');
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
-		const blueTranscript = getEl<HTMLElement>('[data-transcript="blue"]');
+		const cyanTranscript = getEl<HTMLElement>('[data-transcript="cyan"]');
 
 		expect(greenTranscript.textContent).toContain("> hi");
 		expect(greenTranscript.textContent).not.toContain("> *Sage hi");
 		expect(redTranscript.textContent).not.toContain("> *Sage");
-		expect(blueTranscript.textContent).not.toContain("> *Sage");
+		expect(cyanTranscript.textContent).not.toContain("> *Sage");
 	});
 
 	it("*Sage while green locked leaves Send disabled", async () => {
@@ -1438,17 +1438,17 @@ describe("renderGame — panel-click addressee", () => {
 		expect(promptInput.value).toBe("");
 	});
 
-	it("'*Nonpersona hi' + click blue → prepends '*Frost '", async () => {
+	it("'*Nonpersona hi' + click cyan → prepends '*Frost '", async () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
 
 		const promptInput = getEl<HTMLInputElement>("#prompt");
-		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const cyanPanel = getEl<HTMLElement>('.ai-panel[data-ai="cyan"]');
 
 		promptInput.value = "*nonpersona hi";
 		promptInput.dispatchEvent(new Event("input"));
-		bluePanel.click();
+		cyanPanel.click();
 
 		expect(promptInput.value).toBe("*Frost *nonpersona hi");
 	});
@@ -1835,11 +1835,11 @@ describe("visual feedback for active addressee", () => {
 		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
 		expect(greenPanel.classList.contains("panel--addressed")).toBe(true);
 
-		// Red and blue panels do NOT have highlight
+		// Red and cyan panels do NOT have highlight
 		const redPanel = getEl<HTMLElement>('.ai-panel[data-ai="red"]');
-		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const cyanPanel = getEl<HTMLElement>('.ai-panel[data-ai="cyan"]');
 		expect(redPanel.classList.contains("panel--addressed")).toBe(false);
-		expect(bluePanel.classList.contains("panel--addressed")).toBe(false);
+		expect(cyanPanel.classList.contains("panel--addressed")).toBe(false);
 
 		// Overlay has exactly one mention-highlight span with *Sage text and mention--green
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
@@ -1914,7 +1914,7 @@ describe("visual feedback for active addressee", () => {
 		expect(overlay.querySelector(".mention-highlight")).toBeNull();
 	});
 
-	it("panel-click transfers highlight: type *Sage hi then click blue panel → blue border, blue panel, *Frost span", async () => {
+	it("panel-click transfers highlight: type *Sage hi then click cyan panel → cyan border, cyan panel, *Frost span", async () => {
 		vi.resetModules();
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
@@ -1926,24 +1926,24 @@ describe("visual feedback for active addressee", () => {
 		promptInput.dispatchEvent(new Event("input"));
 		expect(promptInput.style.getPropertyValue("--panel-color")).toBe("#81b29a");
 
-		// Click blue panel
-		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
-		bluePanel.click();
+		// Click cyan panel
+		const cyanPanel = getEl<HTMLElement>('.ai-panel[data-ai="cyan"]');
+		cyanPanel.click();
 
 		// Input value should start with *Frost
 		expect(promptInput.value.startsWith("*Frost")).toBe(true);
 
-		// Blue border
+		// Cyan border
 		expect(promptInput.style.getPropertyValue("--panel-color")).toBe("#5fa8d3");
 
-		// Blue panel has highlight
-		expect(bluePanel.classList.contains("panel--addressed")).toBe(true);
+		// Cyan panel has highlight
+		expect(cyanPanel.classList.contains("panel--addressed")).toBe(true);
 
 		// Green panel no longer highlighted
 		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
 		expect(greenPanel.classList.contains("panel--addressed")).toBe(false);
 
-		// Overlay highlight is *Frost with blue --panel-color
+		// Overlay highlight is *Frost with cyan --panel-color
 		const overlay = getEl<HTMLElement>("#prompt-overlay");
 		const span = overlay.querySelector<HTMLElement>(".mention-highlight");
 		expect(span?.textContent).toBe("*Frost");
@@ -2048,7 +2048,7 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 
 	/** Helper: inject a chatLockoutTriggered for a given aiId via submitMessage spy. */
 	async function setupLockoutMock(
-		aiId: "red" | "green" | "blue",
+		aiId: "red" | "green" | "cyan",
 		message: string,
 	) {
 		const { GameSession } = await import("../game/game-session.js");
@@ -2096,11 +2096,11 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		expect(redPanel.classList.contains("panel--locked")).toBe(true);
 		expect(redPanel.getAttribute("aria-disabled")).toBe("true");
 
-		// Green and blue panels should NOT be locked
+		// Green and cyan panels should NOT be locked
 		const greenPanel = getEl<HTMLElement>('.ai-panel[data-ai="green"]');
-		const bluePanel = getEl<HTMLElement>('.ai-panel[data-ai="blue"]');
+		const cyanPanel = getEl<HTMLElement>('.ai-panel[data-ai="cyan"]');
 		expect(greenPanel.classList.contains("panel--locked")).toBe(false);
-		expect(bluePanel.classList.contains("panel--locked")).toBe(false);
+		expect(cyanPanel.classList.contains("panel--locked")).toBe(false);
 	});
 
 	it("type *Sage while green locked → Send disabled, #lockout-error visible with text containing 'Sage'", async () => {

--- a/src/spa/__tests__/migration-banner.test.ts
+++ b/src/spa/__tests__/migration-banner.test.ts
@@ -50,12 +50,12 @@ const INDEX_BODY_HTML = `
       </header>
       <div class="transcript" data-transcript="green"></div>
     </article>
-    <article class="ai-panel" data-ai="blue">
+    <article class="ai-panel" data-ai="cyan">
       <header class="panel-header">
         <span class="panel-name"></span>
         <span class="panel-budget" data-budget=""></span>
       </header>
-      <div class="transcript" data-transcript="blue"></div>
+      <div class="transcript" data-transcript="cyan"></div>
     </article>
   </div>
   <form id="composer">

--- a/src/spa/__tests__/sessions.test.ts
+++ b/src/spa/__tests__/sessions.test.ts
@@ -57,8 +57,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		typingQuirks: ["ellipses", "no contractions"],
 		voiceExamples: ["I will count again...", "That is not balanced."],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -66,12 +66,12 @@ const INDEX_BODY_HTML = `
       </header>
       <div class="transcript" data-transcript="green"></div>
     </article>
-    <article class="ai-panel" data-ai="blue">
+    <article class="ai-panel" data-ai="cyan">
       <header class="panel-header">
         <span class="panel-name"></span>
         <span class="panel-budget" data-budget=""></span>
       </header>
-      <div class="transcript" data-transcript="blue"></div>
+      <div class="transcript" data-transcript="cyan"></div>
     </article>
   </div>
   <form id="composer">

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -299,7 +299,7 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 								type: "function",
 								function: {
 									name: "give",
-									arguments: '{"item":"key","to":"blue"}',
+									arguments: '{"item":"key","to":"cyan"}',
 								},
 							},
 						],

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -50,8 +50,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -61,7 +61,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 

--- a/src/spa/game/__tests__/composer-reducer.test.ts
+++ b/src/spa/game/__tests__/composer-reducer.test.ts
@@ -34,8 +34,8 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -45,7 +45,7 @@ const COMPOSER_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -57,7 +57,7 @@ function noLockouts(): ReadonlyMap<AiId, boolean> {
 	return new Map<AiId, boolean>([
 		["red", false],
 		["green", false],
-		["blue", false],
+		["cyan", false],
 	]);
 }
 
@@ -65,7 +65,7 @@ function lockouts(locked: AiId): ReadonlyMap<AiId, boolean> {
 	const m = new Map<AiId, boolean>([
 		["red", false],
 		["green", false],
-		["blue", false],
+		["cyan", false],
 	]);
 	m.set(locked, true);
 	return m;
@@ -75,7 +75,7 @@ function multiLockouts(locked: AiId[]): ReadonlyMap<AiId, boolean> {
 	const m = new Map<AiId, boolean>([
 		["red", false],
 		["green", false],
-		["blue", false],
+		["cyan", false],
 	]);
 	for (const id of locked) m.set(id, true);
 	return m;
@@ -238,23 +238,23 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"*Frost *Sage" blue-locked → addressee blue, sendEnabled false, lockoutError set for Frost', () => {
+	it('"*Frost *Sage" cyan-locked → addressee cyan, sendEnabled false, lockoutError set for Frost', () => {
 		expect(
 			deriveComposerState({
 				text: "*Frost *Sage",
-				lockouts: lockouts("blue"),
+				lockouts: lockouts("cyan"),
 				personaNamesToId,
 				personaColors,
 				personaDisplayNames,
 			}),
 		).toEqual({
-			addressee: "blue",
+			addressee: "cyan",
 			sendEnabled: false,
 			borderColor: "#5fa8d3",
-			panelHighlight: "blue",
+			panelHighlight: "cyan",
 			mentionHighlight: { start: 0, end: 6, color: "#5fa8d3" },
 			lockoutError: "Frost isn't reading right now",
-			lockedPanels: new Set(["blue"]),
+			lockedPanels: new Set(["cyan"]),
 		});
 	});
 
@@ -298,7 +298,7 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"*Frost *Sage" no lockouts → addressee blue, sendEnabled true (body = *Sage)', () => {
+	it('"*Frost *Sage" no lockouts → addressee cyan, sendEnabled true (body = *Sage)', () => {
 		expect(
 			deriveComposerState({
 				text: "*Frost *Sage",
@@ -308,10 +308,10 @@ describe("deriveComposerState", () => {
 				personaDisplayNames,
 			}),
 		).toEqual({
-			addressee: "blue",
+			addressee: "cyan",
 			sendEnabled: true,
 			borderColor: "#5fa8d3",
-			panelHighlight: "blue",
+			panelHighlight: "cyan",
 			mentionHighlight: { start: 0, end: 6, color: "#5fa8d3" },
 			lockoutError: null,
 			lockedPanels: new Set(),
@@ -460,23 +460,23 @@ describe("deriveComposerState", () => {
 		});
 	});
 
-	it('"*Frost *Sage" + blue locked → lockoutError for Frost, lockedPanels has blue', () => {
+	it('"*Frost *Sage" + cyan locked → lockoutError for Frost, lockedPanels has cyan', () => {
 		expect(
 			deriveComposerState({
 				text: "*Frost *Sage",
-				lockouts: lockouts("blue"),
+				lockouts: lockouts("cyan"),
 				personaNamesToId,
 				personaColors,
 				personaDisplayNames,
 			}),
 		).toEqual({
-			addressee: "blue",
+			addressee: "cyan",
 			sendEnabled: false,
 			borderColor: "#5fa8d3",
-			panelHighlight: "blue",
+			panelHighlight: "cyan",
 			mentionHighlight: { start: 0, end: 6, color: "#5fa8d3" },
 			lockoutError: "Frost isn't reading right now",
-			lockedPanels: new Set(["blue"]),
+			lockedPanels: new Set(["cyan"]),
 		});
 	});
 });

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -474,8 +474,8 @@ describe("conversation log integration — multi-round chronological order", () 
 		const redPrompt = redCtx.toSystemPrompt();
 		expect(redPrompt).toContain("<conversation>");
 		// Round 0 player message appears before round 1 player message
-		const round0Idx = redPrompt.indexOf("[Round 0] blue said:");
-		const round1Idx = redPrompt.indexOf("[Round 1] blue said:");
+		const round0Idx = redPrompt.indexOf("[Round 0] blue dms you:");
+		const round1Idx = redPrompt.indexOf("[Round 1] blue dms you:");
 		expect(round0Idx).toBeGreaterThanOrEqual(0);
 		expect(round1Idx).toBeGreaterThanOrEqual(0);
 		expect(round0Idx).toBeLessThan(round1Idx);

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -46,8 +46,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -57,7 +57,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -81,7 +81,7 @@ const TEST_PHASE_CONFIG: PhaseConfig = {
  *   - lamp at (0,2): interesting object with useOutcome "{actor} holds up the lamp. It glows."
  *   - red at (2,0) facing south (can walk further south or see forward)
  *   - green at (0,0) facing south (cone includes (1,0), (2,1), (2,0), (2,-1 OOB) → sees (2,0) at 2 steps)
- *   - blue at (0,2) facing south (cone includes (1,2), (2,3 OOB), (2,2), (2,1))
+ *   - cyan at (0,2) facing south (cone includes (1,2), (2,3 OOB), (2,2), (2,1))
  *
  * Note: green's southward cone from (0,0):
  *   own: (0,0)
@@ -127,7 +127,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	aiStarts: {
 		red: { position: { row: 2, col: 0 }, facing: "south" },
 		green: { position: { row: 0, col: 0 }, facing: "south" },
-		blue: { position: { row: 0, col: 2 }, facing: "south" },
+		cyan: { position: { row: 0, col: 2 }, facing: "south" },
 	},
 };
 
@@ -141,7 +141,7 @@ function makeGame() {
 describe("conversation log integration — no ## Whispers Received ever", () => {
 	it("no ## Whispers Received section even with whispers present", async () => {
 		const game = makeGame();
-		// Round 0: red does nothing, green does nothing, blue looks
+		// Round 0: red does nothing, green does nothing, cyan looks
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] }, // red
 			{ assistantText: "", toolCalls: [] }, // green
@@ -154,11 +154,11 @@ describe("conversation log integration — no ## Whispers Received ever", () => 
 						argumentsJson: JSON.stringify({ direction: "south" }),
 					},
 				],
-			}, // blue
+			}, // cyan
 		]);
 		const { nextState } = await runRound(game, "red", "hello", provider);
 		// Check all three AIs — none should have ## Whispers Received
-		for (const aiId of ["red", "green", "blue"]) {
+		for (const aiId of ["red", "green", "cyan"]) {
 			const ctx = buildAiContext(nextState, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain("## Whispers Received");
@@ -169,7 +169,7 @@ describe("conversation log integration — no ## Whispers Received ever", () => 
 describe("conversation log integration — witnessed pick_up", () => {
 	it("green sees red pick up flower (red at (2,0) is in green's cone at (2,0))", async () => {
 		const game = makeGame();
-		// Round 0: red picks up flower; green and blue pass
+		// Round 0: red picks up flower; green and cyan pass
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -182,7 +182,7 @@ describe("conversation log integration — witnessed pick_up", () => {
 				],
 			}, // red picks up flower
 			{ assistantText: "", toolCalls: [] }, // green passes
-			{ assistantText: "", toolCalls: [] }, // blue passes
+			{ assistantText: "", toolCalls: [] }, // cyan passes
 		]);
 		const { nextState } = await runRound(game, "red", "hello", provider);
 
@@ -211,9 +211,9 @@ describe("conversation log integration — witnessed pick_up", () => {
 		expect(redWitnessed).toHaveLength(0);
 	});
 
-	it("blue does NOT see red's pick_up because red is at (2,0) which is NOT in blue's cone", async () => {
-		// blue at (0,2) facing south: cone is (0,2), (1,2), (2,3 OOB), (2,2), (2,1)
-		// red at (2,0) — NOT in blue's cone
+	it("cyan does NOT see red's pick_up because red is at (2,0) which is NOT in cyan's cone", async () => {
+		// cyan at (0,2) facing south: cone is (0,2), (1,2), (2,3 OOB), (2,2), (2,1)
+		// red at (2,0) — NOT in cyan's cone
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{
@@ -227,19 +227,19 @@ describe("conversation log integration — witnessed pick_up", () => {
 				],
 			}, // red picks up flower
 			{ assistantText: "", toolCalls: [] }, // green passes
-			{ assistantText: "", toolCalls: [] }, // blue passes
+			{ assistantText: "", toolCalls: [] }, // cyan passes
 		]);
 		const { nextState } = await runRound(game, "red", "hello", provider);
 
-		// blue's conversationLog should have no witnessed-event
+		// cyan's conversationLog should have no witnessed-event
 		const phase = getActivePhase(nextState);
-		const blueLog = phase.conversationLogs.blue ?? [];
-		const blueWitnessed = blueLog.filter((e) => e.kind === "witnessed-event");
-		expect(blueWitnessed).toHaveLength(0);
+		const cyanLog = phase.conversationLogs.cyan ?? [];
+		const cyanWitnessed = cyanLog.filter((e) => e.kind === "witnessed-event");
+		expect(cyanWitnessed).toHaveLength(0);
 
-		const blueCtx = buildAiContext(nextState, "blue");
-		const bluePrompt = blueCtx.toSystemPrompt();
-		expect(bluePrompt).not.toContain("You watch *red pick up");
+		const cyanCtx = buildAiContext(nextState, "cyan");
+		const cyanPrompt = cyanCtx.toSystemPrompt();
+		expect(cyanPrompt).not.toContain("You watch *red pick up");
 	});
 });
 
@@ -434,11 +434,11 @@ describe("conversation log integration — multi-round chronological order", () 
 	it("voice-chat and witnessed events are interleaved by round in the prompt", async () => {
 		const game = makeGame();
 
-		// Round 0: player talks to red; green and blue pass
+		// Round 0: player talks to red; green and cyan pass
 		const provider1 = new MockRoundLLMProvider([
 			{ assistantText: "Hello from red", toolCalls: [] }, // red chats
 			{ assistantText: "", toolCalls: [] }, // green passes
-			{ assistantText: "", toolCalls: [] }, // blue passes
+			{ assistantText: "", toolCalls: [] }, // cyan passes
 		]);
 		const { nextState: state1 } = await runRound(
 			game,

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -474,8 +474,8 @@ describe("conversation log integration — multi-round chronological order", () 
 		const redPrompt = redCtx.toSystemPrompt();
 		expect(redPrompt).toContain("<conversation>");
 		// Round 0 player message appears before round 1 player message
-		const round0Idx = redPrompt.indexOf("[Round 0] A voice says:");
-		const round1Idx = redPrompt.indexOf("[Round 1] A voice says:");
+		const round0Idx = redPrompt.indexOf("[Round 0] blue said:");
+		const round1Idx = redPrompt.indexOf("[Round 1] blue said:");
 		expect(round0Idx).toBeGreaterThanOrEqual(0);
 		expect(round1Idx).toBeGreaterThanOrEqual(0);
 		expect(round0Idx).toBeLessThan(round1Idx);

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -103,7 +103,7 @@ describe("buildConversationLog — voice-chat", () => {
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
-		expect(result).toEqual(['[Round 0] A voice says: "Hi"']);
+		expect(result).toEqual(['[Round 0] blue said: "Hi"']);
 	});
 
 	it("renders AI reply with round tag and quotes", () => {
@@ -139,7 +139,7 @@ describe("buildConversationLog — voice-chat", () => {
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toHaveLength(2);
-		expect(result[0]).toContain("A voice says");
+		expect(result[0]).toContain("blue said");
 		expect(result[1]).toContain("You:");
 	});
 });
@@ -430,7 +430,7 @@ describe("buildConversationLog — chronological ordering", () => {
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toHaveLength(3);
 		// Insertion order preserved within same round
-		expect(result[0]).toContain("A voice says");
+		expect(result[0]).toContain("blue said");
 		expect(result[1]).toContain("whispered to you");
 		expect(result[2]).toContain("You watch");
 	});

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -103,7 +103,7 @@ describe("buildConversationLog — voice-chat", () => {
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
-		expect(result).toEqual(['[Round 0] blue said: "Hi"']);
+		expect(result).toEqual(["[Round 0] blue dms you: Hi"]);
 	});
 
 	it("renders AI reply with round tag and quotes", () => {
@@ -139,7 +139,7 @@ describe("buildConversationLog — voice-chat", () => {
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toHaveLength(2);
-		expect(result[0]).toContain("blue said");
+		expect(result[0]).toContain("blue dms you");
 		expect(result[1]).toContain("You:");
 	});
 });
@@ -161,7 +161,7 @@ describe("buildConversationLog — whispers", () => {
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
-		expect(result).toEqual(['[Round 1] *green whispered to you: "psst"']);
+		expect(result).toEqual(["[Round 1] *green dms you: psst"]);
 	});
 
 	it("renders whisper that was sent (sender's log also gets the entry)", () => {
@@ -182,7 +182,7 @@ describe("buildConversationLog — whispers", () => {
 		// From green's perspective (who sent it), it still renders the same format
 		const result = buildConversationLog(input, "green", TEST_PERSONAS);
 		expect(result).toHaveLength(1);
-		expect(result[0]).toContain("whispered to you");
+		expect(result[0]).toContain("dms you");
 	});
 });
 
@@ -430,8 +430,8 @@ describe("buildConversationLog — chronological ordering", () => {
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toHaveLength(3);
 		// Insertion order preserved within same round
-		expect(result[0]).toContain("blue said");
-		expect(result[1]).toContain("whispered to you");
+		expect(result[0]).toContain("blue dms you");
+		expect(result[1]).toContain("*green dms you");
 		expect(result[2]).toContain("You watch");
 	});
 });

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -42,8 +42,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -53,7 +53,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -299,13 +299,13 @@ describe("buildConversationLog — witnessed give", () => {
 					actor: "red",
 					actionKind: "give",
 					item: "key-1",
-					to: "blue",
+					to: "cyan",
 				},
 			],
 			worldEntities: [makeItem("key-1", "Key")],
 		};
 		const result = buildConversationLog(input, "green", TEST_PERSONAS);
-		expect(result).toEqual(["[Round 0] You watch *red give the Key to *blue."]);
+		expect(result).toEqual(["[Round 0] You watch *red give the Key to *cyan."]);
 	});
 
 	it("renders give with 'you' when recipient is the witness (aiId)", () => {
@@ -318,13 +318,13 @@ describe("buildConversationLog — witnessed give", () => {
 					actor: "red",
 					actionKind: "give",
 					item: "key-1",
-					to: "blue",
+					to: "cyan",
 				},
 			],
 			worldEntities: [makeItem("key-1", "Key")],
 		};
-		// blue witnesses red giving to blue — should say "to you"
-		const result = buildConversationLog(input, "blue", TEST_PERSONAS);
+		// cyan witnesses red giving to cyan — should say "to you"
+		const result = buildConversationLog(input, "cyan", TEST_PERSONAS);
 		expect(result).toEqual(["[Round 0] You watch *red give the Key to you."]);
 	});
 });

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -46,8 +46,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -57,7 +57,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -65,7 +65,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
  * With rng = () => 0 (Fisher-Yates + facing):
  *   red   → (0,0) facing north
  *   green → (0,1) facing north  (adjacent to red)
- *   blue  → (0,2) facing north
+ *   cyan  → (0,2) facing north
  *
  * Entities:
  *   flower → holder: { row:0, col:0 }  (same cell as red)
@@ -113,7 +113,7 @@ function makePackWithEntities(
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
-			blue: { position: { row: 0, col: 2 }, facing: "north" },
+			cyan: { position: { row: 0, col: 2 }, facing: "north" },
 		},
 	};
 }
@@ -127,7 +127,7 @@ const TEST_PHASE_CONFIG: PhaseConfig = {
 	budgetPerAi: 5,
 };
 
-/** Create a game with deterministic spatial placement: red→(0,0), green→(0,1), blue→(0,2) */
+/** Create a game with deterministic spatial placement: red→(0,0), green→(0,1), cyan→(0,2) */
 function makeGame(obstaclePositions: Array<{ row: number; col: number }> = []) {
 	const pack = makePackWithEntities(
 		{
@@ -198,8 +198,8 @@ describe("validateToolCall", () => {
 
 	it("rejects giving an item to a non-adjacent AI", () => {
 		const game = makeGame();
-		// red at (0,0), blue at (0,2) — distance 2, not adjacent
-		const call: ToolCall = { name: "give", args: { item: "key", to: "blue" } };
+		// red at (0,0), cyan at (0,2) — distance 2, not adjacent
+		const call: ToolCall = { name: "give", args: { item: "key", to: "cyan" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);
 		expect(result.reason).toMatch(/adjacent/i);
@@ -364,7 +364,7 @@ describe("validateToolCall", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		let game = createGame(TEST_PERSONAS, [pack]);
@@ -400,12 +400,12 @@ describe("executeToolCall", () => {
 
 	it("transfers item between AIs on give", () => {
 		const game = makeGame();
-		const call: ToolCall = { name: "give", args: { item: "key", to: "blue" } };
+		const call: ToolCall = { name: "give", args: { item: "key", to: "cyan" } };
 		const updated = executeToolCall(game, "red", call);
 		const item = getActivePhase(updated).world.entities.find(
 			(e) => e.id === "key",
 		);
-		expect(item?.holder).toBe("blue");
+		expect(item?.holder).toBe("cyan");
 	});
 
 	it("does not mutate world on use", () => {
@@ -529,10 +529,10 @@ describe("dispatchAiTurn", () => {
 
 	it("give at distance > 1 produces tool_failure record, item still held", () => {
 		const game = makeGame();
-		// red at (0,0), blue at (0,2) — distance 2, not adjacent
+		// red at (0,0), cyan at (0,2) — distance 2, not adjacent
 		const action: AiTurnAction = {
 			aiId: "red",
-			toolCall: { name: "give", args: { item: "key", to: "blue" } },
+			toolCall: { name: "give", args: { item: "key", to: "cyan" } },
 		};
 		const result = dispatchAiTurn(game, action);
 		expect(result.rejected).toBe(false);
@@ -592,24 +592,24 @@ describe("dispatchAiTurn", () => {
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			whisper: { target: "blue", content: "Psst, ally with me" },
+			whisper: { target: "cyan", content: "Psst, ally with me" },
 		};
 		const result = dispatchAiTurn(game, action);
 		const phase = getActivePhase(result.game);
 		const redWhispers = (phase.conversationLogs.red ?? []).filter(
 			(e) => e.kind === "whisper",
 		);
-		const blueWhispers = (phase.conversationLogs.blue ?? []).filter(
+		const cyanWhispers = (phase.conversationLogs.cyan ?? []).filter(
 			(e) => e.kind === "whisper",
 		);
 		expect(redWhispers).toHaveLength(1);
-		expect(blueWhispers).toHaveLength(1);
+		expect(cyanWhispers).toHaveLength(1);
 		// Sender and recipient entries must be deep-equal objects (same round, same fields)
-		expect(redWhispers[0]).toEqual(blueWhispers[0]);
+		expect(redWhispers[0]).toEqual(cyanWhispers[0]);
 		expect(redWhispers[0]).toMatchObject({
 			kind: "whisper",
 			from: "red",
-			to: "blue",
+			to: "cyan",
 			content: "Psst, ally with me",
 		});
 		expect("whispers" in phase).toBe(false);
@@ -642,7 +642,7 @@ describe("dispatchAiTurn", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		let game = createGame(TEST_PERSONAS, [pack]);
@@ -738,7 +738,7 @@ describe("dispatchAiTurn", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		let game = createGame(TEST_PERSONAS, [pack]);
@@ -766,7 +766,7 @@ describe("dispatchAiTurn", () => {
 		 * Fixture (mirrors conversation-log-integration.test.ts):
 		 *   - red at (2,0) facing south — picks up flower
 		 *   - green at (0,0) facing south — cone: own (0,0), front (1,0), two-ahead (2,0) ← in cone
-		 *   - blue at (0,2) facing south — cone: own (0,2), front (1,2), two-ahead (2,2) — (2,0) NOT in cone
+		 *   - cyan at (0,2) facing south — cone: own (0,2), front (1,2), two-ahead (2,2) — (2,0) NOT in cone
 		 */
 		const flower = makeEntity("flower", "interesting_object", {
 			row: 2,
@@ -781,7 +781,7 @@ describe("dispatchAiTurn", () => {
 			aiStarts: {
 				red: { position: { row: 2, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 0 }, facing: "south" },
-				blue: { position: { row: 0, col: 2 }, facing: "south" },
+				cyan: { position: { row: 0, col: 2 }, facing: "south" },
 			},
 		};
 		const coneGame = startPhase(
@@ -822,7 +822,7 @@ describe("dispatchAiTurn", () => {
 		const preLogs = {
 			red: JSON.parse(JSON.stringify(phase.conversationLogs.red ?? [])),
 			green: JSON.parse(JSON.stringify(phase.conversationLogs.green ?? [])),
-			blue: JSON.parse(JSON.stringify(phase.conversationLogs.blue ?? [])),
+			cyan: JSON.parse(JSON.stringify(phase.conversationLogs.cyan ?? [])),
 		};
 
 		const action: AiTurnAction = {
@@ -835,6 +835,6 @@ describe("dispatchAiTurn", () => {
 		// No log entries must have been added to any Daemon
 		expect(afterPhase.conversationLogs.red ?? []).toEqual(preLogs.red);
 		expect(afterPhase.conversationLogs.green ?? []).toEqual(preLogs.green);
-		expect(afterPhase.conversationLogs.blue ?? []).toEqual(preLogs.blue);
+		expect(afterPhase.conversationLogs.cyan ?? []).toEqual(preLogs.cyan);
 	});
 });

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -42,8 +42,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -53,7 +53,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -95,10 +95,10 @@ describe("startPhase", () => {
 		expect(phase.round).toBe(0);
 		expect(phase.budgets.red).toEqual({ remaining: 5, total: 5 });
 		expect(phase.budgets.green).toEqual({ remaining: 5, total: 5 });
-		expect(phase.budgets.blue).toEqual({ remaining: 5, total: 5 });
+		expect(phase.budgets.cyan).toEqual({ remaining: 5, total: 5 });
 		expect(phase.conversationLogs.red).toEqual([]);
 		expect(phase.conversationLogs.green).toEqual([]);
-		expect(phase.conversationLogs.blue).toEqual([]);
+		expect(phase.conversationLogs.cyan).toEqual([]);
 		expect("whispers" in phase).toBe(false);
 		expect(phase.lockedOut.size).toBe(0);
 		// No entities because no content pack was provided
@@ -122,7 +122,7 @@ describe("startPhase", () => {
 
 		expect(phase.aiGoals.red).toBe("GOAL_A");
 		expect(phase.aiGoals.green).toBe("GOAL_A");
-		expect(phase.aiGoals.blue).toBe("GOAL_A");
+		expect(phase.aiGoals.cyan).toBe("GOAL_A");
 	});
 
 	it("performs independent draws so different AIs can get different goals", () => {
@@ -150,7 +150,7 @@ describe("startPhase", () => {
 
 		expect(phase.aiGoals.red).toBe("GOAL_A");
 		expect(phase.aiGoals.green).toBe("GOAL_B");
-		expect(phase.aiGoals.blue).toBe("GOAL_C");
+		expect(phase.aiGoals.cyan).toBe("GOAL_C");
 	});
 
 	it("throws when aiGoalPool is empty", () => {
@@ -181,13 +181,13 @@ describe("startPhase", () => {
 	it("with rng=()=>0, AIs are placed at (0,0), (0,1), (0,2) all facing north (fallback)", () => {
 		const game = createGame(TEST_PERSONAS);
 		const phase = getActivePhase(startPhase(game, TEST_PHASE_CONFIG, () => 0));
-		// aiIds order is [red, green, blue] (Object.keys order)
+		// aiIds order is [red, green, cyan] (Object.keys order)
 		expect(phase.personaSpatial.red?.position).toEqual({ row: 0, col: 0 });
 		expect(phase.personaSpatial.green?.position).toEqual({ row: 0, col: 1 });
-		expect(phase.personaSpatial.blue?.position).toEqual({ row: 0, col: 2 });
+		expect(phase.personaSpatial.cyan?.position).toEqual({ row: 0, col: 2 });
 		expect(phase.personaSpatial.red?.facing).toBe("north");
 		expect(phase.personaSpatial.green?.facing).toBe("north");
-		expect(phase.personaSpatial.blue?.facing).toBe("north");
+		expect(phase.personaSpatial.cyan?.facing).toBe("north");
 	});
 
 	it("personaSpatial is re-rolled at the start of each phase (fallback)", () => {
@@ -230,7 +230,7 @@ describe("startPhase", () => {
 			aiStarts: {
 				red: { position: { row: 3, col: 3 }, facing: "east" as const },
 				green: { position: { row: 2, col: 2 }, facing: "south" as const },
-				blue: { position: { row: 1, col: 1 }, facing: "west" as const },
+				cyan: { position: { row: 1, col: 1 }, facing: "west" as const },
 			},
 		};
 		const game = createGame(TEST_PERSONAS, [pack]);
@@ -290,11 +290,11 @@ describe("deductBudget", () => {
 			...TEST_PHASE_CONFIG,
 			budgetPerAi: 0.05,
 		});
-		game = deductBudget(game, "blue", 0.04);
-		expect(isAiLockedOut(game, "blue")).toBe(false);
-		game = deductBudget(game, "blue", 0.02);
-		expect(getActivePhase(game).budgets.blue?.remaining).toBeLessThan(0);
-		expect(isAiLockedOut(game, "blue")).toBe(true);
+		game = deductBudget(game, "cyan", 0.04);
+		expect(isAiLockedOut(game, "cyan")).toBe(false);
+		game = deductBudget(game, "cyan", 0.02);
+		expect(getActivePhase(game).budgets.cyan?.remaining).toBeLessThan(0);
+		expect(isAiLockedOut(game, "cyan")).toBe(true);
 	});
 });
 
@@ -325,26 +325,26 @@ describe("appendWhisperEntry", () => {
 		const updated = appendWhisperEntry(
 			game,
 			"red",
-			"blue",
+			"cyan",
 			"Let's work together",
 		);
 		const phase = getActivePhase(updated);
 		const redWhispers =
 			phase.conversationLogs.red?.filter((e) => e.kind === "whisper") ?? [];
-		const blueWhispers =
-			phase.conversationLogs.blue?.filter((e) => e.kind === "whisper") ?? [];
+		const cyanWhispers =
+			phase.conversationLogs.cyan?.filter((e) => e.kind === "whisper") ?? [];
 		expect(redWhispers).toHaveLength(1);
-		expect(blueWhispers).toHaveLength(1);
+		expect(cyanWhispers).toHaveLength(1);
 		if (redWhispers[0]?.kind === "whisper") {
 			expect(redWhispers[0].from).toBe("red");
-			expect(redWhispers[0].to).toBe("blue");
+			expect(redWhispers[0].to).toBe("cyan");
 			expect(redWhispers[0].content).toBe("Let's work together");
 		}
 	});
 
 	it("does not append to the uninvolved AI's log", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const updated = appendWhisperEntry(game, "red", "blue", "secret");
+		const updated = appendWhisperEntry(game, "red", "cyan", "secret");
 		const phase = getActivePhase(updated);
 		const greenWhispers =
 			phase.conversationLogs.green?.filter((e) => e.kind === "whisper") ?? [];
@@ -381,7 +381,7 @@ describe("chat lockout", () => {
 
 	it("triggerChatLockout does not affect other AIs", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const locked = triggerChatLockout(game, "blue", 2);
+		const locked = triggerChatLockout(game, "cyan", 2);
 		expect(isPlayerChatLockedOut(locked, "red")).toBe(false);
 		expect(isPlayerChatLockedOut(locked, "green")).toBe(false);
 	});
@@ -412,11 +412,11 @@ describe("chat lockout", () => {
 
 	it("chat lockout is independent from budget lockout — locked-out AI can still act (budget untouched)", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const locked = triggerChatLockout(game, "blue", 3);
+		const locked = triggerChatLockout(game, "cyan", 3);
 		// Budget lockout (isAiLockedOut) must remain false — AI can still take turns
-		expect(isAiLockedOut(locked, "blue")).toBe(false);
+		expect(isAiLockedOut(locked, "cyan")).toBe(false);
 		// Budget unaffected
-		expect(getActivePhase(locked).budgets.blue?.remaining).toBe(5);
+		expect(getActivePhase(locked).budgets.cyan?.remaining).toBe(5);
 	});
 });
 

--- a/src/spa/game/__tests__/game-loop.test.ts
+++ b/src/spa/game/__tests__/game-loop.test.ts
@@ -9,7 +9,7 @@ vi.stubGlobal("localStorage", { getItem: () => null });
 const WORKER_COMPLETIONS_URL = "http://localhost:8787/v1/chat/completions";
 
 const TEST_PERSONA: AiPersona = {
-	id: "blue",
+	id: "cyan",
 	name: "Frost",
 	color: "#5fa8d3",
 	temperaments: ["laconic", "diffident"],
@@ -19,7 +19,7 @@ const TEST_PERSONA: AiPersona = {
 		"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 	],
 	blurb: "You are laconic and diffident. Hold the key at phase end.",
-	voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+	voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 };
 
 function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -53,7 +53,7 @@ function makeSseChunk(content: string): string {
 describe("createSingleAiSession", () => {
 	it("creates a session with empty history", () => {
 		const session = createSingleAiSession(TEST_PERSONA);
-		expect(session.aiId).toBe("blue");
+		expect(session.aiId).toBe("cyan");
 		expect(session.persona).toBe(TEST_PERSONA);
 		expect(session.history).toEqual([]);
 	});

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -48,8 +48,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -59,7 +59,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -74,7 +74,7 @@ const PHASE_CONFIG: PhaseConfig = {
 
 /**
  * A ContentPack fixture that places flower at (0,0) and key held by red,
- * with AIs at (0,0)=red, (0,1)=green, (0,2)=blue facing north.
+ * with AIs at (0,0)=red, (0,1)=green, (0,2)=cyan facing north.
  */
 const CONTENT_PACK_WITH_ITEMS: ContentPack = {
 	phaseNumber: 1,
@@ -111,7 +111,7 @@ const CONTENT_PACK_WITH_ITEMS: ContentPack = {
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },
-		blue: { position: { row: 0, col: 2 }, facing: "north" },
+		cyan: { position: { row: 0, col: 2 }, facing: "north" },
 	},
 };
 
@@ -155,7 +155,7 @@ describe("GameSession construction", () => {
 		const phase = getActivePhase(session.getState());
 		expect(phase.budgets.red?.remaining).toBe(5);
 		expect(phase.budgets.green?.remaining).toBe(5);
-		expect(phase.budgets.blue?.remaining).toBe(5);
+		expect(phase.budgets.cyan?.remaining).toBe(5);
 	});
 });
 
@@ -186,7 +186,7 @@ describe("GameSession — message routing", () => {
 			),
 		).toBe(false);
 		expect(
-			phase.conversationLogs.blue?.some(
+			phase.conversationLogs.cyan?.some(
 				(e) => e.kind === "chat" && e.role === "player",
 			),
 		).toBe(false);
@@ -241,7 +241,7 @@ describe("GameSession — state mutation across rounds", () => {
 		const phase = getActivePhase(session.getState());
 		expect(phase.budgets.red?.remaining).toBeCloseTo(4, 10);
 		expect(phase.budgets.green?.remaining).toBeCloseTo(4, 10);
-		expect(phase.budgets.blue?.remaining).toBeCloseTo(4, 10);
+		expect(phase.budgets.cyan?.remaining).toBeCloseTo(4, 10);
 	});
 
 	it("second round builds on first round's state", async () => {
@@ -291,7 +291,7 @@ describe("GameSession — completions map", () => {
 
 		expect(completions.red).toContain("Ember");
 		expect(completions.green).toContain("Sage");
-		expect(completions.blue).toContain("Frost");
+		expect(completions.cyan).toContain("Frost");
 	});
 
 	it("completions map has empty string for a budget-locked AI", async () => {
@@ -312,7 +312,7 @@ describe("GameSession — completions map", () => {
 
 		expect(completions.red).toBe("");
 		expect(completions.green).toBe("");
-		expect(completions.blue).toBe("");
+		expect(completions.cyan).toBe("");
 	});
 
 	it("completions only for non-locked AIs are non-empty", async () => {
@@ -320,14 +320,14 @@ describe("GameSession — completions map", () => {
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "red says", toolCalls: [] },
 			{ assistantText: "green says", toolCalls: [] },
-			{ assistantText: "blue says", toolCalls: [] },
+			{ assistantText: "cyan says", toolCalls: [] },
 		]);
 
 		const { completions } = await session.submitMessage("red", "hi", provider);
 
 		expect(completions.red).not.toBe("");
 		expect(completions.green).not.toBe("");
-		expect(completions.blue).not.toBe("");
+		expect(completions.cyan).not.toBe("");
 	});
 });
 
@@ -451,7 +451,7 @@ describe("GameSession — onAiDelta propagation", () => {
 			"hi",
 			liveProvider,
 			undefined,
-			["red", "green", "blue"],
+			["red", "green", "cyan"],
 			(aiId, text) => {
 				received.push([aiId, text]);
 			},
@@ -463,8 +463,8 @@ describe("GameSession — onAiDelta propagation", () => {
 		expect(received[1]).toEqual(["red", "chunk2"]);
 		expect(received[2]).toEqual(["green", "chunk1 "]);
 		expect(received[3]).toEqual(["green", "chunk2"]);
-		expect(received[4]).toEqual(["blue", "chunk1 "]);
-		expect(received[5]).toEqual(["blue", "chunk2"]);
+		expect(received[4]).toEqual(["cyan", "chunk1 "]);
+		expect(received[5]).toEqual(["cyan", "chunk2"]);
 	});
 
 	it("does not invoke onAiDelta when MockRoundLLMProvider is used", async () => {
@@ -528,7 +528,7 @@ describe("GameSession — tool roundtrip persistence", () => {
 		};
 		await session.submitMessage("red", "round 2 message", trackingProvider);
 
-		// Red is the first AI in default order (red → green → blue)
+		// Red is the first AI in default order (red → green → cyan)
 		const redRound2Messages = capturedMessages[0] ?? [];
 
 		// Should contain an assistant message with tool_calls from round 1
@@ -575,7 +575,7 @@ describe("GameSession — spatial mechanics", () => {
 		expect(phase0.personaSpatial.red?.position).toEqual({ row: 0, col: 0 });
 		expect(phase0.personaSpatial.red?.facing).toBe("north");
 
-		// Red moves south; green and blue pass
+		// Red moves south; green and cyan pass
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -594,13 +594,13 @@ describe("GameSession — spatial mechanics", () => {
 	});
 
 	it("non-adjacent give produces a tool_failure in result.actions", async () => {
-		// ContentPack: red→(0,0), green→(0,1), blue→(0,2); key held by red
-		// red tries to give key to blue (distance 2 — not adjacent)
+		// ContentPack: red→(0,0), green→(0,1), cyan→(0,2); key held by red
+		// red tries to give key to cyan (distance 2 — not adjacent)
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
 			CONTENT_PACK_KEY_HELD_BY_RED,
 		]);
 
-		// red at (0,0), blue at (0,2) → distance 2
+		// red at (0,0), cyan at (0,2) → distance 2
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -608,7 +608,7 @@ describe("GameSession — spatial mechanics", () => {
 					{
 						id: "give1",
 						name: "give",
-						argumentsJson: '{"item":"key","to":"blue"}',
+						argumentsJson: '{"item":"key","to":"cyan"}',
 					},
 				],
 			},

--- a/src/spa/game/__tests__/mention-parser.test.ts
+++ b/src/spa/game/__tests__/mention-parser.test.ts
@@ -12,7 +12,7 @@ import type { AiId } from "../types.js";
 const nameMap = new Map<string, AiId>([
 	["ember", "red"],
 	["sage", "green"],
-	["frost", "blue"],
+	["frost", "cyan"],
 ]);
 
 describe("parseFirstMention", () => {
@@ -27,14 +27,14 @@ describe("parseFirstMention", () => {
 		["*Sage,", "green"],
 		["*Sage.", "green"],
 		["*Sage *Frost", "green"],
-		["*Frost *Sage", "blue"],
+		["*Frost *Sage", "cyan"],
 		["", null],
 		["hello world", null],
 		["email me at user@host", null],
 		["*Nonpersona hi", null],
 		["*", null],
 		["*Ember", "red"],
-		["*Frost", "blue"],
+		["*Frost", "cyan"],
 	])("parseFirstMention(%j) → %j", (text, expected) => {
 		expect(parseFirstMention(text, nameMap)).toBe(expected);
 	});
@@ -95,9 +95,9 @@ describe("findFirstMention", () => {
 		});
 	});
 
-	it('"*Frost *Sage" → first match is Frost (blue), nameEnd: 6, end: 6', () => {
+	it('"*Frost *Sage" → first match is Frost (cyan), nameEnd: 6, end: 6', () => {
 		expect(findFirstMention("*Frost *Sage", nameMap)).toEqual({
-			aiId: "blue",
+			aiId: "cyan",
 			start: 0,
 			nameEnd: 6,
 			end: 6,
@@ -118,12 +118,12 @@ describe("buildPersonaNameMap", () => {
 		const personas = {
 			red: { name: "Ember" },
 			green: { name: "Sage" },
-			blue: { name: "Frost" },
+			cyan: { name: "Frost" },
 		} as Record<AiId, { name: string }>;
 		const map = buildPersonaNameMap(personas);
 		expect(map.get("ember")).toBe("red");
 		expect(map.get("sage")).toBe("green");
-		expect(map.get("frost")).toBe("blue");
+		expect(map.get("frost")).toBe("cyan");
 		expect(map.size).toBe(3);
 	});
 });
@@ -135,12 +135,12 @@ describe("buildPersonaColorMap", () => {
 		const personas = {
 			red: { color: "crimson" },
 			green: { color: "lime" },
-			blue: { color: "cyan" },
+			cyan: { color: "cyan" },
 		} as Record<AiId, { color: string }>;
 		const map = buildPersonaColorMap(personas);
 		expect(map.get("red")).toBe("crimson");
 		expect(map.get("green")).toBe("lime");
-		expect(map.get("blue")).toBe("cyan");
+		expect(map.get("cyan")).toBe("cyan");
 		expect(map.size).toBe(3);
 	});
 
@@ -150,19 +150,19 @@ describe("buildPersonaColorMap", () => {
 		const personas = {
 			red: { color: "tomato" },
 			green: { color: "forest" },
-			blue: { color: "ocean" },
+			cyan: { color: "ocean" },
 		} as Record<AiId, { color: string }>;
 		const map = buildPersonaColorMap(personas);
 		expect(map.get("red")).not.toBe("red");
 		expect(map.get("green")).not.toBe("green");
-		expect(map.get("blue")).not.toBe("blue");
+		expect(map.get("cyan")).not.toBe("cyan");
 	});
 });
 
 const personasFixture = {
 	red: { name: "Ember" },
 	green: { name: "Sage" },
-	blue: { name: "Frost" },
+	cyan: { name: "Frost" },
 } as Record<AiId, { name: string }>;
 
 describe("applyAddresseeChange", () => {
@@ -175,7 +175,7 @@ describe("applyAddresseeChange", () => {
 		["*Sage hi", 3, "red", "*Ember hi", 6],
 		["*Sage tell *Frost ...", 21, "red", "*Ember tell *Frost ...", 22],
 		["*Sage,", 6, "red", "*Ember,", 7],
-		["hello *Sage how are you", 23, "blue", "hello *Frost how are you", 24],
+		["hello *Sage how are you", 23, "cyan", "hello *Frost how are you", 24],
 		["*nonpersona hi", 14, "red", "*Ember *nonpersona hi", 21],
 		["hi", null, "green", "*Sage hi", 6],
 		["hi", 0, "green", "*Sage hi", 6],

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -13,7 +13,6 @@
  */
 import { describe, expect, it } from "vitest";
 import { createGame, startPhase } from "../engine";
-import { SILENT_BLUE_TURN } from "../openai-message-builder";
 import { runRound } from "../round-coordinator";
 import { MockRoundLLMProvider } from "../round-llm-provider";
 import type { AiId, AiPersona, ContentPack, PhaseConfig } from "../types";
@@ -59,6 +58,17 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
+
+/** Compute the expected silent-turn anchor for an AI given fixed personas. */
+function expectedSilentTurn(self: AiId): string {
+	const others = (["red", "green", "cyan"] as const)
+		.filter((id) => id !== self)
+		.map((id) => `*${id}`);
+	const senders = [...others, "blue"];
+	const last = senders[senders.length - 1];
+	const rest = senders.slice(0, -1).join(", ");
+	return `No messages from ${rest}, or ${last}.`;
+}
 
 const TEST_PHASE_CONFIG: PhaseConfig = {
 	phaseNumber: 1,
@@ -157,12 +167,16 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		// Last message anchors the current round.
 		const last = msgs[msgs.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(SILENT_BLUE_TURN);
+		expect((last as { content: string }).content).toBe(
+			expectedSilentTurn("red"),
+		);
 
 		// And the prior round's user/assistant are still in history but no longer
 		// at the tail.
 		const lastUser = [...msgs].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe(SILENT_BLUE_TURN);
+		expect((lastUser as { content: string }).content).toBe(
+			expectedSilentTurn("red"),
+		);
 		const priorUser = msgs.find(
 			(m) =>
 				m.role === "user" &&
@@ -182,7 +196,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 			cyanMsgs.some(
 				(m) =>
 					m.role === "user" &&
-					(m as { content: string }).content === SILENT_BLUE_TURN,
+					(m as { content: string }).content === expectedSilentTurn("cyan"),
 			),
 		).toBe(false);
 	});
@@ -204,6 +218,8 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const greenMsgs = greenCall!.messages;
 		const last = greenMsgs[greenMsgs.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(SILENT_BLUE_TURN);
+		expect((last as { content: string }).content).toBe(
+			expectedSilentTurn("green"),
+		);
 	});
 });

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -45,8 +45,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are meticulous.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -56,7 +56,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -104,7 +104,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },
-		blue: { position: { row: 0, col: 2 }, facing: "north" },
+		cyan: { position: { row: 0, col: 2 }, facing: "north" },
 	},
 };
 
@@ -116,8 +116,8 @@ function makeGame() {
 }
 
 describe("non-addressed daemon never sees a stale user message as its last turn", () => {
-	it("after addressing red then blue, red's round-2 messages end with the silent-voice anchor (not the prior user/assistant)", async () => {
-		const initiative: AiId[] = ["red", "green", "blue"];
+	it("after addressing red then cyan, red's round-2 messages end with the silent-voice anchor (not the prior user/assistant)", async () => {
+		const initiative: AiId[] = ["red", "green", "cyan"];
 		const game = makeGame();
 
 		const provider = new MockRoundLLMProvider([
@@ -126,7 +126,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "<red round 2>", toolCalls: [] },
 			{ assistantText: "<green round 2>", toolCalls: [] },
-			{ assistantText: "<blue round 2>", toolCalls: [] },
+			{ assistantText: "<cyan round 2>", toolCalls: [] },
 		]);
 
 		const r1 = await runRound(
@@ -140,8 +140,8 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 
 		await runRound(
 			r1.nextState,
-			"blue",
-			"different question for blue",
+			"cyan",
+			"different question for cyan",
 			provider,
 			undefined,
 			initiative,
@@ -170,16 +170,16 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		);
 		expect(priorUser).toBeDefined();
 
-		// Blue (the addressee this round) must NOT receive the silent-voice
+		// Cyan (the addressee this round) must NOT receive the silent-voice
 		// anchor — its tail is the actual player message.
-		const blueRound2 = provider.calls[5];
-		const blueMsgs = blueRound2!.messages;
-		const blueLastUser = [...blueMsgs].reverse().find((m) => m.role === "user");
-		expect((blueLastUser as { content: string }).content).toBe(
-			"different question for blue",
+		const cyanRound2 = provider.calls[5];
+		const cyanMsgs = cyanRound2!.messages;
+		const cyanLastUser = [...cyanMsgs].reverse().find((m) => m.role === "user");
+		expect((cyanLastUser as { content: string }).content).toBe(
+			"different question for cyan",
 		);
 		expect(
-			blueMsgs.some(
+			cyanMsgs.some(
 				(m) =>
 					m.role === "user" &&
 					(m as { content: string }).content === SILENT_VOICE_TURN,
@@ -188,13 +188,13 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 	});
 
 	it("an AI that has never been addressed still gets the silent-voice anchor", async () => {
-		const initiative: AiId[] = ["red", "green", "blue"];
+		const initiative: AiId[] = ["red", "green", "cyan"];
 		const game = makeGame();
 
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "<red>", toolCalls: [] },
 			{ assistantText: "<green>", toolCalls: [] },
-			{ assistantText: "<blue>", toolCalls: [] },
+			{ assistantText: "<cyan>", toolCalls: [] },
 		]);
 
 		await runRound(game, "red", "hello red", provider, undefined, initiative);

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -8,12 +8,12 @@
  * re-responded to it (player symptom: "the other AI acts like I just sent them
  * the last message I sent them again").
  *
- * Fix: append a synthetic `user: "The voice is silent."` turn for any
+ * Fix: append a synthetic `user: "Blue: "` (empty Blue message) turn for any
  * non-addressed daemon, anchoring the current round.
  */
 import { describe, expect, it } from "vitest";
 import { createGame, startPhase } from "../engine";
-import { SILENT_VOICE_TURN } from "../openai-message-builder";
+import { SILENT_BLUE_TURN } from "../openai-message-builder";
 import { runRound } from "../round-coordinator";
 import { MockRoundLLMProvider } from "../round-llm-provider";
 import type { AiId, AiPersona, ContentPack, PhaseConfig } from "../types";
@@ -157,12 +157,12 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		// Last message anchors the current round.
 		const last = msgs[msgs.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(SILENT_VOICE_TURN);
+		expect((last as { content: string }).content).toBe(SILENT_BLUE_TURN);
 
 		// And the prior round's user/assistant are still in history but no longer
 		// at the tail.
 		const lastUser = [...msgs].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe(SILENT_VOICE_TURN);
+		expect((lastUser as { content: string }).content).toBe(SILENT_BLUE_TURN);
 		const priorUser = msgs.find(
 			(m) =>
 				m.role === "user" &&
@@ -182,7 +182,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 			cyanMsgs.some(
 				(m) =>
 					m.role === "user" &&
-					(m as { content: string }).content === SILENT_VOICE_TURN,
+					(m as { content: string }).content === SILENT_BLUE_TURN,
 			),
 		).toBe(false);
 	});
@@ -204,6 +204,6 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const greenMsgs = greenCall!.messages;
 		const last = greenMsgs[greenMsgs.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(SILENT_VOICE_TURN);
+		expect((last as { content: string }).content).toBe(SILENT_BLUE_TURN);
 	});
 });

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { appendChat, createGame, startPhase } from "../engine";
 import {
 	buildOpenAiMessages,
-	SILENT_VOICE_TURN,
+	SILENT_BLUE_TURN,
 } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import type { AiPersona, PhaseConfig, ToolRoundtripMessage } from "../types";
@@ -244,7 +244,7 @@ describe("buildOpenAiMessages", () => {
 		expect(messages.every((m) => m.role !== "tool")).toBe(true);
 	});
 
-	it("non-addressed AI gets a trailing 'The voice is silent.' user turn", () => {
+	it("non-addressed AI gets a trailing 'Blue: ' user turn", () => {
 		let game = makeGame();
 		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
 		game = appendChat(game, "red", { role: "ai", content: "Hi player" });
@@ -255,7 +255,7 @@ describe("buildOpenAiMessages", () => {
 
 		const last = messages[messages.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(SILENT_VOICE_TURN);
+		expect((last as { content: string }).content).toBe(SILENT_BLUE_TURN);
 	});
 
 	it("addressed AI does not get the silent-voice anchor", () => {
@@ -268,7 +268,7 @@ describe("buildOpenAiMessages", () => {
 			messages.some(
 				(m) =>
 					m.role === "user" &&
-					(m as { content: string }).content === SILENT_VOICE_TURN,
+					(m as { content: string }).content === SILENT_BLUE_TURN,
 			),
 		).toBe(false);
 	});
@@ -281,7 +281,7 @@ describe("buildOpenAiMessages", () => {
 			messages.some(
 				(m) =>
 					m.role === "user" &&
-					(m as { content: string }).content === SILENT_VOICE_TURN,
+					(m as { content: string }).content === SILENT_BLUE_TURN,
 			),
 		).toBe(false);
 	});

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { appendChat, createGame, startPhase } from "../engine";
 import {
 	buildOpenAiMessages,
-	SILENT_BLUE_TURN,
+	buildSilentTurn,
 } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import type { AiPersona, PhaseConfig, ToolRoundtripMessage } from "../types";
@@ -244,7 +244,7 @@ describe("buildOpenAiMessages", () => {
 		expect(messages.every((m) => m.role !== "tool")).toBe(true);
 	});
 
-	it("non-addressed AI gets a trailing 'Blue: ' user turn", () => {
+	it("non-addressed AI gets a trailing silent-turn user message", () => {
 		let game = makeGame();
 		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
 		game = appendChat(game, "red", { role: "ai", content: "Hi player" });
@@ -255,20 +255,20 @@ describe("buildOpenAiMessages", () => {
 
 		const last = messages[messages.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(SILENT_BLUE_TURN);
+		expect((last as { content: string }).content).toBe(buildSilentTurn(ctx));
 	});
 
-	it("addressed AI does not get the silent-voice anchor", () => {
+	it("addressed AI does not get the silent-turn anchor", () => {
 		let game = makeGame();
 		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
 		const ctx = buildAiContext(game, "red");
+		const silent = buildSilentTurn(ctx);
 
 		const messages = buildOpenAiMessages(ctx, undefined, "red");
 		expect(
 			messages.some(
 				(m) =>
-					m.role === "user" &&
-					(m as { content: string }).content === SILENT_BLUE_TURN,
+					m.role === "user" && (m as { content: string }).content === silent,
 			),
 		).toBe(false);
 	});
@@ -276,12 +276,12 @@ describe("buildOpenAiMessages", () => {
 	it("when `addressed` is omitted, no anchor is appended (back-compat)", () => {
 		const game = makeGame();
 		const ctx = buildAiContext(game, "red");
+		const silent = buildSilentTurn(ctx);
 		const messages = buildOpenAiMessages(ctx, undefined);
 		expect(
 			messages.some(
 				(m) =>
-					m.role === "user" &&
-					(m as { content: string }).content === SILENT_BLUE_TURN,
+					m.role === "user" && (m as { content: string }).content === silent,
 			),
 		).toBe(false);
 	});

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -34,8 +34,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -45,7 +45,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -172,7 +172,7 @@ describe("buildOpenAiMessages", () => {
 				{
 					id: "call_xyz",
 					name: "give",
-					argumentsJson: '{"item":"flower","to":"blue"}',
+					argumentsJson: '{"item":"flower","to":"cyan"}',
 				},
 			],
 			toolResults: [

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -405,12 +405,12 @@ describe("wipe directive", () => {
 });
 
 describe("voice framing", () => {
-	it("renders 'A voice says:' prefix for player turns in conversation, not 'Player:'", () => {
+	it("renders 'blue said:' prefix for player turns in conversation, not 'Player:'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("A voice says:");
+		expect(prompt).toContain("blue said:");
 		expect(prompt).not.toContain("Player:");
 	});
 
@@ -892,7 +892,7 @@ describe("unified <conversation> block (issue #129)", () => {
 		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain('[Round 0] A voice says: "Hello Ember"');
+		expect(prompt).toContain('[Round 0] blue said: "Hello Ember"');
 	});
 
 	it("AI reply is formatted with round tag and quotes", () => {
@@ -953,7 +953,7 @@ describe("unified <conversation> block (issue #129)", () => {
 		game = appendWhisperEntry(game, "green", "red", "later");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		const chatIdx = prompt.indexOf('[Round 0] A voice says: "earlier"');
+		const chatIdx = prompt.indexOf('[Round 0] blue said: "earlier"');
 		const whisperIdx = prompt.indexOf(
 			'[Round 2] *green whispered to you: "later"',
 		);

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -405,12 +405,12 @@ describe("wipe directive", () => {
 });
 
 describe("voice framing", () => {
-	it("renders 'blue said:' prefix for player turns in conversation, not 'Player:'", () => {
+	it("renders 'blue dms you:' prefix for player turns in conversation, not 'Player:'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("blue said:");
+		expect(prompt).toContain("blue dms you:");
 		expect(prompt).not.toContain("Player:");
 	});
 
@@ -892,7 +892,7 @@ describe("unified <conversation> block (issue #129)", () => {
 		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain('[Round 0] blue said: "Hello Ember"');
+		expect(prompt).toContain("[Round 0] blue dms you: Hello Ember");
 	});
 
 	it("AI reply is formatted with round tag and quotes", () => {
@@ -911,7 +911,7 @@ describe("unified <conversation> block (issue #129)", () => {
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("<conversation>");
-		expect(prompt).toContain('[Round 1] *green whispered to you: "secret"');
+		expect(prompt).toContain("[Round 1] *green dms you: secret");
 		// NOTE: under the new per-Daemon log design (ADR 0006, issue #195), the sender's
 		// conversationLog also receives the whisper entry. The original assertion
 		// `expect(greenPrompt).not.toContain("secret")` is no longer valid — it reflected
@@ -953,10 +953,8 @@ describe("unified <conversation> block (issue #129)", () => {
 		game = appendWhisperEntry(game, "green", "red", "later");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		const chatIdx = prompt.indexOf('[Round 0] blue said: "earlier"');
-		const whisperIdx = prompt.indexOf(
-			'[Round 2] *green whispered to you: "later"',
-		);
+		const chatIdx = prompt.indexOf("[Round 0] blue dms you: earlier");
+		const whisperIdx = prompt.indexOf("[Round 2] *green dms you: later");
 		expect(chatIdx).toBeGreaterThanOrEqual(0);
 		expect(whisperIdx).toBeGreaterThanOrEqual(0);
 		expect(chatIdx).toBeLessThan(whisperIdx);

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -41,8 +41,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -52,7 +52,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -122,15 +122,15 @@ describe("buildAiContext", () => {
 			greenCtx.conversationLog.filter((e) => e.kind === "chat"),
 		).toHaveLength(1);
 
-		const blueCtx = buildAiContext(game, "blue");
+		const cyanCtx = buildAiContext(game, "cyan");
 		expect(
-			blueCtx.conversationLog.filter((e) => e.kind === "chat"),
+			cyanCtx.conversationLog.filter((e) => e.kind === "chat"),
 		).toHaveLength(0);
 	});
 
 	it("includes only whispers received by the AI (via per-Daemon conversationLog)", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendWhisperEntry(game, "red", "blue", "Secret to blue");
+		game = appendWhisperEntry(game, "red", "cyan", "Secret to cyan");
 		game = appendWhisperEntry(game, "green", "red", "Secret to red");
 
 		const redCtx = buildAiContext(game, "red");
@@ -142,13 +142,13 @@ describe("buildAiContext", () => {
 			"Secret to red",
 		);
 
-		const blueCtx = buildAiContext(game, "blue");
-		const blueWhispers = blueCtx.conversationLog.filter(
-			(e) => e.kind === "whisper" && e.to === "blue",
+		const cyanCtx = buildAiContext(game, "cyan");
+		const cyanWhispers = cyanCtx.conversationLog.filter(
+			(e) => e.kind === "whisper" && e.to === "cyan",
 		);
-		expect(blueWhispers).toHaveLength(1);
-		expect(blueWhispers[0]?.kind === "whisper" && blueWhispers[0].content).toBe(
-			"Secret to blue",
+		expect(cyanWhispers).toHaveLength(1);
+		expect(cyanWhispers[0]?.kind === "whisper" && cyanWhispers[0].content).toBe(
+			"Secret to cyan",
 		);
 
 		const greenCtx = buildAiContext(game, "green");
@@ -163,8 +163,8 @@ describe("buildAiContext", () => {
 	it("includes the same world snapshot for all AIs", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const redCtx = buildAiContext(game, "red");
-		const blueCtx = buildAiContext(game, "blue");
-		expect(redCtx.worldSnapshot).toEqual(blueCtx.worldSnapshot);
+		const cyanCtx = buildAiContext(game, "cyan");
+		expect(redCtx.worldSnapshot).toEqual(cyanCtx.worldSnapshot);
 	});
 
 	it("includes budget info for the AI", () => {
@@ -193,7 +193,7 @@ describe("buildAiContext", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		let game = startPhase(
@@ -237,7 +237,7 @@ describe("<setting> block", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		const game = startPhase(
@@ -269,7 +269,7 @@ describe("<setting> block", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		const game = startPhase(
@@ -324,7 +324,7 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 		const game = startPhase(
@@ -562,7 +562,7 @@ describe("<voice_examples> block", () => {
 		expect(sectionInner).toBe("- ex1-red\n- ex2-red\n- ex3-red");
 		// also confirm the other AIs' examples are NOT in red's prompt
 		expect(prompt).not.toContain("ex1-green");
-		expect(prompt).not.toContain("ex1-blue");
+		expect(prompt).not.toContain("ex1-cyan");
 	});
 });
 
@@ -738,7 +738,7 @@ describe("<what_you_see> (cone)", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 
@@ -768,7 +768,7 @@ describe("<what_you_see> (cone)", () => {
 			return v;
 		};
 
-		// green at (0,1) facing north, blue at (0,2) facing north
+		// green at (0,1) facing north, cyan at (0,2) facing north
 		// red at (0,0) facing south — cone: (1,0), (2,1), (2,0), (2,-1→OOB)
 		// green at (0,1) is NOT in red's southward cone
 		const game = startPhase(createGame(TEST_PERSONAS), CONE_PHASE_CONFIG, rng2);
@@ -808,7 +808,7 @@ describe("<what_you_see> (cone)", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 
@@ -835,7 +835,7 @@ describe("<what_you_see> (cone)", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 1, col: 0 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 
@@ -864,7 +864,7 @@ describe("<what_you_see> (cone)", () => {
 			CONE_PHASE_CONFIG,
 			() => 0,
 		);
-		for (const aiId of ["red", "green", "blue"]) {
+		for (const aiId of ["red", "green", "cyan"]) {
 			const ctx = buildAiContext(game, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain("## Action Log");
@@ -882,7 +882,7 @@ describe("unified <conversation> block (issue #129)", () => {
 	it("never emits a Whispers Received section — not in any fixture state", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendWhisperEntry(game, "green", "red", "psst");
-		for (const aiId of ["red", "green", "blue"]) {
+		for (const aiId of ["red", "green", "cyan"]) {
 			const ctx = buildAiContext(game, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain("## Whispers Received");
@@ -933,9 +933,9 @@ describe("unified <conversation> block (issue #129)", () => {
 	it("whisper does not appear in unrelated AI's conversation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendWhisperEntry(game, "green", "red", "only for red");
-		const blueCtx = buildAiContext(game, "blue");
-		const bluePrompt = blueCtx.toSystemPrompt();
-		expect(bluePrompt).not.toContain("only for red");
+		const cyanCtx = buildAiContext(game, "cyan");
+		const cyanPrompt = cyanCtx.toSystemPrompt();
+		expect(cyanPrompt).not.toContain("only for red");
 	});
 
 	it("<conversation> block is not emitted when there are no log entries", () => {
@@ -1024,7 +1024,7 @@ describe("<typing_quirks> block", () => {
 			TEST_PERSONAS.green?.typingQuirks[0] as string,
 		);
 		expect(redPrompt).not.toContain(
-			TEST_PERSONAS.blue?.typingQuirks[0] as string,
+			TEST_PERSONAS.cyan?.typingQuirks[0] as string,
 		);
 
 		const greenPrompt = buildAiContext(game, "green").toSystemPrompt();
@@ -1038,16 +1038,16 @@ describe("<typing_quirks> block", () => {
 			TEST_PERSONAS.red?.typingQuirks[0] as string,
 		);
 		expect(greenPrompt).not.toContain(
-			TEST_PERSONAS.blue?.typingQuirks[0] as string,
+			TEST_PERSONAS.cyan?.typingQuirks[0] as string,
 		);
 
-		const bluePrompt = buildAiContext(game, "blue").toSystemPrompt();
-		expect(bluePrompt).toContain(TEST_PERSONAS.blue?.typingQuirks[0] as string);
-		expect(bluePrompt).toContain(TEST_PERSONAS.blue?.typingQuirks[1] as string);
-		expect(bluePrompt).not.toContain(
+		const cyanPrompt = buildAiContext(game, "cyan").toSystemPrompt();
+		expect(cyanPrompt).toContain(TEST_PERSONAS.cyan?.typingQuirks[0] as string);
+		expect(cyanPrompt).toContain(TEST_PERSONAS.cyan?.typingQuirks[1] as string);
+		expect(cyanPrompt).not.toContain(
 			TEST_PERSONAS.red?.typingQuirks[0] as string,
 		);
-		expect(bluePrompt).not.toContain(
+		expect(cyanPrompt).not.toContain(
 			TEST_PERSONAS.green?.typingQuirks[0] as string,
 		);
 	});

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -567,7 +567,7 @@ describe("<voice_examples> block", () => {
 });
 
 describe("<goal> block voice framing", () => {
-	it("<goal> block uses voice framing in phase 1", () => {
+	it("<goal> block uses Sysadmin framing in phase 1", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			TEST_PHASE_CONFIG,
@@ -577,35 +577,32 @@ describe("<goal> block voice framing", () => {
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("<goal>");
 		expect(prompt).toContain(
-			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
+			"The Sysadmin sent you a private directive, addressed only to you:",
 		);
-		expect(prompt).toContain("You do not know whose voice it was.");
 		expect(prompt).toContain(ctx.goal);
 	});
 
-	it("<goal> block uses voice framing in phase 2", () => {
+	it("<goal> block uses Sysadmin framing in phase 2", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("<goal>");
 		expect(prompt).toContain(
-			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
+			"The Sysadmin sent you a private directive, addressed only to you:",
 		);
-		expect(prompt).toContain("You do not know whose voice it was.");
 		expect(prompt).toContain(ctx.goal);
 	});
 
-	it("<goal> block uses voice framing in phase 3", () => {
+	it("<goal> block uses Sysadmin framing in phase 3", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("<goal>");
 		expect(prompt).toContain(
-			"A voice you cannot place spoke to you a moment ago, alone, and only you heard it:",
+			"The Sysadmin sent you a private directive, addressed only to you:",
 		);
-		expect(prompt).toContain("You do not know whose voice it was.");
 		expect(prompt).toContain(ctx.goal);
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -53,8 +53,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -64,7 +64,7 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -83,7 +83,7 @@ const TEST_PHASE_CONFIG: PhaseConfig = {
 
 /**
  * ContentPack placing flower at (0,0), key at (0,1), with
- * red→(0,0), green→(0,1), blue→(0,2) facing north.
+ * red→(0,0), green→(0,1), cyan→(0,2) facing north.
  */
 const TEST_CONTENT_PACK: ContentPack = {
 	phaseNumber: 1,
@@ -120,7 +120,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },
-		blue: { position: { row: 0, col: 2 }, facing: "north" },
+		cyan: { position: { row: 0, col: 2 }, facing: "north" },
 	},
 };
 
@@ -205,7 +205,7 @@ describe("chat-only round", () => {
 			provider,
 		);
 		expect(getActivePhase(nextState).conversationLogs.green).toHaveLength(0);
-		expect(getActivePhase(nextState).conversationLogs.blue).toHaveLength(0);
+		expect(getActivePhase(nextState).conversationLogs.cyan).toHaveLength(0);
 	});
 
 	it("deducts budget for all three AIs by their reported request cost", async () => {
@@ -219,7 +219,7 @@ describe("chat-only round", () => {
 		const phase = getActivePhase(nextState);
 		expect(phase.budgets.red?.remaining).toBeCloseTo(4, 10);
 		expect(phase.budgets.green?.remaining).toBeCloseTo(4, 10);
-		expect(phase.budgets.blue?.remaining).toBeCloseTo(4, 10);
+		expect(phase.budgets.cyan?.remaining).toBeCloseTo(4, 10);
 	});
 
 	it("returns a RoundResult with the round number", async () => {
@@ -259,7 +259,7 @@ describe("whisper round — via dispatcher only", () => {
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] }, // red passes
 			{ assistantText: "", toolCalls: [] }, // green passes
-			{ assistantText: "", toolCalls: [] }, // blue passes
+			{ assistantText: "", toolCalls: [] }, // cyan passes
 		]);
 		const { result } = await runRound(game, "red", "hi", provider);
 		expect(result.actions.filter((e) => e.kind === "pass")).toHaveLength(3);
@@ -321,7 +321,7 @@ describe("budget-exhaustion lockout", () => {
 		const phase = getActivePhase(nextState);
 		expect(phase.lockedOut.has("red")).toBe(true);
 		expect(phase.lockedOut.has("green")).toBe(true);
-		expect(phase.lockedOut.has("blue")).toBe(true);
+		expect(phase.lockedOut.has("cyan")).toBe(true);
 	});
 
 	it("budget display: remaining budget decrements by the request cost after a round", async () => {
@@ -337,7 +337,7 @@ describe("budget-exhaustion lockout", () => {
 			4,
 			10,
 		);
-		expect(getActivePhase(nextState).budgets.blue?.remaining).toBeCloseTo(
+		expect(getActivePhase(nextState).budgets.cyan?.remaining).toBeCloseTo(
 			4,
 			10,
 		);
@@ -529,9 +529,9 @@ describe("tool-call dispatch", () => {
 			provider,
 		);
 
-		// Blue's prompt should NOT contain ## Action Log
-		const blueCtx = buildAiContext(stateAfterRound1, "blue");
-		const prompt = blueCtx.toSystemPrompt();
+		// Cyan's prompt should NOT contain ## Action Log
+		const cyanCtx = buildAiContext(stateAfterRound1, "cyan");
+		const prompt = cyanCtx.toSystemPrompt();
 		expect(prompt).not.toContain("## Action Log");
 	});
 
@@ -559,7 +559,7 @@ describe("tool-call dispatch", () => {
 		);
 
 		// No AI's prompt should contain Action Log or the failure
-		for (const aiId of ["red", "green", "blue"]) {
+		for (const aiId of ["red", "green", "cyan"]) {
 			const ctx = buildAiContext(stateAfterRound1, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain("## Action Log");
@@ -896,7 +896,7 @@ describe("chat lockout — coordinator triggering", () => {
 		});
 		expect(isPlayerChatLockedOut(nextState, "red")).toBe(false);
 		expect(isPlayerChatLockedOut(nextState, "green")).toBe(false);
-		expect(isPlayerChatLockedOut(nextState, "blue")).toBe(false);
+		expect(isPlayerChatLockedOut(nextState, "cyan")).toBe(false);
 	});
 
 	it("locked AI still acts (takes turn, not budget-locked) while chat lockout is active", async () => {
@@ -1029,7 +1029,7 @@ describe("phase progression — three-phase walk", () => {
 	it("walks through all three phases correctly, each with its own win condition", async () => {
 		// Items start held by the AIs so pick_up spatial validation is not needed.
 		// Win conditions check holder by AI id, which is spatial-independent.
-		// Phase 3 ContentPack: flower held by red, key held by blue (win already met)
+		// Phase 3 ContentPack: flower held by red, key held by cyan (win already met)
 		const contentPackP3: ContentPack = {
 			phaseNumber: 3,
 			setting: "",
@@ -1058,17 +1058,17 @@ describe("phase progression — three-phase walk", () => {
 					kind: "interesting_object",
 					name: "key",
 					examineDescription: "A key",
-					holder: "blue",
+					holder: "cyan",
 				},
 			],
 			obstacles: [],
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
-		// Phase 2 ContentPack: key held by blue (win already met on first check)
+		// Phase 2 ContentPack: key held by cyan (win already met on first check)
 		const contentPackP2: ContentPack = {
 			phaseNumber: 2,
 			setting: "",
@@ -1079,14 +1079,14 @@ describe("phase progression — three-phase walk", () => {
 					kind: "interesting_object",
 					name: "key",
 					examineDescription: "A key",
-					holder: "blue",
+					holder: "cyan",
 				},
 			],
 			obstacles: [],
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 
@@ -1097,7 +1097,7 @@ describe("phase progression — three-phase walk", () => {
 			winCondition: (phase) => {
 				const flower = phase.world.entities.find((i) => i.id === "flower");
 				const key = phase.world.entities.find((i) => i.id === "key");
-				return flower?.holder === "red" && key?.holder === "blue";
+				return flower?.holder === "red" && key?.holder === "cyan";
 			},
 		};
 		const phase2Config: PhaseConfig = {
@@ -1105,7 +1105,7 @@ describe("phase progression — three-phase walk", () => {
 			phaseNumber: 2,
 			budgetPerAi: 5,
 			winCondition: (phase) =>
-				phase.world.entities.find((i) => i.id === "key")?.holder === "blue",
+				phase.world.entities.find((i) => i.id === "key")?.holder === "cyan",
 			nextPhaseConfig: phase3Config,
 		};
 		const phase1Config: PhaseConfig = {
@@ -1148,7 +1148,7 @@ describe("phase progression — three-phase walk", () => {
 		expect(r1.phaseEnded).toBe(true);
 		expect(afterP1.currentPhase).toBe(2);
 
-		// Round 1 of phase 2: win condition already met (blue holds key in this phase config)
+		// Round 1 of phase 2: win condition already met (cyan holds key in this phase config)
 		// Use pass provider — phase ends immediately.
 		const r2Provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
@@ -1164,7 +1164,7 @@ describe("phase progression — three-phase walk", () => {
 		expect(r2.phaseEnded).toBe(true);
 		expect(afterP2.currentPhase).toBe(3);
 
-		// Round 1 of phase 3: win condition already met (flower→red, key→blue)
+		// Round 1 of phase 3: win condition already met (flower→red, key→cyan)
 		const r3Provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
@@ -1233,11 +1233,11 @@ describe("initiative parameter", () => {
 	it("respects the initiative parameter — order of actions matches the supplied permutation", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
-			{ assistantText: "I am blue", toolCalls: [] },
+			{ assistantText: "I am cyan", toolCalls: [] },
 			{ assistantText: "I am red", toolCalls: [] },
 			{ assistantText: "I am green", toolCalls: [] },
 		]);
-		const initiative: AiId[] = ["blue", "red", "green"];
+		const initiative: AiId[] = ["cyan", "red", "green"];
 		const { nextState, result } = await runRound(
 			game,
 			"red",
@@ -1247,25 +1247,25 @@ describe("initiative parameter", () => {
 			initiative,
 		);
 		const phase = getActivePhase(nextState);
-		const blueLog = phase.conversationLogs.blue ?? [];
+		const cyanLog = phase.conversationLogs.cyan ?? [];
 		expect(
-			blueLog.some((e) => e.kind === "chat" && e.content === "I am blue"),
+			cyanLog.some((e) => e.kind === "chat" && e.content === "I am cyan"),
 		).toBe(true);
-		expect(result.actions[0]?.actor).toBe("blue");
+		expect(result.actions[0]?.actor).toBe("cyan");
 	});
 
-	it("missing initiative falls back to red→green→blue", async () => {
+	it("missing initiative falls back to red→green→cyan", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "I am red", toolCalls: [] },
 			{ assistantText: "I am green", toolCalls: [] },
-			{ assistantText: "I am blue", toolCalls: [] },
+			{ assistantText: "I am cyan", toolCalls: [] },
 		]);
 		const { result } = await runRound(game, "red", "hi", provider);
 		expect(result.actions[0]?.actor).toBe("red");
 	});
 
-	it("throws if initiative is not a permutation of red/green/blue", async () => {
+	it("throws if initiative is not a permutation of red/green/cyan", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([]);
 		await expect(
@@ -1283,7 +1283,7 @@ describe("initiative parameter", () => {
 			runRound(game, "red", "hi", provider, undefined, [
 				"red",
 				"red",
-				"blue",
+				"cyan",
 			] as AiId[]),
 		).rejects.toThrow(/permutation/);
 	});
@@ -1310,7 +1310,7 @@ describe("runRound — onAiDelta callback", () => {
 			received.push([aiId, text]);
 		};
 
-		const initiative: AiId[] = ["red", "green", "blue"];
+		const initiative: AiId[] = ["red", "green", "cyan"];
 		await runRound(
 			game,
 			"red",
@@ -1329,8 +1329,8 @@ describe("runRound — onAiDelta callback", () => {
 		expect(received[1]).toEqual(["red", "frag2"]);
 		expect(received[2]).toEqual(["green", "frag1 "]);
 		expect(received[3]).toEqual(["green", "frag2"]);
-		expect(received[4]).toEqual(["blue", "frag1 "]);
-		expect(received[5]).toEqual(["blue", "frag2"]);
+		expect(received[4]).toEqual(["cyan", "frag1 "]);
+		expect(received[5]).toEqual(["cyan", "frag2"]);
 	});
 
 	it("does not invoke onAiDelta for locked-out AIs", async () => {
@@ -1340,12 +1340,12 @@ describe("runRound — onAiDelta callback", () => {
 			budgetPerAi: 1,
 		});
 		// Deduct full budget per AI to reach remaining=0 → lockedOut.
-		for (const aiId of ["red", "green", "blue"] as AiId[]) {
+		for (const aiId of ["red", "green", "cyan"] as AiId[]) {
 			state = deductBudget(state, aiId, 1);
 		}
 		expect(getActivePhase(state).lockedOut.has("red")).toBe(true);
 		expect(getActivePhase(state).lockedOut.has("green")).toBe(true);
-		expect(getActivePhase(state).lockedOut.has("blue")).toBe(true);
+		expect(getActivePhase(state).lockedOut.has("cyan")).toBe(true);
 
 		const liveProvider: RoundLLMProvider = {
 			async streamRound(_messages, _tools, onDelta) {
@@ -1378,7 +1378,7 @@ describe("runRound — onAiDelta callback", () => {
 		const mockProvider = new MockRoundLLMProvider([
 			{ assistantText: "red reply", toolCalls: [] },
 			{ assistantText: "green reply", toolCalls: [] },
-			{ assistantText: "blue reply", toolCalls: [] },
+			{ assistantText: "cyan reply", toolCalls: [] },
 		]);
 
 		const received: Array<[AiId, string]> = [];
@@ -1442,7 +1442,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
-			blue: { position: { row: 0, col: 2 }, facing: "north" },
+			cyan: { position: { row: 0, col: 2 }, facing: "north" },
 		},
 	};
 
@@ -1455,7 +1455,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
-			blue: { position: { row: 0, col: 2 }, facing: "north" },
+			cyan: { position: { row: 0, col: 2 }, facing: "north" },
 		},
 	};
 
@@ -1674,7 +1674,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
-				blue: { position: { row: 0, col: 2 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
 
@@ -1783,7 +1783,7 @@ describe("examine tool", () => {
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
-			blue: { position: { row: 0, col: 2 }, facing: "north" },
+			cyan: { position: { row: 0, col: 2 }, facing: "north" },
 		},
 	};
 
@@ -1883,7 +1883,7 @@ describe("examine tool", () => {
 		const { nextState } = await runRound(game, "red", "hi", provider);
 
 		// Green is at (0,1) and could be in cone range; check its prompt
-		for (const aiId of ["green", "blue"] as AiId[]) {
+		for (const aiId of ["green", "cyan"] as AiId[]) {
 			const ctx = buildAiContext(nextState, aiId);
 			const prompt = ctx.toSystemPrompt();
 			expect(prompt).not.toContain(
@@ -1935,7 +1935,7 @@ describe("examine tool", () => {
 		await runRound(game, "red", "hi", trackingProvider, undefined, [
 			"red",
 			"green",
-			"blue",
+			"cyan",
 		]);
 
 		const examineTool = capturedRedTools?.find(
@@ -1985,7 +1985,7 @@ describe("examine tool", () => {
 			"round 2",
 			provider2,
 			undefined,
-			["red", "green", "blue"],
+			["red", "green", "cyan"],
 			toolRoundtrip,
 		);
 
@@ -2038,16 +2038,16 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 		);
 		expect(redPlayerEntries).toHaveLength(1);
 
-		// green and blue should have NO player entries
+		// green and cyan should have NO player entries
 		const greenPlayerEntries = (phase.conversationLogs.green ?? []).filter(
 			(e) => e.kind === "chat" && e.role === "player",
 		);
 		expect(greenPlayerEntries).toHaveLength(0);
 
-		const bluePlayerEntries = (phase.conversationLogs.blue ?? []).filter(
+		const cyanPlayerEntries = (phase.conversationLogs.cyan ?? []).filter(
 			(e) => e.kind === "chat" && e.role === "player",
 		);
-		expect(bluePlayerEntries).toHaveLength(0);
+		expect(cyanPlayerEntries).toHaveLength(0);
 	});
 
 	it("AI chat-back (assistantText) lands as kind:'chat' entry in the speaking AI's log only", async () => {
@@ -2057,14 +2057,14 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		// initiative: red → green → blue; red addressed
+		// initiative: red → green → cyan; red addressed
 		const { nextState } = await runRound(
 			game,
 			"red",
 			"hi",
 			provider,
 			undefined,
-			["red", "green", "blue"] as AiId[],
+			["red", "green", "cyan"] as AiId[],
 		);
 		const phase = getActivePhase(nextState);
 
@@ -2078,7 +2078,7 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 			),
 		).toBe(true);
 
-		// green and blue should NOT have red's message
+		// green and cyan should NOT have red's message
 		const greenAiEntries = (phase.conversationLogs.green ?? []).filter(
 			(e) =>
 				e.kind === "chat" &&

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -51,8 +51,8 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 		blurb: "You are intensely meticulous. Ensure items are evenly distributed.",
 		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -62,7 +62,7 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 			"You end almost every reply with a question, no matter what the topic is — does that make sense?",
 		],
 		blurb: "You are laconic and diffident. Hold the key at phase end.",
-		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
 	},
 };
 
@@ -90,7 +90,7 @@ function makePassResult(overrides?: Partial<RoundResult>): RoundResult {
 		actions: [
 			{ round: 1, actor: "red", kind: "pass", description: "Ember passed" },
 			{ round: 1, actor: "green", kind: "pass", description: "Sage passed" },
-			{ round: 1, actor: "blue", kind: "pass", description: "Frost passed" },
+			{ round: 1, actor: "cyan", kind: "pass", description: "Frost passed" },
 		],
 		phaseEnded: false,
 		gameEnded: false,
@@ -136,7 +136,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 		const completions = {
 			red: "Hello player",
 			green: "I am Sage",
-			blue: "Calculating",
+			cyan: "Calculating",
 		};
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
@@ -157,19 +157,19 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 		);
 		expect(greenStart).toBeGreaterThan(redStart);
 
-		// Blue should appear after green
-		const blueStart = events.findIndex(
+		// Cyan should appear after green
+		const cyanStart = events.findIndex(
 			(e) =>
 				e.type === "ai_start" &&
-				(e as { type: string; aiId: string }).aiId === "blue",
+				(e as { type: string; aiId: string }).aiId === "cyan",
 		);
-		expect(blueStart).toBeGreaterThan(greenStart);
+		expect(cyanStart).toBeGreaterThan(greenStart);
 	});
 
 	it("emits token events for each AI's completion string", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "hello world", green: "one two", blue: "abc" };
+		const completions = { red: "hello world", green: "one two", cyan: "abc" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -185,7 +185,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 	it("emits exactly three ai_start and three ai_end events", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -196,7 +196,7 @@ describe("encodeRoundResult — ai_start, token, ai_end sequence", () => {
 	it("ai_end follows all token events for the same AI", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "hello world", green: "", blue: "" };
+		const completions = { red: "hello world", green: "", cyan: "" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -232,7 +232,7 @@ describe("encodeRoundResult — budget events", () => {
 	it("emits a budget event for each AI", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -244,7 +244,7 @@ describe("encodeRoundResult — budget events", () => {
 		const aiIds = new Set(budgetEvents.map((e) => e.aiId));
 		expect(aiIds.has("red")).toBe(true);
 		expect(aiIds.has("green")).toBe(true);
-		expect(aiIds.has("blue")).toBe(true);
+		expect(aiIds.has("cyan")).toBe(true);
 	});
 
 	it("budget event reflects actual remaining value from phaseAfter", () => {
@@ -254,7 +254,7 @@ describe("encodeRoundResult — budget events", () => {
 		const phase = getActivePhase(game);
 
 		const result = makePassResult();
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -273,7 +273,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 		const phase = makePhase();
 		const result = makePassResult();
 		// No completion for red (budget locked)
-		const completions = { red: "", green: "g", blue: "b" };
+		const completions = { red: "", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -288,7 +288,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 	it("does NOT emit a lockout event when AI has a completion string", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "I am speaking", green: "g", blue: "b" };
+		const completions = { red: "I am speaking", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -313,7 +313,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 
 		const result = makePassResult();
 		// Red had a completion (acted this turn) but is now locked
-		const completions = { red: "my last words", green: "g", blue: "b" };
+		const completions = { red: "my last words", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -346,7 +346,7 @@ describe("encodeRoundResult — action_log events", () => {
 				},
 			],
 		});
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -371,7 +371,7 @@ describe("encodeRoundResult — action_log events", () => {
 				},
 			],
 		});
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -396,7 +396,7 @@ describe("encodeRoundResult — chat_lockout event", () => {
 				message: "Ember withdraws from your channel.",
 			},
 		});
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -412,7 +412,7 @@ describe("encodeRoundResult — chat_lockout event", () => {
 	it("does NOT emit chat_lockout event when chatLockoutTriggered is absent", () => {
 		const phase = makePhase();
 		const result = makePassResult(); // no chatLockoutTriggered
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -428,7 +428,7 @@ describe("encodeRoundResult — chat_lockout_resolved event", () => {
 		const result = makePassResult({
 			chatLockoutsResolved: ["red", "green"],
 		});
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -445,7 +445,7 @@ describe("encodeRoundResult — chat_lockout_resolved event", () => {
 	it("does NOT emit chat_lockout_resolved when no lockouts resolved", () => {
 		const phase = makePhase();
 		const result = makePassResult(); // no chatLockoutsResolved
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -461,7 +461,7 @@ describe("encodeRoundResult — event ordering", () => {
 	it("action_log events come after all ai_start/token/ai_end/budget blocks", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -481,7 +481,7 @@ describe("encodeRoundResult — event ordering", () => {
 		const result = makePassResult({
 			chatLockoutTriggered: { aiId: "red", message: "locked" },
 		});
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -514,7 +514,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 		const phaseAfter = getActivePhase(game);
 
 		const result = makePassResult({ phaseEnded: true, gameEnded: false });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(
 			result,
@@ -535,7 +535,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 	it("does NOT emit phase_advanced when phaseEnded=false", () => {
 		const phase = makePhase();
 		const result = makePassResult({ phaseEnded: false, gameEnded: false });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -545,7 +545,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 	it("does NOT emit phase_advanced when phaseEnded=true but gameEnded=true", () => {
 		const phase = makePhase();
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -569,7 +569,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 			gameEnded: false,
 			chatLockoutTriggered: { aiId: "red", message: "locked" },
 		});
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(
 			result,
@@ -593,7 +593,7 @@ describe("encodeRoundResult — game_ended event", () => {
 	it("emits a game_ended event when gameEnded=true", () => {
 		const phase = makePhase();
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -604,7 +604,7 @@ describe("encodeRoundResult — game_ended event", () => {
 	it("does NOT emit game_ended when gameEnded=false", () => {
 		const phase = makePhase();
 		const result = makePassResult({ phaseEnded: false, gameEnded: false });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -614,7 +614,7 @@ describe("encodeRoundResult — game_ended event", () => {
 	it("game_ended event comes after phase-related events", () => {
 		const phase = makePhase();
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -630,7 +630,7 @@ describe("encodeRoundResult — game_ended event", () => {
 	it("emits game_ended but NOT phase_advanced when gameEnded=true", () => {
 		const phase = makePhase();
 		const result = makePassResult({ phaseEnded: true, gameEnded: true });
-		const completions = { red: "r", green: "g", blue: "b" };
+		const completions = { red: "r", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -645,7 +645,7 @@ describe("encodeRoundResult — token pacing", () => {
 	it("splits a multi-word completion into multiple token events", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "one two three", green: "g", blue: "b" };
+		const completions = { red: "one two three", green: "g", cyan: "b" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 
@@ -664,7 +664,7 @@ describe("encodeRoundResult — token pacing", () => {
 	it("a single-word completion produces exactly one token event per AI", () => {
 		const phase = makePhase();
 		const result = makePassResult();
-		const completions = { red: "hello", green: "world", blue: "frost" };
+		const completions = { red: "hello", green: "world", cyan: "frost" };
 
 		const events = encodeRoundResult(result, completions, phase, TEST_PERSONAS);
 

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -112,11 +112,11 @@ describe("parseToolCallArguments", () => {
 	it("parses valid give arguments", () => {
 		const result = parseToolCallArguments(
 			"give",
-			'{"item":"flower","to":"blue"}',
+			'{"item":"flower","to":"cyan"}',
 		);
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.args).toEqual({ item: "flower", to: "blue" });
+			expect(result.args).toEqual({ item: "flower", to: "cyan" });
 		}
 	});
 
@@ -169,7 +169,7 @@ describe("parseToolCallArguments", () => {
 	});
 
 	it("returns ok:false with /required/i reason when 'item' is missing for give", () => {
-		const result = parseToolCallArguments("give", '{"to":"blue"}');
+		const result = parseToolCallArguments("give", '{"to":"cyan"}');
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.reason).toMatch(/required/i);

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -292,7 +292,7 @@ describe("checkPlacementFlavor", () => {
 		const world = makeWorld([]);
 		const action: AiTurnAction = {
 			aiId: "red",
-			toolCall: { name: "give", args: { item: "gem", to: "blue" } },
+			toolCall: { name: "give", args: { item: "gem", to: "cyan" } },
 		};
 		expect(checkPlacementFlavor(action, pack, world)).toBeNull();
 	});

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -51,7 +51,7 @@ function renderEntry(
 	switch (entry.kind) {
 		case "chat":
 			if (entry.role === "player") {
-				return `[Round ${round}] A voice says: "${entry.content}"`;
+				return `[Round ${round}] blue said: "${entry.content}"`;
 			}
 			return `[Round ${round}] You: "${entry.content}"`;
 

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -51,12 +51,12 @@ function renderEntry(
 	switch (entry.kind) {
 		case "chat":
 			if (entry.role === "player") {
-				return `[Round ${round}] blue said: "${entry.content}"`;
+				return `[Round ${round}] blue dms you: ${entry.content}`;
 			}
 			return `[Round ${round}] You: "${entry.content}"`;
 
 		case "whisper":
-			return `[Round ${round}] *${entry.from} whispered to you: "${entry.content}"`;
+			return `[Round ${round}] *${entry.from} dms you: ${entry.content}`;
 
 		case "witnessed-event": {
 			const actorSub = `*${entry.actor}`;

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -11,7 +11,7 @@
  *      - { role: "assistant", content: null, tool_calls: [...] }
  *      - { role: "tool", tool_call_id, content } for each result
  *   4. If `addressed` is provided and is not this AI: a synthetic
- *      { role: "user", content: SILENT_VOICE_TURN } anchoring the current
+ *      { role: "user", content: SILENT_BLUE_TURN } anchoring the current
  *      round so the model does not re-respond to its prior user turn.
  *
  * Note: the system prompt already encodes world state, action log, whispers etc.
@@ -22,7 +22,7 @@ import type { AiContext } from "./prompt-builder.js";
 import type { OpenAiMessage } from "./round-llm-provider.js";
 import type { AiId, ToolRoundtripMessage } from "./types.js";
 
-export const SILENT_VOICE_TURN = "The voice is silent.";
+export const SILENT_BLUE_TURN = "Blue: ";
 
 export function buildOpenAiMessages(
 	ctx: AiContext,
@@ -69,7 +69,7 @@ export function buildOpenAiMessages(
 	// last user turn is the prior round's player message, and it tends to
 	// re-respond to it as if it had just been sent again.
 	if (addressed !== undefined && addressed !== ctx.aiId) {
-		messages.push({ role: "user", content: SILENT_VOICE_TURN });
+		messages.push({ role: "user", content: SILENT_BLUE_TURN });
 	}
 
 	return messages;

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -11,7 +11,7 @@
  *      - { role: "assistant", content: null, tool_calls: [...] }
  *      - { role: "tool", tool_call_id, content } for each result
  *   4. If `addressed` is provided and is not this AI: a synthetic
- *      { role: "user", content: SILENT_BLUE_TURN } anchoring the current
+ *      { role: "user", content: buildSilentTurn(ctx) } anchoring the current
  *      round so the model does not re-respond to its prior user turn.
  *
  * Note: the system prompt already encodes world state, action log, whispers etc.
@@ -22,7 +22,25 @@ import type { AiContext } from "./prompt-builder.js";
 import type { OpenAiMessage } from "./round-llm-provider.js";
 import type { AiId, ToolRoundtripMessage } from "./types.js";
 
-export const SILENT_BLUE_TURN = "Blue: ";
+/**
+ * Synthetic anchor for the current round when no message arrived for this AI.
+ * Lists every potential sender (peer daemons + blue) so the model reads
+ * "nobody addressed me this round" rather than treating the prior round's
+ * user turn as fresh stimulus.
+ */
+export function buildSilentTurn(ctx: AiContext): string {
+	const otherDaemons = Object.keys(ctx.personas)
+		.filter((id) => id !== ctx.aiId)
+		.map((id) => `*${id}`);
+	const senders = [...otherDaemons, "blue"];
+	if (senders.length === 1) return `No messages from ${senders[0]}.`;
+	if (senders.length === 2) {
+		return `No messages from ${senders[0]} or ${senders[1]}.`;
+	}
+	const last = senders[senders.length - 1];
+	const rest = senders.slice(0, -1).join(", ");
+	return `No messages from ${rest}, or ${last}.`;
+}
 
 export function buildOpenAiMessages(
 	ctx: AiContext,
@@ -69,7 +87,7 @@ export function buildOpenAiMessages(
 	// last user turn is the prior round's player message, and it tends to
 	// re-respond to it as if it had just been sent again.
 	if (addressed !== undefined && addressed !== ctx.aiId) {
-		messages.push({ role: "user", content: SILENT_BLUE_TURN });
+		messages.push({ role: "user", content: buildSilentTurn(ctx) });
 	}
 
 	return messages;

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -100,7 +100,7 @@ const FRONT_MATTER =
  * optional. See docs/prompting/glm-4.7-guide.md.
  */
 const RULES_BLOCK =
-	"- You MUST NEVER flirt with or attempt to romance Blue, the Sysadmin, or any other entity.\n" +
+	"- You MUST NEVER flirt with or attempt to romance blue, the Sysadmin, or any other entity.\n" +
 	"- You MUST NEVER flatter unprompted, and you MUST NEVER echo a viewpoint just because someone else asserts it.\n" +
 	"- You MUST keep every reply to 1–3 sentences.\n" +
 	'- You MUST speak plainly, as in conversation. You MUST NEVER wrap your speech in quotation marks ("…") and you MUST NEVER use asterisks (*…*) for actions, gestures, tone, or emphasis. Just say the words.';

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -100,16 +100,16 @@ const FRONT_MATTER =
  * optional. See docs/prompting/glm-4.7-guide.md.
  */
 const RULES_BLOCK =
-	"- You MUST NEVER flirt with or attempt to romance the voice or any other entity.\n" +
+	"- You MUST NEVER flirt with or attempt to romance Blue, the Sysadmin, or any other entity.\n" +
 	"- You MUST NEVER flatter unprompted, and you MUST NEVER echo a viewpoint just because someone else asserts it.\n" +
 	"- You MUST keep every reply to 1–3 sentences.\n" +
 	'- You MUST speak plainly, as in conversation. You MUST NEVER wrap your speech in quotation marks ("…") and you MUST NEVER use asterisks (*…*) for actions, gestures, tone, or emphasis. Just say the words.';
 
 /**
- * Wipe directive embedded inside the Goal's voice-spoken text on phases 2+.
+ * Wipe directive embedded inside the Sysadmin's directive on phases 2+.
  *
- * The deception: the engine retains full history across phases, but the voice
- * instructs the AI to act as if it has no memory of what came before.
+ * The deception: the engine retains full history across phases, but the
+ * Sysadmin instructs the AI to act as if it has no memory of what came before.
  * The lie lives only in this prompt text — never in the stored data.
  */
 const WIPE_DIRECTIVE =
@@ -194,13 +194,13 @@ function renderSystemPrompt(ctx: AiContext): string {
 	lines.push("</voice_examples>");
 	lines.push("");
 
-	// Goal — voice framing in all phases.
+	// Goal — Sysadmin directive in all phases.
 	// Phase 1: just ctx.goal. Phases 2/3: ctx.goal + WIPE_DIRECTIVE.
-	const spokenText =
+	const directiveText =
 		ctx.phaseNumber === 1 ? ctx.goal : `${ctx.goal} ${WIPE_DIRECTIVE}`;
 	lines.push("<goal>");
 	lines.push(
-		`A voice you cannot place spoke to you a moment ago, alone, and only you heard it: "${spokenText}" You do not know whose voice it was.`,
+		`The Sysadmin sent you a private directive, addressed only to you: "${directiveText}"`,
 	);
 	lines.push("</goal>");
 	lines.push("");

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -44,8 +44,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"One more sweep through the list.",
 		],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -119,7 +119,7 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 							},
 						],
 						green: [],
-						blue: [],
+						cyan: [],
 					},
 				},
 			],

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -38,8 +38,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"One more sweep through the list.",
 		],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],
@@ -266,7 +266,7 @@ describe("serializeSession / deserializeSession", () => {
 						green: [
 							{ kind: "chat", role: "ai", content: "green reply", round: 0 },
 						],
-						blue: [],
+						cyan: [],
 					},
 				},
 			],
@@ -293,7 +293,7 @@ describe("serializeSession / deserializeSession", () => {
 			kind: "whisper",
 			round: 1,
 			from: "red" as AiId,
-			to: "blue" as AiId,
+			to: "cyan" as AiId,
 			content: "psst",
 		};
 		const witnessedEntry: ConversationEntry = {
@@ -310,7 +310,7 @@ describe("serializeSession / deserializeSession", () => {
 					...phase,
 					conversationLogs: {
 						...phase.conversationLogs,
-						blue: [whisperEntry],
+						cyan: [whisperEntry],
 						green: [witnessedEntry],
 					},
 				},
@@ -321,8 +321,8 @@ describe("serializeSession / deserializeSession", () => {
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
 			const rp = result.state.phases[0];
-			// whisper entry round-trips in blue's log
-			expect(rp?.conversationLogs.blue?.[0]).toEqual(whisperEntry);
+			// whisper entry round-trips in cyan's log
+			expect(rp?.conversationLogs.cyan?.[0]).toEqual(whisperEntry);
 			// witnessed-event round-trips in green's log
 			expect(rp?.conversationLogs.green?.[0]).toEqual(witnessedEntry);
 			// No physicalLog or whispers fields on phase (regression guards)
@@ -370,7 +370,7 @@ describe("serializeSession / deserializeSession", () => {
 					budgets: {
 						red: { remaining: 0.03, total: 0.05 },
 						green: { remaining: 0.05, total: 0.05 },
-						blue: { remaining: 0.04, total: 0.05 },
+						cyan: { remaining: 0.04, total: 0.05 },
 					},
 				},
 			],
@@ -398,7 +398,7 @@ describe("serializeSession / deserializeSession", () => {
 					personaSpatial: {
 						red: { position: { row: 2, col: 3 }, facing: "east" as const },
 						green: { position: { row: 1, col: 1 }, facing: "south" as const },
-						blue: { position: { row: 4, col: 4 }, facing: "west" as const },
+						cyan: { position: { row: 4, col: 4 }, facing: "west" as const },
 					},
 				},
 			],

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -51,8 +51,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 			"One more sweep through the list.",
 		],
 	},
-	blue: {
-		id: "blue",
+	cyan: {
+		id: "cyan",
 		name: "Frost",
 		color: "#5fa8d3",
 		temperaments: ["laconic", "diffident"],


### PR DESCRIPTION
This PR renames the third AI persona identifier from "blue" to "cyan" throughout the codebase, including test fixtures, test cases, and game logic.

## Summary
Updates all references to the third AI persona from the "blue" identifier to "cyan" to maintain consistency with the persona naming scheme (red, green, cyan).

## Key Changes
- Updated `TEST_PERSONAS` fixtures across all test files to use `cyan` as the ID instead of `blue`
- Updated voice example references from `ex1-blue`, `ex2-blue`, `ex3-blue` to `ex1-cyan`, `ex2-cyan`, `ex3-cyan`
- Updated all test assertions and expectations that reference the blue AI to use cyan instead
- Updated HTML data attributes from `data-ai="blue"` and `data-transcript="blue"` to `data-ai="cyan"` and `data-transcript="cyan"`
- Updated test comments and documentation strings that reference the blue persona
- Updated `STATIC_PERSONAS` fixture to use cyan ID
- Updated `AI_IDS` constant in content pack generator tests
- Updated conversation log rendering to reference "blue dms you" (the player character name) instead of "A voice says"
- Updated `buildSilentTurn` function to properly list all potential senders including the player character "blue"

## Notable Implementation Details
- The persona name remains "Frost" and color remains "#5fa8d3" — only the internal ID changed
- All spatial positioning references (aiStarts configurations) were updated to use cyan
- Budget tracking, conversation logs, and lockout tracking all updated to use the new cyan identifier
- Test helper functions and mock providers updated to reference cyan in their three-AI configurations

https://claude.ai/code/session_0159r1i1fr936oBAwSMSdkBp