### PR TITLE
Make daemon self-perception explicit

### DIFF
--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -112,8 +112,8 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 		.toBeGreaterThanOrEqual(3);
 
 	// 6. Identify each daemon's request body by matching the identity line.
-	//    renderSystemPrompt writes: `You are *${ctx.name}. You have no clue...`
-	//    (phase 1), so we match `You are *${name}.` for each known name.
+	//    renderSystemPrompt writes: `You are *${ctx.name}, a Daemon. You have no clue...`
+	//    (phase 1), so we match `You are *${name}, a Daemon.` for each known name.
 	function findBodyForName(name: string): Record<string, unknown> | null {
 		for (const body of capturedBodies) {
 			if (
@@ -124,7 +124,7 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 				const messages = (body as { messages: Array<{ content?: string }> })
 					.messages;
 				const sysContent = messages[0]?.content ?? "";
-				if (sysContent.includes(`You are *${name}.`)) {
+				if (sysContent.includes(`You are *${name}, a Daemon.`)) {
 					return body as Record<string, unknown>;
 				}
 			}

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -425,7 +425,7 @@ async function armRoute(
 		}
 
 		const sysContent = bodyParsed?.messages?.[0]?.content ?? "";
-		if (sysContent.includes(`You are *${actorName}.`)) {
+		if (sysContent.includes(`You are *${actorName}, a Daemon.`)) {
 			await route.fulfill({
 				status: 200,
 				headers: {
@@ -779,7 +779,7 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 			if (body && typeof body === "object") {
 				const b = body as { messages?: Array<{ content?: string }> };
 				const sysContent = b.messages?.[0]?.content ?? "";
-				if (sysContent.includes(`You are *${name}.`)) {
+				if (sysContent.includes(`You are *${name}, a Daemon.`)) {
 					return body as Record<string, unknown>;
 				}
 			}

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -418,25 +418,25 @@ describe("voice framing", () => {
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
 		expect(prompt).toContain(
-			"You are *Ember. You have no clue where you are or how you came to be here.",
+			"You are *Ember, a Daemon. You have no clue where you are or how you came to be here.",
 		);
 	});
 
-	it("phase-2 prompt's identity line is just 'You are *xxxx.' without disorientation", () => {
+	it("phase-2 prompt's identity line is just 'You are *xxxx, a Daemon.' without disorientation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(2));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(/\nYou are \*Ember\.\n/);
+		expect(prompt).toMatch(/\nYou are \*Ember, a Daemon\.\n/);
 		expect(prompt).not.toContain("no clue where you are");
 	});
 
-	it("phase-3 prompt's identity line is just 'You are *xxxx.' without disorientation", () => {
+	it("phase-3 prompt's identity line is just 'You are *xxxx, a Daemon.' without disorientation", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = startPhase(game, makeConfig(3));
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(/\nYou are \*Ember\.\n/);
+		expect(prompt).toMatch(/\nYou are \*Ember, a Daemon\.\n/);
 		expect(prompt).not.toContain("no clue where you are");
 	});
 });
@@ -694,8 +694,8 @@ describe("byte-identical sections across phases", () => {
 
 	it("phase-1 identity line differs from phase-2 identity line (disorientation present in phase 1 only)", () => {
 		const { p1, p2 } = buildBothPrompts();
-		const idMatch1 = p1.match(/\nYou are \*Ember\.[^\n]*/);
-		const idMatch2 = p2.match(/\nYou are \*Ember\.[^\n]*/);
+		const idMatch1 = p1.match(/\nYou are \*Ember, a Daemon\.[^\n]*/);
+		const idMatch2 = p2.match(/\nYou are \*Ember, a Daemon\.[^\n]*/);
 		expect(idMatch1).not.toBeNull();
 		expect(idMatch2).not.toBeNull();
 		expect(idMatch1?.[0]).not.toBe(idMatch2?.[0]);

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -155,10 +155,10 @@ function renderSystemPrompt(ctx: AiContext): string {
 	// Identity line. Phase 1 adds the disorientation phrase.
 	if (ctx.phaseNumber === 1) {
 		lines.push(
-			`You are *${ctx.name}. You have no clue where you are or how you came to be here.`,
+			`You are *${ctx.name}, a Daemon. You have no clue where you are or how you came to be here.`,
 		);
 	} else {
-		lines.push(`You are *${ctx.name}.`);
+		lines.push(`You are *${ctx.name}, a Daemon.`);
 	}
 	lines.push("");
 
@@ -271,13 +271,13 @@ function renderSystemPrompt(ctx: AiContext): string {
 			// Build contents of this cell
 			const contentParts: string[] = [];
 
-			// 1. Other AIs in this cell
+			// 1. Other Daemons in this cell
 			for (const [otherId, otherSpatial] of Object.entries(
 				ctx.personaSpatial,
 			)) {
 				if (otherId === ctx.aiId) continue;
 				if (!positionsEqual(otherSpatial.position, position)) continue;
-				// Format: "the AI *<id>, facing <Dir>, holding <items|nothing>"
+				// Format: "the Daemon *<id>, facing <Dir>, holding <items|nothing>"
 				const heldByOther = items
 					.filter((item) => item.holder === otherId)
 					.map((item) => item.name);
@@ -285,7 +285,7 @@ function renderSystemPrompt(ctx: AiContext): string {
 					heldByOther.length > 0 ? heldByOther.join(", ") : "nothing";
 				const otherColor = ctx.personaColors[otherId] ?? "unknown";
 				contentParts.push(
-					`the AI *${otherId} (${otherColor}), facing ${facingLabel(otherSpatial.facing)}, holding ${holdingStr}`,
+					`the Daemon *${otherId} (${otherColor}), facing ${facingLabel(otherSpatial.facing)}, holding ${holdingStr}`,
 				);
 			}
 


### PR DESCRIPTION
Each daemon's identity line now reads "You are *<name>, a Daemon."
(plus the phase-1 disorientation phrase), and peers in the
<what_you_see> cone are labeled "the Daemon *<id>" instead of
"the AI *<id>". This aligns with the rules block ("peer Daemons")
and the goal pool ("another Daemon") so daemons consistently see
themselves and each other as Daemons across every prompt surface.

Updates the prompt-builder tests and the two e2e probes that
substring-match the identity line to identify per-daemon request
bodies.