### PR TITLE
Fix vertical beading in box-drawing borders using text-shadow

### DIFF
--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -16,30 +16,22 @@ const BANNER_SEGMENTS: ReadonlyArray<readonly [string, string, string]> = [
 	["   ╚═╝  ╚═╝╚═╝      ", "╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝", ""],
 ] as const;
 
-/** Width of the banner body content, in characters — the longest of
- *  the BANNER_SEGMENTS lineLen values. The full banner row is `w + 5`
- *  chars wide (1 leading space + ║ + space + content[w] + space + ║),
- *  so the right ║ glyph centre sits at column `w + 4.5`. Exposed so
- *  the CSS overlay that paints over the beaded ║ columns can position
- *  itself dynamically rather than hardcoding the column index. */
-export const BANNER_W: number = (() => {
-	const len = (s: string): number => [...s].length;
-	const lineLen = (seg: readonly [string, string, string]): number =>
-		len(seg[0]) + len(seg[1]) + len(seg[2]);
-	return Math.max(...BANNER_SEGMENTS.map(lineLen));
-})();
-
-/** Banner as HTML — the BLUE block letters are wrapped in `.banner-blue`. */
+/** Banner as HTML — the BLUE block letters are wrapped in `.banner-blue`.
+ *  Each body-row `║` is wrapped in `.banner-side` so CSS can hide the
+ *  beaded glyph and paint a continuous double-line via a per-cell
+ *  `::before` that extends slightly past the line-box (overlapping the
+ *  next row's overlay so the strip is seamless). */
 export const BANNER: string = (() => {
 	const len = (s: string): number => [...s].length;
 	const lineLen = (seg: readonly [string, string, string]): number =>
 		len(seg[0]) + len(seg[1]) + len(seg[2]);
-	const w = BANNER_W;
+	const w = Math.max(...BANNER_SEGMENTS.map(lineLen));
 	const top = ` ╔${"═".repeat(w + 2)}╗`;
 	const bot = ` ╚${"═".repeat(w + 2)}╝`;
+	const side = `<span class="banner-side">║</span>`;
 	const body = BANNER_SEGMENTS.map(([a, b, c]) => {
 		const pad = " ".repeat(w - lineLen([a, b, c]));
-		return ` ║ ${a}<span class="banner-blue">${b}</span>${c}${pad} ║`;
+		return ` ${side} ${a}<span class="banner-blue">${b}</span>${c}${pad} ${side}`;
 	});
 	return [top, ...body, bot].join("\n");
 })();
@@ -165,15 +157,10 @@ export function topInfoStatus(state: LoadState): LoadStateStatus {
 	}
 }
 
-/** Idempotent: inject the ASCII banner into `#banner` if not already there.
- *  Sets `--banner-w` so the CSS overlay can position over the right ║ column
- *  (whose left edge is `(BANNER_W + 4) * 1ch` from the .banner left edge). */
+/** Idempotent: inject the ASCII banner into `#banner` if not already there. */
 export function paintBanner(doc: Document): void {
 	const el = doc.querySelector<HTMLElement>("#banner");
-	if (el && !el.innerHTML) {
-		el.innerHTML = BANNER;
-		el.style.setProperty("--banner-w", String(BANNER_W));
-	}
+	if (el && !el.innerHTML) el.innerHTML = BANNER;
 }
 
 /** Populate the three topinfo cells (left / right / mobile) from inputs. */

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -16,12 +16,25 @@ const BANNER_SEGMENTS: ReadonlyArray<readonly [string, string, string]> = [
 	["   ╚═╝  ╚═╝╚═╝      ", "╚═════╝ ╚══════╝ ╚═════╝ ╚══════╝", ""],
 ] as const;
 
