### PR TITLE
Surface round errors and connection unstable state (issue #231)

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -89,6 +89,11 @@ async function seedSessionInStub(
 // Matches the body content of src/spa/index.html (three-panel layout)
 const INDEX_BODY_HTML = `
 <main>
+  <div id="topinfo">
+    <span id="topinfo-left"></span>
+    <span id="topinfo-right"></span>
+  </div>
+  <div id="topinfo-mobile-status"></div>
   <div id="phase-banner" hidden></div>
   <div id="panels">
     <article class="ai-panel" data-ai="red">
@@ -119,6 +124,7 @@ const INDEX_BODY_HTML = `
       <input id="prompt" type="text" placeholder="Enter a message…" autocomplete="off" />
     </div>
     <output id="lockout-error" class="lockout-error" role="status" aria-live="polite" hidden></output>
+    <output id="round-error" class="round-error" role="status" aria-live="polite" hidden></output>
     <button id="send" type="submit">Send</button>
   </form>
   <section id="cap-hit" hidden></section>
@@ -2442,5 +2448,93 @@ describe("renderGame — chat lockout visual affordances (panel muting + inline 
 		// Error element is hidden (no addressee)
 		const lockoutError = getEl<HTMLOutputElement>("#lockout-error");
 		expect(lockoutError.hasAttribute("hidden")).toBe(true);
+	});
+});
+
+// Regression for #231: when a round throws a non-CapHitError (e.g. the worker
+// proxy returns 502 upstream_error after an OpenRouter blip) the round used
+// to fail silently — no inline message, no status pip change. Verify the
+// surfaced-error UX: `#round-error` becomes visible and `#topinfo-right`
+// flips to "● connection unstable" (warn class).
+describe("renderGame — round error surfacing (issue #231)", () => {
+	let _stub: ReturnType<typeof makeLocalStorageStub>;
+
+	beforeEach(async () => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+		_stub = makeLocalStorageStub();
+		await seedSessionInStub(_stub);
+		vi.stubGlobal("localStorage", _stub);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("surfaces #round-error and flips topinfo to 'connection unstable' on a 502 round; clears both on the next successful round", async () => {
+		// First submit: every fetch returns 502 (mimics the worker proxy's
+		// `upstream_error` mapping after OpenRouter returns a transient 502).
+		const failingFetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 502,
+			statusText: "Bad Gateway",
+			headers: { get: () => null },
+			json: async () => ({
+				error: {
+					message: "OpenRouter returned 502 Bad Gateway",
+					type: "upstream_error",
+				},
+			}),
+		});
+		vi.stubGlobal("fetch", failingFetch);
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		await renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const form = getEl<HTMLFormElement>("#composer");
+		promptInput.value = "*Sage hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// 1. Inline error visible with non-empty player-readable text.
+		const roundError = getEl<HTMLOutputElement>("#round-error");
+		expect(roundError.hasAttribute("hidden")).toBe(false);
+		expect(roundError.textContent?.trim()).toBeTruthy();
+
+		// 2. Topinfo right cell shows the unstable warn pip.
+		const topinfoRight = getEl<HTMLElement>("#topinfo-right");
+		expect(topinfoRight.textContent).toContain("connection unstable");
+		const pip = topinfoRight.querySelector("span");
+		expect(pip?.className).toBe("warn");
+
+		// 3. Cap-hit overlay stays hidden (this is not a 429).
+		const capHit = getEl<HTMLElement>("#cap-hit");
+		expect(capHit.hasAttribute("hidden")).toBe(true);
+
+		// Second submit: now fetch succeeds for all three daemons. The
+		// round-error should clear and topinfo should return to "stable".
+		const okFetch = makeMessageToolCallFetchMock();
+		vi.stubGlobal("fetch", okFetch);
+		promptInput.value = "*Sage retry";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(roundError.hasAttribute("hidden")).toBe(true);
+		expect(roundError.textContent ?? "").toBe("");
+		expect(topinfoRight.textContent).toContain("connection stable");
+		const pipAfter = topinfoRight.querySelector("span");
+		expect(pipAfter?.className).toBe("ok");
 	});
 });

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -110,13 +110,22 @@ export function formatTopInfoMobile(i: TopInfoInputs): string {
 export const TOPINFO_RIGHT_OK_TEXT = "● connection stable";
 export const TOPINFO_RIGHT_LOADING_TEXT = "● loading daemons";
 export const TOPINFO_RIGHT_GENERATING_TEXT = "● generating room";
+export const TOPINFO_RIGHT_UNSTABLE_TEXT = "● connection unstable";
 
 export const TOPINFO_MOBILE_OK_TEXT = "● stable";
 export const TOPINFO_MOBILE_LOADING_TEXT = "● loading";
 export const TOPINFO_MOBILE_GENERATING_TEXT = "● generating";
+export const TOPINFO_MOBILE_UNSTABLE_TEXT = "● unstable";
 
-/** Three-phase load state used by the start → game progressive loading flow. */
-export type LoadState = "loading-daemons" | "generating-room" | "stable";
+/** Right-cell connection states. `loading-daemons`/`generating-room` are the
+ * progressive boot phases; `unstable` is set by the game route after a round
+ * fails on a non-cap-hit error (e.g. transient upstream 502/503/504) and
+ * cleared when the next round succeeds. */
+export type LoadState =
+	| "loading-daemons"
+	| "generating-room"
+	| "stable"
+	| "unstable";
 
 export interface LoadStateStatus {
 	desktop: string;
@@ -137,6 +146,12 @@ export function topInfoStatus(state: LoadState): LoadStateStatus {
 			return {
 				desktop: TOPINFO_RIGHT_GENERATING_TEXT,
 				mobile: TOPINFO_MOBILE_GENERATING_TEXT,
+				cls: "warn",
+			};
+		case "unstable":
+			return {
+				desktop: TOPINFO_RIGHT_UNSTABLE_TEXT,
+				mobile: TOPINFO_MOBILE_UNSTABLE_TEXT,
 				cls: "warn",
 			};
 		case "stable":

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -166,6 +166,7 @@
 						<input id="prompt" type="text" placeholder="" autocomplete="off" spellcheck="false" />
 					</div>
 					<output id="lockout-error" class="lockout-error" role="status" aria-live="polite" hidden></output>
+					<output id="round-error" class="round-error" role="status" aria-live="polite" hidden></output>
 					<button id="send" class="send" type="submit">[ tx ]</button>
 				</form>
 				<section id="cap-hit" hidden>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -278,6 +278,11 @@ export function renderGame(
 	let personaDisplayNames: ReturnType<typeof buildPersonaDisplayNameMap>;
 	const lockouts: Map<AiId, boolean> = new Map();
 	let roundInFlight = false;
+	// Set when a round throws a non-CapHitError (e.g. transient upstream 502
+	// from the proxy, or a network/fetch failure). Drives the `#round-error`
+	// inline message and the `● connection unstable` topinfo pip; both clear
+	// when the next round succeeds. See issue #231.
+	let connectionUnstable = false;
 
 	// promptInput and sendBtn are guaranteed non-null (checked above).
 	const _promptInput = promptInput;
@@ -918,10 +923,10 @@ export function renderGame(
 		};
 		renderTopInfoLeft(topinfoLeftEl, inputs);
 		topinfoRightEl.textContent = "";
-		const stableStatus = topInfoStatus("stable");
+		const status = topInfoStatus(connectionUnstable ? "unstable" : "stable");
 		const okSpan = doc.createElement("span");
-		okSpan.className = stableStatus.cls;
-		okSpan.textContent = stableStatus.desktop;
+		okSpan.className = status.cls;
+		okSpan.textContent = status.desktop;
 		topinfoRightEl.appendChild(okSpan);
 		if (topinfoMobileEl) {
 			topinfoMobileEl.textContent = formatTopInfoMobile(inputs);
@@ -935,8 +940,8 @@ export function renderGame(
 		if (topinfoMobileStatusEl) {
 			topinfoMobileStatusEl.textContent = "";
 			const sp = doc.createElement("span");
-			sp.className = stableStatus.cls;
-			sp.textContent = ` ${stableStatus.mobile}`;
+			sp.className = status.cls;
+			sp.textContent = ` ${status.mobile}`;
 			topinfoMobileStatusEl.appendChild(sp);
 		}
 	}
@@ -1128,6 +1133,16 @@ export function renderGame(
 		const addressed = addressee;
 		roundInFlight = true;
 		sendBtn.disabled = true;
+
+		// Clear any prior round-level error UI before starting the new round.
+		// If this round also fails, the catch block re-shows it; if it
+		// succeeds, the unstable pip + inline error stay cleared.
+		const roundErrorEl = doc.querySelector<HTMLOutputElement>("#round-error");
+		if (roundErrorEl) {
+			roundErrorEl.textContent = "";
+			roundErrorEl.setAttribute("hidden", "");
+		}
+		connectionUnstable = false;
 
 		// Reset the input to the addressee prefix at send-time so it clears
 		// immediately rather than waiting for all daemons to finish.
@@ -1469,6 +1484,20 @@ export function renderGame(
 			stripAllSpinners();
 			if (err instanceof CapHitError && capHitEl) {
 				capHitEl.removeAttribute("hidden");
+			} else {
+				// Non-cap-hit failures (transient upstream 502/503/504, network
+				// drop, malformed response, …) used to be swallowed silently —
+				// the round just stopped with no UI signal (see issue #231).
+				// Surface them inline so the player knows to retry, and flip
+				// the topinfo pip to `connection unstable` until the next
+				// successful round clears the flag.
+				connectionUnstable = true;
+				const roundErrorEl =
+					doc.querySelector<HTMLOutputElement>("#round-error");
+				if (roundErrorEl) {
+					roundErrorEl.textContent = "the daemons stuttered — try again";
+					roundErrorEl.removeAttribute("hidden");
+				}
 			}
 		} finally {
 			stripAllSpinners();

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -678,6 +678,15 @@ main {
 	text-shadow: 0 0 6px rgba(255, 123, 107, 0.5);
 }
 
+.round-error {
+	color: var(--err);
+	font-size: 11px;
+	letter-spacing: 0.04em;
+	align-self: center;
+	padding: 0 4px;
+	text-shadow: 0 0 6px rgba(255, 123, 107, 0.5);
+}
+
 #send {
 	background: transparent;
 	border: 0;


### PR DESCRIPTION
## Summary
This PR fixes issue #231 by surfacing non-cap-hit round errors to the player with inline messaging and a visual connection status indicator. Previously, when a round failed due to transient upstream errors (e.g., 502 from OpenRouter), network issues, or malformed responses, the failure was silently swallowed with no UI feedback.

## Key Changes

- **Added round error UI elements**: New `#round-error` output element in the composer section to display inline error messages, styled consistently with the lockout error
- **Added topinfo status indicator**: New `#topinfo` and `#topinfo-mobile-status` elements to display connection state ("● connection stable" vs "● connection unstable")
- **Implemented connection unstable state**: Added `connectionUnstable` flag that tracks non-cap-hit failures and flips the topinfo pip to warn state until the next successful round
- **Enhanced error handling**: Modified the round submission catch block to distinguish between `CapHitError` (429 rate limit) and other errors, displaying appropriate UI for each
- **Updated LoadState type**: Extended `LoadState` to include "unstable" as a valid connection state alongside the existing boot phases
- **Added test coverage**: Comprehensive regression test verifying that 502 errors surface the inline message and unstable pip, and that both clear on the next successful round

## Implementation Details

- The `connectionUnstable` flag is cleared at the start of each new round submission, allowing recovery on retry
- Non-cap-hit errors display "the daemons stuttered — try again" as player-readable feedback
- The topinfo right cell uses the same "warn" styling class as the generating state for visual consistency
- Both desktop and mobile layouts are supported with appropriate text variants
- The error UI follows the same accessibility patterns as the existing lockout error (role="status", aria-live="polite")

https://claude.ai/code/session_01AV5RcD3qMAMPk6VsZSGhs6