### PR TITLE
fix(game-route): build persona maps in bootstrap-recursive path too (#224 cluster A)

### DIFF
--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -800,32 +800,33 @@ export function renderGame(
 				return Promise.resolve();
 			}
 		}
+	}
 
-		// Synchronous post-init: runs for the restore path (session is set).
-		if (session !== null) {
-			// Apply SPA-side test affordances from location.search (e.g. ?winImmediately=1
-			// or ?lockout=1). These are gated inside applyTestAffordances to only fire
-			// when __WORKER_BASE_URL__ === "http://localhost:8787" (local dev).
-			// Note: we use location.search (not the hash params) because these flags are
-			// intended to be set on the page URL itself, matching the legacy worker pattern.
-			session = applyTestAffordances(session, effectiveParams);
+	// Synchronous post-init: runs for both the restore path AND the bootstrap-
+	// recursive path (which already set session = built before re-entering).
+	if (session !== null) {
+		// Apply SPA-side test affordances from location.search (e.g. ?winImmediately=1
+		// or ?lockout=1). These are gated inside applyTestAffordances to only fire
+		// when __WORKER_BASE_URL__ === "http://localhost:8787" (local dev).
+		// Note: we use location.search (not the hash params) because these flags are
+		// intended to be set on the page URL itself, matching the legacy worker pattern.
+		session = applyTestAffordances(session, effectiveParams);
 
-			// Build persona maps from runtime state (after affordances may have replaced session)
-			const runtimePersonas = session.getState().personas;
-			personaNamesToId = buildPersonaNameMap(runtimePersonas);
-			personaColors = buildPersonaColorMap(runtimePersonas);
-			personaDisplayNames = buildPersonaDisplayNameMap(runtimePersonas);
+		// Build persona maps from runtime state (after affordances may have replaced session)
+		const runtimePersonas = session.getState().personas;
+		personaNamesToId = buildPersonaNameMap(runtimePersonas);
+		personaColors = buildPersonaColorMap(runtimePersonas);
+		personaDisplayNames = buildPersonaDisplayNameMap(runtimePersonas);
 
-			// Hydrate lockouts from the active phase's chatLockouts map so that
-			// a reload preserves the Send-disabled state for locked-out AIs.
-			const activePhaseForLockouts = getActivePhase(session.getState());
-			for (const aiId of Object.keys(runtimePersonas)) {
-				lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
-			}
-
-			// Reset module-level gameEnded flag on fresh session init
-			gameEnded = false;
+		// Hydrate lockouts from the active phase's chatLockouts map so that
+		// a reload preserves the Send-disabled state for locked-out AIs.
+		const activePhaseForLockouts = getActivePhase(session.getState());
+		for (const aiId of Object.keys(runtimePersonas)) {
+			lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
 		}
+
+		// Reset module-level gameEnded flag on fresh session init
+		gameEnded = false;
 	}
 
 	// Route-entry visibility: game route shows panels/composer and hides start-screen


### PR DESCRIPTION
The post-init block that builds `personaNamesToId` / `personaColors` /
`personaDisplayNames` was nested inside `if (!session) { ... }`, so it only
ran on the localStorage-restore path. The bootstrap-loading flow re-enters
`renderGame` with `session` already set (line 669), causing the entire
`if (!session)` block to be skipped and the maps to stay undefined.

Once the maps are undefined, `refreshComposerState` early-returns on every
input event — so `panel--addressed`, mention-overlay highlight, the
border-color update, prompt-target indicator, and Send-button enable all
silently no-op for any new game.

Dedent the block by one level so it runs on both paths.

Resolves clusters A + B and most singletons in #224 (15 of 22 specs):
visual-feedback (3), mention-addressing (1), addressed-and-parallel (1),
think-disabled (2), responsive-bento (4 of 5), chat-lockout, endgame,
persona-synthesis, token-pacing, whisper-tampering, witnessed-event-reload.

Remaining 7 failures are independent and unrelated to map-building; see
issue thread for the per-cluster sub-issues.

https://claude.ai/code/session_01CroSXp7w63Z74tUxu547au