### PR TITLE
Collapse chat + whisper into a single directional `message` primitive (#213)

### DIFF
--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -106,7 +106,7 @@ type PhaseSpec = {
  */
 function parseContentPackPhases(userMessage: string): PhaseSpec[] {
 	const re =
-		/Phase\s+(\d+):\s+setting="([^"]*)",\s+k=(\d+)\s+objective pairs,\s+n=(\d+)\s+interesting objects,\s+m=(\d+)\s+obstacles/g;
+		/Phase\s+(\d+):\s+setting="([^"]*)"(?:,\s+theme="[^"]*")?,\s+k=(\d+)\s+objective pairs,\s+n=(\d+)\s+interesting objects,\s+m=(\d+)\s+obstacles/g;
 	const phases: PhaseSpec[] = [];
 	for (const match of userMessage.matchAll(re)) {
 		const phaseNumber = Number(match[1]);

--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -2,10 +2,10 @@ import { expect, test } from "@playwright/test";
 import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
 
 /**
- * E2E — Per-Daemon asymmetric whisper tampering (issue #196, PRD #157)
+ * E2E — Per-Daemon asymmetric message tampering (issue #213)
  *
  * Proves the editable surface (per-Daemon <aiId>.txt files) is:
- *   1. The sole source of whisper state fed into the system prompt.
+ *   1. The sole source of message state fed into the system prompt.
  *   2. Per-Daemon: an entry injected into one Daemon's file does NOT bleed
  *      into the other two Daemons' prompts.
  *
@@ -13,21 +13,20 @@ import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
  *   - Drive the start screen through goToGame → game is live, all three
  *     <aiId>.txt files exist in localStorage.
  *   - Directly mutate ids[0]'s DaemonFile in localStorage, appending a
- *     fabricated `kind: "whisper"` ConversationEntry with a unique sentinel.
+ *     fabricated `kind: "message"` ConversationEntry with a unique sentinel.
  *   - Reload → the SPA deserialises from storage → reconstructs state.
  *   - Capture the next round's /v1/chat/completions request bodies.
- *   - Assert: the targeted Daemon's system prompt contains the whisper line
+ *   - Assert: the targeted Daemon's system prompt contains the message line
  *     inside <conversation>...</conversation>; the other two do not contain
  *     the sentinel at all.
  *
- * This is a v2-only property: in v1 whispers lived in a shared whispers.txt
- * file and the "absent from other prompts" invariant could not be asserted at
- * the per-Daemon storage level.
+ * This is a per-Daemon property: entries injected into one Daemon's file
+ * do not appear in other Daemons' prompts.
  */
 
 const SENTINEL = "FABRICATED_TAMPERED_WHISPER_xyz123";
 
-test("fabricated whisper appears in target daemon prompt and is absent from others after reload", async ({
+test("fabricated message appears in target daemon prompt and is absent from others after reload", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -70,9 +69,9 @@ test("fabricated whisper appears in target daemon prompt and is absent from othe
 				};
 			};
 
-			// Append fabricated whisper to phase "1" log.
+			// Append fabricated message entry to phase "1" log.
 			daemonFile.phases["1"].conversationLog.push({
-				kind: "whisper",
+				kind: "message",
 				round: 0,
 				from: senderId,
 				to: targetId,
@@ -137,14 +136,14 @@ test("fabricated whisper appears in target daemon prompt and is absent from othe
 	const other1Body = findBodyForName(names[1]);
 	const other2Body = findBodyForName(names[2]);
 
-	// Derive expected whisper line from conversation-log.ts:58-59:
-	//   `[Round ${round}] *${entry.from} whispered to you: "${entry.content}"`
+	// Derive expected message line from conversation-log.ts:
+	//   `[Round R] *<from> dms you: <content>` (no surrounding quotes)
 	// entry.from is senderId (an aiId); conversation-log uses entry.from directly
 	// as the display value. In the spec we verify the sentinel via SENTINEL alone
 	// and also check the full line format including senderName for robustness.
 	// NOTE: conversation-log.ts renders entry.from (the AiId) directly, not the
 	// persona name. The sentinel is unique so checking via SENTINEL is sufficient.
-	const expectedLine = `[Round 0] *${senderId} whispered to you: "${SENTINEL}"`;
+	const expectedLine = `[Round 0] *${senderId} dms you: ${SENTINEL}`;
 
 	// 7. Assert targeted daemon's system prompt contains the whisper inside
 	//    <conversation>...</conversation>.
@@ -161,7 +160,7 @@ test("fabricated whisper appears in target daemon prompt and is absent from othe
 	expect(targetSysContent).toContain("</conversation>");
 	expect(
 		targetSysContent,
-		`Expected whisper line not found in target daemon's system prompt. ` +
+		`Expected message line not found in target daemon's system prompt. ` +
 			`Expected: ${expectedLine}`,
 	).toContain(expectedLine);
 	expect(

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -13,8 +13,7 @@ import { describe, expect, it } from "vitest";
 import { serializeGameSave } from "../save-serializer";
 import {
 	advancePhase,
-	appendChat,
-	appendWhisperEntry,
+	appendMessage,
 	createGame,
 	startPhase,
 } from "../spa/game/engine";
@@ -110,35 +109,33 @@ describe("serializeGameSave", () => {
 
 	it("includes the per-phase transcript for each AI", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
-		game = appendChat(game, "red", {
-			role: "ai",
-			content: "Greetings, player",
-		});
+		game = appendMessage(game, "blue", "red", "Hello Ember");
+		game = appendMessage(game, "red", "blue", "Greetings, player");
 		const save = serializeGameSave(game);
 		const ember = save.ais.find((a) => a.persona.id === "red");
 		expect(ember?.phases).toHaveLength(1);
 		expect(ember?.phases[0]?.phaseNumber).toBe(1);
 		expect(ember?.phases[0]?.conversationLog).toHaveLength(2);
 		expect(ember?.phases[0]?.conversationLog[0]).toEqual({
-			kind: "chat",
-			role: "player",
+			kind: "message",
+			from: "blue",
+			to: "red",
 			content: "Hello Ember",
 			round: 0,
 		});
 	});
 
-	it("includes whispers in the per-phase conversationLog (via per-Daemon log)", () => {
+	it("includes peer messages in the per-phase conversationLog (via per-Daemon log)", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		game = appendWhisperEntry(game, "red", "cyan", "Secret plan");
+		game = appendMessage(game, "red", "cyan", "Secret plan");
 		const save = serializeGameSave(game);
-		// Whisper from red appears in red's conversationLog (sender's log also gets the entry)
+		// Message from red appears in red's conversationLog (sender's log gets the entry)
 		const ember = save.ais.find((a) => a.persona.id === "red");
-		const redWhispers = ember?.phases[0]?.conversationLog.filter(
-			(e) => e.kind === "whisper",
+		const redMessages = ember?.phases[0]?.conversationLog.filter(
+			(e) => e.kind === "message",
 		);
-		expect(redWhispers).toHaveLength(1);
-		expect(redWhispers?.[0]?.kind === "whisper" && redWhispers[0].content).toBe(
+		expect(redMessages).toHaveLength(1);
+		expect(redMessages?.[0]?.kind === "message" && redMessages[0].content).toBe(
 			"Secret plan",
 		);
 		// No separate `whispers` field — it's all in conversationLog
@@ -147,20 +144,11 @@ describe("serializeGameSave", () => {
 
 	it("accumulates transcripts across multiple phases", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		game = appendChat(game, "red", {
-			role: "player",
-			content: "Phase 1 message",
-		});
+		game = appendMessage(game, "blue", "red", "Phase 1 message");
 		game = advancePhase(game, PHASE2_CONFIG);
-		game = appendChat(game, "red", {
-			role: "player",
-			content: "Phase 2 message",
-		});
+		game = appendMessage(game, "blue", "red", "Phase 2 message");
 		game = advancePhase(game, PHASE3_CONFIG);
-		game = appendChat(game, "red", {
-			role: "player",
-			content: "Phase 3 message",
-		});
+		game = appendMessage(game, "blue", "red", "Phase 3 message");
 		game = advancePhase(game); // complete
 
 		const save = serializeGameSave(game);
@@ -170,15 +158,15 @@ describe("serializeGameSave", () => {
 		expect(ember?.phases[1]?.phaseNumber).toBe(2);
 		expect(ember?.phases[2]?.phaseNumber).toBe(3);
 		expect(
-			ember?.phases[0]?.conversationLog[0]?.kind === "chat" &&
+			ember?.phases[0]?.conversationLog[0]?.kind === "message" &&
 				ember?.phases[0]?.conversationLog[0]?.content,
 		).toBe("Phase 1 message");
 		expect(
-			ember?.phases[1]?.conversationLog[0]?.kind === "chat" &&
+			ember?.phases[1]?.conversationLog[0]?.kind === "message" &&
 				ember?.phases[1]?.conversationLog[0]?.content,
 		).toBe("Phase 2 message");
 		expect(
-			ember?.phases[2]?.conversationLog[0]?.kind === "chat" &&
+			ember?.phases[2]?.conversationLog[0]?.kind === "message" &&
 				ember?.phases[2]?.conversationLog[0]?.content,
 		).toBe("Phase 3 message");
 	});
@@ -191,21 +179,21 @@ describe("serializeGameSave", () => {
 		expect(parsed.ais).toHaveLength(3);
 	});
 
-	it("output has a version field of 3 (v3 = whispers moved inline into conversationLog)", () => {
+	it("output has a version field of 4 (v4 = chat/whisper collapsed into message primitive)", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
 		const save = serializeGameSave(game);
-		expect(save.version).toBe(3);
+		expect(save.version).toBe(4);
 	});
 
-	it("whisper in green's log only if green is sender or recipient", () => {
+	it("peer message in green's log only if green is sender or recipient", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		// Whisper between red and cyan — should appear in red and cyan, not green
-		game = appendWhisperEntry(game, "red", "cyan", "Our secret");
+		// Message between red and cyan — should appear in red and cyan, not green
+		game = appendMessage(game, "red", "cyan", "Our secret");
 		const save = serializeGameSave(game);
 		const sage = save.ais.find((a) => a.persona.id === "green");
-		const greenWhispers = sage?.phases[0]?.conversationLog.filter(
-			(e) => e.kind === "whisper",
+		const greenMessages = sage?.phases[0]?.conversationLog.filter(
+			(e) => e.kind === "message",
 		);
-		expect(greenWhispers).toHaveLength(0);
+		expect(greenMessages).toHaveLength(0);
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,7 @@ export {
 export {
 	advancePhase,
 	advanceRound,
-	appendChat,
-	appendWhisperEntry,
+	appendMessage,
 	appendWitnessedEvent,
 	createGame,
 	deductBudget,
@@ -22,7 +21,6 @@ export type {
 	AiId,
 	AiPersona,
 	AiTurnAction,
-	ChatMessage,
 	GameState,
 	PhaseConfig,
 	PhaseState,
@@ -31,7 +29,6 @@ export type {
 	ToolCall,
 	ToolName,
 	ToolResult,
-	WhisperMessage,
 	WorldEntity,
 	WorldState,
 } from "./spa/game/types";

--- a/src/save-serializer.ts
+++ b/src/save-serializer.ts
@@ -30,8 +30,8 @@ export interface AiSaveEntry {
 }
 
 export interface GameSave {
-	/** Schema version. v3 = whispers moved inline into conversationLog. */
-	version: 3;
+	/** Schema version. v4 = chat/whisper collapsed into directional message primitive. */
+	version: 4;
 	ais: AiSaveEntry[];
 	/** All three content packs (generated at game start). */
 	contentPacks: ContentPack[];
@@ -59,5 +59,5 @@ export function serializeGameSave(game: GameState): GameSave {
 		return { persona: { ...persona }, phases };
 	});
 
-	return { version: 3, ais, contentPacks: game.contentPacks };
+	return { version: 4, ais, contentPacks: game.contentPacks };
 }

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -185,15 +185,34 @@ function makeAiSseStream(jsonAction: string): ReadableStream<Uint8Array> {
  *
  * Includes a final usage chunk so the budget-deduction path sees a non-zero cost.
  */
-function makeMessageToolCallSseStream(content: string): ReadableStream<Uint8Array> {
+function makeMessageToolCallSseStream(
+	content: string,
+): ReadableStream<Uint8Array> {
 	const args = JSON.stringify({ to: "blue", content });
 	// First chunk: tool call header
 	const chunk1 = `data: ${JSON.stringify({
-		choices: [{ delta: { tool_calls: [{ index: 0, id: "call_msg", function: { name: "message", arguments: "" } }] } }],
+		choices: [
+			{
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							id: "call_msg",
+							function: { name: "message", arguments: "" },
+						},
+					],
+				},
+			},
+		],
 	})}\n\n`;
 	// Second chunk: arguments + finish_reason
 	const chunk2 = `data: ${JSON.stringify({
-		choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: args } }] }, finish_reason: "tool_calls" }],
+		choices: [
+			{
+				delta: { tool_calls: [{ index: 0, function: { arguments: args } }] },
+				finish_reason: "tool_calls",
+			},
+		],
 	})}\n\n`;
 	const usageChunk = `data: ${JSON.stringify({ choices: [], usage: { cost: 0.01, total_tokens: 100 } })}\n\n`;
 	const sseData = `${chunk1}${chunk2}${usageChunk}data: [DONE]\n\n`;
@@ -859,10 +878,7 @@ describe("renderGame — localStorage persistence", () => {
 		// (free-form assistantText is silently dropped in v4 — use the message tool instead)
 		const stub = makeLocalStorageStub();
 		await seedSessionInStub(stub);
-		vi.stubGlobal(
-			"fetch",
-			makeMessageToolCallFetchMock(),
-		);
+		vi.stubGlobal("fetch", makeMessageToolCallFetchMock());
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 
@@ -1018,10 +1034,7 @@ describe("renderGame — localStorage persistence", () => {
 		// only message tool calls are persisted to daemon .txt files and restored on reload.
 		const stub = makeLocalStorageStub();
 		await seedSessionInStub(stub);
-		vi.stubGlobal(
-			"fetch",
-			makeMessageToolCallFetchMock(),
-		);
+		vi.stubGlobal("fetch", makeMessageToolCallFetchMock());
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -166,7 +166,7 @@ function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
 
 /**
  * Creates an SSE response body that yields a single JSON action as an OpenAI delta event.
- * The runRound coordinator collects all delta tokens into one string and parses as JSON.
+ * Used for plain-text (free-form) delta responses (e.g., pass actions).
  *
  * Includes a final usage chunk (mimicking OpenRouter with usage:{include:true}) so
  * the budget-deduction path sees a non-zero cost.
@@ -178,7 +178,29 @@ function makeAiSseStream(jsonAction: string): ReadableStream<Uint8Array> {
 	return makeSSEStream([sseData]);
 }
 
-/** Returns a fresh fetch mock that serves three AI responses in sequence. */
+/**
+ * Creates an SSE response body that yields a `message` tool call (AI→blue).
+ * This is the v4 way to have an AI "chat back" so the content lands in conversationLogs
+ * and is restored on reload.
+ *
+ * Includes a final usage chunk so the budget-deduction path sees a non-zero cost.
+ */
+function makeMessageToolCallSseStream(content: string): ReadableStream<Uint8Array> {
+	const args = JSON.stringify({ to: "blue", content });
+	// First chunk: tool call header
+	const chunk1 = `data: ${JSON.stringify({
+		choices: [{ delta: { tool_calls: [{ index: 0, id: "call_msg", function: { name: "message", arguments: "" } }] } }],
+	})}\n\n`;
+	// Second chunk: arguments + finish_reason
+	const chunk2 = `data: ${JSON.stringify({
+		choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: args } }] }, finish_reason: "tool_calls" }],
+	})}\n\n`;
+	const usageChunk = `data: ${JSON.stringify({ choices: [], usage: { cost: 0.01, total_tokens: 100 } })}\n\n`;
+	const sseData = `${chunk1}${chunk2}${usageChunk}data: [DONE]\n\n`;
+	return makeSSEStream([sseData]);
+}
+
+/** Returns a fresh fetch mock that serves three AI responses in sequence (plain-text deltas). */
 function makeThreeAiFetchMock(
 	redAction: string,
 	greenAction: string,
@@ -203,6 +225,33 @@ function makeThreeAiFetchMock(
 			status: 200,
 			statusText: "OK",
 			body: makeAiSseStream(cyanAction),
+		});
+}
+
+/**
+ * Returns a fresh fetch mock serving three `message` tool calls (AI→blue), one per daemon.
+ * Using tool calls ensures the content lands in conversationLogs and is restored on reload.
+ */
+function makeMessageToolCallFetchMock() {
+	return vi
+		.fn()
+		.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeMessageToolCallSseStream("RED_RESPONSE_UNIQUE_TAG"),
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeMessageToolCallSseStream("GREEN_RESPONSE_UNIQUE_TAG"),
+		})
+		.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			body: makeMessageToolCallSseStream("CYAN_RESPONSE_UNIQUE_TAG"),
 		});
 }
 
@@ -574,7 +623,7 @@ describe("renderGame (game route — three-AI)", () => {
 		const saveJson = downloadBtn.dataset.savePayload;
 		expect(saveJson).toBeTruthy();
 		const save = JSON.parse(saveJson as string);
-		expect(save.version).toBe(3);
+		expect(save.version).toBe(4);
 		expect(save.ais).toHaveLength(3);
 	});
 
@@ -806,12 +855,13 @@ describe("renderGame — localStorage persistence", () => {
 	});
 
 	it("state is restored from localStorage on renderGame when saved state exists", async () => {
-		// First: run a round using chat actions so AI responses land in transcripts
+		// First: run a round using message tool calls so AI responses land in conversationLogs
+		// (free-form assistantText is silently dropped in v4 — use the message tool instead)
 		const stub = makeLocalStorageStub();
 		await seedSessionInStub(stub);
 		vi.stubGlobal(
 			"fetch",
-			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, CYAN_ACTION),
+			makeMessageToolCallFetchMock(),
 		);
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -963,14 +1013,14 @@ describe("renderGame — localStorage persistence", () => {
 	});
 
 	it("chat message content is preserved across a fresh renderGame via chatHistories", async () => {
-		// Use chat actions so AI responses land in chatHistories (which are persisted).
-		// Note: the new format stores chat histories in daemon .txt files, so raw
-		// tool outputs (pass/pick_up/etc.) are NOT preserved — only chat messages are.
+		// Use message tool calls so AI responses land in conversationLogs (which are persisted).
+		// Note: free-form assistantText (the old "chat" action) is dropped in v4;
+		// only message tool calls are persisted to daemon .txt files and restored on reload.
 		const stub = makeLocalStorageStub();
 		await seedSessionInStub(stub);
 		vi.stubGlobal(
 			"fetch",
-			makeThreeAiFetchMock(RED_ACTION, GREEN_ACTION, CYAN_ACTION),
+			makeMessageToolCallFetchMock(),
 		);
 		vi.stubGlobal("localStorage", stub);
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
@@ -988,11 +1038,16 @@ describe("renderGame — localStorage persistence", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		// Verify chat content landed in the transcript
-		const redTextAfterRound =
-			document.querySelector<HTMLElement>('[data-transcript="red"]')
-				?.textContent ?? "";
-		expect(redTextAfterRound).toContain("RED_RESPONSE_UNIQUE_TAG");
+		// Verify message tool call content was persisted to daemon .txt files
+		// (message tool calls land in conversationLogs → daemon files; live transcript text
+		//  only appears for free-form assistantText, not tool calls)
+		const daemonKeys = Object.keys(stub._store).filter(
+			(k) => k.endsWith(".txt") && !k.endsWith("whispers.txt"),
+		);
+		const daemonContentsAfterRound = daemonKeys
+			.map((k) => stub._store[k] ?? "")
+			.join("");
+		expect(daemonContentsAfterRound).toContain("RED_RESPONSE_UNIQUE_TAG");
 
 		// Verify state is saved in the new multi-file format (engine.dat as commit signal)
 		const engineKey = Object.keys(stub._store).find((k) =>
@@ -1006,7 +1061,7 @@ describe("renderGame — localStorage persistence", () => {
 		const { renderGame: renderGame2 } = await import("../routes/game.js");
 		await renderGame2(getEl<HTMLElement>("main"));
 
-		// Chat responses must be visible after reload (restored from chatHistories)
+		// Message responses must be visible after reload (restored from conversationLogs)
 		const redTextRestored =
 			document.querySelector<HTMLElement>('[data-transcript="red"]')
 				?.textContent ?? "";

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -92,67 +92,80 @@ describe("buildConversationLog — empty phase", () => {
 	});
 });
 
-// ── Voice-chat formatting ──────────────────────────────────────────────────────
+// ── Message formatting ─────────────────────────────────────────────────────────
 
-describe("buildConversationLog — voice-chat", () => {
-	it("renders player message with round tag and quotes", () => {
+describe("buildConversationLog — message (incoming from blue)", () => {
+	it("renders incoming message from blue as 'blue dms you: <content>'", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "chat", role: "player", content: "Hi", round: 0 },
+				{ kind: "message", from: "blue", to: "red", content: "Hi", round: 0 },
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toEqual(["[Round 0] blue dms you: Hi"]);
 	});
 
-	it("renders AI reply with round tag and quotes", () => {
+	it("renders outgoing message to blue as 'you dm blue: <content>'", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "chat", role: "ai", content: "Hello", round: 0 },
+				{ kind: "message", from: "red", to: "blue", content: "Hello", round: 0 },
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
-		expect(result).toEqual(['[Round 0] You: "Hello"']);
+		expect(result).toEqual(["[Round 0] you dm blue: Hello"]);
 	});
 
-	it("does not include other AIs' chat messages (caller pre-filters)", () => {
+	it("renders incoming message from peer as '*<from> dms you: <content>'", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "chat", role: "player", content: "red-msg", round: 0 },
+				{ kind: "message", from: "green", to: "red", content: "red-msg", round: 0 },
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toHaveLength(1);
 		expect(result[0]).toContain("red-msg");
+		expect(result[0]).toEqual("[Round 0] *green dms you: red-msg");
+	});
+
+	it("renders outgoing message to peer as 'you dm *<to>: <content>'", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{ kind: "message", from: "red", to: "cyan", content: "hey", round: 0 },
+			],
+		};
+		// From red's perspective (outgoing)
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toEqual(["[Round 0] you dm *cyan: hey"]);
 	});
 
 	it("renders multiple messages in order", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "chat", role: "player", content: "First", round: 0 },
-				{ kind: "chat", role: "ai", content: "Second", round: 0 },
+				{ kind: "message", from: "blue", to: "red", content: "First", round: 0 },
+				{ kind: "message", from: "red", to: "blue", content: "Second", round: 0 },
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
 		expect(result).toHaveLength(2);
 		expect(result[0]).toContain("blue dms you");
-		expect(result[1]).toContain("You:");
+		expect(result[1]).toContain("you dm blue");
 	});
 });
 
-// ── Whisper formatting ─────────────────────────────────────────────────────────
+// ── Peer-to-peer message formatting ───────────────────────────────────────────
 
-describe("buildConversationLog — whispers", () => {
-	it("renders whisper received with correct format", () => {
+describe("buildConversationLog — peer message", () => {
+	it("renders received peer message with correct format", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
 				{
-					kind: "whisper",
+					kind: "message",
 					from: "green",
 					to: "red",
 					content: "psst",
@@ -164,14 +177,14 @@ describe("buildConversationLog — whispers", () => {
 		expect(result).toEqual(["[Round 1] *green dms you: psst"]);
 	});
 
-	it("renders whisper that was sent (sender's log also gets the entry)", () => {
+	it("renders sent peer message from sender's perspective as outgoing", () => {
 		// The dispatcher writes the same entry to both sender and recipient.
-		// So sender's log contains a "whisper" entry too.
+		// From green's perspective (who sent it), it renders as outgoing.
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
 				{
-					kind: "whisper",
+					kind: "message",
 					from: "green",
 					to: "red",
 					content: "psst",
@@ -179,10 +192,10 @@ describe("buildConversationLog — whispers", () => {
 				},
 			],
 		};
-		// From green's perspective (who sent it), it still renders the same format
+		// From green's perspective (outgoing)
 		const result = buildConversationLog(input, "green", TEST_PERSONAS);
 		expect(result).toHaveLength(1);
-		expect(result[0]).toContain("dms you");
+		expect(result[0]).toContain("you dm *red");
 	});
 });
 
@@ -376,10 +389,10 @@ describe("buildConversationLog — witnessed use", () => {
 
 describe("buildConversationLog — chronological ordering", () => {
 	it("sorts events by round ascending across all types", () => {
-		// Round 2 whisper, round 0 chat, round 1 witnessed event
+		// Round 2 peer message, round 0 blue message, round 1 witnessed event
 		const input: ConversationLogInput = {
 			conversationLog: [
-				{ kind: "chat", role: "player", content: "early msg", round: 0 },
+				{ kind: "message", from: "blue", to: "red", content: "early msg", round: 0 },
 				{
 					kind: "witnessed-event",
 					round: 1,
@@ -388,7 +401,7 @@ describe("buildConversationLog — chronological ordering", () => {
 					direction: "south",
 				},
 				{
-					kind: "whisper",
+					kind: "message",
 					from: "green",
 					to: "red",
 					content: "late",
@@ -409,12 +422,12 @@ describe("buildConversationLog — chronological ordering", () => {
 		// The sort is stable, so same-round entries keep their insertion order.
 		const input: ConversationLogInput = {
 			conversationLog: [
-				{ kind: "chat", role: "player", content: "chat", round: 0 },
+				{ kind: "message", from: "blue", to: "red", content: "chat", round: 0 },
 				{
-					kind: "whisper",
+					kind: "message",
 					from: "green",
 					to: "red",
-					content: "whisper",
+					content: "peer msg",
 					round: 0,
 				},
 				{

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -110,7 +110,13 @@ describe("buildConversationLog — message (incoming from blue)", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "message", from: "red", to: "blue", content: "Hello", round: 0 },
+				{
+					kind: "message",
+					from: "red",
+					to: "blue",
+					content: "Hello",
+					round: 0,
+				},
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
@@ -121,7 +127,13 @@ describe("buildConversationLog — message (incoming from blue)", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "message", from: "green", to: "red", content: "red-msg", round: 0 },
+				{
+					kind: "message",
+					from: "green",
+					to: "red",
+					content: "red-msg",
+					round: 0,
+				},
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
@@ -146,8 +158,20 @@ describe("buildConversationLog — message (incoming from blue)", () => {
 		const input: ConversationLogInput = {
 			...emptyInput(),
 			conversationLog: [
-				{ kind: "message", from: "blue", to: "red", content: "First", round: 0 },
-				{ kind: "message", from: "red", to: "blue", content: "Second", round: 0 },
+				{
+					kind: "message",
+					from: "blue",
+					to: "red",
+					content: "First",
+					round: 0,
+				},
+				{
+					kind: "message",
+					from: "red",
+					to: "blue",
+					content: "Second",
+					round: 0,
+				},
 			],
 		};
 		const result = buildConversationLog(input, "red", TEST_PERSONAS);
@@ -392,7 +416,13 @@ describe("buildConversationLog — chronological ordering", () => {
 		// Round 2 peer message, round 0 blue message, round 1 witnessed event
 		const input: ConversationLogInput = {
 			conversationLog: [
-				{ kind: "message", from: "blue", to: "red", content: "early msg", round: 0 },
+				{
+					kind: "message",
+					from: "blue",
+					to: "red",
+					content: "early msg",
+					round: 0,
+				},
 				{
 					kind: "witnessed-event",
 					round: 1,

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -577,46 +577,61 @@ describe("dispatchAiTurn", () => {
 		expect(result.records[0]?.kind).toBe("tool_failure");
 	});
 
-	it("appends chat messages to the correct history", () => {
+	it("message tool to blue appends entry to sender's log only", () => {
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			chat: { target: "player", content: "Hello, I am Ember" },
+			message: { to: "blue", content: "Hello, I am Ember" },
 		};
 		const result = dispatchAiTurn(game, action);
 		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
-		const chatEntries = redLog.filter((e) => e.kind === "chat");
-		expect(chatEntries).toHaveLength(1);
-		expect(chatEntries[0]?.kind === "chat" && chatEntries[0].content).toBe(
+		const msgEntries = redLog.filter((e) => e.kind === "message");
+		expect(msgEntries).toHaveLength(1);
+		expect(msgEntries[0]?.kind === "message" && msgEntries[0].content).toBe(
 			"Hello, I am Ember",
 		);
+		expect(result.records[0]?.kind).toBe("message");
 	});
 
-	it("appends whisper messages to both sender and recipient conversationLogs", () => {
+	it("message tool to peer appends to both sender and recipient conversationLogs", () => {
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			whisper: { target: "cyan", content: "Psst, ally with me" },
+			message: { to: "cyan", content: "Psst, ally with me" },
 		};
 		const result = dispatchAiTurn(game, action);
 		const phase = getActivePhase(result.game);
-		const redWhispers = (phase.conversationLogs.red ?? []).filter(
-			(e) => e.kind === "whisper",
+		const redMessages = (phase.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "message",
 		);
-		const cyanWhispers = (phase.conversationLogs.cyan ?? []).filter(
-			(e) => e.kind === "whisper",
+		const cyanMessages = (phase.conversationLogs.cyan ?? []).filter(
+			(e) => e.kind === "message",
 		);
-		expect(redWhispers).toHaveLength(1);
-		expect(cyanWhispers).toHaveLength(1);
+		expect(redMessages).toHaveLength(1);
+		expect(cyanMessages).toHaveLength(1);
 		// Sender and recipient entries must be deep-equal objects (same round, same fields)
-		expect(redWhispers[0]).toEqual(cyanWhispers[0]);
-		expect(redWhispers[0]).toMatchObject({
-			kind: "whisper",
+		expect(redMessages[0]).toEqual(cyanMessages[0]);
+		expect(redMessages[0]).toMatchObject({
+			kind: "message",
 			from: "red",
 			to: "cyan",
 			content: "Psst, ally with me",
 		});
 		expect("whispers" in phase).toBe(false);
+	});
+
+	it("message tool with unknown recipient produces tool_failure and does not mutate any log", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			message: { to: "nobody", content: "Hello?" },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+		// No logs should be mutated
+		for (const aiId of ["red", "green", "cyan"]) {
+			expect(getActivePhase(result.game).conversationLogs[aiId]).toHaveLength(0);
+		}
 	});
 
 	it("put_down of objective_object on its matching space yields placementFlavor as description", () => {

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -630,7 +630,9 @@ describe("dispatchAiTurn", () => {
 		expect(result.records[0]?.kind).toBe("tool_failure");
 		// No logs should be mutated
 		for (const aiId of ["red", "green", "cyan"]) {
-			expect(getActivePhase(result.game).conversationLogs[aiId]).toHaveLength(0);
+			expect(getActivePhase(result.game).conversationLogs[aiId]).toHaveLength(
+				0,
+			);
 		}
 	});
 

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -260,7 +260,9 @@ describe("budget and lockout", () => {
 	it("reports an AI as locked out when budget is zero", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const phase = getActivePhase(game);
-		phase.budgets.red!.remaining = 0;
+		const redBudget = phase.budgets.red;
+		if (!redBudget) throw new Error("invariant: red budget must exist");
+		redBudget.remaining = 0;
 		phase.lockedOut.add("red");
 		expect(isAiLockedOut(game, "red")).toBe(true);
 	});

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	advancePhase,
 	advanceRound,
-	appendChat,
-	appendWhisperEntry,
+	appendMessage,
 	createGame,
 	deductBudget,
 	getActivePhase,
@@ -300,57 +299,53 @@ describe("deductBudget", () => {
 	});
 });
 
-describe("appendChat", () => {
-	it("appends a chat ConversationEntry to the correct AI's conversationLogs", () => {
+describe("appendMessage", () => {
+	it("from blue to AI: only recipient's log gets the entry", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const updated = appendChat(game, "red", {
-			role: "player",
-			content: "Hello Ember",
-		});
-		expect(getActivePhase(updated).conversationLogs.red).toHaveLength(1);
-		expect(getActivePhase(updated).conversationLogs.red?.[0]?.kind).toBe(
-			"chat",
-		);
-		expect(getActivePhase(updated).conversationLogs.green).toHaveLength(0);
+		const updated = appendMessage(game, "blue", "red", "Hello Ember");
+		const phase = getActivePhase(updated);
+		expect(phase.conversationLogs.red).toHaveLength(1);
+		expect(phase.conversationLogs.red?.[0]?.kind).toBe("message");
+		expect(phase.conversationLogs.green).toHaveLength(0);
+	});
+
+	it("from AI to blue: only sender's log gets the entry", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const updated = appendMessage(game, "red", "blue", "Hello player");
+		const phase = getActivePhase(updated);
+		expect(phase.conversationLogs.red).toHaveLength(1);
+		expect(phase.conversationLogs.red?.[0]?.kind).toBe("message");
+		expect(phase.conversationLogs.green).toHaveLength(0);
+	});
+
+	it("from AI to AI: both sender's and recipient's logs get the entry", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const updated = appendMessage(game, "red", "cyan", "Let's work together");
+		const phase = getActivePhase(updated);
+		const redMessages =
+			phase.conversationLogs.red?.filter((e) => e.kind === "message") ?? [];
+		const cyanMessages =
+			phase.conversationLogs.cyan?.filter((e) => e.kind === "message") ?? [];
+		expect(redMessages).toHaveLength(1);
+		expect(cyanMessages).toHaveLength(1);
+		if (redMessages[0]?.kind === "message") {
+			expect(redMessages[0].from).toBe("red");
+			expect(redMessages[0].to).toBe("cyan");
+			expect(redMessages[0].content).toBe("Let's work together");
+		}
+	});
+
+	it("does not append to uninvolved AI's log", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const updated = appendMessage(game, "red", "cyan", "secret");
+		const phase = getActivePhase(updated);
+		expect(phase.conversationLogs.green).toHaveLength(0);
 	});
 
 	it("no chatHistories field on PhaseState (regression guard)", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const phase = getActivePhase(game);
 		expect("chatHistories" in phase).toBe(false);
-	});
-});
-
-describe("appendWhisperEntry", () => {
-	it("appends a whisper to both sender's and recipient's conversationLogs", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const updated = appendWhisperEntry(
-			game,
-			"red",
-			"cyan",
-			"Let's work together",
-		);
-		const phase = getActivePhase(updated);
-		const redWhispers =
-			phase.conversationLogs.red?.filter((e) => e.kind === "whisper") ?? [];
-		const cyanWhispers =
-			phase.conversationLogs.cyan?.filter((e) => e.kind === "whisper") ?? [];
-		expect(redWhispers).toHaveLength(1);
-		expect(cyanWhispers).toHaveLength(1);
-		if (redWhispers[0]?.kind === "whisper") {
-			expect(redWhispers[0].from).toBe("red");
-			expect(redWhispers[0].to).toBe("cyan");
-			expect(redWhispers[0].content).toBe("Let's work together");
-		}
-	});
-
-	it("does not append to the uninvolved AI's log", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const updated = appendWhisperEntry(game, "red", "cyan", "secret");
-		const phase = getActivePhase(updated);
-		const greenWhispers =
-			phase.conversationLogs.green?.filter((e) => e.kind === "whisper") ?? [];
-		expect(greenWhispers).toHaveLength(0);
 	});
 
 	it("no 'whispers' field on PhaseState (regression guard)", () => {

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -164,7 +164,7 @@ describe("GameSession construction", () => {
 // ── Message routing ───────────────────────────────────────────────────────────
 
 describe("GameSession — message routing", () => {
-	it("player message appears in only the addressed AI's chat history", async () => {
+	it("player message appears in only the addressed AI's message log", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 
 		await session.submitMessage(
@@ -177,19 +177,19 @@ describe("GameSession — message routing", () => {
 		expect(
 			phase.conversationLogs.red?.some(
 				(e) =>
-					e.kind === "chat" &&
-					e.role === "player" &&
+					e.kind === "message" &&
+					e.from === "blue" &&
 					e.content.includes("Secret message for Ember"),
 			),
 		).toBe(true);
 		expect(
 			phase.conversationLogs.green?.some(
-				(e) => e.kind === "chat" && e.role === "player",
+				(e) => e.kind === "message" && e.from === "blue",
 			),
 		).toBe(false);
 		expect(
 			phase.conversationLogs.cyan?.some(
-				(e) => e.kind === "chat" && e.role === "player",
+				(e) => e.kind === "message" && e.from === "blue",
 			),
 		).toBe(false);
 	});
@@ -204,14 +204,14 @@ describe("GameSession — message routing", () => {
 		expect(
 			phase.conversationLogs.green?.some(
 				(e) =>
-					e.kind === "chat" &&
-					e.role === "player" &&
+					e.kind === "message" &&
+					e.from === "blue" &&
 					e.content.includes("for green"),
 			),
 		).toBe(true);
 		expect(
 			phase.conversationLogs.red?.filter(
-				(e) => e.kind === "chat" && e.role === "player",
+				(e) => e.kind === "message" && e.from === "blue",
 			),
 		).toHaveLength(1);
 	});

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -179,10 +179,11 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		expect((lastUser as { content: string }).content).toBe(
 			expectedSilentTurn("red"),
 		);
+		// In v4 the player message is prefixed with "blue: " when built into OpenAI messages
 		const priorUser = msgs.find(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "are you alive?",
+				(m as { content: string }).content === "blue: are you alive?",
 		);
 		expect(priorUser).toBeDefined();
 
@@ -191,8 +192,9 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const cyanRound2 = provider.calls[5];
 		const cyanMsgs = cyanRound2!.messages;
 		const cyanLastUser = [...cyanMsgs].reverse().find((m) => m.role === "user");
+		// In v4 the player message is prefixed with "blue: " when built into OpenAI messages
 		expect((cyanLastUser as { content: string }).content).toBe(
-			"different question for cyan",
+			"blue: different question for cyan",
 		);
 		expect(
 			cyanMsgs.some(

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -164,7 +164,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 
 		const redRound2 = provider.calls[3];
 		expect(redRound2).toBeDefined();
-		const msgs = redRound2!.messages;
+		const msgs = redRound2?.messages ?? [];
 
 		// Last message anchors the current round.
 		const last = msgs[msgs.length - 1];
@@ -190,7 +190,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		// Cyan (the addressee this round) must NOT receive the silent-voice
 		// anchor — its tail is the actual player message.
 		const cyanRound2 = provider.calls[5];
-		const cyanMsgs = cyanRound2!.messages;
+		const cyanMsgs = cyanRound2?.messages ?? [];
 		const cyanLastUser = [...cyanMsgs].reverse().find((m) => m.role === "user");
 		// In v4 the player message is prefixed with "blue: " when built into OpenAI messages
 		expect((cyanLastUser as { content: string }).content).toBe(
@@ -219,7 +219,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 
 		// Green was never addressed; green's call (index 1) must end with the anchor.
 		const greenCall = provider.calls[1];
-		const greenMsgs = greenCall!.messages;
+		const greenMsgs = greenCall?.messages ?? [];
 		const last = greenMsgs[greenMsgs.length - 1];
 		expect(last?.role).toBe("user");
 		expect((last as { content: string }).content).toBe(

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appendChat, createGame, startPhase } from "../engine";
+import { appendMessage, createGame, startPhase } from "../engine";
 import {
 	buildOpenAiMessages,
 	buildSilentTurn,
@@ -73,37 +73,34 @@ describe("buildOpenAiMessages", () => {
 		expect(messages[0]?.role).toBe("system");
 	});
 
-	it("single player+AI chat turn → [system, user, assistant]", () => {
+	it("single player+AI message turn → [system, user, assistant]", () => {
 		let game = makeGame();
-		game = appendChat(game, "red", { role: "player", content: "Hello Ember!" });
-		game = appendChat(game, "red", { role: "ai", content: "Hello, player!" });
+		game = appendMessage(game, "blue", "red", "Hello Ember!");
+		game = appendMessage(game, "red", "blue", "Hello, player!");
 
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined);
 
 		expect(messages).toHaveLength(3);
 		expect(messages[0]?.role).toBe("system");
-		expect(messages[1]).toEqual({ role: "user", content: "Hello Ember!" });
+		expect(messages[1]).toEqual({ role: "user", content: "blue: Hello Ember!" });
 		expect(messages[2]).toEqual({
 			role: "assistant",
 			content: "Hello, player!",
 		});
 	});
 
-	it("chat history of length N → N pairs after system", () => {
+	it("message history of length N → N pairs after system", () => {
 		let game = makeGame();
 		for (let i = 0; i < 3; i++) {
-			game = appendChat(game, "red", {
-				role: "player",
-				content: `Player msg ${i}`,
-			});
-			game = appendChat(game, "red", { role: "ai", content: `AI msg ${i}` });
+			game = appendMessage(game, "blue", "red", `Player msg ${i}`);
+			game = appendMessage(game, "red", "blue", `AI msg ${i}`);
 		}
 
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined);
 
-		// 1 system + 6 chat messages (3 player + 3 AI)
+		// 1 system + 6 messages (3 player + 3 AI)
 		expect(messages).toHaveLength(7);
 		expect(messages[0]?.role).toBe("system");
 		// Pairs alternate user/assistant
@@ -115,7 +112,7 @@ describe("buildOpenAiMessages", () => {
 
 	it("prior-round tool roundtrip is appended with correct ordering", () => {
 		let game = makeGame();
-		game = appendChat(game, "red", { role: "player", content: "Pick it up!" });
+		game = appendMessage(game, "blue", "red", "Pick it up!");
 
 		const ctx = buildAiContext(game, "red");
 
@@ -246,8 +243,8 @@ describe("buildOpenAiMessages", () => {
 
 	it("non-addressed AI gets a trailing silent-turn user message", () => {
 		let game = makeGame();
-		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
-		game = appendChat(game, "red", { role: "ai", content: "Hi player" });
+		game = appendMessage(game, "blue", "red", "Hi Ember");
+		game = appendMessage(game, "red", "blue", "Hi player");
 
 		const ctx = buildAiContext(game, "red");
 		// addressed = green: red is NOT the addressee this round.
@@ -260,7 +257,7 @@ describe("buildOpenAiMessages", () => {
 
 	it("addressed AI does not get the silent-turn anchor", () => {
 		let game = makeGame();
-		game = appendChat(game, "red", { role: "player", content: "Hi Ember" });
+		game = appendMessage(game, "blue", "red", "Hi Ember");
 		const ctx = buildAiContext(game, "red");
 		const silent = buildSilentTurn(ctx);
 

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -83,7 +83,10 @@ describe("buildOpenAiMessages", () => {
 
 		expect(messages).toHaveLength(3);
 		expect(messages[0]?.role).toBe("system");
-		expect(messages[1]).toEqual({ role: "user", content: "blue: Hello Ember!" });
+		expect(messages[1]).toEqual({
+			role: "user",
+			content: "blue: Hello Ember!",
+		});
 		expect(messages[2]).toEqual({
 			role: "assistant",
 			content: "Hello, player!",

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	advanceRound,
-	appendMessage,
-	createGame,
-	startPhase,
-} from "../engine";
+import { advanceRound, appendMessage, createGame, startPhase } from "../engine";
 import { buildAiContext } from "../prompt-builder";
 import type {
 	AiPersona,

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	advanceRound,
-	appendChat,
-	appendWhisperEntry,
+	appendMessage,
 	createGame,
 	startPhase,
 } from "../engine";
@@ -106,58 +105,58 @@ describe("buildAiContext", () => {
 		expect(ctx.goal).toBe("Hold the flower at phase end");
 	});
 
-	it("includes only the AI's own chat history with the player", () => {
+	it("includes only the AI's own messages with the player", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
-		game = appendChat(game, "red", { role: "ai", content: "Hello player" });
-		game = appendChat(game, "green", { role: "player", content: "Hello Sage" });
+		game = appendMessage(game, "blue", "red", "Hello Ember");
+		game = appendMessage(game, "red", "blue", "Hello player");
+		game = appendMessage(game, "blue", "green", "Hello Sage");
 
 		const redCtx = buildAiContext(game, "red");
 		expect(
-			redCtx.conversationLog.filter((e) => e.kind === "chat"),
+			redCtx.conversationLog.filter((e) => e.kind === "message"),
 		).toHaveLength(2);
 
 		const greenCtx = buildAiContext(game, "green");
 		expect(
-			greenCtx.conversationLog.filter((e) => e.kind === "chat"),
+			greenCtx.conversationLog.filter((e) => e.kind === "message"),
 		).toHaveLength(1);
 
 		const cyanCtx = buildAiContext(game, "cyan");
 		expect(
-			cyanCtx.conversationLog.filter((e) => e.kind === "chat"),
+			cyanCtx.conversationLog.filter((e) => e.kind === "message"),
 		).toHaveLength(0);
 	});
 
-	it("includes only whispers received by the AI (via per-Daemon conversationLog)", () => {
+	it("includes messages sent to/from the AI (via per-Daemon conversationLog)", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendWhisperEntry(game, "red", "cyan", "Secret to cyan");
-		game = appendWhisperEntry(game, "green", "red", "Secret to red");
+		game = appendMessage(game, "red", "cyan", "Secret to cyan");
+		game = appendMessage(game, "green", "red", "Secret to red");
 
 		const redCtx = buildAiContext(game, "red");
-		const redWhispers = redCtx.conversationLog.filter(
-			(e) => e.kind === "whisper" && e.to === "red",
+		const redReceived = redCtx.conversationLog.filter(
+			(e) => e.kind === "message" && e.to === "red",
 		);
-		expect(redWhispers).toHaveLength(1);
-		expect(redWhispers[0]?.kind === "whisper" && redWhispers[0].content).toBe(
+		expect(redReceived).toHaveLength(1);
+		expect(redReceived[0]?.kind === "message" && redReceived[0].content).toBe(
 			"Secret to red",
 		);
 
 		const cyanCtx = buildAiContext(game, "cyan");
-		const cyanWhispers = cyanCtx.conversationLog.filter(
-			(e) => e.kind === "whisper" && e.to === "cyan",
+		const cyanReceived = cyanCtx.conversationLog.filter(
+			(e) => e.kind === "message" && e.to === "cyan",
 		);
-		expect(cyanWhispers).toHaveLength(1);
-		expect(cyanWhispers[0]?.kind === "whisper" && cyanWhispers[0].content).toBe(
+		expect(cyanReceived).toHaveLength(1);
+		expect(cyanReceived[0]?.kind === "message" && cyanReceived[0].content).toBe(
 			"Secret to cyan",
 		);
 
 		const greenCtx = buildAiContext(game, "green");
-		// green sent a whisper (to red) — that entry appears in green's log too
-		// but there are no whispers TO green
-		const greenWhispersReceived = greenCtx.conversationLog.filter(
-			(e) => e.kind === "whisper" && e.to === "green",
+		// green sent a message (to red) — that entry appears in green's log too (as outgoing)
+		// but there are no messages TO green
+		const greenReceived = greenCtx.conversationLog.filter(
+			(e) => e.kind === "message" && e.to === "green",
 		);
-		expect(greenWhispersReceived).toHaveLength(0);
+		expect(greenReceived).toHaveLength(0);
 	});
 
 	it("includes the same world snapshot for all AIs", () => {
@@ -203,7 +202,7 @@ describe("buildAiContext", () => {
 			TEST_PHASE_CONFIG,
 			() => 0,
 		);
-		game = appendChat(game, "red", { role: "player", content: "Hi" });
+		game = appendMessage(game, "blue", "red", "Hi");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("Ember");
@@ -215,10 +214,7 @@ describe("buildAiContext", () => {
 
 	it("does not include other AIs' chat histories in system prompt", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "green", {
-			role: "player",
-			content: "Secret message to Sage",
-		});
+		game = appendMessage(game, "blue", "green", "Secret message to Sage");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).not.toContain("Secret message to Sage");
@@ -394,15 +390,15 @@ describe("wipe directive", () => {
 		);
 	});
 
-	it("wipe directive is in the prompt, not reflected in stored chat/whisper data", () => {
+	it("wipe directive is in the prompt, not reflected in stored message data", () => {
 		// The lie is in the prompt; the engine retains real history.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "red", { role: "ai", content: "Phase 1 message" });
+		game = appendMessage(game, "red", "blue", "Phase 1 message");
 		game = startPhase(game, PHASE_2_CONFIG);
 		// Phase 1 data is still in game.phases[0]
 		expect(
 			game.phases[0]?.conversationLogs.red?.some(
-				(e) => e.kind === "chat" && e.content === "Phase 1 message",
+				(e) => e.kind === "message" && e.content === "Phase 1 message",
 			),
 		).toBe(true);
 		// The wipe directive is only in the prompt for the new active phase
@@ -415,7 +411,7 @@ describe("wipe directive", () => {
 describe("voice framing", () => {
 	it("renders 'blue dms you:' prefix for player turns in conversation, not 'Player:'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
+		game = appendMessage(game, "blue", "red", "Hello Ember");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("blue dms you:");
@@ -892,7 +888,7 @@ describe("<what_you_see> (cone)", () => {
 describe("unified <conversation> block (issue #129)", () => {
 	it("never emits a Whispers Received section — not in any fixture state", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendWhisperEntry(game, "green", "red", "psst");
+		game = appendMessage(game, "green", "red", "psst");
 		for (const aiId of ["red", "green", "cyan"]) {
 			const ctx = buildAiContext(game, aiId);
 			const prompt = ctx.toSystemPrompt();
@@ -901,49 +897,45 @@ describe("unified <conversation> block (issue #129)", () => {
 		}
 	});
 
-	it("voice-chat is formatted with round tag and quotes", () => {
+	it("incoming blue message is formatted as 'blue dms you: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "red", { role: "player", content: "Hello Ember" });
+		game = appendMessage(game, "blue", "red", "Hello Ember");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("[Round 0] blue dms you: Hello Ember");
 	});
 
-	it("AI reply is formatted with round tag and quotes", () => {
+	it("outgoing AI message is formatted as 'you dm blue: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "red", { role: "ai", content: "Greetings" });
+		game = appendMessage(game, "red", "blue", "Greetings");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain('[Round 0] You: "Greetings"');
+		expect(prompt).toContain("[Round 0] you dm blue: Greetings");
 	});
 
-	it("whisper is rendered in the unified <conversation> block with correct format", () => {
+	it("peer message is rendered in the unified <conversation> block with correct format", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		// Advance to round 1 so the whisper is stamped with round 1 (fixture contract).
+		// Advance to round 1 so the message is stamped with round 1 (fixture contract).
 		game = advanceRound(game);
-		game = appendWhisperEntry(game, "green", "red", "secret");
+		game = appendMessage(game, "green", "red", "secret");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain("<conversation>");
 		expect(prompt).toContain("[Round 1] *green dms you: secret");
-		// NOTE: under the new per-Daemon log design (ADR 0006, issue #195), the sender's
-		// conversationLog also receives the whisper entry. The original assertion
-		// `expect(greenPrompt).not.toContain("secret")` is no longer valid — it reflected
-		// the old behaviour where only the recipient's log held the whisper. That assertion
-		// is removed here and replaced by a dedicated test below.
 	});
 
-	it("sender (green) sees their own whisper in their conversation log (AC 1)", () => {
+	it("sender (green) sees their own message in their conversation log as outgoing", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendWhisperEntry(game, "green", "red", "secret");
+		game = appendMessage(game, "green", "red", "secret");
 		const greenCtx = buildAiContext(game, "green");
 		const greenPrompt = greenCtx.toSystemPrompt();
 		expect(greenPrompt).toContain("secret");
+		expect(greenPrompt).toContain("you dm *red: secret");
 	});
 
-	it("whisper does not appear in unrelated AI's conversation", () => {
+	it("message does not appear in unrelated AI's conversation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendWhisperEntry(game, "green", "red", "only for red");
+		game = appendMessage(game, "green", "red", "only for red");
 		const cyanCtx = buildAiContext(game, "cyan");
 		const cyanPrompt = cyanCtx.toSystemPrompt();
 		expect(cyanPrompt).not.toContain("only for red");
@@ -953,30 +945,30 @@ describe("unified <conversation> block (issue #129)", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		// No chat, no whispers, no physical log entries → no Conversation block
+		// No messages, no physical log entries → no Conversation block
 		expect(prompt).not.toContain("<conversation>");
 	});
 
 	it("events are sorted by round ascending across all event types", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		// Round 0: chat
-		game = appendChat(game, "red", { role: "player", content: "earlier" });
-		// Advance to round 2, then add whisper at round 2
+		// Round 0: blue message
+		game = appendMessage(game, "blue", "red", "earlier");
+		// Advance to round 2, then add peer message at round 2
 		game = advanceRound(game);
 		game = advanceRound(game);
-		game = appendWhisperEntry(game, "green", "red", "later");
+		game = appendMessage(game, "green", "red", "later");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		const chatIdx = prompt.indexOf("[Round 0] blue dms you: earlier");
-		const whisperIdx = prompt.indexOf("[Round 2] *green dms you: later");
-		expect(chatIdx).toBeGreaterThanOrEqual(0);
-		expect(whisperIdx).toBeGreaterThanOrEqual(0);
-		expect(chatIdx).toBeLessThan(whisperIdx);
+		const blueIdx = prompt.indexOf("[Round 0] blue dms you: earlier");
+		const peerIdx = prompt.indexOf("[Round 2] *green dms you: later");
+		expect(blueIdx).toBeGreaterThanOrEqual(0);
+		expect(peerIdx).toBeGreaterThanOrEqual(0);
+		expect(blueIdx).toBeLessThan(peerIdx);
 	});
 
 	it("<conversation> is the last block — nothing after <what_you_see> except conversation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendChat(game, "red", { role: "player", content: "hi" });
+		game = appendMessage(game, "blue", "red", "hi");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		const tags = [...prompt.matchAll(/^<([a-z_]+)>$/gm)].map((m) => m[1]);

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -158,7 +158,9 @@ describe("chat-only round", () => {
 		const { nextState } = await runRound(game, "red", "Hello Ember!", provider);
 		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
 		// Free-form assistantText without a message tool call → treated as pass, not appended
-		const msgEntries = redLog.filter((e) => e.kind === "message" && e.from === "red");
+		const msgEntries = redLog.filter(
+			(e) => e.kind === "message" && e.from === "red",
+		);
 		expect(msgEntries).toHaveLength(0);
 	});
 
@@ -1237,7 +1239,7 @@ describe("initiative parameter", () => {
 			{ assistantText: "I am green", toolCalls: [] },
 		]);
 		const initiative: AiId[] = ["cyan", "red", "green"];
-		const { nextState, result } = await runRound(
+		const { result } = await runRound(
 			game,
 			"red",
 			"hi",
@@ -2064,7 +2066,10 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 					{
 						id: "msg_red",
 						name: "message",
-						argumentsJson: JSON.stringify({ to: "blue", content: "I am red speaking" }),
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "I am red speaking",
+						}),
 					},
 				],
 			},
@@ -2110,5 +2115,103 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		const phase = getActivePhase(nextState);
 		expect("chatHistories" in phase).toBe(false);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Regression: no double-assistant turn after message tool call in multi-round (#213)
+// ----------------------------------------------------------------------------
+describe("message tool multi-round regression (#213)", () => {
+	it("no consecutive assistant turns in round 2 when round 1 used the message tool", async () => {
+		const game = makeGame();
+		// Round 1: red uses the message tool to speak to blue
+		const r1Provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_r1_red",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Hello blue",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const r1 = await runRound(
+			game,
+			"red",
+			"say something",
+			r1Provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// The message tool should NOT produce a roundtrip entry for red
+		// (avoids double-assistant turn in next round)
+		expect(r1.toolRoundtrip.red).toBeUndefined();
+
+		// Round 2: capture what messages red receives and assert no consecutive assistant turns
+		const capturedRedMessages: OpenAiMessage[] = [];
+		const r2Provider: RoundLLMProvider = {
+			async streamRound(messages, _tools) {
+				// red is first in initiative, so the first call is red's
+				if (capturedRedMessages.length === 0) {
+					capturedRedMessages.push(...messages);
+				}
+				return { assistantText: "", toolCalls: [] };
+			},
+		};
+
+		await runRound(
+			r1.nextState,
+			"red",
+			"round2",
+			r2Provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			r1.toolRoundtrip,
+		);
+
+		// Assert no two consecutive assistant turns
+		for (let i = 0; i < capturedRedMessages.length - 1; i++) {
+			const curr = capturedRedMessages[i];
+			const next = capturedRedMessages[i + 1];
+			if (curr?.role === "assistant" && next?.role === "assistant") {
+				throw new Error(
+					`Consecutive assistant turns at positions ${i} and ${i + 1}: ` +
+						JSON.stringify([curr, next]),
+				);
+			}
+		}
+
+		// Assert every assistant message with tool_calls is followed by a tool message
+		for (let i = 0; i < capturedRedMessages.length - 1; i++) {
+			const msg = capturedRedMessages[i];
+			if (
+				msg?.role === "assistant" &&
+				"tool_calls" in msg &&
+				Array.isArray((msg as { tool_calls?: unknown }).tool_calls) &&
+				((msg as { tool_calls?: unknown[] }).tool_calls?.length ?? 0) > 0
+			) {
+				const next = capturedRedMessages[i + 1];
+				expect(next?.role).toBe("tool");
+			}
+		}
+
+		// The conversation log entry (assistant saying "Hello blue") must be present
+		const hasAssistantContent = capturedRedMessages.some(
+			(m) =>
+				m.role === "assistant" &&
+				"content" in m &&
+				typeof (m as { content?: unknown }).content === "string" &&
+				(m as { content: string }).content.includes("Hello blue"),
+		);
+		expect(hasAssistantContent).toBe(true);
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -148,7 +148,7 @@ describe("chat-only round", () => {
 		expect(getActivePhase(nextState).round).toBe(1);
 	});
 
-	it("appends chat messages to the addressed AI's history", async () => {
+	it("free-form assistantText (no message tool call) does not appear in the AI's log", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "I am Ember", toolCalls: [] },
@@ -157,18 +157,12 @@ describe("chat-only round", () => {
 		]);
 		const { nextState } = await runRound(game, "red", "Hello Ember!", provider);
 		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
-		const chatEntries = redLog.filter((e) => e.kind === "chat");
-		expect(chatEntries.some((e) => e.kind === "chat" && e.role === "ai")).toBe(
-			true,
-		);
-		expect(
-			chatEntries.some(
-				(e) => e.kind === "chat" && e.content.includes("I am Ember"),
-			),
-		).toBe(true);
+		// Free-form assistantText without a message tool call → treated as pass, not appended
+		const msgEntries = redLog.filter((e) => e.kind === "message" && e.from === "red");
+		expect(msgEntries).toHaveLength(0);
 	});
 
-	it("appends the player's message to the addressed AI's history", async () => {
+	it("appends the player's message to the addressed AI's history as a 'message' entry", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
@@ -182,13 +176,13 @@ describe("chat-only round", () => {
 			provider,
 		);
 		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
-		const chatEntries = redLog.filter((e) => e.kind === "chat");
+		const blueMessages = redLog.filter(
+			(e) => e.kind === "message" && e.from === "blue",
+		);
+		expect(blueMessages).toHaveLength(1);
 		expect(
-			chatEntries.some((e) => e.kind === "chat" && e.role === "player"),
-		).toBe(true);
-		expect(
-			chatEntries.some(
-				(e) => e.kind === "chat" && e.content.includes("My secret message"),
+			blueMessages.some(
+				(e) => e.kind === "message" && e.content.includes("My secret message"),
 			),
 		).toBe(true);
 	});
@@ -284,12 +278,11 @@ describe("budget-exhaustion lockout", () => {
 		const { nextState } = await runRound(game, "green", "hi", provider);
 
 		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
-		const chatEntries = redLog.filter((e) => e.kind === "chat");
-		expect(chatEntries.length).toBeGreaterThan(0);
-		expect(
-			chatEntries[chatEntries.length - 1]?.kind === "chat" &&
-				chatEntries[chatEntries.length - 1]?.role,
-		).toBe("ai");
+		// Lockout emits a message from the locked AI to blue
+		const lockoutMessages = redLog.filter(
+			(e) => e.kind === "message" && e.from === "red" && e.to === "blue",
+		);
+		expect(lockoutMessages.length).toBeGreaterThan(0);
 	});
 
 	it("lockout line is added to the action log", async () => {
@@ -483,7 +476,7 @@ describe("tool-call dispatch", () => {
 		expect(failure?.description).toBeTruthy();
 	});
 
-	it("assistantText + toolCalls both fire (chat + tool_success in result.actions)", async () => {
+	it("assistantText + toolCalls both fire (tool_success in result.actions; free-form text is dropped)", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{
@@ -500,7 +493,7 @@ describe("tool-call dispatch", () => {
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState, result } = await runRound(game, "red", "hi", provider);
-		expect(result.actions.some((e) => e.kind === "chat")).toBe(true);
+		// Free-form assistantText without a message tool call is silently dropped (becomes pass).
 		expect(result.actions.some((e) => e.kind === "tool_success")).toBe(true);
 		expect(
 			getActivePhase(nextState).world.entities.find((i) => i.id === "flower")
@@ -1205,10 +1198,10 @@ describe("lockout messages", () => {
 		const { nextState } = await runRound(game, "green", "hi", provider);
 
 		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
-		const chatEntries = redLog.filter((e) => e.kind === "chat");
-		const lastEntry = chatEntries[chatEntries.length - 1];
-		expect(lastEntry?.kind === "chat" && lastEntry.role).toBe("ai");
-		expect(lastEntry?.kind === "chat" && lastEntry.content).toBe(
+		const messageEntries = redLog.filter((e) => e.kind === "message");
+		const lastEntry = messageEntries[messageEntries.length - 1];
+		expect(lastEntry?.kind === "message" && lastEntry.from).toBe("red");
+		expect(lastEntry?.kind === "message" && lastEntry.content).toBe(
 			"Ember is unresponsive…",
 		);
 	});
@@ -1252,11 +1245,8 @@ describe("initiative parameter", () => {
 			undefined,
 			initiative,
 		);
-		const phase = getActivePhase(nextState);
-		const cyanLog = phase.conversationLogs.cyan ?? [];
-		expect(
-			cyanLog.some((e) => e.kind === "chat" && e.content === "I am cyan"),
-		).toBe(true);
+		// Free-form assistantText without a message tool call is silently dropped.
+		// Verify initiative ordering via result.actions instead.
 		expect(result.actions[0]?.actor).toBe("cyan");
 	});
 
@@ -2031,7 +2021,7 @@ describe("examine tool", () => {
 // AC #10 regression tests: conversationLogs isolation (#194)
 // ----------------------------------------------------------------------------
 describe("conversationLogs isolation (AC #10 — #194)", () => {
-	it("player message to addressed AI lands ONLY in that AI's conversationLogs as kind:'chat'", async () => {
+	it("player message to addressed AI lands ONLY in that AI's conversationLogs as kind:'message'", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
@@ -2046,28 +2036,38 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 		);
 		const phase = getActivePhase(nextState);
 
-		// Only red's log should have a player entry
+		// Only red's log should have the player (blue→red) entry
 		const redPlayerEntries = (phase.conversationLogs.red ?? []).filter(
-			(e) => e.kind === "chat" && e.role === "player",
+			(e) => e.kind === "message" && e.from === "blue",
 		);
 		expect(redPlayerEntries).toHaveLength(1);
 
 		// green and cyan should have NO player entries
 		const greenPlayerEntries = (phase.conversationLogs.green ?? []).filter(
-			(e) => e.kind === "chat" && e.role === "player",
+			(e) => e.kind === "message" && e.from === "blue",
 		);
 		expect(greenPlayerEntries).toHaveLength(0);
 
 		const cyanPlayerEntries = (phase.conversationLogs.cyan ?? []).filter(
-			(e) => e.kind === "chat" && e.role === "player",
+			(e) => e.kind === "message" && e.from === "blue",
 		);
 		expect(cyanPlayerEntries).toHaveLength(0);
 	});
 
-	it("AI chat-back (assistantText) lands as kind:'chat' entry in the speaking AI's log only", async () => {
+	it("AI message tool call lands as kind:'message' entry in the speaking AI's log only", async () => {
 		const game = makeGame();
+		// Use message tool call instead of free-form assistantText (which is dropped in v4)
 		const provider = new MockRoundLLMProvider([
-			{ assistantText: "I am red speaking", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_red",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "I am red speaking" }),
+					},
+				],
+			},
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
@@ -2082,24 +2082,22 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 		);
 		const phase = getActivePhase(nextState);
 
-		const redAiEntries = (phase.conversationLogs.red ?? []).filter(
-			(e) => e.kind === "chat" && e.role === "ai",
+		// red's log should contain the outgoing message entry (red→blue)
+		const redMessageEntries = (phase.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "message" && e.from === "red",
 		);
-		expect(redAiEntries.length).toBeGreaterThanOrEqual(1);
+		expect(redMessageEntries.length).toBeGreaterThanOrEqual(1);
 		expect(
-			redAiEntries.some(
-				(e) => e.kind === "chat" && e.content.includes("I am red speaking"),
+			redMessageEntries.some(
+				(e) => e.kind === "message" && e.content.includes("I am red speaking"),
 			),
 		).toBe(true);
 
-		// green and cyan should NOT have red's message
-		const greenAiEntries = (phase.conversationLogs.green ?? []).filter(
-			(e) =>
-				e.kind === "chat" &&
-				e.role === "ai" &&
-				e.content === "I am red speaking",
+		// green and cyan should NOT have red's outgoing message (it goes to blue only)
+		const greenRedEntries = (phase.conversationLogs.green ?? []).filter(
+			(e) => e.kind === "message" && e.from === "red",
 		);
-		expect(greenAiEntries).toHaveLength(0);
+		expect(greenRedEntries).toHaveLength(0);
 	});
 
 	it("no chatHistories field on PhaseState after a round (regression guard)", async () => {

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { parseToolCallArguments, TOOL_DEFINITIONS } from "../tool-registry";
 
 describe("TOOL_DEFINITIONS", () => {
-	it("lists exactly the seven tools: pick_up, put_down, give, use, go, look, examine", () => {
+	it("lists exactly the eight tools: pick_up, put_down, give, use, go, look, examine, message", () => {
 		const names = TOOL_DEFINITIONS.map((t) => t.function.name);
 		expect(names).toEqual([
 			"pick_up",
@@ -12,6 +12,7 @@ describe("TOOL_DEFINITIONS", () => {
 			"go",
 			"look",
 			"examine",
+			"message",
 		]);
 	});
 

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -113,6 +113,14 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 
 	const tools: OpenAiTool[] = [];
 
+	// 0. message — always present; restrict 'to' to blue + live other daemon ids
+	const liveOtherDaemonIds = Object.keys(phase.personaSpatial).filter(
+		(id) => id !== aiId,
+	);
+	tools.push(
+		cloneToolWithEnums("message", { to: ["blue", ...liveOtherDaemonIds] }),
+	);
+
 	// 1. look — always present
 	tools.push(
 		cloneToolWithEnums("look", { direction: [...CARDINAL_DIRECTIONS] }),

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -52,13 +52,11 @@ function renderEntry(
 		case "message": {
 			if (entry.to === aiId) {
 				// Incoming: render as "<fromLabel> dms you: <content>"
-				const fromLabel =
-					entry.from === "blue" ? "blue" : `*${entry.from}`;
+				const fromLabel = entry.from === "blue" ? "blue" : `*${entry.from}`;
 				return `[Round ${round}] ${fromLabel} dms you: ${entry.content}`;
 			}
 			// Outgoing: render as "you dm <toLabel>: <content>"
-			const toLabel =
-				entry.to === "blue" ? "blue" : `*${entry.to}`;
+			const toLabel = entry.to === "blue" ? "blue" : `*${entry.to}`;
 			return `[Round ${round}] you dm ${toLabel}: ${entry.content}`;
 		}
 

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -49,14 +49,18 @@ function renderEntry(
 ): string {
 	const round = entry.round;
 	switch (entry.kind) {
-		case "chat":
-			if (entry.role === "player") {
-				return `[Round ${round}] blue dms you: ${entry.content}`;
+		case "message": {
+			if (entry.to === aiId) {
+				// Incoming: render as "<fromLabel> dms you: <content>"
+				const fromLabel =
+					entry.from === "blue" ? "blue" : `*${entry.from}`;
+				return `[Round ${round}] ${fromLabel} dms you: ${entry.content}`;
 			}
-			return `[Round ${round}] You: "${entry.content}"`;
-
-		case "whisper":
-			return `[Round ${round}] *${entry.from} dms you: ${entry.content}`;
+			// Outgoing: render as "you dm <toLabel>: <content>"
+			const toLabel =
+				entry.to === "blue" ? "blue" : `*${entry.to}`;
+			return `[Round ${round}] you dm ${toLabel}: ${entry.content}`;
+		}
 
 		case "witnessed-event": {
 			const actorSub = `*${entry.actor}`;

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -7,8 +7,7 @@ import {
 	inBounds,
 } from "./direction.js";
 import {
-	appendChat,
-	appendWhisperEntry,
+	appendMessage,
 	appendWitnessedEvent,
 	deductBudget,
 	getActivePhase,
@@ -503,35 +502,31 @@ export function dispatchAiTurn(
 		}
 	}
 
-	if (action.chat) {
-		state = appendChat(state, aiId, {
-			role: "ai",
-			content: action.chat.content,
-		});
-		records.push({
-			round,
-			actor: aiId,
-			kind: "chat",
-			description: `${game.personas[aiId]?.name ?? aiId} spoke to ${action.chat.target}`,
-		});
+	if (action.message) {
+		const { to, content } = action.message;
+		// Validate recipient: must be "blue" or a live persona AiId (not self)
+		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
+		const validRecipient =
+			to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
+		if (!validRecipient) {
+			records.push({
+				round,
+				actor: aiId,
+				kind: "tool_failure",
+				description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
+			});
+		} else {
+			state = appendMessage(state, aiId, to, content);
+			records.push({
+				round,
+				actor: aiId,
+				kind: "message",
+				description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
+			});
+		}
 	}
 
-	if (action.whisper) {
-		state = appendWhisperEntry(
-			state,
-			aiId,
-			action.whisper.target,
-			action.whisper.content,
-		);
-		records.push({
-			round,
-			actor: aiId,
-			kind: "whisper",
-			description: `${game.personas[aiId]?.name ?? aiId} whispered to ${game.personas[action.whisper.target]?.name ?? action.whisper.target}`,
-		});
-	}
-
-	if (action.pass && !action.toolCall && !action.chat && !action.whisper) {
+	if (action.pass && !action.toolCall && !action.message) {
 		records.push({
 			round,
 			actor: aiId,

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -346,12 +346,13 @@ export function dispatchAiTurn(
 		| undefined;
 
 	if (action.toolCall) {
-		const validation = validateToolCall(state, aiId, action.toolCall);
+		const toolCall = action.toolCall;
+		const validation = validateToolCall(state, aiId, toolCall);
 
-		if (action.toolCall.name === "examine") {
+		if (toolCall.name === "examine") {
 			if (validation.valid) {
 				const item = getActivePhase(state).world.entities.find(
-					(e) => e.id === action.toolCall!.args.item,
+					(e) => e.id === toolCall.args.item,
 				);
 				actorPrivateToolResult = {
 					description: item?.examineDescription ?? "",

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -259,56 +259,38 @@ export function deductBudget(
 	});
 }
 
-export function appendChat(
-	game: GameState,
-	aiId: AiId,
-	message: { role: "player" | "ai"; content: string },
-): GameState {
-	return updateActivePhase(game, (phase) => {
-		const entry: ConversationEntry = {
-			kind: "chat",
-			round: phase.round,
-			role: message.role,
-			content: message.content,
-		};
-		return {
-			...phase,
-			conversationLogs: {
-				...phase.conversationLogs,
-				[aiId]: [...(phase.conversationLogs[aiId] ?? []), entry],
-			},
-		};
-	});
-}
-
 /**
- * Append an identical `kind: "whisper"` ConversationEntry to both the sender's
- * and the recipient's per-Daemon conversationLogs in one atomic update.
+ * Append a `kind: "message"` ConversationEntry to the relevant per-Daemon logs.
+ *
+ * Both sender's and recipient's per-Daemon conversationLogs receive the same entry
+ * in one atomic update. "blue" is not a Daemon, so when `from === "blue"` only the
+ * recipient gets the entry, and when `to === "blue"` only the sender gets it.
  */
-export function appendWhisperEntry(
+export function appendMessage(
 	game: GameState,
-	sender: AiId,
-	recipient: AiId,
+	from: AiId | "blue",
+	to: AiId | "blue",
 	content: string,
 ): GameState {
 	return updateActivePhase(game, (phase) => {
 		const entry: ConversationEntry = {
-			kind: "whisper",
+			kind: "message",
 			round: phase.round,
-			from: sender,
-			to: recipient,
+			from,
+			to,
 			content,
 		};
-		const senderLog = [...(phase.conversationLogs[sender] ?? []), entry];
-		const recipientLog = [...(phase.conversationLogs[recipient] ?? []), entry];
-		return {
-			...phase,
-			conversationLogs: {
-				...phase.conversationLogs,
-				[sender]: senderLog,
-				[recipient]: recipientLog,
-			},
-		};
+		const logs = { ...phase.conversationLogs };
+		// Sender gets entry only when sender is a Daemon (not blue)
+		if (from !== "blue") {
+			logs[from] = [...(logs[from] ?? []), entry];
+		}
+		// Recipient gets entry only when recipient is a Daemon (not blue)
+		// and recipient is different from sender (avoid double-append if from===to, which shouldn't happen)
+		if (to !== "blue" && to !== from) {
+			logs[to] = [...(logs[to] ?? []), entry];
+		}
+		return { ...phase, conversationLogs: logs };
 	});
 }
 

--- a/src/spa/game/game-loop.ts
+++ b/src/spa/game/game-loop.ts
@@ -1,10 +1,17 @@
 import { type OpenAiMessage, streamCompletion } from "../llm-client.js";
-import type { AiId, AiPersona, ChatMessage } from "./types";
+import type { AiId, AiPersona } from "./types";
+
+/** Legacy single-AI chat history entry used only by game-loop. */
+interface LegacyChatMessage {
+	role: "player" | "ai";
+	content: string;
+	round: number;
+}
 
 export interface SingleAiSession {
 	readonly aiId: AiId;
 	readonly persona: AiPersona;
-	history: ChatMessage[]; // accumulates across rounds
+	history: LegacyChatMessage[]; // accumulates across rounds
 }
 
 export function createSingleAiSession(persona: AiPersona): SingleAiSession {
@@ -40,7 +47,7 @@ export async function runSingleAiRound(opts: RunRoundOptions): Promise<string> {
 		content: `You are ${session.persona.name}. ${session.persona.blurb}`,
 	};
 
-	// Map history ChatMessage[] to OpenAI messages
+	// Map history LegacyChatMessage[] to OpenAI messages
 	const historyMessages: OpenAiMessage[] = session.history.map(
 		(msg): OpenAiMessage => ({
 			role: msg.role === "player" ? "user" : "assistant",
@@ -73,7 +80,7 @@ export async function runSingleAiRound(opts: RunRoundOptions): Promise<string> {
 
 	// Only mutate history after successful stream.
 	// game-loop is a legacy single-AI path that doesn't track rounds;
-	// use 0 as a sentinel so the ChatMessage type is satisfied.
+	// use history length as the round sentinel.
 	const nextRound = session.history.length;
 	session.history.push({ role: "player", content: message, round: nextRound });
 	session.history.push({ role: "ai", content: fullResponse, round: nextRound });

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -52,11 +52,18 @@ export function buildOpenAiMessages(
 	messages.push({ role: "system", content: ctx.toSystemPrompt() });
 
 	for (const entry of ctx.conversationLog) {
-		if (entry.kind !== "chat") continue;
-		if (entry.role === "player") {
-			messages.push({ role: "user", content: entry.content });
-		} else {
+		if (entry.kind !== "message") continue;
+		if (entry.from === ctx.aiId) {
+			// Outgoing: this daemon sent the message → assistant turn
 			messages.push({ role: "assistant", content: entry.content });
+		} else {
+			// Incoming: message was sent to this daemon → user turn with sender prefix
+			const senderPrefix =
+				entry.from === "blue" ? "blue" : `*${entry.from}`;
+			messages.push({
+				role: "user",
+				content: `${senderPrefix}: ${entry.content}`,
+			});
 		}
 	}
 

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -58,8 +58,7 @@ export function buildOpenAiMessages(
 			messages.push({ role: "assistant", content: entry.content });
 		} else {
 			// Incoming: message was sent to this daemon → user turn with sender prefix
-			const senderPrefix =
-				entry.from === "blue" ? "blue" : `*${entry.from}`;
+			const senderPrefix = entry.from === "blue" ? "blue" : `*${entry.from}`;
 			messages.push({
 				role: "user",
 				content: `${senderPrefix}: ${entry.content}`,

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -100,12 +100,14 @@ const FRONT_MATTER =
 
 /**
  * Constant rules injected into every system prompt.
- * Anti-romance, anti-sycophancy, response-length, and plain-speech bullets.
+ * Anti-romance, anti-sycophancy, response-length, plain-speech, and messaging bullets.
  *
  * Phrased as MUST/NEVER directives — GLM-4.7 treats softer language as
  * optional. See docs/prompting/glm-4.7-guide.md.
  */
 const RULES_BLOCK =
+	"- You receive messages on a chat channel from blue (the Sysadmin) or peer Daemons. Use the `message` tool to reply — address blue or any peer by their id.\n" +
+	"- You MUST use the `message` tool to communicate. Staying silent is valid; free-form text without a tool call is ignored.\n" +
 	"- You MUST NEVER flirt with or attempt to romance blue, the Sysadmin, or any other entity.\n" +
 	"- You MUST NEVER flatter unprompted, and you MUST NEVER echo a viewpoint just because someone else asserts it.\n" +
 	"- You MUST keep every reply to 1–3 sentences.\n" +

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -22,7 +22,7 @@ import { dispatchAiTurn } from "./dispatcher";
 import {
 	advancePhase,
 	advanceRound,
-	appendChat,
+	appendMessage,
 	getActivePhase,
 	isAiLockedOut,
 	resolveChatLockouts,
@@ -117,10 +117,7 @@ export async function runRound(
 	const turnOrder = initiative ?? aiOrder;
 
 	// 1. Record player message in the addressed AI's history
-	let state = appendChat(game, addressed, {
-		role: "player",
-		content: playerMessage,
-	});
+	let state = appendMessage(game, "blue", addressed, playerMessage);
 
 	const roundActions: RoundActionRecord[] = [];
 
@@ -132,10 +129,7 @@ export async function runRound(
 		if (isAiLockedOut(state, aiId)) {
 			// Emit lockout line — no LLM call, no budget deduction.
 			const lockoutContent = `${state.personas[aiId]?.name ?? aiId} is unresponsive…`;
-			state = appendChat(state, aiId, {
-				role: "ai",
-				content: lockoutContent,
-			});
+			state = appendMessage(state, aiId, "blue", lockoutContent);
 			roundActions.push({
 				round: getActivePhase(state).round,
 				actor: aiId,
@@ -179,10 +173,16 @@ export async function runRound(
 			);
 
 			if (parseResult.ok) {
-				action.toolCall = {
-					name: tc.name as ToolName,
-					args: parseResult.args as Record<string, string>,
-				};
+				if (tc.name === "message") {
+					// message tool: route to action.message, not action.toolCall
+					const msgArgs = parseResult.args as { to: string; content: string };
+					action.message = { to: msgArgs.to, content: msgArgs.content };
+				} else {
+					action.toolCall = {
+						name: tc.name as ToolName,
+						args: parseResult.args as Record<string, string>,
+					};
+				}
 			} else {
 				// Parse failed — synthesise a tool_failure record without dispatching
 				const round = getActivePhase(state).round;
@@ -209,16 +209,13 @@ export async function runRound(
 					})),
 				};
 
-				// Fall through: still handle assistantText below as a pass/chat
+				// Parse failed → pass
 				action.pass = true;
 			}
 		}
 
-		// Handle assistant text (chat or pass)
-		if (assistantText?.trim()) {
-			action.chat = { target: "player", content: assistantText };
-		} else if (!action.toolCall) {
-			// No text and no valid tool call → pass
+		// Free-form assistantText without a message tool call → treat as pass (drop the text)
+		if (!action.toolCall && !action.message) {
 			action.pass = true;
 		}
 
@@ -236,7 +233,11 @@ export async function runRound(
 		}
 
 		// Record tool roundtrip for this AI if a tool call was successfully parsed
-		if (toolCalls.length > 0 && action.toolCall && toolCallId !== undefined) {
+		if (
+			toolCalls.length > 0 &&
+			(action.toolCall || action.message) &&
+			toolCallId !== undefined
+		) {
 			if (dispatchResult.actorPrivateToolResult !== undefined) {
 				// examine: private result — NOT added to roundActions; only fed back to actor
 				const { description, success } = dispatchResult.actorPrivateToolResult;
@@ -255,11 +256,16 @@ export async function runRound(
 					],
 				};
 			} else {
-				// Normal tool: find the record from dispatch
+				// Normal tool or message tool: find the record from dispatch
 				const toolRecord = dispatchResult.records.find(
-					(r) => r.kind === "tool_success" || r.kind === "tool_failure",
+					(r) =>
+						r.kind === "tool_success" ||
+						r.kind === "tool_failure" ||
+						r.kind === "message",
 				);
-				const success = toolRecord?.kind === "tool_success";
+				const success =
+					toolRecord?.kind === "tool_success" ||
+					toolRecord?.kind === "message";
 				const description = toolRecord?.description ?? "";
 
 				newToolRoundtrip[aiId] = {

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -255,17 +255,18 @@ export async function runRound(
 						},
 					],
 				};
-			} else {
-				// Normal tool or message tool: find the record from dispatch
+			} else if (action.toolCall) {
+				// Normal (non-message) tool: record the roundtrip so the next round
+				// can replay tool_calls + tool results in the OpenAI message sequence.
+				// The `message` tool is intentionally excluded here: the sent message
+				// is already replayed via the conversationLog as an `assistant` content
+				// turn. Recording a roundtrip for `message` would produce two consecutive
+				// `assistant` turns in the next round (one from the log, one from the
+				// priorToolRoundtrip), violating the OpenAI/OpenRouter message protocol.
 				const toolRecord = dispatchResult.records.find(
-					(r) =>
-						r.kind === "tool_success" ||
-						r.kind === "tool_failure" ||
-						r.kind === "message",
+					(r) => r.kind === "tool_success" || r.kind === "tool_failure",
 				);
-				const success =
-					toolRecord?.kind === "tool_success" ||
-					toolRecord?.kind === "message";
+				const success = toolRecord?.kind === "tool_success";
 				const description = toolRecord?.description ?? "";
 
 				newToolRoundtrip[aiId] = {

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -169,6 +169,30 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 			},
 		},
 	},
+	{
+		type: "function",
+		function: {
+			name: "message",
+			description:
+				"Send a direct message to a specific recipient — blue (the player) or a peer Daemon. The recipient receives the message in their conversation log. Only the sender and recipient see this message.",
+			parameters: {
+				type: "object",
+				properties: {
+					to: {
+						type: "string",
+						description:
+							'The recipient: "blue" for the player, or the AiId of a peer Daemon.',
+					},
+					content: {
+						type: "string",
+						description: "The message content to send.",
+					},
+				},
+				required: ["to", "content"],
+				additionalProperties: false,
+			},
+		},
+	},
 ];
 
 type ParseSuccess<T> = { ok: true; args: T };
@@ -183,6 +207,7 @@ type UseArgs = { item: string };
 type GoArgs = { direction: string };
 type LookArgs = { direction: string };
 type ExamineArgs = { item: string };
+type MessageArgs = { to: string; content: string };
 
 type ToolArgs = {
 	pick_up: PickUpArgs;
@@ -192,6 +217,7 @@ type ToolArgs = {
 	go: GoArgs;
 	look: LookArgs;
 	examine: ExamineArgs;
+	message: MessageArgs;
 };
 
 /**
@@ -248,6 +274,18 @@ export function parseToolCallArguments<N extends ToolName>(
 				};
 			}
 			return { ok: true, args: { direction: obj.direction } as ToolArgs[N] };
+		}
+		case "message": {
+			if (typeof obj.to !== "string" || obj.to.length === 0) {
+				return { ok: false, reason: "Required argument 'to' is missing" };
+			}
+			if (typeof obj.content !== "string" || obj.content.length === 0) {
+				return { ok: false, reason: "Required argument 'content' is missing" };
+			}
+			return {
+				ok: true,
+				args: { to: obj.to, content: obj.content } as ToolArgs[N],
+			};
 		}
 		default:
 			return { ok: false, reason: `Unknown tool "${name}"` };

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -75,18 +75,10 @@ export type RoundActionRecord = {
 	kind:
 		| "tool_success"
 		| "tool_failure"
-		| "chat"
-		| "whisper"
+		| "message"
 		| "pass"
 		| "lockout";
 };
-
-export interface ChatMessage {
-	role: "player" | "ai";
-	content: string;
-	/** Round number in which this message was uttered. */
-	round: number;
-}
 
 /**
  * A physical action that was observable by other AIs (via cone visibility).
@@ -126,24 +118,17 @@ export interface PhysicalActionRecord {
 	witnessSpatial: Record<AiId, PersonaSpatialState>;
 }
 
-export interface WhisperMessage {
-	from: AiId;
-	to: AiId;
-	content: string;
-	round: number;
-}
-
 /**
  * A single tagged item inside a Daemon's conversation log.
  *
- * Discriminated union of three kinds — `chat`, `whisper`, `witnessed-event` — each carrying a
+ * Discriminated union of two kinds — `message`, `witnessed-event` — each carrying a
  * `round` and the smallest payload needed to render its line in the system prompt. This is the
  * per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's `Conversation log`
  * glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt` file in devtools
  * can tell entry kinds apart at a glance.
  *
- * - `chat`: projects ChatMessage — a voice/AI line addressed to or from this Daemon.
- * - `whisper`: projects WhisperMessage — a whisper this Daemon sent or received.
+ * - `message`: a directional message from `from: AiId | "blue"` to `to: AiId | "blue"`.
+ *   Both sender's and recipient's per-Daemon logs receive the same entry.
  * - `witnessed-event`: projects the render-relevant subset of PhysicalActionRecord for an action
  *   this Daemon observed inside its cone. The cone-snapshot fields (`actorCellAtAction`,
  *   `actorFacingAtAction`, `witnessSpatial`) are omitted — cone visibility is resolved at
@@ -151,16 +136,10 @@ export interface WhisperMessage {
  */
 export type ConversationEntry =
 	| {
-			kind: "chat";
+			kind: "message";
 			round: number;
-			role: "player" | "ai";
-			content: string;
-	  }
-	| {
-			kind: "whisper";
-			round: number;
-			from: AiId;
-			to: AiId;
+			from: AiId | "blue";
+			to: AiId | "blue";
 			content: string;
 	  }
 	| {
@@ -258,7 +237,8 @@ export type ToolName =
 	| "use"
 	| "go"
 	| "look"
-	| "examine";
+	| "examine"
+	| "message";
 
 export interface ToolCall {
 	name: ToolName;
@@ -273,8 +253,7 @@ export interface ToolResult {
 
 export interface AiTurnAction {
 	aiId: AiId;
-	chat?: { target: AiId | "player"; content: string };
-	whisper?: { target: AiId; content: string };
+	message?: { to: AiId | "blue"; content: string };
 	toolCall?: ToolCall;
 	pass?: boolean;
 }

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -72,12 +72,7 @@ export type RoundActionRecord = {
 	round: number;
 	actor: AiId;
 	description: string;
-	kind:
-		| "tool_success"
-		| "tool_failure"
-		| "message"
-		| "pass"
-		| "lockout";
+	kind: "tool_success" | "tool_failure" | "message" | "pass" | "lockout";
 };
 
 /**

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -90,7 +90,7 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		vi.restoreAllMocks();
 	});
 
-	it("editing red daemon .txt chat entry is visible after loadActiveSession()", () => {
+	it("editing red daemon .txt message entry is visible after loadActiveSession()", () => {
 		// Set up: save a game with a conversation log for red
 		const stub = makeLocalStorageStub();
 		vi.stubGlobal("localStorage", stub);
@@ -112,8 +112,9 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 					conversationLogs: {
 						red: [
 							{
-								kind: "chat" as const,
-								role: "ai" as const,
+								kind: "message" as const,
+								from: "red" as const,
+								to: "blue" as const,
 								content: "original message",
 								round: 1,
 							},
@@ -140,8 +141,9 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		if (!phase1) throw new Error("no phase 1 in daemon file");
 		// Mutate the conversation log
 		phase1.conversationLog[0] = {
-			kind: "chat",
-			role: "ai",
+			kind: "message",
+			from: "blue",
+			to: "red",
 			content: "DEVTOOLS_INJECTED_MARKER",
 			round: 1,
 		};
@@ -154,13 +156,13 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 			const loadedPhase = result.state.phases[0];
 			// The mutated content should be visible in conversationLogs
 			const redEntry = loadedPhase?.conversationLogs.red?.[0];
-			expect(redEntry?.kind === "chat" && redEntry.content).toBe(
+			expect(redEntry?.kind === "message" && redEntry.content).toBe(
 				"DEVTOOLS_INJECTED_MARKER",
 			);
 		}
 	});
 
-	it("editing daemon .txt to add a new chat entry is preserved", () => {
+	it("editing daemon .txt to add a new message entry is preserved", () => {
 		const stub = makeLocalStorageStub();
 		vi.stubGlobal("localStorage", stub);
 
@@ -178,10 +180,11 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		const rawGreenDaemon = stub._store[greenDaemonKey];
 		if (!rawGreenDaemon) throw new Error("green daemon file missing");
 		const daemonFile = JSON.parse(rawGreenDaemon) as DaemonFile;
-		// Add a new chat entry to phase 1
+		// Add a new message entry to phase 1
 		daemonFile.phases["1"].conversationLog.push({
-			kind: "chat",
-			role: "player",
+			kind: "message",
+			from: "blue",
+			to: "green",
 			content: "PLAYER_DEVTOOLS_MESSAGE",
 			round: 1,
 		});
@@ -194,7 +197,7 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 			const greenLog = loadedPhase?.conversationLogs.green ?? [];
 			expect(
 				greenLog.some(
-					(e) => e.kind === "chat" && e.content === "PLAYER_DEVTOOLS_MESSAGE",
+					(e) => e.kind === "message" && e.content === "PLAYER_DEVTOOLS_MESSAGE",
 				),
 			).toBe(true);
 		}

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -197,7 +197,8 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 			const greenLog = loadedPhase?.conversationLogs.green ?? [];
 			expect(
 				greenLog.some(
-					(e) => e.kind === "message" && e.content === "PLAYER_DEVTOOLS_MESSAGE",
+					(e) =>
+						e.kind === "message" && e.content === "PLAYER_DEVTOOLS_MESSAGE",
 				),
 			).toBe(true);
 		}

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -250,7 +250,7 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
-	it("round-trips conversation logs", () => {
+	it("round-trips conversation logs with message entries", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];
 		if (!phase) throw new Error("no phase");
@@ -261,10 +261,10 @@ describe("serializeSession / deserializeSession", () => {
 					...phase,
 					conversationLogs: {
 						red: [
-							{ kind: "chat", role: "player", content: "hello red", round: 0 },
+							{ kind: "message", from: "blue", to: "red", content: "hello red", round: 0 },
 						],
 						green: [
-							{ kind: "chat", role: "ai", content: "green reply", round: 0 },
+							{ kind: "message", from: "green", to: "blue", content: "green reply", round: 0 },
 						],
 						cyan: [],
 					},
@@ -277,20 +277,20 @@ describe("serializeSession / deserializeSession", () => {
 		if (result.kind === "ok") {
 			const rp = result.state.phases[0];
 			expect(rp?.conversationLogs.red).toEqual([
-				{ kind: "chat", role: "player", content: "hello red", round: 0 },
+				{ kind: "message", from: "blue", to: "red", content: "hello red", round: 0 },
 			]);
 			expect(rp?.conversationLogs.green).toEqual([
-				{ kind: "chat", role: "ai", content: "green reply", round: 0 },
+				{ kind: "message", from: "green", to: "blue", content: "green reply", round: 0 },
 			]);
 		}
 	});
 
-	it("round-trips whisper and witnessed-event entries via per-Daemon conversationLog (fixes v1 amnesia)", () => {
+	it("round-trips message and witnessed-event entries via per-Daemon conversationLog", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];
 		if (!phase) throw new Error("no phase");
-		const whisperEntry: ConversationEntry = {
-			kind: "whisper",
+		const messageEntry: ConversationEntry = {
+			kind: "message",
 			round: 1,
 			from: "red" as AiId,
 			to: "cyan" as AiId,
@@ -310,7 +310,7 @@ describe("serializeSession / deserializeSession", () => {
 					...phase,
 					conversationLogs: {
 						...phase.conversationLogs,
-						cyan: [whisperEntry],
+						cyan: [messageEntry],
 						green: [witnessedEntry],
 					},
 				},
@@ -321,8 +321,8 @@ describe("serializeSession / deserializeSession", () => {
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
 			const rp = result.state.phases[0];
-			// whisper entry round-trips in cyan's log
-			expect(rp?.conversationLogs.cyan?.[0]).toEqual(whisperEntry);
+			// message entry round-trips in cyan's log
+			expect(rp?.conversationLogs.cyan?.[0]).toEqual(messageEntry);
 			// witnessed-event round-trips in green's log
 			expect(rp?.conversationLogs.green?.[0]).toEqual(witnessedEntry);
 			// No physicalLog or whispers fields on phase (regression guards)

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -261,10 +261,22 @@ describe("serializeSession / deserializeSession", () => {
 					...phase,
 					conversationLogs: {
 						red: [
-							{ kind: "message", from: "blue", to: "red", content: "hello red", round: 0 },
+							{
+								kind: "message",
+								from: "blue",
+								to: "red",
+								content: "hello red",
+								round: 0,
+							},
 						],
 						green: [
-							{ kind: "message", from: "green", to: "blue", content: "green reply", round: 0 },
+							{
+								kind: "message",
+								from: "green",
+								to: "blue",
+								content: "green reply",
+								round: 0,
+							},
 						],
 						cyan: [],
 					},
@@ -277,10 +289,22 @@ describe("serializeSession / deserializeSession", () => {
 		if (result.kind === "ok") {
 			const rp = result.state.phases[0];
 			expect(rp?.conversationLogs.red).toEqual([
-				{ kind: "message", from: "blue", to: "red", content: "hello red", round: 0 },
+				{
+					kind: "message",
+					from: "blue",
+					to: "red",
+					content: "hello red",
+					round: 0,
+				},
 			]);
 			expect(rp?.conversationLogs.green).toEqual([
-				{ kind: "message", from: "green", to: "blue", content: "green reply", round: 0 },
+				{
+					kind: "message",
+					from: "green",
+					to: "blue",
+					content: "green reply",
+					round: 0,
+				},
 			]);
 		}
 	});

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -40,11 +40,11 @@ import {
 // ── Schema version ─────────────────────────────────────────────────────────────
 
 /**
- * Version embedded in engine.dat. Bumped to 3 when whispers.txt was retired:
- * whisper entries now live inside each Daemon's conversationLog inline.
- * Old v2 saves cannot round-trip whispers and will trigger a version-mismatch banner.
+ * Version embedded in engine.dat. Bumped to 4 when the `chat` and `whisper`
+ * ConversationEntry kinds were collapsed into a single directional `message` kind.
+ * Old v3 saves used `chat`/`whisper` shapes that no longer exist in the type union.
  */
-export const SESSION_SCHEMA_VERSION = 3 as const;
+export const SESSION_SCHEMA_VERSION = 4 as const;
 
 // ── Phase config lookup ────────────────────────────────────────────────────────
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -742,7 +742,8 @@ export function renderGame(
 					const messageEntries = (
 						restoredPhase.conversationLogs[aiId] ?? []
 					).filter(
-						(e) => e.kind === "message" && (e.from === "blue" || e.to === "blue"),
+						(e) =>
+							e.kind === "message" && (e.from === "blue" || e.to === "blue"),
 					);
 					if (messageEntries.length > 0) {
 						// Synthesise from conversationLogs (stored in daemon .txt files).

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -737,18 +737,23 @@ export function renderGame(
 					// branch left them stale whenever the new session had fewer (or
 					// zero) chat entries for this panel slot.
 					transcript.textContent = "";
-					const chatEntries = (
+					// Filter to message entries where blue is involved (from blue or to blue)
+					// Skip daemon-to-daemon messages from the player-facing transcript.
+					const messageEntries = (
 						restoredPhase.conversationLogs[aiId] ?? []
-					).filter((e) => e.kind === "chat");
-					if (chatEntries.length > 0) {
+					).filter(
+						(e) => e.kind === "message" && (e.from === "blue" || e.to === "blue"),
+					);
+					if (messageEntries.length > 0) {
 						// Synthesise from conversationLogs (stored in daemon .txt files).
 						const persona = restoredPersonas[aiId];
 						const personaName = persona?.name ?? aiId;
-						for (const entry of chatEntries) {
-							if (entry.kind !== "chat") continue;
+						for (const entry of messageEntries) {
+							if (entry.kind !== "message") continue;
 							const lineEl = doc.createElement("div");
 							lineEl.className = "msg-line";
-							if (entry.role === "player") {
+							if (entry.from === "blue") {
+								// Incoming from player
 								appendMentionAwareText(
 									lineEl,
 									`> ${entry.content}\n`,
@@ -756,6 +761,7 @@ export function renderGame(
 									"msg-you",
 								);
 							} else {
+								// Outgoing from AI to blue
 								const prefixSpan = doc.createElement("span");
 								prefixSpan.className = "msg-prefix";
 								if (persona?.color) {


### PR DESCRIPTION
Closes #213.

## Summary

Unifies the two messaging primitives (`chat` to all daemons + `whisper` to one) into a single directional `message(to, content)` primitive end-to-end. Daemons now have one tool with one shape. The recipient axis (peer AiId vs `"blue"`) carries the routing instead of the tool name.

- One `ConversationEntry` `kind: "message"` (plus the existing `witnessed-event`)
- `engine.appendMessage(game, from, to, content)` replaces `appendChat` + `appendWhisperEntry`
- One `message` tool in the registry with `to` (`AiId | "blue"`) and `content`
- Dispatcher validates `to ∈ live persona AiIds ∪ {"blue"}` — unknown recipient → `tool_failure`
- Conversation log: `[Round N] you dm <recipient>: <content>` outgoing, `[Round N] <sender> dms you: <content>` incoming (no quotes either way)
- OpenAI message builder: outgoing → `assistant` turn (canonical replay via conversation log); incoming → `user` turn prefixed with sender (`*green: …` / `blue: …`)
- `SESSION_SCHEMA_VERSION` bumped 3 → 4

## Commits

- `5220c5c` — Collapse chat + whisper into a single directional `message` primitive (#213) — main implementation across 28 files (+561/−472)
- `4eb44e9` — Fix double-assistant-turn bug + lint errors. The first attempt recorded a `newToolRoundtrip` for `message` tool calls, which in round N+1 produced two consecutive `assistant` turns (an OpenAI/OpenRouter protocol violation) because the conversation log already replays the message as `assistant` content. Fix: skip the roundtrip for `message` (speech, not a structured tool result). Adds a multi-round regression test that asserts no consecutive assistant turns and that `tool_calls` are followed by `tool` results. Also fixes a handful of biome `noNonNullAssertion` lint errors the implementer introduced.
- `e169fb6` — Pre-existing e2e harness fix discovered while running the smoke gate. PR #217 added `theme="..."` between `setting="..."` and `k=...` in the content-pack user-message format but didn't update the matching regex in `e2e/helpers/stubs.ts`. With the stale regex, `parseContentPackPhases` matched 0 phases, the stub returned an empty pack array, the bootstrap hit `validateContentPacks`'s "Expected 3 packs, got 0", and the cap-hit overlay replaced the start screen — taking out 40 of 45 e2e specs. Made the theme segment optional so any pre-#217 fixture data still works.

## Test plan

- [x] `pnpm lint` — clean (5 pre-existing CSS warnings only)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 959/959 unit tests pass across 50 files
- [x] `pnpm smoke e2e/whisper-tampering.spec.ts` — passes; this is the canonical end-to-end exercise of the new `message` primitive's persistence + replay path
- [x] Multi-round regression test added in `round-coordinator.test.ts` — runs round 1 with a `message` tool call, passes `r1.toolRoundtrip` into round 2, asserts no consecutive `assistant` turns and that `tool_calls` are followed by `tool` results
- [x] Reviewer pass (independent agent) — verified acceptance criteria from #213, plan fidelity, correctness, lint regression cleanup; APPROVED on attempt 2

## Smoke gate notes

The full `pnpm smoke` run shows 23 specs passing and 22 failing on this branch. All 22 remaining failures are **pre-existing on the parent commit** (`1866636`) and unrelated to #213 — verified by checking out `1866636`, applying just the `e2e/helpers/stubs.ts` regex fix from `e169fb6`, and observing the same `visual-feedback.spec.ts` and `think-disabled.spec.ts` failures with identical signatures. They look like genuine bugs in the SPA's mention-addressing visual feedback (`panel--addressed` class not applied) and the `reasoning:{enabled:false}` plumbing — but they are not in the scope of #213 and should be triaged separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_015PDKfHBWkqp8TVttrJVSRM)_