### PR TITLE
Remove [N daemons online] indicator from topinfo right cell

### DIFF
--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -84,7 +84,6 @@ export interface TopInfoInputs {
 	phaseNumber: number;
 	totalPhases: number;
 	turn: number;
-	daemonsOnline: number;
 }
 
 export function formatTopInfoLeft(i: TopInfoInputs): string {
@@ -102,18 +101,10 @@ export function renderTopInfoLeft(el: HTMLElement, i: TopInfoInputs): void {
 }
 
 /** Compact form rendered into `#topinfo-mobile` for the <=720px bento
- * layout — drops the labels and the daemons-online/connection trailer. */
+ * layout — drops the labels and the connection trailer. */
 export function formatTopInfoMobile(i: TopInfoInputs): string {
 	const phase = `${String(i.phaseNumber).padStart(2, "0")}/${String(i.totalPhases).padStart(2, "0")}`;
 	return `${i.sessionId} · ${phase} · TRN ${i.turn}`;
-}
-
-/** Prefix portion of the topinfo right cell — the "● connection stable"
- * trailer is appended at the call site as a span so it can carry its own
- * green color. Kept here so the daemons-online wording stays in one place. */
-export function formatTopInfoRight(i: TopInfoInputs): string {
-	const word = i.daemonsOnline === 1 ? "daemon" : "daemons";
-	return `[${i.daemonsOnline} ${word} online] · `;
 }
 
 export const TOPINFO_RIGHT_OK_TEXT = "● connection stable";
@@ -170,7 +161,7 @@ export function paintTopInfo(doc: Document, inputs: TopInfoInputs): void {
 	const mobile = doc.querySelector<HTMLElement>("#topinfo-mobile");
 	if (left) left.textContent = formatTopInfoLeft(inputs);
 	if (right) {
-		right.textContent = formatTopInfoRight(inputs);
+		right.textContent = "";
 		const okSpan = doc.createElement("span");
 		okSpan.className = "ok";
 		okSpan.textContent = TOPINFO_RIGHT_OK_TEXT;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -3,7 +3,6 @@ import { serializeGameSave } from "../../save-serializer.js";
 import {
 	BANNER,
 	formatTopInfoMobile,
-	formatTopInfoRight,
 	initPanelChrome,
 	type LoadState,
 	renderTopInfoLeft,
@@ -439,7 +438,7 @@ export function renderGame(
 	/** Paint the right-hand topinfo cell for one of the three load states.
 	 * Used during progressive loading; the normal `refreshTopInfo` (session
 	 * required) takes over once we transition to stable. */
-	function renderLoadingTopInfo(state: LoadState, daemonsOnline: number): void {
+	function renderLoadingTopInfo(state: LoadState): void {
 		const topinfoLeftEl = doc.querySelector<HTMLElement>("#topinfo-left");
 		const topinfoRightEl = doc.querySelector<HTMLElement>("#topinfo-right");
 		const topinfoMobileEl = doc.querySelector<HTMLElement>("#topinfo-mobile");
@@ -460,11 +459,10 @@ export function renderGame(
 			phaseNumber: 1,
 			totalPhases: total,
 			turn: 0,
-			daemonsOnline,
 		};
 		if (topinfoLeftEl) renderTopInfoLeft(topinfoLeftEl, inputs);
 		if (topinfoRightEl) {
-			topinfoRightEl.textContent = formatTopInfoRight(inputs);
+			topinfoRightEl.textContent = "";
 			const span = doc.createElement("span");
 			span.className = status.cls;
 			span.textContent = status.desktop;
@@ -535,7 +533,7 @@ export function renderGame(
 		_promptInput.placeholder = "loading…";
 
 		setStageLoadState("loading-daemons");
-		renderLoadingTopInfo("loading-daemons", 0);
+		renderLoadingTopInfo("loading-daemons");
 
 		// Braille spinner machinery — duplicated from the round-submit path so
 		// we can ride spinners on the panel-name labels while content packs
@@ -618,7 +616,7 @@ export function renderGame(
 			.then((personas) => {
 				buildLoadingPersonaShape(personas);
 				setStageLoadState("generating-room");
-				renderLoadingTopInfo("generating-room", Object.keys(personas).length);
+				renderLoadingTopInfo("generating-room");
 				startSpinners();
 				startBrightnessWipe();
 				return pending.contentPacksPromise.then((packs) => ({
@@ -904,19 +902,14 @@ export function renderGame(
 			total += 1;
 			cursor = cursor.nextPhaseConfig;
 		}
-		const personas = state.personas;
-		const daemons = Object.keys(personas).filter(
-			(id) => !phase.chatLockouts.has(id),
-		).length;
 		const inputs = {
 			sessionId,
 			phaseNumber: phase.phaseNumber,
 			totalPhases: total,
 			turn: phase.round,
-			daemonsOnline: daemons,
 		};
 		renderTopInfoLeft(topinfoLeftEl, inputs);
-		topinfoRightEl.textContent = formatTopInfoRight(inputs);
+		topinfoRightEl.textContent = "";
 		const stableStatus = topInfoStatus("stable");
 		const okSpan = doc.createElement("span");
 		okSpan.className = stableStatus.cls;

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -112,15 +112,11 @@ export function renderSessions(
 			total += 1;
 			cursor = cursor.nextPhaseConfig;
 		}
-		const daemonsOnline = Object.keys(loadResult.state.personas).filter(
-			(id) => !phase.chatLockouts.has(id),
-		).length;
 		paintTopInfo(doc, {
 			sessionId: loadResult.sessionId,
 			phaseNumber: phase.phaseNumber,
 			totalPhases: total,
 			turn: phase.round,
-			daemonsOnline,
 		});
 	}
 


### PR DESCRIPTION
The right-hand topinfo cell now shows only the connection status
(e.g. "● connection stable") without the preceding "[3 daemons online] · "
prefix. Drops the now-unused daemonsOnline field from TopInfoInputs and
the formatTopInfoRight helper.