### PR TITLE
Fix budget calculation in game localStorage persistence test

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1039,11 +1039,11 @@ describe("renderGame — localStorage persistence", () => {
 		const { renderGame: renderGame2 } = await import("../routes/game.js");
 		await renderGame2(getEl<HTMLElement>("main"));
 
-		// Budget should reflect round 1 complete: 5¢ - 1¢ cost = 4.000¢
+		// Budget should reflect round 1 complete: 50¢ - 1¢ cost = 49.000¢
 		const redBudget = document.querySelector<HTMLSpanElement>(
 			'.ai-panel[data-ai="red"] .panel-budget',
 		);
-		expect(redBudget?.textContent).toBe("4.000¢");
+		expect(redBudget?.textContent).toBe("49.000¢");
 
 		// Transcripts must be restored from chatHistories (new format uses chatHistories fallback)
 		const redTranscript = document.querySelector<HTMLElement>(


### PR DESCRIPTION
## Summary
Corrected the expected budget values in the game localStorage persistence test to reflect the actual initial budget amount.

## Changes
- Updated test expectations for the red AI's budget after round 1 completion
  - Changed expected budget from `4.000¢` to `49.000¢`
  - Updated corresponding comment to reflect correct calculation: `50¢ - 1¢ cost = 49.000¢` (instead of `5¢ - 1¢ cost = 4.000¢`)

## Details
The test was verifying that budget values are correctly restored from localStorage after a game reload. The initial budget appears to be 50¢ (not 5¢), and after a 1¢ cost in round 1, the remaining budget should be 49.000¢. This fix ensures the test accurately validates the budget persistence behavior.

https://claude.ai/code/session_01VcUyN5ftgXnZbsXsrXJJfM