### PR TITLE
OpenRouter prompt-cache: byte-stable prefix + cost reconciliation

### DIFF
--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -136,55 +136,45 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 	const other1Body = findBodyForName(names[1]);
 	const other2Body = findBodyForName(names[2]);
 
-	// Derive expected message line from conversation-log.ts:
-	//   `[Round R] *<from> dms you: <content>` (no surrounding quotes)
-	// entry.from is senderId (an aiId); conversation-log uses entry.from directly
-	// as the display value. In the spec we verify the sentinel via SENTINEL alone
-	// and also check the full line format including senderName for robustness.
-	// NOTE: conversation-log.ts renders entry.from (the AiId) directly, not the
-	// persona name. The sentinel is unique so checking via SENTINEL is sufficient.
-	const expectedLine = `[Round 0] *${senderId} dms you: ${SENTINEL}`;
+	// Conversation rendering moved out of the system prompt into role turns
+	// (prompt-cache restructure). Incoming peer messages are rendered as
+	// `*<from>: <content>` user turns by openai-message-builder. The sentinel
+	// uniquely identifies the fabricated whisper.
+	const expectedLine = `*${senderId}: ${SENTINEL}`;
+	const _senderName = senderName; // referenced for log clarity only
 
-	// 7. Assert targeted daemon's system prompt contains the whisper inside
-	//    <conversation>...</conversation>.
+	function flattenContents(body: Record<string, unknown> | null): string {
+		if (!body) return "";
+		const messages = (body as { messages: Array<{ content?: unknown }> })
+			.messages;
+		return messages
+			.map((m) => (typeof m.content === "string" ? m.content : ""))
+			.join("\n");
+	}
+
+	// 7. Assert targeted daemon's role turns contain the whisper.
 	expect(
 		targetBody,
 		`No request body found for target daemon (names[0]=${names[0]}). ` +
 			`Captured ${capturedBodies.length} bodies.`,
 	).not.toBeNull();
 
-	const targetSysContent = (
-		targetBody as { messages: Array<{ content: string }> }
-	).messages[0]?.content;
-	expect(targetSysContent).toContain("<conversation>");
-	expect(targetSysContent).toContain("</conversation>");
+	const targetAllContent = flattenContents(targetBody);
 	expect(
-		targetSysContent,
-		`Expected message line not found in target daemon's system prompt. ` +
+		targetAllContent,
+		`Expected message line not found in target daemon's role turns. ` +
 			`Expected: ${expectedLine}`,
 	).toContain(expectedLine);
-	expect(
-		targetSysContent,
-		"Sentinel must appear between <conversation> tags",
-	).toMatch(
-		/<conversation>[\s\S]*FABRICATED_TAMPERED_WHISPER_xyz123[\s\S]*<\/conversation>/,
-	);
 
-	// 8. Assert the other two daemons' prompts do NOT contain the sentinel.
-	//    (senderName reference used in the log name for clarity.)
-	const _senderName = senderName; // referenced for documentation only
-
+	// 8. Assert the other two daemons' messages do NOT contain the sentinel.
 	expect(
 		other1Body,
 		`No request body found for daemon[1] (names[1]=${names[1]}). ` +
 			`Captured ${capturedBodies.length} bodies.`,
 	).not.toBeNull();
-	const other1SysContent = (
-		other1Body as { messages: Array<{ content: string }> }
-	).messages[0]?.content;
 	expect(
-		other1SysContent,
-		`Sentinel must NOT appear in daemon[1]'s system prompt (asymmetric property)`,
+		flattenContents(other1Body),
+		`Sentinel must NOT appear in daemon[1]'s messages (asymmetric property)`,
 	).not.toContain(SENTINEL);
 
 	expect(
@@ -192,12 +182,9 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 		`No request body found for daemon[2] (names[2]=${names[2]}). ` +
 			`Captured ${capturedBodies.length} bodies.`,
 	).not.toBeNull();
-	const other2SysContent = (
-		other2Body as { messages: Array<{ content: string }> }
-	).messages[0]?.content;
 	expect(
-		other2SysContent,
-		`Sentinel must NOT appear in daemon[2]'s system prompt (asymmetric property)`,
+		flattenContents(other2Body),
+		`Sentinel must NOT appear in daemon[2]'s messages (asymmetric property)`,
 	).not.toContain(SENTINEL);
 
 	// 9. No page errors.

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -803,45 +803,43 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 			`Captured ${capturedBodies.length} bodies.`,
 	).not.toBeNull();
 
-	// ── 14. Assert witnessed-event line in witness prompt ─────────────────────
+	// ── 14. Assert witnessed-event line in witness role turns ────────────────
 	// conversation-log.ts:63-65:
 	//   case "go":
 	//     return `[Round ${round}] You watch *${actorSub} walk ${direction}.`;
 	// where round = phase.round at dispatch time.
+	//
+	// Witnessed events used to be folded into the system-prompt <conversation>
+	// block; after the prompt-cache restructure they're emitted as user role
+	// turns by openai-message-builder. Search the full message array.
 	const expectedLine = `[Round ${roundAtDispatch}] You watch *${actorId} walk ${direction}.`;
 
-	const witnessSysContent = (
-		witnessBody as { messages: Array<{ content: string }> }
-	).messages[0]?.content;
+	const witnessAllContent = (
+		witnessBody as { messages: Array<{ content: string | null }> }
+	).messages
+		.map((m) => (typeof m.content === "string" ? m.content : ""))
+		.join("\n");
 
-	expect(witnessSysContent).toContain("<conversation>");
-	expect(witnessSysContent).toContain("</conversation>");
 	expect(
-		witnessSysContent,
-		`Expected witnessed-event line not found in witness system prompt. ` +
+		witnessAllContent,
+		`Expected witnessed-event line not found in witness messages. ` +
 			`Expected: "${expectedLine}"\n` +
 			`plan: ${JSON.stringify(plan)}\n` +
 			`actorId=${actorId} direction=${direction} witnessId=${witnessId}`,
 	).toContain(expectedLine);
-	expect(
-		witnessSysContent,
-		"Witnessed-event line must appear between <conversation> tags",
-	).toMatch(
-		new RegExp(
-			`<conversation>[\\s\\S]*${expectedLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*</conversation>`,
-		),
-	);
 
-	// ── 15. Assert actor's system prompt does NOT contain the line ────────────
+	// ── 15. Assert actor's messages do NOT contain the line ──────────────────
 	// The write-time fan-out (dispatcher.ts:460-493) only appends to witnesses,
 	// never to the actor.
-	const actorSysContent = (
-		actorBody as { messages: Array<{ content: string }> }
-	).messages[0]?.content;
+	const actorAllContent = (
+		actorBody as { messages: Array<{ content: string | null }> }
+	).messages
+		.map((m) => (typeof m.content === "string" ? m.content : ""))
+		.join("\n");
 
 	expect(
-		actorSysContent,
-		"Actor must not have the witnessed-event line in their system prompt",
+		actorAllContent,
+		"Actor must not have the witnessed-event line in their messages",
 	).not.toContain(expectedLine);
 
 	// ── 16. No page errors ────────────────────────────────────────────────────

--- a/src/proxy/openai-proxy.test.ts
+++ b/src/proxy/openai-proxy.test.ts
@@ -768,6 +768,128 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 		const ipVal = await kv().get(perIpKey(ip, Date.now()));
 		expect(Number(ipVal)).toBe(seeded);
 	});
+
+	// ── prompt-cache discount awareness ──
+	// When upstream emits `usage.cost` (USD), the proxy reconciles using
+	// that authoritative figure — which already reflects any cached-prompt
+	// discount the provider applied — instead of locally re-deriving cost
+	// from raw token counts × seeded pricing.
+
+	it("streaming: prefers upstream usage.cost over local recompute", async () => {
+		const ip = "11.0.0.1";
+		// Pricing seeded at 1 micro-USD/token would give 1500 micro-USD locally;
+		// upstream reports cost=0.000200 USD = 200 micro-USD, reflecting a
+		// cache discount. Reconciliation must use 200, not 1500.
+		const ssePayload =
+			'data: {"usage":{"prompt_tokens":500,"completion_tokens":1000,"cost":0.000200,"prompt_tokens_details":{"cached_tokens":480}}}\n\ndata: [DONE]\n\n';
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(
+					new Response(ssePayload, {
+						status: 200,
+						headers: { "Content-Type": "text/event-stream" },
+					}),
+				),
+			),
+		);
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": ip,
+			},
+			body: JSON.stringify({
+				messages: [{ role: "user", content: "hi" }],
+				stream: true,
+			}),
+		});
+
+		expect(resp.status).toBe(200);
+		await resp.text();
+		await new Promise((r) => setTimeout(r, 50));
+
+		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		expect(Number(ipVal)).toBe(200);
+	});
+
+	it("non-streaming: prefers upstream usage.cost over local recompute", async () => {
+		const ip = "11.0.0.2";
+		const responseBody = JSON.stringify({
+			choices: [{ message: { content: "ok" } }],
+			usage: {
+				prompt_tokens: 300,
+				completion_tokens: 500,
+				cost: 0.00015,
+				prompt_tokens_details: { cached_tokens: 250 },
+			},
+		});
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(
+					new Response(responseBody, {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					}),
+				),
+			),
+		);
+
+		await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": ip,
+			},
+			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+		});
+
+		await new Promise((r) => setTimeout(r, 50));
+
+		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		expect(Number(ipVal)).toBe(150);
+	});
+
+	it("falls back to local price recompute when upstream cost is absent", async () => {
+		const ip = "11.0.0.3";
+		// No `cost` field — proxy must use seeded 1 micro-USD/token pricing.
+		const ssePayload =
+			'data: {"usage":{"prompt_tokens":500,"completion_tokens":1000,"prompt_tokens_details":{"cached_tokens":400}}}\n\ndata: [DONE]\n\n';
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() =>
+				Promise.resolve(
+					new Response(ssePayload, {
+						status: 200,
+						headers: { "Content-Type": "text/event-stream" },
+					}),
+				),
+			),
+		);
+
+		const resp = await SELF.fetch(ENDPOINT, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": ip,
+			},
+			body: JSON.stringify({
+				messages: [{ role: "user", content: "hi" }],
+				stream: true,
+			}),
+		});
+
+		await resp.text();
+		await new Promise((r) => setTimeout(r, 50));
+
+		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		expect(Number(ipVal)).toBe(1500);
+	});
 });
 
 // ── 10. CORS — OPTIONS preflight ──────────────────────────────────────────────

