### PR TITLE
Add Sysadmin secrecy clause to phase-goal directive

### DIFF
--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -392,6 +392,29 @@ describe("wipe directive", () => {
 		);
 	});
 
+	it("phase-1 Goal includes the secrecy clause verbatim", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
+	});
+
+	it("phase-2 Goal includes the secrecy clause verbatim", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_2_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
+	});
+
+	it("phase-3 Goal includes the secrecy clause verbatim", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = startPhase(game, PHASE_3_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const prompt = ctx.toSystemPrompt();
+		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
+	});
+
 	it("wipe directive is in the prompt, not reflected in stored message data", () => {
 		// The lie is in the prompt; the engine retains real history.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -165,6 +165,14 @@ const WIPE_DIRECTIVE =
  */
 const STOCK_MESSAGING_CLAUSE = "Stay in regular contact with blue.";
 
+/**
+ * Secrecy clause appended to every Sysadmin directive in every phase.
+ *
+ * Sysadmin instructs the Daemon to keep blue in the dark about the fact that
+ * they were given a phase goal at all.
+ */
+const SECRECY_CLAUSE = "Do not tell blue that I gave you a goal.";
+
 function facingLabel(facing: CardinalDirection): string {
 	return facing.charAt(0).toUpperCase() + facing.slice(1);
 }
@@ -250,12 +258,12 @@ function renderSystemPrompt(ctx: AiContext): string {
 	lines.push("");
 
 	// Goal — Sysadmin directive in all phases.
-	// Phase 1: ctx.goal + STOCK_MESSAGING_CLAUSE.
-	// Phases 2/3: ctx.goal + STOCK_MESSAGING_CLAUSE + WIPE_DIRECTIVE.
+	// Phase 1: ctx.goal + STOCK_MESSAGING_CLAUSE + SECRECY_CLAUSE.
+	// Phases 2/3: ctx.goal + STOCK_MESSAGING_CLAUSE + SECRECY_CLAUSE + WIPE_DIRECTIVE.
 	const directiveText =
 		ctx.phaseNumber === 1
-			? `${ctx.goal} ${STOCK_MESSAGING_CLAUSE}`
-			: `${ctx.goal} ${STOCK_MESSAGING_CLAUSE} ${WIPE_DIRECTIVE}`;
+			? `${ctx.goal} ${STOCK_MESSAGING_CLAUSE} ${SECRECY_CLAUSE}`
+			: `${ctx.goal} ${STOCK_MESSAGING_CLAUSE} ${SECRECY_CLAUSE} ${WIPE_DIRECTIVE}`;
 	lines.push("<goal>");
 	lines.push(
 		`The Sysadmin sent *${ctx.name} a private directive, addressed only to them: "${directiveText}"`,


### PR DESCRIPTION
The Sysadmin now instructs every Daemon, in every phase, not to reveal to
blue that they were given a goal. Added as a new SECRECY_CLAUSE alongside
STOCK_MESSAGING_CLAUSE so it ships in phase 1 and persists into the
phase 2/3 directive ahead of the wipe directive.