### PR TITLE
Refine send button styling and update button label

### DIFF
--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -166,7 +166,7 @@
 						<input id="prompt" type="text" placeholder="" autocomplete="off" spellcheck="false" />
 					</div>
 					<output id="lockout-error" class="lockout-error" role="status" aria-live="polite" hidden></output>
-					<button id="send" class="send" type="submit">↵ TX</button>
+					<button id="send" class="send" type="submit">[ tx ]</button>
 				</form>
 				<section id="cap-hit" hidden>
 					<h2>the AIs are sleeping</h2>

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -642,19 +642,18 @@ main {
 
 #send {
 	background: transparent;
-	border: 1px solid var(--amber-dim);
+	border: 0;
 	color: var(--amber-dim);
 	font-family: inherit;
 	font-size: 11px;
 	letter-spacing: 0.18em;
-	padding: 3px 10px;
+	padding: 3px 4px;
 	cursor: pointer;
 	text-shadow: inherit;
 }
 
 #send:hover:not(:disabled) {
 	color: var(--amber);
-	border-color: var(--amber);
 }
 
 #send:disabled {


### PR DESCRIPTION
## Summary
Updated the send button's visual design and text label for improved aesthetics and consistency with the UI design language.

## Key Changes
- **Button label**: Changed from "↵ TX" to "[ tx ]" for a more stylized appearance
- **Border styling**: Removed the border entirely (changed from `1px solid var(--amber-dim)` to `border: 0`)
- **Hover state**: Removed the `border-color` change on hover since the border no longer exists
- **Padding adjustment**: Reduced horizontal padding from `10px` to `4px` to accommodate the new label width

## Implementation Details
The changes maintain the button's transparent background and color-based visual feedback on hover, while simplifying the border treatment. The padding adjustment ensures proper spacing with the new bracket-enclosed label format.

https://claude.ai/code/session_01DD7vhLS7T4qJpPmbSMM3QR