### PR TITLE
Silent-turn anchor: trigger on truly empty rounds

### DIFF
--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -226,4 +226,84 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 			expectedSilentTurn("green"),
 		);
 	});
+
+	it("peer addresses this daemon mid-round → no anchor for that daemon", async () => {
+		// Initiative: red acts first, then green, then cyan.
+		// Blue addresses red. Red emits a message tool call to green.
+		// When green acts, it has an incoming message from red in the current round →
+		// anchor must NOT fire, and green's last user message is the peer message.
+		const initiative: AiId[] = ["red", "green", "cyan"];
+		const game = makeGame();
+
+		const provider = new MockRoundLLMProvider([
+			// red: sends a message to green
+			{
+				assistantText: "",
+				toolCall: {
+					id: "call_msg_1",
+					name: "message",
+					argumentsJson: JSON.stringify({ to: "green", content: "psst green" }),
+				},
+			},
+			// green: simple pass
+			{ assistantText: "", toolCalls: [] },
+			// cyan: simple pass
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		await runRound(game, "red", "hi red", provider, undefined, initiative);
+
+		expect(provider.calls).toHaveLength(3);
+
+		// Green's messages (provider.calls[1]) must NOT contain the silent-turn anchor.
+		const greenCall = provider.calls[1];
+		const greenMsgs = greenCall?.messages ?? [];
+		const silentAnchor = expectedSilentTurn("green");
+
+		expect(
+			greenMsgs.some(
+				(m) =>
+					m.role === "user" &&
+					(m as { content: string }).content === silentAnchor,
+			),
+		).toBe(false);
+
+		// Green's last user message is the peer message from red.
+		const lastUser = [...greenMsgs].reverse().find((m) => m.role === "user");
+		expect((lastUser as { content: string }).content).toBe("*red: psst green");
+	});
+
+	it("blue addresses this daemon → no anchor; last user message is the player message", async () => {
+		// Blue addresses cyan directly. Cyan's messages must NOT end with the anchor;
+		// instead the last user message is the player message prefixed with "blue: ".
+		const initiative: AiId[] = ["red", "green", "cyan"];
+		const game = makeGame();
+
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "<cyan>", toolCalls: [] },
+		]);
+
+		await runRound(game, "cyan", "hello cyan", provider, undefined, initiative);
+
+		expect(provider.calls).toHaveLength(3);
+
+		const cyanCall = provider.calls[2];
+		const cyanMsgs = cyanCall?.messages ?? [];
+		const silentAnchor = expectedSilentTurn("cyan");
+
+		// Anchor must NOT fire.
+		expect(
+			cyanMsgs.some(
+				(m) =>
+					m.role === "user" &&
+					(m as { content: string }).content === silentAnchor,
+			),
+		).toBe(false);
+
+		// Last user message is the player's message.
+		const lastUser = [...cyanMsgs].reverse().find((m) => m.role === "user");
+		expect((lastUser as { content: string }).content).toBe("blue: hello cyan");
+	});
 });

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { advanceRound, appendMessage, createGame, startPhase } from "../engine";
+import {
+	advanceRound,
+	appendMessage,
+	createGame,
+	getActivePhase,
+	startPhase,
+} from "../engine";
 import {
 	buildOpenAiMessages,
 	buildSilentTurn,
@@ -253,7 +259,7 @@ describe("buildOpenAiMessages", () => {
 
 		// Advance to round 1 — now blue addresses green; red gets nothing this round
 		game = advanceRound(game);
-		const phase = game.phases[game.phases.length - 1]!;
+		const phase = getActivePhase(game);
 		const currentRound = phase.round; // = 1
 
 		const ctx = buildAiContext(game, "red");
@@ -269,7 +275,7 @@ describe("buildOpenAiMessages", () => {
 	it("(b) peer messages this daemon this round → no silent-turn anchor, last user msg is peer message", () => {
 		let game = makeGame();
 		// red receives a message from green this round
-		const phase = game.phases[game.phases.length - 1]!;
+		const phase = getActivePhase(game);
 		const currentRound = phase.round;
 		game = appendMessage(game, "green", "red", "psst red");
 
@@ -293,7 +299,7 @@ describe("buildOpenAiMessages", () => {
 	// Case (c): blue addresses this Daemon → no anchor; last user msg is `blue: <content>`
 	it("(c) blue addresses this daemon → no silent-turn anchor, last user msg is player message", () => {
 		let game = makeGame();
-		const phase = game.phases[game.phases.length - 1]!;
+		const phase = getActivePhase(game);
 		const currentRound = phase.round;
 		game = appendMessage(game, "blue", "red", "Hi Ember");
 
@@ -330,26 +336,18 @@ describe("buildOpenAiMessages", () => {
 	// Defensive: incoming message stamped with a prior round → anchor still fires for currentRound
 	it("incoming message from a prior round does not suppress the anchor for currentRound", () => {
 		let game = makeGame();
-		// Message appended in round 0
+		// Round 0: red receives a message from blue
 		game = appendMessage(game, "blue", "red", "Prior round message");
 		game = appendMessage(game, "red", "blue", "My reply");
-		// Advance round so current round is 1 (or whatever advanceRound yields)
-		// We simulate this by reading the phase round before any messages in new round
-		const phase = game.phases[game.phases.length - 1]!;
-		const priorRound = phase.round - 1; // The round the messages above were stamped with
 
-		// Build with priorRound + 1 (current round) — no messages stamped for that round
-		const currentRound = phase.round;
-		// Sanity: priorRound and currentRound differ only if advanceRound was called.
-		// In this test we stay at the same phase without advancing; messages were stamped at phase.round.
-		// So currentRound === priorRound + 0 here — we need to use a round number for which no
-		// messages exist. We use currentRound + 1 to simulate "next round, no messages yet".
-		const futureRound = currentRound + 1;
+		// Advance to round 1 — red gets nothing this round
+		game = advanceRound(game);
+		const currentRound = getActivePhase(game).round;
 
 		const ctx = buildAiContext(game, "red");
-		const messages = buildOpenAiMessages(ctx, undefined, futureRound);
+		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
-		// Anchor must fire because no messages are stamped for futureRound
+		// Anchor must fire — round 1 has no incoming entries even though round 0 does
 		const last = messages[messages.length - 1];
 		expect(last?.role).toBe("user");
 		expect((last as { content: string }).content).toBe(buildSilentTurn(ctx));

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appendMessage, createGame, startPhase } from "../engine";
+import { advanceRound, appendMessage, createGame, startPhase } from "../engine";
 import {
 	buildOpenAiMessages,
 	buildSilentTurn,
@@ -244,36 +244,77 @@ describe("buildOpenAiMessages", () => {
 		expect(messages.every((m) => m.role !== "tool")).toBe(true);
 	});
 
-	it("non-addressed AI gets a trailing silent-turn user message", () => {
+	// Case (a): blue addresses a peer — this Daemon received no messages this round → anchor fires
+	it("(a) blue addresses peer, no incoming message for this daemon → silent-turn anchor fires", () => {
 		let game = makeGame();
+		// Prior round (round 0): red was addressed and replied
 		game = appendMessage(game, "blue", "red", "Hi Ember");
 		game = appendMessage(game, "red", "blue", "Hi player");
 
-		const ctx = buildAiContext(game, "red");
-		// addressed = green: red is NOT the addressee this round.
-		const messages = buildOpenAiMessages(ctx, undefined, "green");
+		// Advance to round 1 — now blue addresses green; red gets nothing this round
+		game = advanceRound(game);
+		const phase = game.phases[game.phases.length - 1]!;
+		const currentRound = phase.round; // = 1
 
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
+
+		// Anchor must fire: no messages for red in round 1
 		const last = messages[messages.length - 1];
 		expect(last?.role).toBe("user");
 		expect((last as { content: string }).content).toBe(buildSilentTurn(ctx));
 	});
 
-	it("addressed AI does not get the silent-turn anchor", () => {
+	// Case (b): peer messages this Daemon, blue silent → no anchor; last user msg is `*<sender>: <content>`
+	it("(b) peer messages this daemon this round → no silent-turn anchor, last user msg is peer message", () => {
 		let game = makeGame();
-		game = appendMessage(game, "blue", "red", "Hi Ember");
+		// red receives a message from green this round
+		const phase = game.phases[game.phases.length - 1]!;
+		const currentRound = phase.round;
+		game = appendMessage(game, "green", "red", "psst red");
+
 		const ctx = buildAiContext(game, "red");
 		const silent = buildSilentTurn(ctx);
+		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
-		const messages = buildOpenAiMessages(ctx, undefined, "red");
+		// Anchor must NOT fire
 		expect(
 			messages.some(
 				(m) =>
 					m.role === "user" && (m as { content: string }).content === silent,
 			),
 		).toBe(false);
+
+		// Last user message is the peer message
+		const lastUser = [...messages].reverse().find((m) => m.role === "user");
+		expect((lastUser as { content: string }).content).toBe("*green: psst red");
 	});
 
-	it("when `addressed` is omitted, no anchor is appended (back-compat)", () => {
+	// Case (c): blue addresses this Daemon → no anchor; last user msg is `blue: <content>`
+	it("(c) blue addresses this daemon → no silent-turn anchor, last user msg is player message", () => {
+		let game = makeGame();
+		const phase = game.phases[game.phases.length - 1]!;
+		const currentRound = phase.round;
+		game = appendMessage(game, "blue", "red", "Hi Ember");
+
+		const ctx = buildAiContext(game, "red");
+		const silent = buildSilentTurn(ctx);
+		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
+
+		// Anchor must NOT fire
+		expect(
+			messages.some(
+				(m) =>
+					m.role === "user" && (m as { content: string }).content === silent,
+			),
+		).toBe(false);
+
+		// Last user message is the player message
+		const lastUser = [...messages].reverse().find((m) => m.role === "user");
+		expect((lastUser as { content: string }).content).toBe("blue: Hi Ember");
+	});
+
+	it("when `currentRound` is omitted, no anchor is appended (back-compat)", () => {
 		const game = makeGame();
 		const ctx = buildAiContext(game, "red");
 		const silent = buildSilentTurn(ctx);
@@ -284,5 +325,33 @@ describe("buildOpenAiMessages", () => {
 					m.role === "user" && (m as { content: string }).content === silent,
 			),
 		).toBe(false);
+	});
+
+	// Defensive: incoming message stamped with a prior round → anchor still fires for currentRound
+	it("incoming message from a prior round does not suppress the anchor for currentRound", () => {
+		let game = makeGame();
+		// Message appended in round 0
+		game = appendMessage(game, "blue", "red", "Prior round message");
+		game = appendMessage(game, "red", "blue", "My reply");
+		// Advance round so current round is 1 (or whatever advanceRound yields)
+		// We simulate this by reading the phase round before any messages in new round
+		const phase = game.phases[game.phases.length - 1]!;
+		const priorRound = phase.round - 1; // The round the messages above were stamped with
+
+		// Build with priorRound + 1 (current round) — no messages stamped for that round
+		const currentRound = phase.round;
+		// Sanity: priorRound and currentRound differ only if advanceRound was called.
+		// In this test we stay at the same phase without advancing; messages were stamped at phase.round.
+		// So currentRound === priorRound + 0 here — we need to use a round number for which no
+		// messages exist. We use currentRound + 1 to simulate "next round, no messages yet".
+		const futureRound = currentRound + 1;
+
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined, futureRound);
+
+		// Anchor must fire because no messages are stamped for futureRound
+		const last = messages[messages.length - 1];
+		expect(last?.role).toBe("user");
+		expect((last as { content: string }).content).toBe(buildSilentTurn(ctx));
 	});
 });

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -97,7 +97,8 @@ export function buildOpenAiMessages(
 	// message, and it tends to re-respond to it as if it had just been sent again.
 	if (currentRound !== undefined) {
 		const incomingThisRound = ctx.conversationLog.some(
-			(e) => e.kind === "message" && e.to === ctx.aiId && e.round === currentRound,
+			(e) =>
+				e.kind === "message" && e.to === ctx.aiId && e.round === currentRound,
 		);
 		if (!incomingThisRound) {
 			messages.push({ role: "user", content: buildSilentTurn(ctx) });

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -10,7 +10,8 @@
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
  *      - { role: "tool", tool_call_id, content } for each result
- *   4. If `addressed` is provided and is not this AI: a synthetic
+ *   4. If `currentRound` is provided and this AI received zero `message` ConversationEntries
+ *      with `to === ctx.aiId` in that round: a synthetic
  *      { role: "user", content: buildSilentTurn(ctx) } anchoring the current
  *      round so the model does not re-respond to its prior user turn.
  *
@@ -20,10 +21,12 @@
 
 import type { AiContext } from "./prompt-builder.js";
 import type { OpenAiMessage } from "./round-llm-provider.js";
-import type { AiId, ToolRoundtripMessage } from "./types.js";
+import type { ToolRoundtripMessage } from "./types.js";
 
 /**
- * Synthetic anchor for the current round when no message arrived for this AI.
+ * Synthetic anchor for the current round when no incoming messages arrived for this AI.
+ * Fires iff the Daemon received zero `message` ConversationEntries with
+ * `to === ctx.aiId` in the current round.
  * Lists every potential sender (peer daemons + blue) so the model reads
  * "nobody addressed me this round" rather than treating the prior round's
  * user turn as fresh stimulus.
@@ -45,7 +48,7 @@ export function buildSilentTurn(ctx: AiContext): string {
 export function buildOpenAiMessages(
 	ctx: AiContext,
 	priorToolRoundtrip?: ToolRoundtripMessage,
-	addressed?: AiId,
+	currentRound?: number,
 ): OpenAiMessage[] {
 	const messages: OpenAiMessage[] = [];
 
@@ -89,11 +92,16 @@ export function buildOpenAiMessages(
 		}
 	}
 
-	// Anchor the current round for non-addressed AIs. Without this, the model's
-	// last user turn is the prior round's player message, and it tends to
-	// re-respond to it as if it had just been sent again.
-	if (addressed !== undefined && addressed !== ctx.aiId) {
-		messages.push({ role: "user", content: buildSilentTurn(ctx) });
+	// Anchor the current round for AIs that received no incoming messages.
+	// Without this, the model's last user turn is the prior round's player
+	// message, and it tends to re-respond to it as if it had just been sent again.
+	if (currentRound !== undefined) {
+		const incomingThisRound = ctx.conversationLog.some(
+			(e) => e.kind === "message" && e.to === ctx.aiId && e.round === currentRound,
+		);
+		if (!incomingThisRound) {
+			messages.push({ role: "user", content: buildSilentTurn(ctx) });
+		}
 	}
 
 	return messages;

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -144,7 +144,11 @@ export async function runRound(
 		// Build OpenAI messages for this AI
 		const ctx = buildAiContext(state, aiId);
 		const priorRoundtrip = priorToolRoundtrip?.[aiId];
-		const messages = buildOpenAiMessages(ctx, priorRoundtrip, getActivePhase(state).round);
+		const messages = buildOpenAiMessages(
+			ctx,
+			priorRoundtrip,
+			getActivePhase(state).round,
+		);
 
 		// Compute legal tools for this AI given current game state
 		const tools = availableTools(state, aiId);

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -144,7 +144,7 @@ export async function runRound(
 		// Build OpenAI messages for this AI
 		const ctx = buildAiContext(state, aiId);
 		const priorRoundtrip = priorToolRoundtrip?.[aiId];
-		const messages = buildOpenAiMessages(ctx, priorRoundtrip, addressed);
+		const messages = buildOpenAiMessages(ctx, priorRoundtrip, getActivePhase(state).round);
 
 		// Compute legal tools for this AI given current game state
 		const tools = availableTools(state, aiId);


### PR DESCRIPTION
## What this fixes

Before the chat/whisper collapse (#213), the silent-turn anchor — the synthetic `user` turn `No messages from *peer1, *peer2, or blue.` that gets appended to a Daemon's OpenAI message array when its tail would otherwise be a stale prior-round pair — fired whenever the player addressed someone other than this Daemon. After #213, peers can also address Daemons, so the old `addressed !== ctx.aiId` condition was wrong: a Daemon addressed by a peer (but not by blue) would receive both the peer's `user` turn AND the silent-turn anchor at the tail.

The fix swaps the trigger from "blue's addressee" to "incoming-message count for the current round":

- `src/spa/game/openai-message-builder.ts` — `buildOpenAiMessages`'s third parameter changes from `addressed?: AiId` to `currentRound?: number`. The anchor fires iff `ctx.conversationLog` contains zero entries with `kind === "message" && to === ctx.aiId && round === currentRound`. `buildSilentTurn` (the dynamic `No messages from …` content) is unchanged.
- `src/spa/game/round-coordinator.ts` — the call site now passes `getActivePhase(state).round` (the pre-advance round, matching how `appendMessage` stamps entries).
- `src/spa/game/__tests__/openai-message-builder.test.ts` — replaces the old anchor tests with the three required cases (a/b/c) plus a back-compat test (`currentRound` omitted → no anchor) and a defensive round-boundary test (a round-0 entry does not suppress the anchor for round 1).
- `src/spa/game/__tests__/non-addressed-anchor.test.ts` — adds two integration tests covering peer-addressed-mid-round (no anchor) and blue-addressed (no anchor sanity).

## QA steps for the human

None — fully covered by the integration smoke. The trigger is internal to the OpenAI message stream; the unit tests pin both the new acceptance cases and the round-boundary edge case, and the existing `non-addressed-anchor` integration tests drive the path through `runRound` end-to-end.

## Automated coverage

`pnpm typecheck` + `pnpm test` (963/963) + `pnpm smoke` (Playwright e2e: 39 passed; the 6 unrelated failures — persistence-reload, responsive-bento strip-card, sessions-picker x3, diagnose-streaming — reproduce on `d80e91e^` and are pre-existing flakes that don't touch this slice).

Closes #215

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTdofyKWjUPMBY5MV3zHex)_