+/** Width of the banner body content, in characters — the longest of
+ *  the BANNER_SEGMENTS lineLen values. The full banner row is `w + 5`
+ *  chars wide (1 leading space + ║ + space + content[w] + space + ║),
+ *  so the right ║ glyph centre sits at column `w + 4.5`. Exposed so
+ *  the CSS overlay that paints over the beaded ║ columns can position
+ *  itself dynamically rather than hardcoding the column index. */
+export const BANNER_W: number = (() => {
+	const len = (s: string): number => [...s].length;
+	const lineLen = (seg: readonly [string, string, string]): number =>
+		len(seg[0]) + len(seg[1]) + len(seg[2]);
+	return Math.max(...BANNER_SEGMENTS.map(lineLen));
+})();
+
 /** Banner as HTML — the BLUE block letters are wrapped in `.banner-blue`. */
 export const BANNER: string = (() => {
 	const len = (s: string): number => [...s].length;
 	const lineLen = (seg: readonly [string, string, string]): number =>
 		len(seg[0]) + len(seg[1]) + len(seg[2]);
-	const w = Math.max(...BANNER_SEGMENTS.map(lineLen));
+	const w = BANNER_W;
 	const top = ` ╔${"═".repeat(w + 2)}╗`;
 	const bot = ` ╚${"═".repeat(w + 2)}╝`;
 	const body = BANNER_SEGMENTS.map(([a, b, c]) => {
@@ -152,10 +165,15 @@ export function topInfoStatus(state: LoadState): LoadStateStatus {
 	}
 }
 
-/** Idempotent: inject the ASCII banner into `#banner` if not already there. */
+/** Idempotent: inject the ASCII banner into `#banner` if not already there.
+ *  Sets `--banner-w` so the CSS overlay can position over the right ║ column
+ *  (whose left edge is `(BANNER_W + 4) * 1ch` from the .banner left edge). */
 export function paintBanner(doc: Document): void {
 	const el = doc.querySelector<HTMLElement>("#banner");
-	if (el && !el.innerHTML) el.innerHTML = BANNER;
+	if (el && !el.innerHTML) {
+		el.innerHTML = BANNER;
+		el.style.setProperty("--banner-w", String(BANNER_W));
+	}
 }
 
 /** Populate the three topinfo cells (left / right / mobile) from inputs. */

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -17,10 +17,10 @@ const BANNER_SEGMENTS: ReadonlyArray<readonly [string, string, string]> = [
 ] as const;
 
 /** Banner as HTML — the BLUE block letters are wrapped in `.banner-blue`.
- *  Each body-row `║` is wrapped in `.banner-side` so CSS can hide the
- *  beaded glyph and paint a continuous double-line via a per-cell
- *  `::before` that extends slightly past the line-box (overlapping the
- *  next row's overlay so the strip is seamless). */
+ *  Each body-row `║` is wrapped in `.banner-side` so CSS can stamp
+ *  vertically-offset clones of the glyph (sharp text-shadows) to fill
+ *  the 1-2 px inter-line gap that causes vertical beading. The shadow
+ *  is the glyph's own ink, so it auto-aligns with the corner glyphs. */
 export const BANNER: string = (() => {
 	const len = (s: string): number => [...s].length;
 	const lineLen = (seg: readonly [string, string, string]): number =>

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -125,13 +125,14 @@ header {
 	font-size: 13px;
 	letter-spacing: 0;
 	color: var(--amber);
+	/* Same per-glyph halo accumulation as the panel chrome — the banner
+	   frame's `║` columns sit in separate line-boxes and bead under the
+	   inherited body text-shadow. */
+	text-shadow: none;
 }
 
 .banner-blue {
 	color: var(--blue);
-	text-shadow:
-		0 0 1px var(--blue),
-		0 0 6px rgba(127, 182, 255, 0.5);
 }
 
 /* `.login-tag b` and `.login-sysinfo b` set color: var(--amber) at
@@ -316,6 +317,11 @@ main {
 	position: relative;
 	min-width: 0;
 	color: var(--panel-color);
+	/* Borders are runs of box-drawing glyphs; the body's inherited
+	   text-shadow halos overlap per-glyph and bead along vertical sides
+	   (where line-box gaps interrupt the ink column). Drop the halo on
+	   the chrome so the eye fuses the glyphs into a continuous line. */
+	text-shadow: none;
 }
 
 .corner,
@@ -439,6 +445,7 @@ main {
 	flex: 0 0 auto;
 	user-select: none;
 	color: var(--panel-color);
+	text-shadow: none;
 }
 
 .panel-content {
@@ -800,6 +807,7 @@ main {
 	overflow: hidden;
 	position: relative;
 	color: var(--amber);
+	text-shadow: none;
 }
 
 .login-frame-brow .fill {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -145,7 +145,10 @@ header {
 .banner-side::before {
 	content: "";
 	position: absolute;
-	left: calc(50% - 1.5px);
+	/* JBM's `║`/`╔`/`╗` glyphs draw the double-stroke ~1px right of cell
+	   centre, so the painted line is offset (-0.5px instead of -1.5px)
+	   to land axially under the corner glyphs' vertical strokes. */
+	left: calc(50% - 0.5px);
 	width: 3px;
 	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
 	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -129,6 +129,40 @@ header {
 	   frame's `║` columns sit in separate line-boxes and bead under the
 	   inherited body text-shadow. */
 	text-shadow: none;
+	/* Shrink to content so the ::before/::after overlays (positioned
+	   from left/right) land on the actual `║` columns rather than the
+	   far edges of the surrounding grid cell. */
+	width: max-content;
+	position: relative;
+}
+
+/* Paint a continuous double-line over the beaded `║` glyph columns on the
+   left and right of the banner body rows. Spans the 6 body rows only —
+   the top (`╔══╗`) and bottom (`╚══╝`) rows keep their corner glyphs. */
+.banner::before,
+.banner::after {
+	content: "";
+	position: absolute;
+	top: 1em;
+	bottom: 1em;
+	width: 3px;
+	background: linear-gradient(
+		to right,
+		var(--amber) 0 1px,
+		transparent 1px 2px,
+		var(--amber) 2px 3px
+	);
+	pointer-events: none;
+}
+
+.banner::before {
+	/* Left `║` is at column 1 (after the leading space) — centre at 1.5ch. */
+	left: calc(1.5ch - 1.5px);
+}
+
+.banner::after {
+	/* Right `║` is the last column before the trailing space — centre at 0.5ch from right. */
+	right: calc(0.5ch - 1.5px);
 }
 
 .banner-blue {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -444,8 +444,32 @@ main {
 	width: 1ch;
 	flex: 0 0 auto;
 	user-select: none;
-	color: var(--panel-color);
+	/* The vertical border was rendered as a column of `│` glyphs, one per
+	   line-box. Fonts draw `│` slightly shorter than the em-square, so
+	   adjacent glyphs leave a 1-2px gap that reads as beading down the
+	   column. Hide the glyphs and paint a continuous 1px line via a
+	   background gradient at the cell's horizontal centre — same width
+	   and position as the corner glyphs' vertical strokes above/below. */
+	color: transparent;
 	text-shadow: none;
+	background: linear-gradient(
+		to right,
+		transparent calc(50% - 0.5px),
+		var(--panel-color, var(--amber)) calc(50% - 0.5px) calc(50% + 0.5px),
+		transparent calc(50% + 0.5px)
+	);
+}
+
+.ai-panel.panel--addressed .side-heavy {
+	/* `║` is a double line — two 1px strokes with a 1px gap. */
+	background: linear-gradient(
+		to right,
+		transparent calc(50% - 1.5px),
+		var(--panel-color, var(--amber)) calc(50% - 1.5px) calc(50% - 0.5px),
+		transparent calc(50% - 0.5px) calc(50% + 0.5px),
+		var(--panel-color, var(--amber)) calc(50% + 0.5px) calc(50% + 1.5px),
+		transparent calc(50% + 1.5px)
+	);
 }
 
 .panel-content {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -456,16 +456,17 @@ main {
 	line-height: 1;
 	overflow: hidden;
 	word-break: break-all;
-	width: 1ch;
+	/* No explicit width — `1ch` is the advance of `0`, but JBM's box-
+	   drawing glyphs have a (very slightly) different advance, so
+	   pinning the column to 1ch shifts the `│` stroke half a pixel
+	   left of the corner glyphs' vertical arms. Let the box auto-size
+	   from the `│` glyph's own advance and the column lines up exactly. */
 	flex: 0 0 auto;
 	user-select: none;
 	color: var(--panel-color);
 	/* Same approach as the banner `║` — stamp clones of the glyph 1 px
-	   above and below itself with zero-blur text-shadows. The clones
-	   extend the glyph's own ink into the inter-line gap that causes
-	   vertical beading, and because the shadow is the glyph itself, it
-	   self-aligns with the corner glyphs above/below — no positioning
-	   math, no subpixel guessing. */
+	   above and below itself with zero-blur text-shadows so the `│`
+	   ink bleeds into the inter-line gap that causes vertical beading. */
 	text-shadow:
 		0 1px 0 var(--panel-color, var(--amber)),
 		0 -1px 0 var(--panel-color, var(--amber));

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -145,10 +145,10 @@ header {
 .banner-side::before {
 	content: "";
 	position: absolute;
-	/* JBM's `║`/`╔`/`╗` glyphs sit a fractional pixel right of cell
-	   centre — found empirically: -1.5px lands a hair left, -1px
-	   lands a hair right, so split the difference. */
-	left: calc(50% - 1.25px);
+	/* JBM's `║`/`╔`/`╗` glyphs sit a small fractional pixel right of cell
+	   centre — found empirically: -1.5px lands ~1px left, -1.25px lands
+	   a bit right, so the corner-stroke offset is roughly 0.1px. */
+	left: calc(50% - 1.4px);
 	width: 3px;
 	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
 	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -145,10 +145,10 @@ header {
 .banner-side::before {
 	content: "";
 	position: absolute;
-	/* JBM's `║`/`╔`/`╗` glyphs draw the double-stroke ~0.5px right of
-	   cell centre, so the painted line is shifted by half a pixel
-	   (-1px instead of -1.5px) to land axially under the corners. */
-	left: calc(50% - 1px);
+	/* JBM's `║`/`╔`/`╗` glyphs sit a fractional pixel right of cell
+	   centre — found empirically: -1.5px lands a hair left, -1px
+	   lands a hair right, so split the difference. */
+	left: calc(50% - 1.25px);
 	width: 3px;
 	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
 	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -145,10 +145,10 @@ header {
 .banner-side::before {
 	content: "";
 	position: absolute;
-	/* JBM's `║`/`╔`/`╗` glyphs draw the double-stroke ~1px right of cell
-	   centre, so the painted line is offset (-0.5px instead of -1.5px)
-	   to land axially under the corner glyphs' vertical strokes. */
-	left: calc(50% - 0.5px);
+	/* JBM's `║`/`╔`/`╗` glyphs draw the double-stroke ~0.5px right of
+	   cell centre, so the painted line is shifted by half a pixel
+	   (-1px instead of -1.5px) to land axially under the corners. */
+	left: calc(50% - 1px);
 	width: 3px;
 	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
 	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -129,16 +129,17 @@ header {
 	   frame's `║` columns sit in separate line-boxes and bead under the
 	   inherited body text-shadow. */
 	text-shadow: none;
-	/* Shrink to content so the ::before/::after overlays (positioned
-	   from left/right) land on the actual `║` columns rather than the
-	   far edges of the surrounding grid cell. */
-	width: max-content;
 	position: relative;
 }
 
 /* Paint a continuous double-line over the beaded `║` glyph columns on the
    left and right of the banner body rows. Spans the 6 body rows only —
-   the top (`╔══╗`) and bottom (`╚══╝`) rows keep their corner glyphs. */
+   the top (`╔══╗`) and bottom (`╚══╝`) rows keep their corner glyphs. Both
+   overlays use `left:` (not `right:`) so positioning is independent of the
+   banner element's box width — the `<pre>` may stretch to fill its grid
+   cell, but the `║` glyphs themselves sit at known character offsets from
+   the content's left edge. The fallback 84 matches the current BANNER_W;
+   paintBanner() sets the actual value on the element. */
 .banner::before,
 .banner::after {
 	content: "";
@@ -161,8 +162,8 @@ header {
 }
 
 .banner::after {
-	/* Right `║` is the last column before the trailing space — centre at 0.5ch from right. */
-	right: calc(0.5ch - 1.5px);
+	/* Right `║` is at column (banner-w + 4) — centre at (banner-w + 4.5)ch. */
+	left: calc((var(--banner-w, 84) + 4.5) * 1ch - 1.5px);
 }
 
 .banner-blue {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -459,32 +459,16 @@ main {
 	width: 1ch;
 	flex: 0 0 auto;
 	user-select: none;
-	/* The vertical border was rendered as a column of `│` glyphs, one per
-	   line-box. Fonts draw `│` slightly shorter than the em-square, so
-	   adjacent glyphs leave a 1-2px gap that reads as beading down the
-	   column. Hide the glyphs and paint a continuous 1px line via a
-	   background gradient at the cell's horizontal centre — same width
-	   and position as the corner glyphs' vertical strokes above/below. */
-	color: transparent;
-	text-shadow: none;
-	background: linear-gradient(
-		to right,
-		transparent calc(50% - 0.5px),
-		var(--panel-color, var(--amber)) calc(50% - 0.5px) calc(50% + 0.5px),
-		transparent calc(50% + 0.5px)
-	);
-}
-
-.ai-panel.panel--addressed .side-heavy {
-	/* `║` is a double line — two 1px strokes with a 1px gap. */
-	background: linear-gradient(
-		to right,
-		transparent calc(50% - 1.5px),
-		var(--panel-color, var(--amber)) calc(50% - 1.5px) calc(50% - 0.5px),
-		transparent calc(50% - 0.5px) calc(50% + 0.5px),
-		var(--panel-color, var(--amber)) calc(50% + 0.5px) calc(50% + 1.5px),
-		transparent calc(50% + 1.5px)
-	);
+	color: var(--panel-color);
+	/* Same approach as the banner `║` — stamp clones of the glyph 1 px
+	   above and below itself with zero-blur text-shadows. The clones
+	   extend the glyph's own ink into the inter-line gap that causes
+	   vertical beading, and because the shadow is the glyph itself, it
+	   self-aligns with the corner glyphs above/below — no positioning
+	   math, no subpixel guessing. */
+	text-shadow:
+		0 1px 0 var(--panel-color, var(--amber)),
+		0 -1px 0 var(--panel-color, var(--amber));
 }
 
 .panel-content {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -131,14 +131,15 @@ header {
 	text-shadow: none;
 }
 
-/* Each body-row `║` is wrapped in `.banner-side`. Hide the glyph and paint
-   the line via a `::before` that extends slightly past the cell vertically
-   so adjacent rows' overlays overlap into one continuous strip — no font
-   metric guesswork, position is locally anchored to the cell. */
+/* Each body-row `║` is wrapped in `.banner-side`. The span stays display:
+   inline (so its character cell renders identically to the bare `╔`/`╝`
+   corner glyphs in the top/bottom rows — no inline-block layout shift)
+   and hosts an absolute `::before` that paints the line. The line bleeds
+   slightly above and below each cell so adjacent rows' overlays overlap
+   into one continuous strip. */
 .banner-side {
 	color: transparent;
 	position: relative;
-	display: inline-block;
 }
 
 .banner-side::before {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -143,9 +143,7 @@ header {
 .banner-side {
 	text-shadow:
 		0 1px 0 var(--amber),
-		0 -1px 0 var(--amber),
-		0 2px 0 var(--amber),
-		0 -2px 0 var(--amber);
+		0 -1px 0 var(--amber);
 }
 
 .banner-blue {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -456,6 +456,12 @@ main {
 	line-height: 1;
 	overflow: hidden;
 	word-break: break-all;
+	/* Match `.brow`'s explicit 13px so the `│` glyph cell width tracks
+	   the corner glyph cell width — at responsive (mobile) breakpoints
+	   the body drops to 12px and an inherited side would shrink the
+	   column ~0.6px narrower than the corner, shifting the `│` stroke
+	   visibly left of the `┌`/`└` vertical arms. */
+	font-size: 13px;
 	/* No explicit width — `1ch` is the advance of `0`, but JBM's box-
 	   drawing glyphs have a (very slightly) different advance, so
 	   pinning the column to 1ch shifts the `│` stroke half a pixel

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -148,7 +148,7 @@ header {
 	/* JBM's `║`/`╔`/`╗` glyphs sit a small fractional pixel right of cell
 	   centre — found empirically: -1.5px lands ~1px left, -1.25px lands
 	   a bit right, so the corner-stroke offset is roughly 0.1px. */
-	left: calc(50% - 1.4px);
+	left: calc(50% - 1.45px);
 	width: 3px;
 	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
 	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -131,38 +131,21 @@ header {
 	text-shadow: none;
 }
 
-/* Each body-row `║` is wrapped in `.banner-side`. The span stays display:
-   inline (so its character cell renders identically to the bare `╔`/`╝`
-   corner glyphs in the top/bottom rows — no inline-block layout shift)
-   and hosts an absolute `::before` that paints the line. The line bleeds
-   slightly above and below each cell so adjacent rows' overlays overlap
-   into one continuous strip. */
+/* Each body-row `║` is wrapped in `.banner-side`. The glyph stays
+   visible at whatever stroke position the font draws it, and a stack
+   of zero-blur `text-shadow`s stamps clones of the glyph 1 and 2 pixels
+   above and below itself. The clones extend the glyph's own ink into
+   the inter-line gap that line-height: 1 leaves between adjacent rows,
+   so the column reads as a continuous double-line. Because the shadow
+   tracks the glyph (not a calc'd cell offset), it self-aligns with the
+   `╔`/`╗`/`╚`/`╝` corner glyphs above and below — no positioning math,
+   no subpixel guessing. */
 .banner-side {
-	color: transparent;
-	position: relative;
-}
-
-.banner-side::before {
-	content: "";
-	position: absolute;
-	/* JBM's `║`/`╔`/`╗` glyphs sit a small fractional pixel right of cell
-	   centre — found empirically: -1.5px lands ~1px left, -1.25px lands
-	   a bit right, so the corner-stroke offset is roughly 0.1px. */
-	left: calc(50% - 1.45px);
-	width: 3px;
-	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
-	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap
-	   and overlaps with neighbours' bleed without intruding into the
-	   `╔══╗` / `╚══╝` rows (whose corner glyphs own those cells). */
-	top: -0.1em;
-	bottom: -0.1em;
-	background: linear-gradient(
-		to right,
-		var(--amber) 0 1px,
-		transparent 1px 2px,
-		var(--amber) 2px 3px
-	);
-	pointer-events: none;
+	text-shadow:
+		0 1px 0 var(--amber),
+		0 -1px 0 var(--amber),
+		0 2px 0 var(--amber),
+		0 -2px 0 var(--amber);
 }
 
 .banner-blue {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -129,24 +129,29 @@ header {
 	   frame's `║` columns sit in separate line-boxes and bead under the
 	   inherited body text-shadow. */
 	text-shadow: none;
-	position: relative;
 }
 
-/* Paint a continuous double-line over the beaded `║` glyph columns on the
-   left and right of the banner body rows. Spans the 6 body rows only —
-   the top (`╔══╗`) and bottom (`╚══╝`) rows keep their corner glyphs. Both
-   overlays use `left:` (not `right:`) so positioning is independent of the
-   banner element's box width — the `<pre>` may stretch to fill its grid
-   cell, but the `║` glyphs themselves sit at known character offsets from
-   the content's left edge. The fallback 84 matches the current BANNER_W;
-   paintBanner() sets the actual value on the element. */
-.banner::before,
-.banner::after {
+/* Each body-row `║` is wrapped in `.banner-side`. Hide the glyph and paint
+   the line via a `::before` that extends slightly past the cell vertically
+   so adjacent rows' overlays overlap into one continuous strip — no font
+   metric guesswork, position is locally anchored to the cell. */
+.banner-side {
+	color: transparent;
+	position: relative;
+	display: inline-block;
+}
+
+.banner-side::before {
 	content: "";
 	position: absolute;
-	top: 1em;
-	bottom: 1em;
+	left: calc(50% - 1.5px);
 	width: 3px;
+	/* Tiny vertical bleed: the per-row line-box is 1em tall, but the
+	   `║` glyph leaves a 1-2px gap. 0.1em on each side covers the gap
+	   and overlaps with neighbours' bleed without intruding into the
+	   `╔══╗` / `╚══╝` rows (whose corner glyphs own those cells). */
+	top: -0.1em;
+	bottom: -0.1em;
 	background: linear-gradient(
 		to right,
 		var(--amber) 0 1px,
@@ -154,16 +159,6 @@ header {
 		var(--amber) 2px 3px
 	);
 	pointer-events: none;
-}
-
-.banner::before {
-	/* Left `║` is at column 1 (after the leading space) — centre at 1.5ch. */
-	left: calc(1.5ch - 1.5px);
-}
-
-.banner::after {
-	/* Right `║` is at column (banner-w + 4) — centre at (banner-w + 4.5)ch. */
-	left: calc((var(--banner-w, 84) + 4.5) * 1ch - 1.5px);
 }
 
 .banner-blue {


### PR DESCRIPTION
## Summary
This PR fixes visual artifacts ("beading") that appeared in vertical box-drawing characters (│ and ║) by using CSS text-shadows to extend glyph ink into inter-line gaps. The solution leverages zero-blur text-shadows positioned 1-2 pixels above and below glyphs to create the illusion of continuous lines.

## Key Changes

- **Banner side columns**: Wrapped `║` characters in `.banner-side` spans with text-shadow clones positioned ±1px vertically to fill gaps between line boxes
- **Panel borders**: Applied the same text-shadow technique to `.side` (│) characters to maintain visual continuity
- **Removed blur-based shadows**: Replaced the blue glow effect on `.banner-blue` with the new sharp shadow approach for consistency
- **Font sizing**: Explicitly set `font-size: 13px` on `.side` to match `.brow` and prevent responsive breakpoint misalignment
- **Removed width constraint**: Changed `.side` from `width: 1ch` to `flex: 0 0 auto` to let the glyph's natural advance determine column width, preventing subpixel misalignment with corner glyphs
- **Disabled inherited shadows**: Added `text-shadow: none` to chrome elements (header, `.panel-chrome`, `.login-frame-brow`) to prevent shadow accumulation on box-drawing characters

## Implementation Details

The fix uses a clever approach where text-shadows are positioned relative to the glyph itself rather than calculated cell offsets. This ensures automatic alignment with corner glyphs (╔/╗/╚/╝) without positioning math or subpixel guessing. The shadows use the same color as the glyph to create seamless visual extension into the inter-line gaps caused by `line-height: 1`.

https://claude.ai/code/session_01CJ1Xbc7sigMyVjq6ZEUzQ2