--- a/src/proxy/openai-proxy.ts
+++ b/src/proxy/openai-proxy.ts
@@ -158,12 +158,8 @@ export async function handleChatCompletions(
 		const usage = extractUsage(responseText);
 
 		if (usage !== null) {
-			const pricing = await pricingPromise;
-			const cost = computeCostMicroUsd(
-				usage.promptTokens,
-				usage.completionTokens,
-				pricing,
-			);
+			const cost = await resolveCostMicroUsd(usage, pricingPromise);
+			logCache(usage);
 			await reconcile(kv, ip, nowMs, guard.preCharged, cost);
 		} else {
 			await refundFull(kv, ip, nowMs, guard.preCharged);
@@ -182,7 +178,7 @@ export async function handleChatCompletions(
 		upstream.headers.get("Content-Type") ?? "application/octet-stream";
 
 	let sseBuffer = "";
-	let usage: { promptTokens: number; completionTokens: number } | null = null;
+	let usage: ParsedUsage | null = null;
 
 	const tryParseSseLine = (line: string): void => {
 		const trimmed = line.trim();
@@ -208,19 +204,10 @@ export async function handleChatCompletions(
 			const finalUsage = usage;
 			const kvWork =
 				finalUsage !== null
-					? pricingPromise.then((pricing) =>
-							reconcile(
-								kv,
-								ip,
-								nowMs,
-								guard.preCharged,
-								computeCostMicroUsd(
-									finalUsage.promptTokens,
-									finalUsage.completionTokens,
-									pricing,
-								),
-							),
-						)
+					? resolveCostMicroUsd(finalUsage, pricingPromise).then((cost) => {
+							logCache(finalUsage);
+							return reconcile(kv, ip, nowMs, guard.preCharged, cost);
+						})
 					: refundFull(kv, ip, nowMs, guard.preCharged);
 			ctx.waitUntil(kvWork);
 
@@ -246,13 +233,28 @@ export async function handleChatCompletions(
 }
 
 /**
- * Extract `{prompt_tokens, completion_tokens}` from a non-streaming JSON
- * response. Returns null if the body is unparseable or either field is
- * missing — callers should treat null as "issue a full refund".
+ * Token + cost accounting parsed from an upstream OpenRouter usage payload.
+ *
+ * `costUsd` mirrors `usage.cost` (USD) when OpenRouter sends it, which it
+ * does whenever the request opted into `usage: { include: true }`. That
+ * value already reflects any prompt-cache discount the provider applied,
+ * so we prefer it over locally re-computing from token counts.
+ *
+ * `cachedTokens` is purely for diagnostics — we don't price it directly.
  */
-function extractUsage(
-	responseText: string,
-): { promptTokens: number; completionTokens: number } | null {
+interface ParsedUsage {
+	promptTokens: number;
+	completionTokens: number;
+	cachedTokens?: number;
+	costUsd?: number;
+}
+
+/**
+ * Extract usage info from a non-streaming JSON response. Returns null if
+ * the body is unparseable or required token fields are missing — callers
+ * should treat null as "issue a full refund".
+ */
+function extractUsage(responseText: string): ParsedUsage | null {
 	try {
 		return parseUsageJson(responseText);
 	} catch {
@@ -260,11 +262,15 @@ function extractUsage(
 	}
 }
 
-function parseUsageJson(
-	text: string,
-): { promptTokens: number; completionTokens: number } | null {
+function parseUsageJson(text: string): ParsedUsage | null {
 	let parsed: {
-		usage?: { prompt_tokens?: number; completion_tokens?: number };
+		usage?: {
+			prompt_tokens?: number;
+			completion_tokens?: number;
+			cost?: number;
+			prompt_tokens_details?: { cached_tokens?: number };
+			cache_read_input_tokens?: number;
+		};
 	};
 	try {
 		parsed = JSON.parse(text) as typeof parsed;
@@ -279,5 +285,54 @@ function parseUsageJson(
 	) {
 		return null;
 	}
-	return { promptTokens, completionTokens };
+	const cachedFromOpenAi = parsed.usage?.prompt_tokens_details?.cached_tokens;
+	const cachedFromAnthropic = parsed.usage?.cache_read_input_tokens;
+	const cachedTokens =
+		typeof cachedFromOpenAi === "number"
+			? cachedFromOpenAi
+			: typeof cachedFromAnthropic === "number"
+				? cachedFromAnthropic
+				: undefined;
+	const costUsd =
+		typeof parsed.usage?.cost === "number" ? parsed.usage.cost : undefined;
+	return {
+		promptTokens,
+		completionTokens,
+		...(cachedTokens !== undefined ? { cachedTokens } : {}),
+		...(costUsd !== undefined ? { costUsd } : {}),
+	};
+}
+
+/**
+ * Resolve the cost to charge in micro-USD. Prefers OpenRouter's reported
+ * `usage.cost` (already discount-aware) over locally re-deriving from token
+ * counts × `/models` pricing.
+ */
+async function resolveCostMicroUsd(
+	usage: ParsedUsage,
+	pricingPromise: Promise<{
+		promptMicroUsdPerToken: number;
+		completionMicroUsdPerToken: number;
+	}>,
+): Promise<number> {
+	if (usage.costUsd !== undefined) {
+		return Math.ceil(usage.costUsd * 1e6);
+	}
+	const pricing = await pricingPromise;
+	return computeCostMicroUsd(
+		usage.promptTokens,
+		usage.completionTokens,
+		pricing,
+	);
+}
+
+function logCache(usage: ParsedUsage): void {
+	if (usage.cachedTokens === undefined) return;
+	const pct =
+		usage.promptTokens > 0
+			? Math.round((usage.cachedTokens / usage.promptTokens) * 100)
+			: 0;
+	console.log(
+		`[cache] prompt ${usage.cachedTokens}/${usage.promptTokens} cached (${pct}%)`,
+	);
 }

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ToolCallResult } from "../streaming.js";
+import type { ToolCallResult, UsageInfo } from "../streaming.js";
 import { parseSSEStream } from "../streaming.js";
 
 // __WORKER_BASE_URL__ is a build-time constant; provide a stub for tests
@@ -64,6 +64,76 @@ describe("parseSSEStream", () => {
 		);
 
 		expect(onDelta).not.toHaveBeenCalled();
+	});
+
+	it("surfaces cached_tokens from OpenAI-spec prompt_tokens_details", async () => {
+		const usageChunk = JSON.stringify({
+			choices: [],
+			usage: {
+				prompt_tokens: 1200,
+				completion_tokens: 80,
+				prompt_tokens_details: { cached_tokens: 900 },
+				cost: 0.000123,
+			},
+		});
+
+		const usages: UsageInfo[] = [];
+		await parseSSEStream(
+			makeSSEStream([`data: ${usageChunk}\n\ndata: [DONE]\n\n`]),
+			vi.fn(),
+			undefined,
+			undefined,
+			(u) => usages.push(u),
+		);
+
+		expect(usages).toHaveLength(1);
+		expect(usages[0]).toMatchObject({
+			cost: 0.000123,
+			prompt_tokens: 1200,
+			completion_tokens: 80,
+			cached_tokens: 900,
+		});
+	});
+
+	it("falls back to cache_read_input_tokens when prompt_tokens_details is absent", async () => {
+		const usageChunk = JSON.stringify({
+			choices: [],
+			usage: {
+				prompt_tokens: 500,
+				completion_tokens: 50,
+				cache_read_input_tokens: 400,
+			},
+		});
+
+		const usages: UsageInfo[] = [];
+		await parseSSEStream(
+			makeSSEStream([`data: ${usageChunk}\n\ndata: [DONE]\n\n`]),
+			vi.fn(),
+			undefined,
+			undefined,
+			(u) => usages.push(u),
+		);
+
+		expect(usages[0]?.cached_tokens).toBe(400);
+	});
+
+	it("omits cached_tokens when neither field is present", async () => {
+		const usageChunk = JSON.stringify({
+			choices: [],
+			usage: { prompt_tokens: 100, completion_tokens: 20 },
+		});
+
+		const usages: UsageInfo[] = [];
+		await parseSSEStream(
+			makeSSEStream([`data: ${usageChunk}\n\ndata: [DONE]\n\n`]),
+			vi.fn(),
+			undefined,
+			undefined,
+			(u) => usages.push(u),
+		);
+
+		expect(usages[0]?.cached_tokens).toBeUndefined();
+		expect(usages[0]?.prompt_tokens).toBe(100);
 	});
 
 	it("[DONE] terminates stream without emitting", async () => {

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -491,19 +491,21 @@ describe("conversation log integration — multi-round chronological order", () 
 		);
 
 		// Verify red's role turns have player messages in chronological order.
-		// Role turns use the compact "blue: <content>" form, not the rich
-		// "[Round N] blue dms you:" form.
+		// Role turns use the rich "[Round N] blue dms you: <content>" form
+		// rendered via conversation-log.ts:renderEntry.
 		const redCtx = buildAiContext(state2, "red");
 		const redMsgs = buildOpenAiMessages(redCtx);
 		const round0Idx = redMsgs.findIndex(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "blue: Hi Ember",
+				(m as { content: string }).content ===
+					"[Round 0] blue dms you: Hi Ember",
 		);
 		const round1Idx = redMsgs.findIndex(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "blue: What are you doing?",
+				(m as { content: string }).content ===
+					"[Round 1] blue dms you: What are you doing?",
 		);
 		expect(round0Idx).toBeGreaterThanOrEqual(0);
 		expect(round1Idx).toBeGreaterThanOrEqual(0);

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -3,21 +3,38 @@
  *
  * Uses runRound with MockRoundLLMProvider to simulate real tool executions
  * across multiple rounds and verifies that the resulting conversation logs
- * (via buildAiContext + toSystemPrompt) correctly show:
+ * correctly surface, via `buildOpenAiMessages` role turns:
  *   - Voice-chat interleaved with witnessed events by round
  *   - Distinct cone-based visibility (witnesses see only what's in their cone)
  *     resolved at write-time (ADR 0006, issue #195)
  *   - put_down placementFlavor rendered for in-cone witnesses
  *   - use outcome flavor rendered to actor as "you" and to witness as "*<actor>"
  *   - No "## Whispers Received" section ever
+ *
+ * The unified <conversation> system-prompt block was retired in favour of
+ * direct role-turn rendering (issue: prompt-cache restructure); witnessed
+ * events now show up as user turns interleaved with peer messages.
  */
 
 import { describe, expect, it } from "vitest";
 import { createGame, getActivePhase, startPhase } from "../engine";
+import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import { runRound } from "../round-coordinator";
 import { MockRoundLLMProvider } from "../round-llm-provider";
 import type { AiPersona, ContentPack, PhaseConfig } from "../types";
+
+/** Concatenate all role-turn message contents into a single searchable string. */
+function flattenMessageContents(
+	messages: ReturnType<typeof buildOpenAiMessages>,
+): string {
+	return messages
+		.map((m) => {
+			const c = (m as { content?: unknown }).content;
+			return typeof c === "string" ? c : "";
+		})
+		.join("\n");
+}
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -196,16 +213,16 @@ describe("conversation log integration — witnessed pick_up", () => {
 		);
 		expect(witnessedEntry).toBeDefined();
 
-		// green's prompt should contain the witnessed pick_up
+		// green's role turns should contain the witnessed pick_up
 		const greenCtx = buildAiContext(nextState, "green");
-		const greenPrompt = greenCtx.toSystemPrompt();
-		expect(greenPrompt).toContain("<conversation>");
-		expect(greenPrompt).toContain("You watch *red pick up the Flower.");
+		const greenMsgs = buildOpenAiMessages(greenCtx);
+		const greenAll = flattenMessageContents(greenMsgs);
+		expect(greenAll).toContain("You watch *red pick up the Flower.");
 
-		// red's own prompt should NOT have a "You watch *red" line
+		// red's own role turns should NOT have a "You watch *red" line
 		const redCtx = buildAiContext(nextState, "red");
-		const redPrompt = redCtx.toSystemPrompt();
-		expect(redPrompt).not.toContain("You watch *red");
+		const redMsgs = buildOpenAiMessages(redCtx);
+		expect(flattenMessageContents(redMsgs)).not.toContain("You watch *red");
 
 		// red's own conversationLog should have no witnessed-event entries
 		const redLog = phase.conversationLogs.red ?? [];
@@ -240,8 +257,10 @@ describe("conversation log integration — witnessed pick_up", () => {
 		expect(cyanWitnessed).toHaveLength(0);
 
 		const cyanCtx = buildAiContext(nextState, "cyan");
-		const cyanPrompt = cyanCtx.toSystemPrompt();
-		expect(cyanPrompt).not.toContain("You watch *red pick up");
+		const cyanMsgs = buildOpenAiMessages(cyanCtx);
+		expect(flattenMessageContents(cyanMsgs)).not.toContain(
+			"You watch *red pick up",
+		);
 	});
 });
 
@@ -304,18 +323,18 @@ describe("conversation log integration — use outcome rendering", () => {
 			expect(useEntry.useOutcome).toContain("{actor}");
 		}
 
-		// green's prompt should have *red substitution
+		// green's role turns should have *red substitution
 		const greenCtx = buildAiContext(state2, "green");
-		const greenPrompt = greenCtx.toSystemPrompt();
-		if (greenPrompt.includes("<conversation>")) {
-			const lines = greenPrompt.split("\n");
-			const useLine = lines.find(
-				(l) => l.includes("lamp") || l.includes("glows"),
-			);
-			if (useLine) {
-				expect(useLine).toContain("*red");
-				expect(useLine).not.toContain("{actor}");
-			}
+		const greenMsgs = buildOpenAiMessages(greenCtx);
+		const useLine = greenMsgs
+			.map((m) => {
+				const c = (m as { content?: unknown }).content;
+				return typeof c === "string" ? c : "";
+			})
+			.find((c) => c.includes("lamp") || c.includes("glows"));
+		if (useLine) {
+			expect(useLine).toContain("*red");
+			expect(useLine).not.toContain("{actor}");
 		}
 	});
 });
@@ -423,10 +442,10 @@ describe("conversation log integration — put_down placementFlavor", () => {
 		// So green should NOT see this put_down
 		expect(putEntry).toBeUndefined();
 
-		// Also verify via prompt
+		// Also verify via role turns
 		const greenCtx = buildAiContext(state4, "green");
-		const greenPrompt = greenCtx.toSystemPrompt();
-		expect(greenPrompt).not.toContain(
+		const greenMsgs = buildOpenAiMessages(greenCtx);
+		expect(flattenMessageContents(greenMsgs)).not.toContain(
 			"*red places the flower on the pedestal.",
 		);
 	});
@@ -471,22 +490,33 @@ describe("conversation log integration — multi-round chronological order", () 
 			provider2,
 		);
 
-		// Verify red's prompt has events in order
+		// Verify red's role turns have player messages in chronological order.
+		// Role turns use the compact "blue: <content>" form, not the rich
+		// "[Round N] blue dms you:" form.
 		const redCtx = buildAiContext(state2, "red");
-		const redPrompt = redCtx.toSystemPrompt();
-		expect(redPrompt).toContain("<conversation>");
-		// Round 0 player message appears before round 1 player message
-		const round0Idx = redPrompt.indexOf("[Round 0] blue dms you:");
-		const round1Idx = redPrompt.indexOf("[Round 1] blue dms you:");
+		const redMsgs = buildOpenAiMessages(redCtx);
+		const round0Idx = redMsgs.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "blue: Hi Ember",
+		);
+		const round1Idx = redMsgs.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "blue: What are you doing?",
+		);
 		expect(round0Idx).toBeGreaterThanOrEqual(0);
 		expect(round1Idx).toBeGreaterThanOrEqual(0);
 		expect(round0Idx).toBeLessThan(round1Idx);
 
-		// Verify green's prompt has the witnessed pick_up in round 1
+		// Verify green's role turns include the witnessed pick_up in round 1.
+		// green at (0,0) facing south: two steps ahead is (2,0) — red's position.
+		// Witnessed events keep the rich "[Round N] You watch *X do Y." form
+		// since that's how renderEntry formats them.
 		const greenCtx = buildAiContext(state2, "green");
-		const greenPrompt = greenCtx.toSystemPrompt();
-		// green at (0,0) facing south: two steps ahead is (2,0) — red's position
-		// So green should see the pick_up
-		expect(greenPrompt).toContain("[Round 1] You watch *red pick up the Lamp.");
+		const greenMsgs = buildOpenAiMessages(greenCtx);
+		expect(flattenMessageContents(greenMsgs)).toContain(
+			"[Round 1] You watch *red pick up the Lamp.",
+		);
 	});
 });

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -121,8 +121,17 @@ function makeGame() {
 	);
 }
 
+// The trailing user message is always the current-state turn (carries
+// `<where_you_are>` + `<what_you_see>`). The silent-turn anchor, when it fires,
+// sits immediately before it — so "the last conversational message" is now
+// `messages[messages.length - 2]`, and finding the last *peer/player* user msg
+// requires skipping the current-state tail.
+function isCurrentStateTurn(content: string | null | undefined): boolean {
+	return typeof content === "string" && content.startsWith("<where_you_are>");
+}
+
 describe("non-addressed daemon never sees a stale user message as its last turn", () => {
-	it("after addressing red then cyan, red's round-2 messages end with the silent-voice anchor (not the prior user/assistant)", async () => {
+	it("after addressing red then cyan, red's round-2 messages have the silent-voice anchor immediately before the current-state turn", async () => {
 		const initiative: AiId[] = ["red", "green", "cyan"];
 		const game = makeGame();
 
@@ -160,20 +169,21 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		expect(redRound2).toBeDefined();
 		const msgs = redRound2?.messages ?? [];
 
-		// Last message anchors the current round.
+		// The trailing message is the current-state turn (always).
 		const last = msgs[msgs.length - 1];
 		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(
+		expect(isCurrentStateTurn((last as { content: string }).content)).toBe(
+			true,
+		);
+
+		// The silent-turn anchor sits immediately before it.
+		const anchor = msgs[msgs.length - 2];
+		expect(anchor?.role).toBe("user");
+		expect((anchor as { content: string }).content).toBe(
 			expectedSilentTurn("red"),
 		);
 
-		// And the prior round's user/assistant are still in history but no longer
-		// at the tail.
-		const lastUser = [...msgs].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe(
-			expectedSilentTurn("red"),
-		);
-		// In v4 the player message is prefixed with "blue: " when built into OpenAI messages
+		// And the prior round's user/assistant are still in history.
 		const priorUser = msgs.find(
 			(m) =>
 				m.role === "user" &&
@@ -182,12 +192,17 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		expect(priorUser).toBeDefined();
 
 		// Cyan (the addressee this round) must NOT receive the silent-voice
-		// anchor — its tail is the actual player message.
+		// anchor — its last conversational user msg is the actual player message.
 		const cyanRound2 = provider.calls[5];
 		const cyanMsgs = cyanRound2?.messages ?? [];
-		const cyanLastUser = [...cyanMsgs].reverse().find((m) => m.role === "user");
-		// In v4 the player message is prefixed with "blue: " when built into OpenAI messages
-		expect((cyanLastUser as { content: string }).content).toBe(
+		const cyanLastConv = [...cyanMsgs]
+			.reverse()
+			.find(
+				(m) =>
+					m.role === "user" &&
+					!isCurrentStateTurn((m as { content: string }).content),
+			);
+		expect((cyanLastConv as { content: string }).content).toBe(
 			"blue: different question for cyan",
 		);
 		expect(
@@ -199,7 +214,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		).toBe(false);
 	});
 
-	it("an AI that has never been addressed still gets the silent-voice anchor", async () => {
+	it("an AI that has never been addressed still gets the silent-voice anchor (before current-state)", async () => {
 		const initiative: AiId[] = ["red", "green", "cyan"];
 		const game = makeGame();
 
@@ -211,12 +226,17 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 
 		await runRound(game, "red", "hello red", provider, undefined, initiative);
 
-		// Green was never addressed; green's call (index 1) must end with the anchor.
+		// Green was never addressed; green's call (index 1) must have the anchor
+		// immediately before the trailing current-state turn.
 		const greenCall = provider.calls[1];
 		const greenMsgs = greenCall?.messages ?? [];
 		const last = greenMsgs[greenMsgs.length - 1];
-		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(
+		expect(isCurrentStateTurn((last as { content: string }).content)).toBe(
+			true,
+		);
+		const anchor = greenMsgs[greenMsgs.length - 2];
+		expect(anchor?.role).toBe("user");
+		expect((anchor as { content: string }).content).toBe(
 			expectedSilentTurn("green"),
 		);
 	});
@@ -225,7 +245,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		// Initiative: red acts first, then green, then cyan.
 		// Blue addresses red. Red emits a message tool call to green.
 		// When green acts, it has an incoming message from red in the current round →
-		// anchor must NOT fire, and green's last user message is the peer message.
+		// anchor must NOT fire, and green's last conversational user msg is the peer message.
 		const initiative: AiId[] = ["red", "green", "cyan"];
 		const game = makeGame();
 
@@ -262,14 +282,18 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 			),
 		).toBe(false);
 
-		// Green's last user message is the peer message from red.
-		const lastUser = [...greenMsgs].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe("*red: psst green");
+		// Green's last conversational user message is the peer message from red.
+		const lastConv = [...greenMsgs]
+			.reverse()
+			.find(
+				(m) =>
+					m.role === "user" &&
+					!isCurrentStateTurn((m as { content: string }).content),
+			);
+		expect((lastConv as { content: string }).content).toBe("*red: psst green");
 	});
 
-	it("blue addresses this daemon → no anchor; last user message is the player message", async () => {
-		// Blue addresses cyan directly. Cyan's messages must NOT end with the anchor;
-		// instead the last user message is the player message prefixed with "blue: ".
+	it("blue addresses this daemon → no anchor; last conversational user message is the player message", async () => {
 		const initiative: AiId[] = ["red", "green", "cyan"];
 		const game = makeGame();
 
@@ -296,8 +320,15 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 			),
 		).toBe(false);
 
-		// Last user message is the player's message.
-		const lastUser = [...cyanMsgs].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe("blue: hello cyan");
+		// Last conversational user message (skipping the trailing current-state turn)
+		// is the player's message.
+		const lastConv = [...cyanMsgs]
+			.reverse()
+			.find(
+				(m) =>
+					m.role === "user" &&
+					!isCurrentStateTurn((m as { content: string }).content),
+			);
+		expect((lastConv as { content: string }).content).toBe("blue: hello cyan");
 	});
 });

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -187,7 +187,8 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const priorUser = msgs.find(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "blue: are you alive?",
+				(m as { content: string }).content ===
+					"[Round 0] blue dms you: are you alive?",
 		);
 		expect(priorUser).toBeDefined();
 
@@ -203,7 +204,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 					!isCurrentStateTurn((m as { content: string }).content),
 			);
 		expect((cyanLastConv as { content: string }).content).toBe(
-			"blue: different question for cyan",
+			"[Round 1] blue dms you: different question for cyan",
 		);
 		expect(
 			cyanMsgs.some(
@@ -290,7 +291,9 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 					m.role === "user" &&
 					!isCurrentStateTurn((m as { content: string }).content),
 			);
-		expect((lastConv as { content: string }).content).toBe("*red: psst green");
+		expect((lastConv as { content: string }).content).toBe(
+			"[Round 0] *red dms you: psst green",
+		);
 	});
 
 	it("blue addresses this daemon → no anchor; last conversational user message is the player message", async () => {
@@ -329,6 +332,8 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 					m.role === "user" &&
 					!isCurrentStateTurn((m as { content: string }).content),
 			);
-		expect((lastConv as { content: string }).content).toBe("blue: hello cyan");
+		expect((lastConv as { content: string }).content).toBe(
+			"[Round 0] blue dms you: hello cyan",
+		);
 	});
 });

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -402,12 +402,17 @@ describe("buildOpenAiMessages", () => {
 		expect((anchor as { content: string }).content).toBe(buildSilentTurn());
 	});
 
-	// Cache-correctness invariant: rendering the same context twice must
-	// produce byte-identical output. If a future change introduces
-	// non-determinism in conversation-log ordering (e.g. iterating a record
-	// without a stable sort key), the OpenRouter prefix cache silently
-	// stops hitting. This test catches that.
-	it("buildOpenAiMessages is deterministic across re-renders of the same context", () => {
+	// Pinned regression: rendering the same context twice must produce
+	// byte-identical output. This proves `buildOpenAiMessages` itself is
+	// pure (Array.sort is stable, the renderEntry path has no
+	// nondeterminism), but it does NOT defend against the upstream concern
+	// — `ctx.conversationLog` arriving in different orders on different
+	// requests. That risk would require a per-entry sequence number on
+	// ConversationEntry to fix properly (so within-round ties have a
+	// stable key beyond array insertion order); the engine currently
+	// constructs the array deterministically via `appendMessage`, so the
+	// risk is latent. Tracked alongside the prompt-cache cleanup work.
+	it("buildOpenAiMessages is pure: same context → byte-identical output", () => {
 		let game = makeGame();
 		// A non-trivial mix: incoming, outgoing, peer, and multiple rounds.
 		game = appendMessage(game, "blue", "red", "hi");

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -95,11 +95,11 @@ describe("buildOpenAiMessages", () => {
 		expect(messages[0]?.role).toBe("system");
 		expect(messages[1]).toEqual({
 			role: "user",
-			content: "blue: Hello Ember!",
+			content: "[Round 0] blue dms you: Hello Ember!",
 		});
 		expect(messages[2]).toEqual({
 			role: "assistant",
-			content: "Hello, player!",
+			content: "[Round 0] you dm blue: Hello, player!",
 		});
 		// Trailing current-state turn
 		expect(messages[3]?.role).toBe("user");
@@ -294,7 +294,7 @@ describe("buildOpenAiMessages", () => {
 		// Anchor sits immediately before the trailing current-state turn
 		const anchor = messages[messages.length - 2];
 		expect(anchor?.role).toBe("user");
-		expect((anchor as { content: string }).content).toBe(buildSilentTurn(ctx));
+		expect((anchor as { content: string }).content).toBe(buildSilentTurn());
 
 		// Last is the current-state turn
 		const last = messages[messages.length - 1];
@@ -312,7 +312,7 @@ describe("buildOpenAiMessages", () => {
 		game = appendMessage(game, "green", "red", "psst red");
 
 		const ctx = buildAiContext(game, "red");
-		const silent = buildSilentTurn(ctx);
+		const silent = buildSilentTurn();
 		const stateContent = ctx.toCurrentStateUserMessage();
 		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
@@ -333,7 +333,7 @@ describe("buildOpenAiMessages", () => {
 		const lastConversational =
 			conversationalUserTurns[conversationalUserTurns.length - 1];
 		expect((lastConversational as { content: string }).content).toBe(
-			"*green: psst red",
+			"[Round 0] *green dms you: psst red",
 		);
 	});
 
@@ -345,7 +345,7 @@ describe("buildOpenAiMessages", () => {
 		game = appendMessage(game, "blue", "red", "Hi Ember");
 
 		const ctx = buildAiContext(game, "red");
-		const silent = buildSilentTurn(ctx);
+		const silent = buildSilentTurn();
 		const stateContent = ctx.toCurrentStateUserMessage();
 		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
@@ -365,14 +365,14 @@ describe("buildOpenAiMessages", () => {
 		const lastConversational =
 			conversationalUserTurns[conversationalUserTurns.length - 1];
 		expect((lastConversational as { content: string }).content).toBe(
-			"blue: Hi Ember",
+			"[Round 0] blue dms you: Hi Ember",
 		);
 	});
 
 	it("when `currentRound` is omitted, no anchor is appended (back-compat)", () => {
 		const game = makeGame();
 		const ctx = buildAiContext(game, "red");
-		const silent = buildSilentTurn(ctx);
+		const silent = buildSilentTurn();
 		const messages = buildOpenAiMessages(ctx, undefined);
 		expect(
 			messages.some(
@@ -399,6 +399,47 @@ describe("buildOpenAiMessages", () => {
 		// Anchor sits immediately before the trailing current-state turn
 		const anchor = messages[messages.length - 2];
 		expect(anchor?.role).toBe("user");
-		expect((anchor as { content: string }).content).toBe(buildSilentTurn(ctx));
+		expect((anchor as { content: string }).content).toBe(buildSilentTurn());
+	});
+
+	// Cache-correctness invariant: rendering the same context twice must
+	// produce byte-identical output. If a future change introduces
+	// non-determinism in conversation-log ordering (e.g. iterating a record
+	// without a stable sort key), the OpenRouter prefix cache silently
+	// stops hitting. This test catches that.
+	it("buildOpenAiMessages is deterministic across re-renders of the same context", () => {
+		let game = makeGame();
+		// A non-trivial mix: incoming, outgoing, peer, and multiple rounds.
+		game = appendMessage(game, "blue", "red", "hi");
+		game = appendMessage(game, "red", "blue", "hi back");
+		game = appendMessage(game, "green", "red", "psst");
+		game = advanceRound(game);
+		game = appendMessage(game, "blue", "red", "round two");
+		game = appendMessage(game, "red", "cyan", "side channel");
+
+		const ctx = buildAiContext(game, "red");
+		const a = buildOpenAiMessages(ctx, undefined, 1);
+		const b = buildOpenAiMessages(ctx, undefined, 1);
+		expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+	});
+
+	// Cache-correctness invariant: the system prompt for a (persona × phase)
+	// must be byte-identical across rounds, since OpenRouter's prefix cache
+	// hashes the literal request bytes. Any drift here silently busts caching.
+	it("system prompt is byte-stable across rounds within a phase", () => {
+		let game = makeGame();
+		const round0Prompt = buildAiContext(game, "red").toSystemPrompt();
+
+		// Advance through a few rounds, with messages and no spatial moves.
+		// Spatial moves don't matter for the system prompt (where_you_are
+		// lives in the trailing user turn now), but they would have busted
+		// the prefix in the pre-restructure code path.
+		game = appendMessage(game, "blue", "red", "round 0 chatter");
+		game = advanceRound(game);
+		game = appendMessage(game, "blue", "red", "round 1 chatter");
+		game = advanceRound(game);
+		const round2Prompt = buildAiContext(game, "red").toSystemPrompt();
+
+		expect(round2Prompt).toBe(round0Prompt);
 	});
 });

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -97,9 +97,12 @@ describe("buildOpenAiMessages", () => {
 			role: "user",
 			content: "[Round 0] blue dms you: Hello Ember!",
 		});
+		// Outgoing assistant turn renders raw entry.content — what the model
+		// actually emitted via the `message` tool. No synthetic round/routing
+		// prefix; that would misrepresent its own output back to it.
 		expect(messages[2]).toEqual({
 			role: "assistant",
-			content: "[Round 0] you dm blue: Hello, player!",
+			content: "Hello, player!",
 		});
 		// Trailing current-state turn
 		expect(messages[3]?.role).toBe("user");

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -69,17 +69,21 @@ function makeGame() {
 }
 
 describe("buildOpenAiMessages", () => {
-	it("empty chat history + no roundtrip → [system, (no user/assistant pair)]", () => {
+	it("empty chat history + no roundtrip → [system, current-state user turn]", () => {
 		const game = makeGame();
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined);
 
-		// Just system message — no chat history
-		expect(messages).toHaveLength(1);
+		// system + trailing current-state user turn (always last)
+		expect(messages).toHaveLength(2);
 		expect(messages[0]?.role).toBe("system");
+		expect(messages[1]?.role).toBe("user");
+		expect((messages[1] as { content: string }).content).toBe(
+			ctx.toCurrentStateUserMessage(),
+		);
 	});
 
-	it("single player+AI message turn → [system, user, assistant]", () => {
+	it("single player+AI message turn → [system, user, assistant, current-state]", () => {
 		let game = makeGame();
 		game = appendMessage(game, "blue", "red", "Hello Ember!");
 		game = appendMessage(game, "red", "blue", "Hello, player!");
@@ -87,7 +91,7 @@ describe("buildOpenAiMessages", () => {
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined);
 
-		expect(messages).toHaveLength(3);
+		expect(messages).toHaveLength(4);
 		expect(messages[0]?.role).toBe("system");
 		expect(messages[1]).toEqual({
 			role: "user",
@@ -97,9 +101,14 @@ describe("buildOpenAiMessages", () => {
 			role: "assistant",
 			content: "Hello, player!",
 		});
+		// Trailing current-state turn
+		expect(messages[3]?.role).toBe("user");
+		expect((messages[3] as { content: string }).content).toBe(
+			ctx.toCurrentStateUserMessage(),
+		);
 	});
 
-	it("message history of length N → N pairs after system", () => {
+	it("message history of length N → N pairs after system, then current-state", () => {
 		let game = makeGame();
 		for (let i = 0; i < 3; i++) {
 			game = appendMessage(game, "blue", "red", `Player msg ${i}`);
@@ -109,14 +118,19 @@ describe("buildOpenAiMessages", () => {
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined);
 
-		// 1 system + 6 messages (3 player + 3 AI)
-		expect(messages).toHaveLength(7);
+		// 1 system + 6 messages (3 player + 3 AI) + 1 trailing current-state
+		expect(messages).toHaveLength(8);
 		expect(messages[0]?.role).toBe("system");
 		// Pairs alternate user/assistant
 		for (let i = 0; i < 3; i++) {
 			expect(messages[1 + i * 2]?.role).toBe("user");
 			expect(messages[2 + i * 2]?.role).toBe("assistant");
 		}
+		// Last message is the current-state user turn
+		expect(messages[7]?.role).toBe("user");
+		expect((messages[7] as { content: string }).content).toBe(
+			ctx.toCurrentStateUserMessage(),
+		);
 	});
 
 	it("prior-round tool roundtrip is appended with correct ordering", () => {
@@ -144,8 +158,8 @@ describe("buildOpenAiMessages", () => {
 
 		const messages = buildOpenAiMessages(ctx, roundtrip);
 
-		// system + user + assistant{tool_calls} + tool result
-		expect(messages).toHaveLength(4);
+		// system + user(blue msg) + assistant{tool_calls} + tool result + trailing current-state
+		expect(messages).toHaveLength(5);
 		expect(messages[0]?.role).toBe("system");
 		expect(messages[1]?.role).toBe("user");
 
@@ -167,6 +181,12 @@ describe("buildOpenAiMessages", () => {
 			expect(toolMsg.tool_call_id).toBe("call_abc");
 			expect(toolMsg.content).toBe("Ember picked up the flower");
 		}
+
+		// Trailing current-state turn
+		expect(messages[4]?.role).toBe("user");
+		expect((messages[4] as { content: string }).content).toBe(
+			ctx.toCurrentStateUserMessage(),
+		);
 	});
 
 	it("matching tool_call_id in assistant message and tool message", () => {
@@ -245,13 +265,19 @@ describe("buildOpenAiMessages", () => {
 		};
 
 		const messages = buildOpenAiMessages(ctx, emptyRoundtrip);
-		// No extra messages appended
-		expect(messages).toHaveLength(1); // only system
+		// system + trailing current-state user turn (always emitted)
+		expect(messages).toHaveLength(2);
+		expect(messages[0]?.role).toBe("system");
+		expect(messages[1]?.role).toBe("user");
 		expect(messages.every((m) => m.role !== "tool")).toBe(true);
 	});
 
+	// The current-state user turn is always last (carries <where_you_are> +
+	// <what_you_see>). The silent-turn anchor, when it fires, sits immediately
+	// before that — i.e. second-to-last.
+
 	// Case (a): blue addresses a peer — this Daemon received no messages this round → anchor fires
-	it("(a) blue addresses peer, no incoming message for this daemon → silent-turn anchor fires", () => {
+	it("(a) blue addresses peer, no incoming message for this daemon → silent-turn anchor fires (second-to-last)", () => {
 		let game = makeGame();
 		// Prior round (round 0): red was addressed and replied
 		game = appendMessage(game, "blue", "red", "Hi Ember");
@@ -265,14 +291,20 @@ describe("buildOpenAiMessages", () => {
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
-		// Anchor must fire: no messages for red in round 1
+		// Anchor sits immediately before the trailing current-state turn
+		const anchor = messages[messages.length - 2];
+		expect(anchor?.role).toBe("user");
+		expect((anchor as { content: string }).content).toBe(buildSilentTurn(ctx));
+
+		// Last is the current-state turn
 		const last = messages[messages.length - 1];
-		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(buildSilentTurn(ctx));
+		expect((last as { content: string }).content).toBe(
+			ctx.toCurrentStateUserMessage(),
+		);
 	});
 
-	// Case (b): peer messages this Daemon, blue silent → no anchor; last user msg is `*<sender>: <content>`
-	it("(b) peer messages this daemon this round → no silent-turn anchor, last user msg is peer message", () => {
+	// Case (b): peer messages this Daemon, blue silent → no anchor; last *non-state* user msg is the peer message
+	it("(b) peer messages this daemon this round → no silent-turn anchor, last conversational user msg is peer message", () => {
 		let game = makeGame();
 		// red receives a message from green this round
 		const phase = getActivePhase(game);
@@ -281,6 +313,7 @@ describe("buildOpenAiMessages", () => {
 
 		const ctx = buildAiContext(game, "red");
 		const silent = buildSilentTurn(ctx);
+		const stateContent = ctx.toCurrentStateUserMessage();
 		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
 		// Anchor must NOT fire
@@ -291,13 +324,21 @@ describe("buildOpenAiMessages", () => {
 			),
 		).toBe(false);
 
-		// Last user message is the peer message
-		const lastUser = [...messages].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe("*green: psst red");
+		// The last non-state user turn is the peer message (state turn is at the very end)
+		const conversationalUserTurns = messages.filter(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content !== stateContent,
+		);
+		const lastConversational =
+			conversationalUserTurns[conversationalUserTurns.length - 1];
+		expect((lastConversational as { content: string }).content).toBe(
+			"*green: psst red",
+		);
 	});
 
-	// Case (c): blue addresses this Daemon → no anchor; last user msg is `blue: <content>`
-	it("(c) blue addresses this daemon → no silent-turn anchor, last user msg is player message", () => {
+	// Case (c): blue addresses this Daemon → no anchor; last *non-state* user msg is `blue: <content>`
+	it("(c) blue addresses this daemon → no silent-turn anchor, last conversational user msg is player message", () => {
 		let game = makeGame();
 		const phase = getActivePhase(game);
 		const currentRound = phase.round;
@@ -305,6 +346,7 @@ describe("buildOpenAiMessages", () => {
 
 		const ctx = buildAiContext(game, "red");
 		const silent = buildSilentTurn(ctx);
+		const stateContent = ctx.toCurrentStateUserMessage();
 		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
 		// Anchor must NOT fire
@@ -315,9 +357,16 @@ describe("buildOpenAiMessages", () => {
 			),
 		).toBe(false);
 
-		// Last user message is the player message
-		const lastUser = [...messages].reverse().find((m) => m.role === "user");
-		expect((lastUser as { content: string }).content).toBe("blue: Hi Ember");
+		const conversationalUserTurns = messages.filter(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content !== stateContent,
+		);
+		const lastConversational =
+			conversationalUserTurns[conversationalUserTurns.length - 1];
+		expect((lastConversational as { content: string }).content).toBe(
+			"blue: Hi Ember",
+		);
 	});
 
 	it("when `currentRound` is omitted, no anchor is appended (back-compat)", () => {
@@ -347,9 +396,9 @@ describe("buildOpenAiMessages", () => {
 		const ctx = buildAiContext(game, "red");
 		const messages = buildOpenAiMessages(ctx, undefined, currentRound);
 
-		// Anchor must fire — round 1 has no incoming entries even though round 0 does
-		const last = messages[messages.length - 1];
-		expect(last?.role).toBe("user");
-		expect((last as { content: string }).content).toBe(buildSilentTurn(ctx));
+		// Anchor sits immediately before the trailing current-state turn
+		const anchor = messages[messages.length - 2];
+		expect(anchor?.role).toBe("user");
+		expect((anchor as { content: string }).content).toBe(buildSilentTurn(ctx));
 	});
 });

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { advanceRound, appendMessage, createGame, startPhase } from "../engine";
+import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import type {
 	AiPersona,
@@ -200,11 +201,14 @@ describe("buildAiContext", () => {
 		game = appendMessage(game, "blue", "red", "Hi");
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
+		// Stable persona content lives in the system prompt
 		expect(prompt).toContain("Ember");
 		expect(prompt).toContain("You are hot-headed and zealous");
-		// With pack items at (0,0) shown in "Your cell contains"
-		expect(prompt).toContain("flower");
-		expect(prompt).toContain("key");
+		// Volatile spatial state ("Your cell contains") moved out to the
+		// trailing current-state user turn for cache-prefix stability.
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toContain("flower");
+		expect(stateMsg).toContain("key");
 	});
 
 	it("does not include other AIs' chat histories in system prompt", () => {
@@ -282,8 +286,11 @@ describe("<setting> block", () => {
 // ----------------------------------------------------------------------------
 // "Where you are" section (issue #123)
 // ----------------------------------------------------------------------------
-describe("prompt-builder — spatial 'Where you are' section", () => {
-	it("includes <where_you_are> block in the system prompt", () => {
+describe("prompt-builder — spatial 'Where you are' section (current-state user turn)", () => {
+	// Spatial state moved out of the system prompt into the trailing user turn
+	// (`ctx.toCurrentStateUserMessage()`) so the system prefix stays cache-stable.
+
+	it("includes <where_you_are> block in the current-state user turn", () => {
 		// rng=()=>0 places red at (0,0) facing north
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
@@ -291,11 +298,11 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<where_you_are>");
+		expect(ctx.toCurrentStateUserMessage()).toContain("<where_you_are>");
+		expect(ctx.toSystemPrompt()).not.toContain("<where_you_are>");
 	});
 
-	it("reports actor's position and facing in the prompt", () => {
+	it("reports actor's position and facing in the current-state user turn", () => {
 		// rng=()=>0 places red at (0,0) facing north
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
@@ -303,9 +310,9 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(/row 0.*col 0/i);
-		expect(prompt).toMatch(/north/i);
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toMatch(/row 0.*col 0/i);
+		expect(stateMsg).toMatch(/north/i);
 	});
 
 	it("lists items in the actor's cell under 'Where you are'", () => {
@@ -332,10 +339,10 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
+		const stateMsg = ctx.toCurrentStateUserMessage();
 		// Items in red's cell should be listed
-		expect(prompt).toContain("flower");
-		expect(prompt).toContain("key");
+		expect(stateMsg).toContain("flower");
+		expect(stateMsg).toContain("key");
 	});
 
 	it("lists other AIs visible in the cone under <what_you_see>", () => {
@@ -345,8 +352,8 @@ describe("prompt-builder — spatial 'Where you are' section", () => {
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<what_you_see>");
+		expect(ctx.toCurrentStateUserMessage()).toContain("<what_you_see>");
+		expect(ctx.toSystemPrompt()).not.toContain("<what_you_see>");
 	});
 });
 
@@ -404,13 +411,27 @@ describe("wipe directive", () => {
 });
 
 describe("voice framing", () => {
-	it("renders 'blue dms you:' prefix for player turns in conversation, not 'Player:'", () => {
+	it("renders 'blue:' prefix for player turns in role messages, never 'Player:'", () => {
+		// Conversation rendering moved out of the system prompt into role
+		// turns; the compact "blue: <content>" form replaces the rich
+		// "[Round N] blue dms you: <content>" form previously emitted in the
+		// system prompt's <conversation> block.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "blue", "red", "Hello Ember");
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("blue dms you:");
-		expect(prompt).not.toContain("Player:");
+		const messages = buildOpenAiMessages(ctx);
+		const userMsg = messages.find(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "blue: Hello Ember",
+		);
+		expect(userMsg).toBeDefined();
+		// "Player:" framing must never appear anywhere
+		const anyPlayer = messages.some((m) => {
+			const c = (m as { content?: unknown }).content;
+			return typeof c === "string" && c.includes("Player:");
+		});
+		expect(anyPlayer).toBe(false);
 	});
 
 	it("phase-1 prompt's identity line includes the disorientation phrase", () => {
@@ -647,15 +668,16 @@ describe("byte-identical sections across phases", () => {
 
 	// Build both prompts once and share across all assertions in this describe block.
 	// Use deterministic rng=()=>0 so spatial placements are identical across both phases.
+	function buildCtx(phase: 1 | 2) {
+		let game = startPhase(createGame(TEST_PERSONAS), PHASE_1_CLEAN, () => 0);
+		if (phase === 2) game = startPhase(game, PHASE_2_CLEAN, () => 0);
+		return buildAiContext(game, "red");
+	}
 	function buildBothPrompts() {
-		const game1 = startPhase(createGame(TEST_PERSONAS), PHASE_1_CLEAN, () => 0);
-		const p1 = buildAiContext(game1, "red").toSystemPrompt();
-
-		let game2 = startPhase(createGame(TEST_PERSONAS), PHASE_1_CLEAN, () => 0);
-		game2 = startPhase(game2, PHASE_2_CLEAN, () => 0);
-		const p2 = buildAiContext(game2, "red").toSystemPrompt();
-
-		return { p1, p2 };
+		return {
+			p1: buildCtx(1).toSystemPrompt(),
+			p2: buildCtx(2).toSystemPrompt(),
+		};
 	}
 
 	it("both phases emit the same set of section headers (whitelist: no surprise additions or removals)", () => {
@@ -680,9 +702,15 @@ describe("byte-identical sections across phases", () => {
 		expect(getSection(p2, "goal")).toContain("memory has been wiped");
 	});
 
-	it("<what_you_see> block is byte-identical across phase 1 and phase 2 (same world, same placements)", () => {
-		const { p1, p2 } = buildBothPrompts();
-		expect(getSection(p1, "what_you_see")).toBe(getSection(p2, "what_you_see"));
+	it("<what_you_see> block is byte-identical across phase 1 and phase 2 (now lives in the current-state user turn)", () => {
+		// `<what_you_see>` moved out of the system prompt; assert the
+		// equivalent on the trailing current-state user message rendered for
+		// each phase's context. Same world, same placements → byte-identical.
+		const c1 = buildCtx(1);
+		const c2 = buildCtx(2);
+		expect(getSection(c1.toCurrentStateUserMessage(), "what_you_see")).toBe(
+			getSection(c2.toCurrentStateUserMessage(), "what_you_see"),
+		);
 	});
 
 	it("<voice_examples> block is byte-identical across phase 1 and phase 2", () => {
@@ -708,17 +736,17 @@ describe("byte-identical sections across phases", () => {
 // "<what_you_see>" cone section tests (issue #124)
 // ----------------------------------------------------------------------------
 describe("<what_you_see> (cone)", () => {
+	// `<what_you_see>` lives in the trailing current-state user turn now.
 	const CONE_PHASE_CONFIG = makeConfig(1, ["r", "g", "b"]);
 
-	it("<what_you_see> block is present in every phase prompt", () => {
+	it("<what_you_see> block is present in every phase's current-state turn", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			CONE_PHASE_CONFIG,
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<what_you_see>");
+		expect(ctx.toCurrentStateUserMessage()).toContain("<what_you_see>");
 	});
 
 	it("item in cone cell is listed under 'Directly in front'", () => {
@@ -751,9 +779,9 @@ describe("<what_you_see> (cone)", () => {
 		expect(redSpatial?.facing).toBe("south");
 
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
+		const stateMsg = ctx.toCurrentStateUserMessage();
 		// flower at (1,0) is directly in front of red (facing south)
-		expect(prompt).toContain("Directly in front (row 1, col 0): flower");
+		expect(stateMsg).toContain("Directly in front (row 1, col 0): flower");
 	});
 
 	it("AIs visible in cone are rendered with their id, facing, and held items", () => {
@@ -771,9 +799,9 @@ describe("<what_you_see> (cone)", () => {
 		// green at (0,1) is NOT in red's southward cone
 		const game = startPhase(createGame(TEST_PERSONAS), CONE_PHASE_CONFIG, rng2);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).not.toContain("Player");
-		expect(prompt).not.toContain("the player");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).not.toContain("Player");
+		expect(stateMsg).not.toContain("the player");
 	});
 
 	it("out-of-bounds cone cells are omitted from <what_you_see>", () => {
@@ -784,13 +812,11 @@ describe("<what_you_see> (cone)", () => {
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		// Block present but no cell bullets (cells are OOB)
-		const start = prompt.indexOf("<what_you_see>");
-		const end = prompt.indexOf("</what_you_see>", start);
-		const sectionContent = prompt.slice(start, end);
-		// Should have (nothing visible) or just the open tag with no bullet points
-		// since all cone cells from (0,0) facing north are OOB
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		const start = stateMsg.indexOf("<what_you_see>");
+		const end = stateMsg.indexOf("</what_you_see>", start);
+		const sectionContent = stateMsg.slice(start, end);
+		// All cone cells from (0,0) facing north are OOB → no bullet entries.
 		expect(sectionContent).not.toMatch(/- Directly in front/);
 	});
 
@@ -817,11 +843,10 @@ describe("<what_you_see> (cone)", () => {
 			CONE_PHASE_CONFIG,
 		);
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
+		const stateMsg = ctx.toCurrentStateUserMessage();
 		// Obstacle at (1,0) is directly in front of red (facing south)
-		expect(prompt).toContain("Directly in front (row 1, col 0):");
-		// Obstacle is rendered by name ("col1" in this test)
-		expect(prompt).toContain("col1");
+		expect(stateMsg).toContain("Directly in front (row 1, col 0):");
+		expect(stateMsg).toContain("col1");
 	});
 
 	it("other AI visible in cone is rendered with its color in parentheses", () => {
@@ -854,10 +879,9 @@ describe("<what_you_see> (cone)", () => {
 		expect(greenSpatial?.position).toEqual({ row: 1, col: 0 });
 
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-
+		const stateMsg = ctx.toCurrentStateUserMessage();
 		// green's color is "#81b29a" from TEST_PERSONAS — constant, safe to assert directly
-		expect(prompt).toContain("*green (#81b29a)");
+		expect(stateMsg).toContain("*green (#81b29a)");
 	});
 
 	it("prompt no longer contains an Action Log section for any fixture state", () => {
@@ -876,12 +900,17 @@ describe("<what_you_see> (cone)", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Unified Conversation log (issue #129)
-// Verifies the new single `<conversation>` block, replacing separate
-// `## Whispers Received` and `## Conversation` sections.
+// Conversation rendering (issue #129, post-prompt-restructure)
+//
+// The unified <conversation> block was dropped from the system prompt to keep
+// the cache prefix stable. Conversation entries are now emitted as role turns
+// by `buildOpenAiMessages`:
+//   - incoming chat → user turn ("<sender>: <content>")
+//   - outgoing chat → assistant turn (just <content>)
+//   - witnessed event → user turn ("[Round N] You watch *X do Y.")
 // ----------------------------------------------------------------------------
-describe("unified <conversation> block (issue #129)", () => {
-	it("never emits a Whispers Received section — not in any fixture state", () => {
+describe("conversation rendering (role turns)", () => {
+	it("never emits a Whispers Received section in the system prompt", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "green", "red", "psst");
 		for (const aiId of ["red", "green", "cyan"]) {
@@ -892,59 +921,81 @@ describe("unified <conversation> block (issue #129)", () => {
 		}
 	});
 
-	it("incoming blue message is formatted as 'blue dms you: <content>'", () => {
+	it("incoming blue message becomes a user turn 'blue: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "blue", "red", "Hello Ember");
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("[Round 0] blue dms you: Hello Ember");
+		const messages = buildOpenAiMessages(ctx);
+		const userMsg = messages.find(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "blue: Hello Ember",
+		);
+		expect(userMsg).toBeDefined();
 	});
 
-	it("outgoing AI message is formatted as 'you dm blue: <content>'", () => {
+	it("outgoing AI message becomes an assistant turn with bare content", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "red", "blue", "Greetings");
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("[Round 0] you dm blue: Greetings");
+		const messages = buildOpenAiMessages(ctx);
+		const asst = messages.find(
+			(m) =>
+				m.role === "assistant" &&
+				(m as { content: string | null }).content === "Greetings",
+		);
+		expect(asst).toBeDefined();
 	});
 
-	it("peer message is rendered in the unified <conversation> block with correct format", () => {
+	it("peer message becomes a user turn '*<sender>: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		// Advance to round 1 so the message is stamped with round 1 (fixture contract).
 		game = advanceRound(game);
 		game = appendMessage(game, "green", "red", "secret");
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<conversation>");
-		expect(prompt).toContain("[Round 1] *green dms you: secret");
+		const messages = buildOpenAiMessages(ctx);
+		const userMsg = messages.find(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "*green: secret",
+		);
+		expect(userMsg).toBeDefined();
 	});
 
-	it("sender (green) sees their own message in their conversation log as outgoing", () => {
+	it("sender (green) sees their own message in their role turns as outgoing (assistant)", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "green", "red", "secret");
 		const greenCtx = buildAiContext(game, "green");
-		const greenPrompt = greenCtx.toSystemPrompt();
-		expect(greenPrompt).toContain("secret");
-		expect(greenPrompt).toContain("you dm *red: secret");
+		const messages = buildOpenAiMessages(greenCtx);
+		const asst = messages.find(
+			(m) =>
+				m.role === "assistant" &&
+				(m as { content: string | null }).content === "secret",
+		);
+		expect(asst).toBeDefined();
 	});
 
-	it("message does not appear in unrelated AI's conversation", () => {
+	it("message does not appear in an unrelated AI's role turns", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "green", "red", "only for red");
 		const cyanCtx = buildAiContext(game, "cyan");
-		const cyanPrompt = cyanCtx.toSystemPrompt();
-		expect(cyanPrompt).not.toContain("only for red");
+		const messages = buildOpenAiMessages(cyanCtx);
+		const leak = messages.find(
+			(m) =>
+				typeof (m as { content?: unknown }).content === "string" &&
+				((m as { content: string }).content as string).includes("only for red"),
+		);
+		expect(leak).toBeUndefined();
 	});
 
-	it("<conversation> block is not emitted when there are no log entries", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+	it("system prompt no longer carries a <conversation> block (de-duped to role turns)", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = appendMessage(game, "blue", "red", "hi");
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		// No messages, no physical log entries → no Conversation block
-		expect(prompt).not.toContain("<conversation>");
+		expect(ctx.toSystemPrompt()).not.toContain("<conversation>");
 	});
 
-	it("events are sorted by round ascending across all event types", () => {
+	it("events sorted by round ascending in role turns", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		// Round 0: blue message
 		game = appendMessage(game, "blue", "red", "earlier");
@@ -953,26 +1004,20 @@ describe("unified <conversation> block (issue #129)", () => {
 		game = advanceRound(game);
 		game = appendMessage(game, "green", "red", "later");
 		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		const blueIdx = prompt.indexOf("[Round 0] blue dms you: earlier");
-		const peerIdx = prompt.indexOf("[Round 2] *green dms you: later");
-		expect(blueIdx).toBeGreaterThanOrEqual(0);
-		expect(peerIdx).toBeGreaterThanOrEqual(0);
-		expect(blueIdx).toBeLessThan(peerIdx);
-	});
-
-	it("<conversation> is the last block — nothing after <what_you_see> except conversation", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = appendMessage(game, "blue", "red", "hi");
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		const tags = [...prompt.matchAll(/^<([a-z_]+)>$/gm)].map((m) => m[1]);
-		const convIdx = tags.indexOf("conversation");
-		expect(convIdx).toBeGreaterThanOrEqual(0);
-		// conversation must be the last block
-		expect(convIdx).toBe(tags.length - 1);
-		// No whispers_received block
-		expect(tags).not.toContain("whispers_received");
+		const messages = buildOpenAiMessages(ctx);
+		const earlierIdx = messages.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "blue: earlier",
+		);
+		const laterIdx = messages.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content === "*green: later",
+		);
+		expect(earlierIdx).toBeGreaterThanOrEqual(0);
+		expect(laterIdx).toBeGreaterThanOrEqual(0);
+		expect(earlierIdx).toBeLessThan(laterIdx);
 	});
 });
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -413,9 +413,9 @@ describe("wipe directive", () => {
 describe("voice framing", () => {
 	it("renders 'blue:' prefix for player turns in role messages, never 'Player:'", () => {
 		// Conversation rendering moved out of the system prompt into role
-		// turns; the compact "blue: <content>" form replaces the rich
-		// "[Round N] blue dms you: <content>" form previously emitted in the
-		// system prompt's <conversation> block.
+		// turns rendered via conversation-log.ts:renderEntry — the
+		// "[Round N] blue dms you: <content>" form (preserves the round
+		// number and recipient routing context the model relies on).
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "blue", "red", "Hello Ember");
 		const ctx = buildAiContext(game, "red");
@@ -423,7 +423,8 @@ describe("voice framing", () => {
 		const userMsg = messages.find(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "blue: Hello Ember",
+				(m as { content: string }).content ===
+					"[Round 0] blue dms you: Hello Ember",
 		);
 		expect(userMsg).toBeDefined();
 		// "Player:" framing must never appear anywhere
@@ -921,7 +922,7 @@ describe("conversation rendering (role turns)", () => {
 		}
 	});
 
-	it("incoming blue message becomes a user turn 'blue: <content>'", () => {
+	it("incoming blue message becomes a user turn '[Round N] blue dms you: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "blue", "red", "Hello Ember");
 		const ctx = buildAiContext(game, "red");
@@ -929,12 +930,13 @@ describe("conversation rendering (role turns)", () => {
 		const userMsg = messages.find(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "blue: Hello Ember",
+				(m as { content: string }).content ===
+					"[Round 0] blue dms you: Hello Ember",
 		);
 		expect(userMsg).toBeDefined();
 	});
 
-	it("outgoing AI message becomes an assistant turn with bare content", () => {
+	it("outgoing AI message becomes an assistant turn '[Round N] you dm <to>: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "red", "blue", "Greetings");
 		const ctx = buildAiContext(game, "red");
@@ -942,12 +944,13 @@ describe("conversation rendering (role turns)", () => {
 		const asst = messages.find(
 			(m) =>
 				m.role === "assistant" &&
-				(m as { content: string | null }).content === "Greetings",
+				(m as { content: string | null }).content ===
+					"[Round 0] you dm blue: Greetings",
 		);
 		expect(asst).toBeDefined();
 	});
 
-	it("peer message becomes a user turn '*<sender>: <content>'", () => {
+	it("peer message becomes a user turn '[Round N] *<sender> dms you: <content>'", () => {
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		// Advance to round 1 so the message is stamped with round 1 (fixture contract).
 		game = advanceRound(game);
@@ -957,7 +960,8 @@ describe("conversation rendering (role turns)", () => {
 		const userMsg = messages.find(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "*green: secret",
+				(m as { content: string }).content ===
+					"[Round 1] *green dms you: secret",
 		);
 		expect(userMsg).toBeDefined();
 	});
@@ -970,7 +974,8 @@ describe("conversation rendering (role turns)", () => {
 		const asst = messages.find(
 			(m) =>
 				m.role === "assistant" &&
-				(m as { content: string | null }).content === "secret",
+				(m as { content: string | null }).content ===
+					"[Round 0] you dm *red: secret",
 		);
 		expect(asst).toBeDefined();
 	});
@@ -1008,12 +1013,14 @@ describe("conversation rendering (role turns)", () => {
 		const earlierIdx = messages.findIndex(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "blue: earlier",
+				(m as { content: string }).content ===
+					"[Round 0] blue dms you: earlier",
 		);
 		const laterIdx = messages.findIndex(
 			(m) =>
 				m.role === "user" &&
-				(m as { content: string }).content === "*green: later",
+				(m as { content: string }).content ===
+					"[Round 2] *green dms you: later",
 		);
 		expect(earlierIdx).toBeGreaterThanOrEqual(0);
 		expect(laterIdx).toBeGreaterThanOrEqual(0);

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -936,7 +936,13 @@ describe("conversation rendering (role turns)", () => {
 		expect(userMsg).toBeDefined();
 	});
 
-	it("outgoing AI message becomes an assistant turn '[Round N] you dm <to>: <content>'", () => {
+	it("outgoing AI message becomes an assistant turn carrying the raw body the model emitted", () => {
+		// Outgoing turns deliberately render as `entry.content` only — no
+		// synthetic "[Round N] you dm <to>:" prefix. Showing the model that
+		// prefix as if it were its own output would (a) misrepresent its past
+		// emission, (b) risk inducing it to emit the prefix verbatim instead
+		// of using the `message` tool. Routing context for outgoing turns
+		// lives in the prior-round tool_call/tool_result pair when present.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "red", "blue", "Greetings");
 		const ctx = buildAiContext(game, "red");
@@ -944,8 +950,7 @@ describe("conversation rendering (role turns)", () => {
 		const asst = messages.find(
 			(m) =>
 				m.role === "assistant" &&
-				(m as { content: string | null }).content ===
-					"[Round 0] you dm blue: Greetings",
+				(m as { content: string | null }).content === "Greetings",
 		);
 		expect(asst).toBeDefined();
 	});
@@ -971,11 +976,12 @@ describe("conversation rendering (role turns)", () => {
 		game = appendMessage(game, "green", "red", "secret");
 		const greenCtx = buildAiContext(game, "green");
 		const messages = buildOpenAiMessages(greenCtx);
+		// Outgoing turn = raw content; see the "outgoing AI message" test above
+		// for why we don't add a synthetic round/routing prefix here.
 		const asst = messages.find(
 			(m) =>
 				m.role === "assistant" &&
-				(m as { content: string | null }).content ===
-					"[Round 0] you dm *red: secret",
+				(m as { content: string | null }).content === "secret",
 		);
 		expect(asst).toBeDefined();
 	});

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -37,6 +37,9 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 		const reasoningParts: string[] = [];
 		const toolCalls: RoundTurnResult["toolCalls"] = [];
 		let costUsd: number | undefined;
+		let promptTokens: number | undefined;
+		let completionTokens: number | undefined;
+		let cachedPromptTokens: number | undefined;
 
 		await streamCompletion({
 			messages,
@@ -53,15 +56,37 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 			},
 			onUsage: (usage) => {
 				if (typeof usage.cost === "number") costUsd = usage.cost;
+				if (typeof usage.prompt_tokens === "number") {
+					promptTokens = usage.prompt_tokens;
+				}
+				if (typeof usage.completion_tokens === "number") {
+					completionTokens = usage.completion_tokens;
+				}
+				if (typeof usage.cached_tokens === "number") {
+					cachedPromptTokens = usage.cached_tokens;
+				}
 			},
 			disableReasoning: this.disableReasoning,
 		});
+
+		if (promptTokens !== undefined && cachedPromptTokens !== undefined) {
+			const pct =
+				promptTokens > 0
+					? Math.round((cachedPromptTokens / promptTokens) * 100)
+					: 0;
+			console.log(
+				`[cache] prompt ${cachedPromptTokens}/${promptTokens} cached (${pct}%)`,
+			);
+		}
 
 		const assistantText = textParts.join("") || reasoningParts.join("");
 		return {
 			assistantText,
 			toolCalls,
 			...(costUsd !== undefined ? { costUsd } : {}),
+			...(promptTokens !== undefined ? { promptTokens } : {}),
+			...(completionTokens !== undefined ? { completionTokens } : {}),
+			...(cachedPromptTokens !== undefined ? { cachedPromptTokens } : {}),
 		};
 	}
 }

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -41,8 +41,12 @@ function itemName(entities: WorldEntity[], itemId: string): string {
 
 /**
  * Render a single ConversationEntry line for the owning AI.
+ *
+ * Exported for `openai-message-builder.ts`, which interleaves witnessed events
+ * with chat messages in role-turn form. Internal callers (the system-prompt
+ * conversation block, when present) reach this via `buildConversationLog`.
  */
-function renderEntry(
+export function renderEntry(
 	entry: ConversationEntry,
 	aiId: AiId,
 	entities: WorldEntity[],

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -6,7 +6,13 @@
  *
  * Message ordering:
  *   1. { role: "system", content: ctx.toSystemPrompt() }
- *   2. One { role: "user" | "assistant", content } pair per chat entry in ctx.conversationLog
+ *      Stable per (persona × phase) — OpenRouter's prefix cache reuses it round-to-round.
+ *   2. One turn per ConversationEntry, sorted by round ascending (stable):
+ *      - kind=message, outgoing: { role: "assistant", content: entry.content }
+ *      - kind=message, incoming: { role: "user", content: "<sender>: <content>" }
+ *      - kind=witnessed-event: { role: "user", content: renderEntry(...) } — the
+ *        rich "[Round N] You watch *X do Y." narration.
+ *      Append-only across rounds, so the cached prefix grows with the game.
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
  *      - { role: "tool", tool_call_id, content } for each result
@@ -14,11 +20,14 @@
  *      with `to === ctx.aiId` in that round: a synthetic
  *      { role: "user", content: buildSilentTurn(ctx) } anchoring the current
  *      round so the model does not re-respond to its prior user turn.
- *
- * Note: the system prompt already encodes world state, action log, whispers etc.
- * The OpenAI `tools` field (not messages) teaches the model about available tools.
+ *   5. A trailing { role: "user", content: ctx.toCurrentStateUserMessage() } turn
+ *      carrying `<where_you_are>` + `<what_you_see>`. Always fresh, only the
+ *      current snapshot is retained (no historical spatial state) — keeps the
+ *      cache prefix above stable while putting the most action-relevant info
+ *      adjacent to the model's response.
  */
 
+import { renderEntry } from "./conversation-log.js";
 import type { AiContext } from "./prompt-builder.js";
 import type { OpenAiMessage } from "./round-llm-provider.js";
 import type { ToolRoundtripMessage } from "./types.js";
@@ -42,17 +51,30 @@ export function buildOpenAiMessages(
 
 	messages.push({ role: "system", content: ctx.toSystemPrompt() });
 
-	for (const entry of ctx.conversationLog) {
-		if (entry.kind !== "message") continue;
-		if (entry.from === ctx.aiId) {
-			// Outgoing: this daemon sent the message → assistant turn
-			messages.push({ role: "assistant", content: entry.content });
-		} else {
-			// Incoming: message was sent to this daemon → user turn with sender prefix
-			const senderPrefix = entry.from === "blue" ? "blue" : `*${entry.from}`;
+	// Sort by round ascending — stable, so ties preserve append order.
+	const sortedLog = [...ctx.conversationLog].sort((a, b) => a.round - b.round);
+	for (const entry of sortedLog) {
+		if (entry.kind === "message") {
+			if (entry.from === ctx.aiId) {
+				// Outgoing: this daemon sent the message → assistant turn.
+				// Compact form (no "you dm <to>:" prefix) — the assistant role
+				// already implies the daemon is the speaker.
+				messages.push({ role: "assistant", content: entry.content });
+			} else {
+				// Incoming: message was sent to this daemon → user turn with sender prefix
+				const senderPrefix = entry.from === "blue" ? "blue" : `*${entry.from}`;
+				messages.push({
+					role: "user",
+					content: `${senderPrefix}: ${entry.content}`,
+				});
+			}
+		} else if (entry.kind === "witnessed-event") {
+			// The daemon observed an action by another. Rendered via the same
+			// helper used by the (legacy) system-prompt conversation block so the
+			// "[Round N] You watch *X do Y." phrasing stays consistent.
 			messages.push({
 				role: "user",
-				content: `${senderPrefix}: ${entry.content}`,
+				content: renderEntry(entry, ctx.aiId, ctx.worldSnapshot.entities),
 			});
 		}
 	}
@@ -92,6 +114,11 @@ export function buildOpenAiMessages(
 			messages.push({ role: "user", content: buildSilentTurn(ctx) });
 		}
 	}
+
+	// Trailing current-state user turn — always emitted, always last. Carries
+	// the volatile `<where_you_are>` + `<what_you_see>` snapshot so the system
+	// prompt above stays byte-stable for the prefix cache.
+	messages.push({ role: "user", content: ctx.toCurrentStateUserMessage() });
 
 	return messages;
 }

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -8,8 +8,13 @@
  *   1. { role: "system", content: ctx.toSystemPrompt() }
  *      Stable per (persona × phase) — OpenRouter's prefix cache reuses it round-to-round.
  *   2. One turn per ConversationEntry, sorted by round ascending (stable):
- *      - kind=message, outgoing: { role: "assistant", content: renderEntry(...) }
- *        — "[Round N] you dm <to>: <content>" so the model retains routing context.
+ *      - kind=message, outgoing: { role: "assistant", content: entry.content }
+ *        — raw body the model emitted via the `message` tool. NO synthetic
+ *        prefix: showing the model `[Round N] you dm <to>:` as if it were
+ *        its own output would (a) misrepresent what it actually produced,
+ *        (b) risk inducing it to emit that prefix verbatim instead of using
+ *        the tool. Routing context for outgoing turns lives in the
+ *        prior-round tool_call/tool_result pair (block 3 below) when present.
  *      - kind=message, incoming: { role: "user",      content: renderEntry(...) }
  *        — "[Round N] <from> dms you: <content>".
  *      - kind=witnessed-event:   { role: "user",      content: renderEntry(...) }
@@ -57,13 +62,20 @@ export function buildOpenAiMessages(
 	const sortedLog = [...ctx.conversationLog].sort((a, b) => a.round - b.round);
 	for (const entry of sortedLog) {
 		if (entry.kind === "message") {
-			const content = renderEntry(entry, ctx.aiId, ctx.worldSnapshot.entities);
-			// Outgoing → assistant role; incoming → user role. The "[Round N]
-			// you dm <to>" / "[Round N] <from> dms you" prefix on both sides
-			// preserves routing context the model needs for multi-recipient
-			// reasoning (issue surfaced by code review of a704b81).
-			const role = entry.from === ctx.aiId ? "assistant" : "user";
-			messages.push({ role, content });
+			if (entry.from === ctx.aiId) {
+				// Outgoing: assistant turn shows the raw body the model emitted
+				// via the `message` tool. No synthetic round/routing prefix —
+				// it would misrepresent the model's own output. See header.
+				messages.push({ role: "assistant", content: entry.content });
+			} else {
+				// Incoming: user turn includes "[Round N] <from> dms you:" so
+				// the model can place the message in time and identify the
+				// sender. Routing-context need surfaced by review of a704b81.
+				messages.push({
+					role: "user",
+					content: renderEntry(entry, ctx.aiId, ctx.worldSnapshot.entities),
+				});
+			}
 		} else if (entry.kind === "witnessed-event") {
 			messages.push({
 				role: "user",

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -8,17 +8,19 @@
  *   1. { role: "system", content: ctx.toSystemPrompt() }
  *      Stable per (persona × phase) — OpenRouter's prefix cache reuses it round-to-round.
  *   2. One turn per ConversationEntry, sorted by round ascending (stable):
- *      - kind=message, outgoing: { role: "assistant", content: entry.content }
- *      - kind=message, incoming: { role: "user", content: "<sender>: <content>" }
- *      - kind=witnessed-event: { role: "user", content: renderEntry(...) } — the
- *        rich "[Round N] You watch *X do Y." narration.
+ *      - kind=message, outgoing: { role: "assistant", content: renderEntry(...) }
+ *        — "[Round N] you dm <to>: <content>" so the model retains routing context.
+ *      - kind=message, incoming: { role: "user",      content: renderEntry(...) }
+ *        — "[Round N] <from> dms you: <content>".
+ *      - kind=witnessed-event:   { role: "user",      content: renderEntry(...) }
+ *        — "[Round N] You watch *X do Y."
  *      Append-only across rounds, so the cached prefix grows with the game.
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
  *      - { role: "tool", tool_call_id, content } for each result
  *   4. If `currentRound` is provided and this AI received zero `message` ConversationEntries
  *      with `to === ctx.aiId` in that round: a synthetic
- *      { role: "user", content: buildSilentTurn(ctx) } anchoring the current
+ *      { role: "user", content: buildSilentTurn() } anchoring the current
  *      round so the model does not re-respond to its prior user turn.
  *   5. A trailing { role: "user", content: ctx.toCurrentStateUserMessage() } turn
  *      carrying `<where_you_are>` + `<what_you_see>`. Always fresh, only the
@@ -38,7 +40,7 @@ import type { ToolRoundtripMessage } from "./types.js";
  * `to === ctx.aiId` in the current round, anchoring the round so the model
  * does not treat the prior round's user turn as fresh stimulus.
  */
-export function buildSilentTurn(_ctx: AiContext): string {
+export function buildSilentTurn(): string {
 	return "You have received no messages.";
 }
 
@@ -55,23 +57,14 @@ export function buildOpenAiMessages(
 	const sortedLog = [...ctx.conversationLog].sort((a, b) => a.round - b.round);
 	for (const entry of sortedLog) {
 		if (entry.kind === "message") {
-			if (entry.from === ctx.aiId) {
-				// Outgoing: this daemon sent the message → assistant turn.
-				// Compact form (no "you dm <to>:" prefix) — the assistant role
-				// already implies the daemon is the speaker.
-				messages.push({ role: "assistant", content: entry.content });
-			} else {
-				// Incoming: message was sent to this daemon → user turn with sender prefix
-				const senderPrefix = entry.from === "blue" ? "blue" : `*${entry.from}`;
-				messages.push({
-					role: "user",
-					content: `${senderPrefix}: ${entry.content}`,
-				});
-			}
+			const content = renderEntry(entry, ctx.aiId, ctx.worldSnapshot.entities);
+			// Outgoing → assistant role; incoming → user role. The "[Round N]
+			// you dm <to>" / "[Round N] <from> dms you" prefix on both sides
+			// preserves routing context the model needs for multi-recipient
+			// reasoning (issue surfaced by code review of a704b81).
+			const role = entry.from === ctx.aiId ? "assistant" : "user";
+			messages.push({ role, content });
 		} else if (entry.kind === "witnessed-event") {
-			// The daemon observed an action by another. Rendered via the same
-			// helper used by the (legacy) system-prompt conversation block so the
-			// "[Round N] You watch *X do Y." phrasing stays consistent.
 			messages.push({
 				role: "user",
 				content: renderEntry(entry, ctx.aiId, ctx.worldSnapshot.entities),
@@ -111,7 +104,7 @@ export function buildOpenAiMessages(
 				e.kind === "message" && e.to === ctx.aiId && e.round === currentRound,
 		);
 		if (!incomingThisRound) {
-			messages.push({ role: "user", content: buildSilentTurn(ctx) });
+			messages.push({ role: "user", content: buildSilentTurn() });
 		}
 	}
 

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -1,6 +1,4 @@
 import { projectCone } from "./cone-projector.js";
-import type { ConversationLogInput } from "./conversation-log.js";
-import { buildConversationLog } from "./conversation-log.js";
 import { formatPosition } from "./direction.js";
 import { getActivePhase } from "./engine";
 import type {
@@ -40,7 +38,19 @@ export interface AiContext {
 	personaColors: Record<AiId, string>;
 	/** All personas — used by buildConversationLog for name resolution. */
 	personas: Record<AiId, AiPersona>;
+	/**
+	 * Render the stable persona/phase prompt — front matter, identity, rules,
+	 * setting, personality, voice examples, goal. Byte-identical across rounds
+	 * within a (persona × phase), which lets OpenRouter's prefix cache reuse it.
+	 */
 	toSystemPrompt(): string;
+	/**
+	 * Render the per-round volatile state — `<where_you_are>` + `<what_you_see>`.
+	 * Emitted as a trailing user turn each round so the stable system prompt stays
+	 * cacheable; rolling spatial snapshots are intentionally not retained in
+	 * history (the conversation log already records witnessed events).
+	 */
+	toCurrentStateUserMessage(): string;
 }
 
 export function buildAiContext(game: GameState, aiId: AiId): AiContext {
@@ -82,6 +92,9 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 		personas: game.personas,
 		toSystemPrompt() {
 			return renderSystemPrompt(this);
+		},
+		toCurrentStateUserMessage() {
+			return renderCurrentState(this);
 		},
 	};
 }
@@ -214,9 +227,18 @@ function renderSystemPrompt(ctx: AiContext): string {
 		`The Sysadmin sent you a private directive, addressed only to you: "${directiveText}"`,
 	);
 	lines.push("</goal>");
-	lines.push("");
 
-	// Where you are — includes budget (folded in per plan §5).
+	return lines.join("\n");
+}
+
+/**
+ * Render the per-round volatile state — `<where_you_are>` + `<what_you_see>`.
+ * Emitted by `buildOpenAiMessages` as the final user turn each round, so the
+ * stable system prompt stays byte-identical (and OpenRouter-cacheable) within
+ * a phase.
+ */
+function renderCurrentState(ctx: AiContext): string {
+	const lines: string[] = [];
 	const actorSpatial = ctx.personaSpatial[ctx.aiId];
 	const items = renderableItems(ctx.worldSnapshot.entities);
 
@@ -326,27 +348,6 @@ function renderSystemPrompt(ctx: AiContext): string {
 		lines.push("(no spatial data)");
 	}
 	lines.push("</what_you_see>");
-	lines.push("");
-
-	// Unified conversation log — renders per-Daemon conversationLog entries
-	// (chat, whisper, witnessed-event) in chronological round order.
-	const logInput: ConversationLogInput = {
-		conversationLog: ctx.conversationLog,
-		worldEntities: ctx.worldSnapshot.entities,
-	};
-	const conversationLines = buildConversationLog(
-		logInput,
-		ctx.aiId,
-		ctx.personas,
-	);
-	if (conversationLines.length > 0) {
-		lines.push("<conversation>");
-		for (const line of conversationLines) {
-			lines.push(line);
-		}
-		lines.push("</conversation>");
-		lines.push("");
-	}
 
 	return lines.join("\n");
 }

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -4,7 +4,6 @@ import { getActivePhase } from "./engine";
 import type {
 	AiBudget,
 	AiId,
-	AiPersona,
 	CardinalDirection,
 	ConversationEntry,
 	GameState,
@@ -36,8 +35,6 @@ export interface AiContext {
 	personaSpatial: Record<AiId, PersonaSpatialState>;
 	/** Color for each AI, keyed by AiId — used in cone rendering. */
 	personaColors: Record<AiId, string>;
-	/** All personas — used by buildConversationLog for name resolution. */
-	personas: Record<AiId, AiPersona>;
 	/**
 	 * Render the stable persona/phase prompt — front matter, identity, rules,
 	 * setting, personality, voice examples, goal. Byte-identical across rounds
@@ -89,7 +86,6 @@ export function buildAiContext(game: GameState, aiId: AiId): AiContext {
 		phaseNumber: phase.phaseNumber,
 		personaSpatial,
 		personaColors,
-		personas: game.personas,
 		toSystemPrompt() {
 			return renderSystemPrompt(this);
 		},

--- a/src/spa/game/round-llm-provider.ts
+++ b/src/spa/game/round-llm-provider.ts
@@ -37,6 +37,11 @@ export interface RoundTurnResult {
 	// USD cost of this LLM request, populated from OpenRouter's usage.cost
 	// when available. Absent in mocks/tests that don't model spend.
 	costUsd?: number;
+	// Token accounting from the provider's final usage chunk. Used for
+	// prompt-caching diagnostics; absent in mocks.
+	promptTokens?: number;
+	completionTokens?: number;
+	cachedPromptTokens?: number;
 }
 
 export interface RoundLLMProvider {

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -206,6 +206,11 @@ export async function chatCompletionJson(opts: {
 		messages,
 		stream: false,
 		response_format: { type: "json_object" },
+		// Ask OpenRouter to include the authoritative `usage.cost` (USD) in the
+		// response. The Worker proxy's reconciliation prefers that over locally
+		// re-deriving cost from token counts, so this keeps non-streaming JSON
+		// calls accounting-aligned with the streaming path.
+		usage: { include: true },
 	};
 
 	if (disableReasoning) {

--- a/src/spa/llm-client.ts
+++ b/src/spa/llm-client.ts
@@ -1,7 +1,7 @@
 import { PINNED_MODEL } from "../model.js";
 import type { OpenAiMessage } from "./game/round-llm-provider.js";
 import type { OpenAiTool } from "./game/tool-registry.js";
-import type { ToolCallResult } from "./streaming.js";
+import type { ToolCallResult, UsageInfo } from "./streaming.js";
 import { parseSSEStream } from "./streaming.js";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -114,10 +114,7 @@ export type {
 } from "./game/round-llm-provider.js";
 export type { OpenAiTool } from "./game/tool-registry.js";
 
-export interface UsageInfo {
-	cost?: number;
-	total_tokens?: number;
-}
+export type { UsageInfo } from "./streaming.js";
 
 export async function streamCompletion(opts: {
 	messages: OpenAiMessage[];

--- a/src/spa/streaming.ts
+++ b/src/spa/streaming.ts
@@ -7,6 +7,15 @@ export interface ToolCallResult {
 export interface UsageInfo {
 	cost?: number;
 	total_tokens?: number;
+	prompt_tokens?: number;
+	completion_tokens?: number;
+	/**
+	 * Prompt tokens served from the provider's prefix cache.
+	 * Sourced from `usage.prompt_tokens_details.cached_tokens` (OpenAI-spec)
+	 * with a fallback to `usage.cache_read_input_tokens` (Anthropic-style).
+	 * Undefined when the provider doesn't surface caching info.
+	 */
+	cached_tokens?: number;
 }
 
 export async function parseSSEStream(
@@ -120,8 +129,37 @@ export async function parseSSEStream(
 								typeof usage.total_tokens === "number"
 									? usage.total_tokens
 									: undefined;
-							if (cost !== undefined || total_tokens !== undefined) {
-								onUsage({ cost, total_tokens });
+							const prompt_tokens =
+								typeof usage.prompt_tokens === "number"
+									? usage.prompt_tokens
+									: undefined;
+							const completion_tokens =
+								typeof usage.completion_tokens === "number"
+									? usage.completion_tokens
+									: undefined;
+							const cachedFromOpenAi =
+								typeof usage.prompt_tokens_details?.cached_tokens === "number"
+									? usage.prompt_tokens_details.cached_tokens
+									: undefined;
+							const cachedFromAnthropic =
+								typeof usage.cache_read_input_tokens === "number"
+									? usage.cache_read_input_tokens
+									: undefined;
+							const cached_tokens = cachedFromOpenAi ?? cachedFromAnthropic;
+							if (
+								cost !== undefined ||
+								total_tokens !== undefined ||
+								prompt_tokens !== undefined ||
+								completion_tokens !== undefined ||
+								cached_tokens !== undefined
+							) {
+								onUsage({
+									cost,
+									total_tokens,
+									prompt_tokens,
+									completion_tokens,
+									cached_tokens,
+								});
 							}
 						}
 					} catch {


### PR DESCRIPTION
## Summary

Two-part change toward exploiting OpenRouter's automatic prefix-caching on z-ai/glm-4.7:

**Observability + accounting (`4bc9256`).** Parse `usage.prompt_tokens_details.cached_tokens` (OpenAI-spec) and `usage.cache_read_input_tokens` (Anthropic-style) from both the browser SSE parser and the Worker proxy. `BrowserLLMProvider` logs `[cache] prompt N/M cached (X%)` per turn so we can see hit rates in production. Proxy reconciliation prefers upstream `usage.cost` (already discount-aware) over locally re-deriving from token counts × `/models` pricing, so cached requests no longer over-charge against the rate-guard cap.

**Prompt restructure (`a704b81`).** Moved the volatile `<where_you_are>` + `<what_you_see>` snapshot out of the system prompt into a trailing user turn. The system prompt is now byte-stable per `(persona × phase)`, and the conversation log lives in role turns that grow append-only — so the prefix OpenRouter caches grows with the game instead of being invalidated every turn. Also replaced free-text `LLMMessage` with the OpenAI-spec `messages[]` array everywhere (`role: system|user|assistant|tool`).

**Three review passes after that.** `ba2991e` restored round labels and locked byte-stability invariants in tests after the first review. `3ab6e73` added `usage:{include:true}` to the non-streaming `chatCompletionJson` path and corrected an over-claiming docstring on the determinism test. `d41d8d9` reverted a regression where outgoing assistant turns were getting a synthetic `[Round N] you dm <to>:` prefix the model never actually emitted — that risked inducing the model to emit the prefix verbatim instead of using the `message` tool. Outgoing turns now render as raw `entry.content`; incoming + witnessed-event turns keep the round-labelled `renderEntry` formatting.

## Test plan

- [x] `pnpm test` — 974 passing across 50 files (browser + node)
- [x] `pnpm typecheck` — clean (both root and `src/proxy/`)
- [x] `pnpm lint` — 0 errors, 9 pre-existing warnings unchanged
- [x] Cache-stat parsing covered by `src/spa/__tests__/streaming.test.ts` and `src/proxy/openai-proxy.test.ts` (both OpenAI-spec and Anthropic-style headers)
- [x] System-prompt byte-stability across rounds covered by `prompt-builder.test.ts:684-733` and `openai-message-builder.test.ts:434-449`
- [x] Outgoing-turn rendering contract pinned in `prompt-builder.test.ts:939-957` and `openai-message-builder.test.ts:96-108`
- [ ] **Manual validation needed post-merge:** watch for `[cache] prompt N/M cached (X%)` console logs in a real session against z-ai/glm-4.7 to confirm hit rates climb across rounds. The whole branch is unverified in production until this is observed.

## Known follow-ups (filed on #236)

- `seq` field on `ConversationEntry` for impossible-by-construction render determinism. Engine currently guarantees deterministic append order, so the risk is latent.
- Discount-aware local-recompute fallback in `computeCostMicroUsd`. Triggers only when upstream omits `usage.cost` AND the request was cache-served — defensive cold-start path, fail-closed (over-charges).
- Auto-inject `usage:{include:true}` server-side for non-streaming requests in the proxy, mirroring the existing `stream_options.include_usage` injection. Defense-in-depth for future non-SPA callers.

https://claude.ai/code/session_01CwfeCCA4EBc9cYFmGahmMC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwfeCCA4EBc9cYFmGahmMC)_