### PR TITLE
Simplify silent-turn anchor to "You have received no messages."

### DIFF
--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -60,14 +60,8 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 };
 
 /** Compute the expected silent-turn anchor for an AI given fixed personas. */
-function expectedSilentTurn(self: AiId): string {
-	const others = (["red", "green", "cyan"] as const)
-		.filter((id) => id !== self)
-		.map((id) => `*${id}`);
-	const senders = [...others, "blue"];
-	const last = senders[senders.length - 1];
-	const rest = senders.slice(0, -1).join(", ");
-	return `No messages from ${rest}, or ${last}.`;
+function expectedSilentTurn(_self: AiId): string {
+	return "You have received no messages.";
 }
 
 const TEST_PHASE_CONFIG: PhaseConfig = {

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -26,23 +26,11 @@ import type { ToolRoundtripMessage } from "./types.js";
 /**
  * Synthetic anchor for the current round when no incoming messages arrived for this AI.
  * Fires iff the Daemon received zero `message` ConversationEntries with
- * `to === ctx.aiId` in the current round.
- * Lists every potential sender (peer daemons + blue) so the model reads
- * "nobody addressed me this round" rather than treating the prior round's
- * user turn as fresh stimulus.
+ * `to === ctx.aiId` in the current round, anchoring the round so the model
+ * does not treat the prior round's user turn as fresh stimulus.
  */
-export function buildSilentTurn(ctx: AiContext): string {
-	const otherDaemons = Object.keys(ctx.personas)
-		.filter((id) => id !== ctx.aiId)
-		.map((id) => `*${id}`);
-	const senders = [...otherDaemons, "blue"];
-	if (senders.length === 1) return `No messages from ${senders[0]}.`;
-	if (senders.length === 2) {
-		return `No messages from ${senders[0]} or ${senders[1]}.`;
-	}
-	const last = senders[senders.length - 1];
-	const rest = senders.slice(0, -1).join(", ");
-	return `No messages from ${rest}, or ${last}.`;
+export function buildSilentTurn(_ctx: AiContext): string {
+	return "You have received no messages.";
 }
 
 export function buildOpenAiMessages(


### PR DESCRIPTION
Drops the per-sender list (peer daemons + blue) in favor of a single
fixed string. Tests updated accordingly.