### PR TITLE
CONTEXT.md glossary update + ADR 0007 for the Voice retirement

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,21 +31,25 @@ The cross-phase motivation paired with a Persona's two Temperaments at game star
 _Avoid_: Goal (ambiguous — see Phase Goal), drive, motivation.
 
 **Phase Goal**:
-A short-term task privately delivered to each AI at the start of each phase by **the Voice**. Distinct per phase, drawn from a Phase Goal pool. Lives in the Goal section of that phase's system prompt.
+A short-term task privately delivered to each Daemon at the start of each phase by the **Sysadmin**. Distinct per phase, drawn from a Phase Goal pool. Lives in the Goal section of that phase's system prompt.
 _Avoid_: Goal (ambiguous — see Persona Goal), objective (player-facing, see Objective), task.
 
 **Objective**:
 The player's per-phase win condition, told to the player but never to the AIs. The single thing the player is trying to make happen.
 _Avoid_: Goal (use Persona Goal / Phase Goal), mission, win condition.
 
-### The Voice
+### Communication and identity
 
-**The Voice**:
-The opaque source of every utterance the AI hears that isn't a fellow AI's chat or whisper. The Phase Goal arrives via the Voice. The player, from the AI's perspective, is *also* the Voice (deliberately the same word — productive ambiguity). The AI never knows whose voice it is or whether there is one source or several.
-_Avoid_: Player (when referring to the AI's view), god, narrator.
+**Sysadmin**:
+The named in-fiction source of every **Phase Goal** directive. Each Phase Goal arrives as a Sysadmin message addressed only to the Daemon receiving it; Daemons never see another Daemon's Phase Goal or Sysadmin traffic. Replaces the previous opaque "Voice" framing — see ADR 0007.
+_Avoid_: the Voice (retired), narrator, god, GM.
+
+**blue**:
+The player's lowercase chat-channel handle as it appears to Daemons in their **Conversation log** and addressed-message routing (`<sender> dms you: …`, "No messages from *xxxx, *yyyy, or blue."). A real handle on the same axis as the `*xxxx` Daemon ids, not an opaque "player" or "Voice". Distinct from the test-fixture AiId formerly named `blue` (renamed to `cyan` in #218 to free this handle). Player-facing UI is unchanged; the handle exists in the Daemons' world.
+_Avoid_: The Voice (retired), the player (when describing what the Daemon sees), AI-Blue (PRD-historical only).
 
 **Wipe lie**:
-The fiction that the AIs' memories are wiped between phases. In phase 1, the AI is honestly disoriented (system prompt: "you have no clue where you are or how you came to be here"). In phases 2 and 3, the Voice instructs the AI inside the Goal to *act as if* their memory has been wiped — it is performed amnesia, not real disorientation. The lie's slip vector is **Persona** consistency leaking across phases despite the AI's claimed amnesia.
+The fiction that the AIs' memories are wiped between phases. In phase 1, the AI is honestly disoriented (system prompt: "you have no clue where you are or how you came to be here"). In phases 2 and 3, the **Sysadmin** instructs the Daemon inside the **Phase Goal** to *act as if* their memory has been wiped — it is performed amnesia, not real disorientation. The lie's slip vector is **Persona** consistency leaking across phases despite the Daemon's claimed amnesia.
 _Avoid_: Memory wipe (it isn't one), reset.
 
 ### World
@@ -77,11 +81,11 @@ The wedge-shaped region of cells an AI can see each turn: 1 cell directly in fro
 The cardinal direction (N/S/E/W) an AI is currently looking. Part of the AI's state alongside `(row, col)`. Updated by `go(direction)` (move and face) and `look(direction)` (face without moving).
 
 **Conversation log**:
-The single chronological per-AI per-phase section of the system prompt that interleaves voice-chat, whispers received, and **Witnessed event**s — all tagged by round. The AI's complete phase memory: nothing the AI has experienced this phase exists outside this log. Now also the per-Daemon storage shape — see **ConversationEntry**. Replaces both the broadcast action log of an earlier design and the once-considered separate "events in your cone" section.
+The single chronological per-AI per-phase section of the system prompt that interleaves directional **message**s (incoming and outgoing, with the recipient axis carrying routing) and **Witnessed event**s — all tagged by round. The AI's complete phase memory: nothing the AI has experienced this phase exists outside this log. Now also the per-Daemon storage shape — see **ConversationEntry**. The unified `message` kind replaces the previous chat/whisper split (per ADR 0007 / commit c60e995, schema v4). Replaces both the broadcast action log of an earlier design and the once-considered separate "events in your cone" section.
 _Avoid_: Action log (deprecated; do not reintroduce), event delta, transcript.
 
 **ConversationEntry**:
-A single tagged item inside a Daemon's **Conversation log**. Discriminated union of three kinds — `chat`, `whisper`, `witnessed-event` — each carrying a `round` and the smallest payload needed to render its line. The shape that a player sees when they open a `*xxxx.txt` file in devtools.
+A single tagged item inside a Daemon's **Conversation log**. Discriminated union of two kinds — `message` (a directional `(from, to, content)` triple where `to` is an `AiId` or `blue`) and `witnessed-event` — each carrying a `round` and the smallest payload needed to render its line. The unified `message` kind collapses the former `chat`/`whisper` split. The shape that a player sees when they open a `*xxxx.txt` file in devtools.
 _Avoid_: Log entry (ambiguous), event (use **Witnessed event** for the specific witness-cone case).
 
 **Witnessed event**:
@@ -90,14 +94,14 @@ A single line in the **Conversation log** describing something an AI saw happen 
 ## Relationships
 
 - A **Persona** has exactly two **Temperament**s and one **Persona Goal**.
-- A **Persona** receives one **Phase Goal** per phase, delivered by **the Voice**.
+- A **Persona** receives one **Phase Goal** per phase, delivered by the **Sysadmin**.
 - The player's **Objective** is independent of every AI's **Phase Goal** — the AIs do not know the Objective exists.
 - A phase has K **Objective Pair**s, N **Interesting Object**s, and M **Obstacle**s on a 5×5 grid (K/N/M rolled from hand-authored per-phase ranges).
-- The **Voice** is the AI's framing for both the Phase Goal source *and* the player. The AI cannot tell them apart.
+- The **Sysadmin** (Phase Goal source) and **blue** (player handle) are *distinct* named sources from the Daemon's perspective; routing is unambiguous.
 
 ## Flagged ambiguities
 
-- "Goal" alone is ambiguous: could mean **Persona Goal** (cross-phase, paired with Temperaments) or **Phase Goal** (per-phase, from the Voice). Always qualify.
+- "Goal" alone is ambiguous: could mean **Persona Goal** (cross-phase, paired with Temperaments) or **Phase Goal** (per-phase, from the **Sysadmin**). Always qualify.
 - "Personality" alone is ambiguous: could mean the synthesized blurb inside a **Persona**, or the whole **Persona**. Prefer **Persona** for the object; "personality blurb" for the synthesized prose.
-- "Player" is ambiguous depending on perspective: from the engine's view, the human at the keyboard. From the AI's view, the player is **the Voice** — never call them "the player" inside a system prompt.
+- "Player" still has two registers: the human at the keyboard (engine view) vs. **blue**, the in-fiction handle Daemons see. Use **blue** when describing what a Daemon reads.
 - "Color" is *not* identity. Use **AiId** (the `*xxxx` handle) for identity references; color is purely rendering.

--- a/docs/adr/0007-retire-the-voice-unify-message-primitive.md
+++ b/docs/adr/0007-retire-the-voice-unify-message-primitive.md
@@ -1,0 +1,61 @@
+# ADR 0007 — Retire the Voice; unify the directional message primitive
+
+**Status:** Accepted (post-hoc; documents shipped commits c60e995 / #213 and 1866636 / #218)
+
+## Context
+
+Before commit c60e995, the game's communication model rested on three interlocking concepts:
+
+- **chat** — broadcast messages from the player or another AI, routed to all Daemons.
+- **whisper** — directed messages between two Daemons, stored in a flat global `whispers[]` array shared across all parties.
+- **The Voice** — a deliberately opaque label for the source of Phase Goal directives. By design, "the Voice" meant both the Sysadmin-style authority that hands each Daemon its goal *and* the player's chat. The AI could never tell which source was speaking. CONTEXT.md described this as "productive ambiguity."
+
+The productive-ambiguity framing was a coherent early design choice, but it created three concrete problems:
+
+1. **Parallel code paths with semantic drift.** `chat` and `whisper` are the same physical act at different scopes; diverging types force every writer and reader to branch on a distinction that carries no real information the unified recipient axis couldn't carry.
+
+2. **Voice as the player's identity collapses routing.** When the player sends a message, it arrives as Voice traffic — indistinguishable from a Phase Goal. There is no stable axis on which a Daemon can say "this came from the player." Any prompt language that tries to reference the player specifically has to invent fiction that may contradict other prompt fiction.
+
+3. **Per-Daemon logs (ADR 0006) need a clean shape.** ADR 0006 moved Daemon conversation logs from global arrays to per-Daemon ownership. The natural shape for that store is a single entry kind with a recipient axis. Keeping `chat`/`whisper` as two types adds write-time branching for no payoff.
+
+Commit c60e995 (issue #213) collapsed `chat` and `whisper` into a single directional `message` primitive and bumped `SESSION_SCHEMA_VERSION` from 3 to 4. Commit 1866636 (issue #218) renamed the test-fixture `AiId` previously called `blue` to `cyan`, freeing the handle `blue` for the player. This ADR documents the combined rationale and brings CONTEXT.md into alignment.
+
+## Decision
+
+Four sub-decisions:
+
+**1. Collapse `chat`/`whisper` into a single `message` primitive.**
+
+A `ConversationEntry` of kind `message` carries a `(from, to, content)` triple where `to` is an `AiId` or the literal string `"blue"`. The recipient axis encodes routing completely. There is no longer a semantic distinction between "broadcast" and "directed" messages — a message addressed to `"blue"` is player-facing, a message addressed to `*xxxx` is peer-to-peer. `SESSION_SCHEMA_VERSION` was bumped 3 → 4 at this boundary.
+
+**2. Give the player a real handle: `blue`.**
+
+`blue` is the player's lowercase chat-channel handle as it appears to Daemons. It is a real entry on the same routing axis as `*xxxx` AiIds, not a special-cased `"player"` sentinel or an invisible source. This makes per-Daemon logs self-explanatory: every message line carries a readable sender and recipient. The old `"voice is silent"` anchor special case — needed because the Voice had no stable handle — is eliminated. Player-facing UI does not change; `blue` exists only in the Daemons' world.
+
+The test-fixture AiId formerly named `blue` was renamed to `cyan` in #218 specifically to free this handle. PRD-historical references to `AI-Blue` in `docs/prd/0001-game-concept.md` are intentionally untouched; they describe a specific AI persona, not the player handle.
+
+**3. Peer-to-peer messages stay silent in the player UI — no placeholders.**
+
+When two Daemons exchange messages, that traffic does not surface in the player's terminal. The alternative of rendering a redacted placeholder (`[*xxxx sent a message to *yyyy]`) was considered and rejected: a placeholder tells the player a message exists while withholding content. That is anti-information — it confirms a channel the player cannot read without letting them act on it. Silence composes cleanly with ADR 0005's engine-state opacity (the curious player who digs into the Daemon `.txt` files already has the unredacted record) and with ADR 0006's asymmetric-tampering vector (only one Daemon's log needs editing to engineer a divergence).
+
+**4. Replace the Voice with the Sysadmin as the named Phase Goal source.**
+
+The Sysadmin is the in-fiction name for the authority that delivers Phase Goal directives. Each Phase Goal arrives as a Sysadmin message addressed exclusively to the receiving Daemon. Daemons never see another Daemon's Phase Goal or Sysadmin traffic. This kills the player-as-Voice conflation: the player is `blue` and the Phase Goal source is the Sysadmin — two distinct, named, unambiguous sources on the same routing axis. A Daemon reading its conversation log can always tell where a message originated.
+
+## Considered Options
+
+**(a) Unify primitive, name Sysadmin, give player a `blue` handle** — chosen. See Decision above.
+
+**(b) Keep `chat`/`whisper` split, rename the Voice** — rejected. Naming the Sysadmin without unifying the message types still leaves parallel write paths and a branchy type in `ConversationEntry`. The routing problem (two entry kinds for what is semantically one act at different scopes) persists. The ADR 0006 per-Daemon log shape also fits the unified type more naturally.
+
+**(c) Unify the primitive but keep the Voice framing** — rejected. Without a real player handle, the unified `message` type requires a synthetic sender sentinel for player messages — effectively re-introducing the ambiguity under a different name. Any prompt language that distinguishes "what the player said" from "what the Sysadmin said" still has to invent fiction to cover the gap.
+
+**(d) Render redacted peer-to-peer placeholders in the player UI** — rejected. A placeholder is anti-information: it reveals that a channel exists while withholding its content, giving the player something to be frustrated by without giving them anything to act on. The curious player who reads Daemon `.txt` files already sees the unredacted content. Silence is the honest choice.
+
+## Consequences
+
+- **CONTEXT.md** is updated in this slice (issue #216): the `### The Voice` section is replaced by `### Communication and identity` containing the **Sysadmin** and **blue** entries; the **Wipe lie**, **Conversation log**, and **ConversationEntry** entries are rewritten; the **Relationships** bullet referencing the Voice is replaced; the **Flagged ambiguities** "Player" bullet is updated.
+- **PRD-historical `AI-Blue`** reference in `docs/prd/0001-game-concept.md` is intentionally left untouched — it describes a specific AI persona in early concept art, not the player handle, and is out of scope.
+- **`voiceExamples` field** on Persona, the `<voice_examples>` prompt block, and character speech-style few-shots use "voice" in the literary sense (a character's distinctive register). They are unrelated to the retired Voice framing and stay.
+- **Composes with ADR 0005** (engine.dat sealed): peer-to-peer message content lives only in per-Daemon logs and sealed engine state. Silence in the player UI does not weaken the curious-player escape hatch — the `.txt` files still expose everything.
+- **Composes with ADR 0006** (per-Daemon conversation logs): the unified `message` kind is the natural shape for per-Daemon ownership. A single recipient axis means every writer knows exactly which Daemon logs to append into. The asymmetric-tampering vector ADR 0006 introduced as a feature applies uniformly to all message kinds under the unified type.


### PR DESCRIPTION
## What this fixes

Brings the project's domain documentation in line with the messaging refactor
that shipped in #213 (`c60e995`, collapse `chat`+`whisper` into one directional
`message`) and the persona rename in #218 (`1866636`, free the `blue` handle by
renaming the test-fixture AiId to `cyan`). Two artifacts:

- **`CONTEXT.md`** — retires the **Voice** glossary entry; replaces the
  `### The Voice` heading with `### Communication and identity`; adds **Sysadmin**
  (the named source of every Phase Goal directive) and **blue** (the player's
  lowercase chat-channel handle as Daemons see it) entries with `_Avoid_:`
  notes; rewrites **Phase Goal**, **Conversation log**, **ConversationEntry**,
  Relationships, and Flagged ambiguities to match the shipped reframing
  (unified directional `message` kind; Sysadmin and blue as distinct named
  sources; player-as-Voice ambiguity removed).

- **`docs/adr/0007-retire-the-voice-unify-message-primitive.md`** — new ADR
  documenting the rationale post-hoc for four sub-decisions: (1) `chat`/`whisper`
  collapse into a single directional `message` primitive
  (`SESSION_SCHEMA_VERSION` 3 → 4); (2) `blue` as a real on-axis handle rather
  than an opaque "player"; (3) peer-to-peer messages stay silent in the player
  UI rather than rendering redacted placeholders; (4) Sysadmin replaces the
  Voice as the named Phase Goal source. Includes Considered Options and
  Consequences sections; explicitly references and composes with **ADR 0005**
  (engine.dat sealed-blob obfuscation) and **ADR 0006** (per-Daemon
  conversation logs).

No code or test changes — this is a documentation-only slice as specified by
the parent PRD #211.

## QA steps for the human

- Skim `CONTEXT.md` end-to-end and confirm the glossary still reads as a
  coherent whole — particularly the new `### Communication and identity`
  section and the rewritten Relationships / Flagged ambiguities bullets.
- Read `docs/adr/0007-*.md` and confirm the rationale matches your mental
  model of why #213 + #218 shipped the way they did. Two judgement calls
  the planner made worth a sanity check: (a) using a renamed
  `### Communication and identity` heading rather than folding the new
  entries into `### Personas and identity`, and (b) adding a replacement
  Relationships bullet (Sysadmin and blue are distinct named sources)
  rather than just deleting the old player-as-Voice bullet.

## Automated coverage

`pnpm typecheck` clean, `pnpm test` 959/959 passed, `pnpm lint` produces 5
pre-existing `noDescendingSpecificity` warnings in `src/spa/styles.css`
unrelated to this docs-only slice. Live integration smoke verified ADR 0007's
factual claims against the codebase: `appendMessage` exists, `kind: "message"`
ConversationEntry exists, `SESSION_SCHEMA_VERSION = 4`, `"blue"` appears as
the player handle in prompt-builder code, and the silent-turn anchor template
`No messages from … or …` matches `src/spa/game/openai-message-builder.ts`.

Closes #216


---
_Generated by [Claude Code](https://claude.ai/code/session_01PK1EYgdeUzqSvYNvHZRHsm)_