### PR TITLE
Daemon turn: free message + action via parallel tool calls (single LLM call per turn)

### DIFF
--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -893,8 +893,7 @@ describe("dispatchAiTurn", () => {
 		expect(
 			redLog.some(
 				(e) =>
-					e.kind === "message" &&
-					e.content.includes("I'll grab the flower"),
+					e.kind === "message" && e.content.includes("I'll grab the flower"),
 			),
 		).toBe(true);
 

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -864,4 +864,44 @@ describe("dispatchAiTurn", () => {
 		expect(afterPhase.conversationLogs.green ?? []).toEqual(preLogs.green);
 		expect(afterPhase.conversationLogs.cyan ?? []).toEqual(preLogs.cyan);
 	});
+
+	// -------------------------------------------------------------------------
+	// P0-1 record-ordering: message before toolCall (issue #238)
+	// -------------------------------------------------------------------------
+
+	it("both message + toolCall populated: message record appears before tool_success record in result.records", () => {
+		// red at (0,0), flower at (0,0) — red can pick up flower.
+		// red also sends a message to blue.
+		// The dispatcher must process action.message BEFORE action.toolCall so that
+		// "I'll grab the key" + picks up flower reads as one narrative beat.
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			message: { to: "blue", content: "I'll grab the flower" },
+			toolCall: { name: "pick_up", args: { item: "flower" } },
+		};
+		const result = dispatchAiTurn(game, action);
+
+		expect(result.rejected).toBe(false);
+		expect(result.records).toHaveLength(2);
+		// Message record MUST come first (P0-1 ordering requirement)
+		expect(result.records[0]?.kind).toBe("message");
+		expect(result.records[1]?.kind).toBe("tool_success");
+
+		// Conversation log must have the spoken line
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.content.includes("I'll grab the flower"),
+			),
+		).toBe(true);
+
+		// World state must reflect the pick_up
+		const flower = getActivePhase(result.game).world.entities.find(
+			(e) => e.id === "flower",
+		);
+		expect(flower?.holder).toBe("red");
+	});
 });

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -628,3 +628,80 @@ describe("GameSession — spatial mechanics", () => {
 		expect(key?.holder).toBe("red");
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Parallel tool calls integration (#238): one provider call per AI per round
+// ----------------------------------------------------------------------------
+describe("parallel tool calls integration (#238)", () => {
+	it("Daemon emitting [msg, pick_up] in one provider call produces both outputs; cost is single-call valued", async () => {
+		// red at (0,0) holding key; flower at (0,0); red can pick up flower.
+		// red emits message + pick_up in a single LLM call.
+		// Guard: only ONE provider call should have fired for red (not two).
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
+			CONTENT_PACK_WITH_ITEMS,
+		]);
+
+		let redCallCount = 0;
+		const trackingProvider: RoundLLMProvider = {
+			async streamRound(_messages, _tools) {
+				redCallCount++;
+				// First call is red's (initiative order: red, green, cyan)
+				if (redCallCount === 1) {
+					return {
+						assistantText: "",
+						toolCalls: [
+							{
+								id: "msg_parallel_id",
+								name: "message",
+								argumentsJson: JSON.stringify({
+									to: "blue",
+									content: "I'll grab the flower",
+								}),
+							},
+							{
+								id: "pickup_parallel_id",
+								name: "pick_up",
+								argumentsJson: JSON.stringify({ item: "flower" }),
+							},
+						],
+						costUsd: 1,
+					};
+				}
+				return { assistantText: "", toolCalls: [], costUsd: 0 };
+			},
+		};
+
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			trackingProvider,
+		);
+
+		// One provider call per AI per round (3 total, not 4 or 6)
+		expect(redCallCount).toBe(3);
+
+		// Both message and tool_success dispatched for red
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		expect(redActions.some((a) => a.kind === "message")).toBe(true);
+		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
+
+		// Red's budget: 5 - 1 (single call cost) = 4
+		const phase = getActivePhase(session.getState());
+		expect(phase.budgets.red?.remaining).toBeCloseTo(4, 10);
+
+		// Flower is picked up
+		const flower = phase.world.entities.find((e) => e.id === "flower");
+		expect(flower?.holder).toBe("red");
+
+		// Conversation log has the message
+		const redLog = phase.conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("I'll grab the flower"),
+			),
+		).toBe(true);
+	});
+});

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -451,3 +451,199 @@ describe("buildOpenAiMessages", () => {
 		expect(round2Prompt).toBe(round0Prompt);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Multi-id roundtrip shapes (issue #238 parallel tool calls)
+// ----------------------------------------------------------------------------
+describe("multi-id roundtrip replay shapes (#238)", () => {
+	// Test: N=2 assistantToolCalls produces the correct message ordering:
+	// [..., assistant{tool_calls:[a,b]}, tool{a-result}, tool{b-result}, ...]
+	it("roundtrip with 2 assistantToolCalls produces assistant{tool_calls:[a,b]} + 2 tool messages", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{ id: "call_a", name: "pick_up", argumentsJson: '{"item":"flower"}' },
+				{ id: "call_b", name: "go", argumentsJson: '{"direction":"south"}' },
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_a",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+				{
+					tool_call_id: "call_b",
+					success: false,
+					description: "Ember tried to go but failed: blocked",
+					reason: "blocked",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		// Find the assistant message with tool_calls
+		const assistantToolMsg = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantToolMsg).toBeDefined();
+		if (assistantToolMsg?.role === "assistant") {
+			expect(assistantToolMsg.tool_calls).toHaveLength(2);
+			expect(assistantToolMsg.tool_calls?.[0]?.id).toBe("call_a");
+			expect(assistantToolMsg.tool_calls?.[1]?.id).toBe("call_b");
+		}
+
+		// Both tool results follow, in order
+		const toolMsgs = messages.filter((m) => m.role === "tool");
+		expect(toolMsgs).toHaveLength(2);
+		if (toolMsgs[0]?.role === "tool" && toolMsgs[1]?.role === "tool") {
+			expect(toolMsgs[0].tool_call_id).toBe("call_a");
+			expect(toolMsgs[0].content).toBe("Ember picked up the flower");
+			expect(toolMsgs[1].tool_call_id).toBe("call_b");
+			// Failed result is prefixed with FAILED:
+			expect(toolMsgs[1].content).toMatch(/^FAILED:/);
+			expect(toolMsgs[1].content).toContain("blocked");
+		}
+
+		// assistant{tool_calls} is immediately followed by the first tool message
+		const assistantIdx = assistantToolMsg
+			? messages.indexOf(assistantToolMsg)
+			: -1;
+		expect(assistantIdx).toBeGreaterThanOrEqual(0);
+		const firstToolMsg = messages[assistantIdx + 1];
+		expect(firstToolMsg?.role).toBe("tool");
+
+		// The two tool messages are consecutive (assistant{tool_calls}, tool{a}, tool{b})
+		expect(messages[assistantIdx + 2]?.role).toBe("tool");
+	});
+
+	// Row 4 shape: first fail + second success (msg-fail + action-success)
+	it("roundtrip with [msg-fail, action-success] produces both tool messages with correct success flags", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "msg_fail_id",
+					name: "message",
+					argumentsJson: '{"to":"nobody","content":"hi"}',
+				},
+				{
+					id: "pickup_id",
+					name: "pick_up",
+					argumentsJson: '{"item":"flower"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "msg_fail_id",
+					success: false,
+					description:
+						"Ember tried to message nobody but failed: unknown or invalid recipient",
+				},
+				{
+					tool_call_id: "pickup_id",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		const toolMsgs = messages.filter((m) => m.role === "tool");
+		expect(toolMsgs).toHaveLength(2);
+
+		if (toolMsgs[0]?.role === "tool" && toolMsgs[1]?.role === "tool") {
+			// Message failure comes first, prefixed with FAILED:
+			expect(toolMsgs[0].tool_call_id).toBe("msg_fail_id");
+			expect(toolMsgs[0].content).toMatch(/^FAILED:/);
+
+			// Action success comes second
+			expect(toolMsgs[1].tool_call_id).toBe("pickup_id");
+			expect(toolMsgs[1].content).toBe("Ember picked up the flower");
+		}
+	});
+
+	// Row 3 wire shape: [msg-success, action] produces two consecutive assistant turns.
+	//
+	// In the row-3 case, the round-coordinator EXCLUDES the successful message call
+	// from the roundtrip (per ADR 0007 — it replays via conversationLog as
+	// assistant{content}). The action call DOES go in the roundtrip. This means
+	// the next round's message array has:
+	//   assistant{content: "<msg>"} — from conversationLog
+	//   assistant{tool_calls:[actionId]} — from roundtrip
+	//   tool{actionId, result}
+	//
+	// Two consecutive assistant turns is intentional and OpenAI-spec-permitted
+	// (the strict pairing rule is only that tool_calls → matching tool results
+	// directly after). Do NOT generalize the #213 invariant ("no consecutive
+	// assistant turns for message-only turns") to this case.
+	it("row-3 wire shape: conversationLog msg + roundtrip action produces consecutive assistant turns (intentional)", () => {
+		let game = makeGame();
+		// Simulate a prior round where red sent a message to blue (goes in conversationLog)
+		game = appendMessage(game, "red", "blue", "I'll grab the flower");
+
+		const ctx = buildAiContext(game, "red");
+
+		// The roundtrip carries ONLY the action call (msg-success excluded per ADR 0007)
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "pickup_r3_id",
+					name: "pick_up",
+					argumentsJson: '{"item":"flower"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "pickup_r3_id",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		// The conversation log assistant turn (message body) appears first
+		const assistantContentMsg = messages.find(
+			(m) =>
+				m.role === "assistant" &&
+				"content" in m &&
+				typeof (m as { content?: unknown }).content === "string" &&
+				(m as { content: string }).content.includes("I'll grab the flower"),
+		);
+		expect(assistantContentMsg).toBeDefined();
+
+		// The roundtrip assistant{tool_calls} turn appears after it
+		const assistantToolMsg = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantToolMsg).toBeDefined();
+
+		const contentIdx = assistantContentMsg
+			? messages.indexOf(assistantContentMsg)
+			: -1;
+		const toolIdx = assistantToolMsg ? messages.indexOf(assistantToolMsg) : -1;
+		expect(contentIdx).toBeLessThan(toolIdx);
+
+		// INTENTIONAL: these two assistant turns are consecutive (no user turn between them).
+		// This is correct for row-3 because the conversation log entry and the roundtrip
+		// are from the same AI turn but are separate message-protocol constructs.
+		// Note: the #213 invariant ("no consecutive assistant turns") applies ONLY to
+		// message-only turns where no roundtrip is recorded. In the row-3 case, two
+		// consecutive assistant turns are correct and expected.
+		expect(messages[contentIdx + 1]).toBe(assistantToolMsg);
+
+		// The tool result follows immediately after the assistant{tool_calls}
+		const toolMsg = messages[toolIdx + 1];
+		expect(toolMsg?.role).toBe("tool");
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.tool_call_id).toBe("pickup_r3_id");
+		}
+	});
+});

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -2119,6 +2119,424 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 });
 
 // ----------------------------------------------------------------------------
+// Parallel tool calls: message + action in one turn (issue #238)
+// ----------------------------------------------------------------------------
+describe("parallel tool calls (message + action in one turn) (#238)", () => {
+	// Table row 3: [msg-success, action] → roundtrip has action id only;
+	// conversation log gets the message body.
+	it("[msg, pick_up]: both dispatched; message record first; roundtrip has only pick_up id", async () => {
+		const game = makeGame();
+		// red at (0,0), flower at (0,0) — red can pick up flower
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "I'll grab the flower",
+						}),
+					},
+					{
+						id: "pickup_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// Both dispatched
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		expect(redActions.some((a) => a.kind === "message")).toBe(true);
+		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
+
+		// message record BEFORE tool_success (P0-1 ordering)
+		const msgIdx = redActions.findIndex((a) => a.kind === "message");
+		const toolIdx = redActions.findIndex((a) => a.kind === "tool_success");
+		expect(msgIdx).toBeLessThan(toolIdx);
+
+		// Conversation log has the spoken message
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("I'll grab the flower"),
+			),
+		).toBe(true);
+
+		// World state reflects pick_up
+		const flower = getActivePhase(nextState).world.entities.find(
+			(e) => e.id === "flower",
+		);
+		expect(flower?.holder).toBe("red");
+
+		// Roundtrip has ONLY pick_up id (msg-success excluded per ADR 0007 / table row 3)
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls).toHaveLength(1);
+		expect(rt?.assistantToolCalls[0]?.id).toBe("pickup_id");
+		expect(rt?.toolResults).toHaveLength(1);
+		expect(rt?.toolResults[0]?.tool_call_id).toBe("pickup_id");
+		expect(rt?.toolResults[0]?.success).toBe(true);
+	});
+
+	// Table row 2: [action]-only → roundtrip has the action id; regression guard
+	it("[pick_up]-only: existing single-call behavior unchanged; roundtrip has action id", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "pickup_only_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		expect(
+			result.actions.some(
+				(a) => a.kind === "tool_success" && a.actor === "red",
+			),
+		).toBe(true);
+		expect(
+			getActivePhase(nextState).world.entities.find((e) => e.id === "flower")
+				?.holder,
+		).toBe("red");
+
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls).toHaveLength(1);
+		expect(rt?.assistantToolCalls[0]?.id).toBe("pickup_only_id");
+		expect(rt?.toolResults[0]?.tool_call_id).toBe("pickup_only_id");
+	});
+
+	// Table row 1: [msg-success]-only → no roundtrip; conversation log has message
+	it("[msg-success]-only: no roundtrip recorded; conversation log has message", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_only_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Just saying hi",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// No roundtrip for red (msg-success excluded per ADR 0007)
+		expect(toolRoundtrip.red).toBeUndefined();
+
+		// Conversation log has the message
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("Just saying hi"),
+			),
+		).toBe(true);
+	});
+
+	// Table row 4: [msg-fail, pick_up] → roundtrip has BOTH ids; msgFailure + actionResult
+	it("[msg-fail-bad-recipient, pick_up]: roundtrip has both ids; msg failure + pick_up success", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_fail_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "nobody_invalid",
+							content: "Hello?",
+						}),
+					},
+					{
+						id: "pickup_row4_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// Message failure and tool_success both in result.actions for red
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		expect(redActions.some((a) => a.kind === "tool_failure")).toBe(true);
+		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
+
+		// Flower still picked up
+		expect(
+			getActivePhase(nextState).world.entities.find((e) => e.id === "flower")
+				?.holder,
+		).toBe("red");
+
+		// Roundtrip has BOTH ids: msg_fail_id and pickup_row4_id
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls).toHaveLength(2);
+		const ids = rt?.assistantToolCalls.map((c) => c.id);
+		expect(ids).toContain("msg_fail_id");
+		expect(ids).toContain("pickup_row4_id");
+
+		// Message result is failure (FAILED: ...)
+		const msgResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "msg_fail_id",
+		);
+		expect(msgResult?.success).toBe(false);
+
+		// Pickup result is success
+		const pickupResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "pickup_row4_id",
+		);
+		expect(pickupResult?.success).toBe(true);
+	});
+
+	// Duplicate-within-slot: [msg, msg] → first dispatched, second is tool_failure in roundtrip
+	it("[msg, msg] duplicate: first message dispatched; second in roundtrip as failure", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_first_id",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "First msg" }),
+					},
+					{
+						id: "msg_dup_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Duplicate msg",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// First message is dispatched (in conversation log)
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("First msg"),
+			),
+		).toBe(true);
+
+		// Duplicate produces a tool_failure in result.actions
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		const failureRecord = redActions.find(
+			(a) =>
+				a.kind === "tool_failure" && /only one message/i.test(a.description),
+		);
+		expect(failureRecord).toBeDefined();
+
+		// Roundtrip has the DUPLICATE id (not the success id), with failure result
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls.map((c) => c.id)).toContain("msg_dup_id");
+		const dupResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "msg_dup_id",
+		);
+		expect(dupResult?.success).toBe(false);
+	});
+
+	// Duplicate-within-slot: [pick_up, go] → first action dispatched, second is tool_failure
+	it("[pick_up, go] duplicate action slot: first action dispatched; second in roundtrip as failure", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "pickup_first_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+					{
+						id: "go_dup_id",
+						name: "go",
+						argumentsJson: JSON.stringify({ direction: "south" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// First action (pick_up) dispatched
+		expect(
+			getActivePhase(nextState).world.entities.find((e) => e.id === "flower")
+				?.holder,
+		).toBe("red");
+
+		// Second action (go) produces tool_failure in result.actions
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		const failureRecord = redActions.find(
+			(a) =>
+				a.kind === "tool_failure" && /only one action/i.test(a.description),
+		);
+		expect(failureRecord).toBeDefined();
+
+		// Roundtrip has both pick_up (success) and go (failure)
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		const ids = rt?.assistantToolCalls.map((c) => c.id);
+		expect(ids).toContain("pickup_first_id");
+		expect(ids).toContain("go_dup_id");
+		const pickupResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "pickup_first_id",
+		);
+		expect(pickupResult?.success).toBe(true);
+		const goResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "go_dup_id",
+		);
+		expect(goResult?.success).toBe(false);
+	});
+
+	// Cost: single costUsd from the single provider call (not doubled)
+	it("cost deduction is the single call's costUsd, not doubled", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_cost_id",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "hi" }),
+					},
+					{
+						id: "pickup_cost_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+				costUsd: 1,
+			},
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+		]);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// Red budget: 5 - 1 = 4 (single call cost, not 2)
+		expect(getActivePhase(nextState).budgets.red?.remaining).toBeCloseTo(4, 10);
+	});
+
+	// Empty toolCalls → pass record (existing regression guard)
+	it("[] empty toolCalls → pass record produced", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result } = await runRound(game, "red", "hi", provider, undefined, [
+			"red",
+			"green",
+			"cyan",
+		] as AiId[]);
+
+		expect(
+			result.actions.filter((a) => a.actor === "red" && a.kind === "pass"),
+		).toHaveLength(1);
+	});
+});
+
+// ----------------------------------------------------------------------------
 // Regression: no double-assistant turn after message tool call in multi-round (#213)
 // ----------------------------------------------------------------------------
 describe("message tool multi-round regression (#213)", () => {

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -345,6 +345,34 @@ export function dispatchAiTurn(
 		| { description: string; success: boolean }
 		| undefined;
 
+	// Process message BEFORE toolCall so that result.records reflects
+	// speak-then-act order (P0-1 fix for issue #238).
+	// Validation uses live personaSpatial from pre-action state — persona
+	// membership cannot be changed by an action in scope here, so this is safe.
+	if (action.message) {
+		const { to, content } = action.message;
+		// Validate recipient: must be "blue" or a live persona AiId (not self)
+		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
+		const validRecipient =
+			to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
+		if (!validRecipient) {
+			records.push({
+				round,
+				actor: aiId,
+				kind: "tool_failure",
+				description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
+			});
+		} else {
+			state = appendMessage(state, aiId, to, content);
+			records.push({
+				round,
+				actor: aiId,
+				kind: "message",
+				description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
+			});
+		}
+	}
+
 	if (action.toolCall) {
 		const toolCall = action.toolCall;
 		const validation = validateToolCall(state, aiId, toolCall);
@@ -499,30 +527,6 @@ export function dispatchAiTurn(
 				actor: aiId,
 				kind: "tool_failure",
 				description: `${game.personas[aiId]?.name ?? aiId} tried to ${action.toolCall.name} ${action.toolCall.args.item ?? action.toolCall.args.direction ?? ""} but failed: ${validation.reason}`,
-			});
-		}
-	}
-
-	if (action.message) {
-		const { to, content } = action.message;
-		// Validate recipient: must be "blue" or a live persona AiId (not self)
-		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
-		const validRecipient =
-			to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
-		if (!validRecipient) {
-			records.push({
-				round,
-				actor: aiId,
-				kind: "tool_failure",
-				description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
-			});
-		} else {
-			state = appendMessage(state, aiId, to, content);
-			records.push({
-				round,
-				actor: aiId,
-				kind: "message",
-				description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
 			});
 		}
 	}

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -199,58 +199,135 @@ export async function runRound(
 		// Capture completion text
 		completionSink?.(aiId, assistantText);
 
-		// Translate the result into an AiTurnAction
+		// Translate the result into an AiTurnAction.
+		// Iterate all toolCalls from this response; route by name into two slots:
+		//   - message slot (at most one accepted `message`-named call)
+		//   - action slot  (at most one accepted non-message call)
+		// Duplicates within either slot and parse-failures are recorded as
+		// tool_failure records and included in the roundtrip.
 		const action: AiTurnAction = { aiId };
 
-		// Handle tool call (take first tool call if present)
-		let toolCallId: string | undefined;
-		const [tc] = toolCalls;
-		if (tc !== undefined) {
-			toolCallId = tc.id;
+		// Slot guards: track whether each slot has been accepted
+		let messageAssigned = false;
+		let actionAssigned = false;
+
+		// ID of the accepted non-message action call (needed to match dispatcher result)
+		let acceptedActionCallId: string | undefined;
+
+		// Roundtrip accumulators — built inline, applied after dispatch
+		const recordedAssistantToolCalls: Array<{
+			id: string;
+			name: string;
+			argumentsJson: string;
+		}> = [];
+		const recordedToolResults: Array<{
+			tool_call_id: string;
+			success: boolean;
+			description: string;
+			reason?: string;
+		}> = [];
+
+		const round = getActivePhase(state).round;
+		const actorName = state.personas[aiId]?.name ?? aiId;
+
+		for (const tc of toolCalls) {
 			const parseResult = parseToolCallArguments(
 				tc.name as ToolName,
 				tc.argumentsJson,
 			);
 
-			if (parseResult.ok) {
-				if (tc.name === "message") {
-					// message tool: route to action.message, not action.toolCall
+			if (!parseResult.ok) {
+				// Parse-failed call: always goes to roundtrip as failure, never to action.*
+				const failDesc = `${actorName} tried to ${tc.name} but failed: ${parseResult.reason}`;
+				roundActions.push({
+					round,
+					actor: aiId,
+					kind: "tool_failure",
+					description: failDesc,
+				});
+				recordedAssistantToolCalls.push({
+					id: tc.id,
+					name: tc.name,
+					argumentsJson: tc.argumentsJson,
+				});
+				recordedToolResults.push({
+					tool_call_id: tc.id,
+					success: false,
+					description: failDesc,
+					reason: parseResult.reason,
+				});
+			} else if (tc.name === "message") {
+				if (!messageAssigned) {
+					// Accept into message slot
 					const msgArgs = parseResult.args as { to: string; content: string };
 					action.message = { to: msgArgs.to, content: msgArgs.content };
+					messageAssigned = true;
+					// Do NOT add to recordedAssistantToolCalls here — we decide post-dispatch
+					// whether the message succeeded (row 3 vs row 4 of the table).
 				} else {
+					// Duplicate message slot — reject as tool_failure
+					const dupDesc = `${actorName} tried to send more than one message in a turn: only one message tool call per turn`;
+					roundActions.push({
+						round,
+						actor: aiId,
+						kind: "tool_failure",
+						description: dupDesc,
+					});
+					recordedAssistantToolCalls.push({
+						id: tc.id,
+						name: tc.name,
+						argumentsJson: tc.argumentsJson,
+					});
+					recordedToolResults.push({
+						tool_call_id: tc.id,
+						success: false,
+						description: dupDesc,
+						reason: "only one message tool call per turn",
+					});
+				}
+			} else {
+				// Non-message tool call
+				if (!actionAssigned) {
+					// Accept into action slot
 					action.toolCall = {
 						name: tc.name as ToolName,
 						args: parseResult.args as Record<string, string>,
 					};
-				}
-			} else {
-				// Parse failed — synthesise a tool_failure record without dispatching
-				const round = getActivePhase(state).round;
-				const failureRecord: RoundActionRecord = {
-					round,
-					actor: aiId,
-					kind: "tool_failure",
-					description: `${state.personas[aiId]?.name ?? aiId} tried to ${tc.name} but failed: ${parseResult.reason}`,
-				};
-				roundActions.push(failureRecord);
-
-				// Record the tool failure in the roundtrip for the next round
-				newToolRoundtrip[aiId] = {
-					assistantToolCalls: toolCalls.map((c) => ({
-						id: c.id,
-						name: c.name,
-						argumentsJson: c.argumentsJson,
-					})),
-					toolResults: toolCalls.map((c) => ({
-						tool_call_id: c.id,
+					actionAssigned = true;
+					acceptedActionCallId = tc.id;
+					// Add to roundtrip accumulators — result filled in post-dispatch
+					recordedAssistantToolCalls.push({
+						id: tc.id,
+						name: tc.name,
+						argumentsJson: tc.argumentsJson,
+					});
+					// Placeholder — will be updated with actual success/description after dispatch
+					recordedToolResults.push({
+						tool_call_id: tc.id,
 						success: false,
-						description: `${state.personas[aiId]?.name ?? aiId} tried to ${tc.name} but failed: ${parseResult.reason}`,
-						reason: parseResult.reason,
-					})),
-				};
-
-				// Parse failed → pass
-				action.pass = true;
+						description: "",
+					});
+				} else {
+					// Duplicate action slot — reject as tool_failure
+					const dupDesc = `${actorName} tried to take more than one action in a turn: only one action tool call per turn`;
+					roundActions.push({
+						round,
+						actor: aiId,
+						kind: "tool_failure",
+						description: dupDesc,
+					});
+					recordedAssistantToolCalls.push({
+						id: tc.id,
+						name: tc.name,
+						argumentsJson: tc.argumentsJson,
+					});
+					recordedToolResults.push({
+						tool_call_id: tc.id,
+						success: false,
+						description: dupDesc,
+						reason: "only one action tool call per turn",
+					});
+				}
 			}
 		}
 
@@ -278,58 +355,84 @@ export async function runRound(
 			roundActions.push(record);
 		}
 
-		// Record tool roundtrip for this AI if a tool call was successfully parsed
-		if (
-			toolCalls.length > 0 &&
-			(action.toolCall || action.message) &&
-			toolCallId !== undefined
-		) {
-			if (dispatchResult.actorPrivateToolResult !== undefined) {
-				// examine: private result — NOT added to roundActions; only fed back to actor
-				const { description, success } = dispatchResult.actorPrivateToolResult;
-				newToolRoundtrip[aiId] = {
-					assistantToolCalls: toolCalls.map((c) => ({
-						id: c.id,
-						name: c.name,
-						argumentsJson: c.argumentsJson,
-					})),
-					toolResults: [
-						{
-							tool_call_id: toolCallId,
-							success,
-							description,
-						},
-					],
-				};
-			} else if (action.toolCall) {
-				// Normal (non-message) tool: record the roundtrip so the next round
-				// can replay tool_calls + tool results in the OpenAI message sequence.
-				// The `message` tool is intentionally excluded here: the sent message
-				// is already replayed via the conversationLog as an `assistant` content
-				// turn. Recording a roundtrip for `message` would produce two consecutive
-				// `assistant` turns in the next round (one from the log, one from the
-				// priorToolRoundtrip), violating the OpenAI/OpenRouter message protocol.
-				const toolRecord = dispatchResult.records.find(
-					(r) => r.kind === "tool_success" || r.kind === "tool_failure",
-				);
-				const success = toolRecord?.kind === "tool_success";
-				const description = toolRecord?.description ?? "";
-
-				newToolRoundtrip[aiId] = {
-					assistantToolCalls: toolCalls.map((c) => ({
-						id: c.id,
-						name: c.name,
-						argumentsJson: c.argumentsJson,
-					})),
-					toolResults: [
-						{
-							tool_call_id: toolCallId,
-							success,
-							description,
-						},
-					],
-				};
+		// Post-dispatch: resolve the accepted message call's roundtrip status.
+		// Successful message: EXCLUDE from roundtrip (replays via conversationLog per ADR 0007).
+		// Failed message (invalid recipient): INCLUDE in roundtrip with failure result.
+		let msgFailRecord: RoundActionRecord | undefined;
+		if (messageAssigned && action.message !== undefined) {
+			// Find whether the dispatcher produced a tool_failure for the message slot.
+			// dispatcher.ts applies message before toolCall (P0-1 swap), so the message
+			// dispatch record comes first. The message failure is identified by the
+			// "tried to message" text in the description (matches dispatcher.ts line).
+			msgFailRecord = dispatchResult.records.find(
+				(r) =>
+					r.kind === "tool_failure" &&
+					r.description.includes("tried to message"),
+			);
+			if (msgFailRecord) {
+				// Message failed — include in roundtrip so model sees the rejection next round
+				const acceptedMsgTc = toolCalls.find((tc) => tc.name === "message");
+				if (acceptedMsgTc) {
+					recordedAssistantToolCalls.unshift({
+						id: acceptedMsgTc.id,
+						name: acceptedMsgTc.name,
+						argumentsJson: acceptedMsgTc.argumentsJson,
+					});
+					recordedToolResults.unshift({
+						tool_call_id: acceptedMsgTc.id,
+						success: false,
+						description: msgFailRecord.description,
+					});
+				}
 			}
+			// If message succeeded: do NOT add to roundtrip (ADR 0007).
+		}
+
+		// Post-dispatch: resolve the accepted action call's result in the roundtrip.
+		if (actionAssigned && acceptedActionCallId !== undefined) {
+			const actionResultIdx = recordedToolResults.findIndex(
+				(r) => r.tool_call_id === acceptedActionCallId && r.description === "",
+			);
+			if (actionResultIdx >= 0) {
+				if (dispatchResult.actorPrivateToolResult !== undefined) {
+					// examine: private result fed back to actor only
+					const { description, success } =
+						dispatchResult.actorPrivateToolResult;
+					recordedToolResults[actionResultIdx] = {
+						tool_call_id: acceptedActionCallId,
+						success,
+						description,
+					};
+				} else {
+					// Normal tool: find the tool_success or tool_failure record from dispatcher.
+					// If the message also failed, dispatchResult.records has BOTH a msg-failure
+					// record and the action's record. Skip the message failure record (already
+					// identified as msgFailRecord) and look for the action's record, which is
+					// either tool_success or a tool_failure NOT from the message slot.
+					const toolRecord = dispatchResult.records.find(
+						(r) =>
+							(r.kind === "tool_success" || r.kind === "tool_failure") &&
+							r !== msgFailRecord,
+					);
+					const success = toolRecord?.kind === "tool_success";
+					const description = toolRecord?.description ?? "";
+					recordedToolResults[actionResultIdx] = {
+						tool_call_id: acceptedActionCallId,
+						success,
+						description,
+					};
+				}
+			}
+		}
+
+		// Save roundtrip only when there are entries to replay.
+		// msg-success-only (row 1) and pass (no calls) produce empty lists → no entry.
+		// This preserves the #213 fix: no spurious double-assistant turn for message-only turns.
+		if (recordedAssistantToolCalls.length > 0) {
+			newToolRoundtrip[aiId] = {
+				assistantToolCalls: recordedAssistantToolCalls,
+				toolResults: recordedToolResults,
+			};
 		}
 	}
 


### PR DESCRIPTION
## What this fixes

Today every Daemon turn is exactly one tool call: speak (`message`) **or**
act (`go`/`pick_up`/`put_down`/`give`/`use`/`look`/`examine`), never both
— the coordinator drops the tail of `toolCalls` (`const [tc] = toolCalls;`
at `round-coordinator.ts:207`). A Daemon that wants to react verbally and
take a physical action in the same beat has to choose. This PR makes a
turn "speak (optional) + act (optional)" in a **single LLM call** via
OpenAI/OpenRouter's `parallel_tool_calls: true` (already wired in
`llm-client.ts:159` from #246).

### Two commits

- **`0ba3077 dispatcher: apply action.message before action.toolCall (P0-1)`**
  Swaps the two blocks in `dispatchAiTurn` so when both slots are
  populated, `result.records` has the message at index 0 and the tool
  result at index 1. Speak-then-act narrative beat. Unobservable until
  the coordinator change lands; pre-existing single-slot turns are
  unaffected.

- **`cdceecf round-coordinator: route parallel tool calls + generalize roundtrip to N results`**
  Replaces single-call extraction with a loop. Routes the first
  `message` to `action.message`, the first non-`message` to
  `action.toolCall`, and any duplicates within either slot to
  `tool_failure` records (visible to the model next round). Generalizes
  the roundtrip composition to match the four-row table from the issue
  body:

  | Model emits | `assistantToolCalls` | `toolResults` | Conversation log |
  | --- | --- | --- | --- |
  | `[msg-success]` only | (none) | (none) | `assistant{content}` |
  | `[action]` only | `[actionId]` | `[actionResult]` | nothing |
  | `[msg-success, action]` | `[actionId]` | `[actionResult]` | `assistant{content}` |
  | `[msg-fail, action]` | `[msgId, actionId]` | `[msgFail, actionResult]` | nothing |

  The `recordedAssistantToolCalls.length > 0` gate preserves the #213
  invariant (no spurious double-assistant turn for message-only turns).
  Examine's `actorPrivateToolResult` is wired to `acceptedActionCallId`.
  `TurnStep` abstraction held back per the issue's "Implementation
  Decisions" — inline routing is ~30 lines and obvious.

## QA steps for the human

None required for protocol-level correctness — the 13 new unit tests
cover the four-row table, both duplicate-within-slot cases, the
single-call cost path, and the consecutive-assistant-turns wire shape
that row 3 produces (with a test-name comment noting it's intentional
and OpenAI-spec-valid). The full unit suite is at 999/999.

Optional live exercise: open the SPA, drive a session that warrants
both speak+act (e.g. "*xqr9 tell me what you see and step toward the
nearest item"). Per #239 step 7, GLM-4.7 with C12 framing emits parallel
`message+action` ~41% of the time. Verify the panel transcript shows
the message first then the action narration in the same round.

## Automated coverage

- `pnpm exec tsc -p tsconfig.json --noEmit` — clean
- `pnpm exec vitest run` — 999/999 (+13 vs main)
- `pnpm smoke` — 39/44; the 5 failing specs (sessions-picker x3,
  whisper-tampering, witnessed-event-reload) fail identically on the
  source branch (`claude/review-issue-239-ZroCF`) and are pre-existing,
  not regressions from this PR.

## Follow-up coverage gap

No e2e spec drives a multi-tool-call response shape from
`stubChatCompletions`. Unit tests cover the path; a future spec
exercising `[message+action]` parallel emission through the live
integration surface would close the gap. Not blocking for this PR.

Closes #238.

https://claude.ai/code/session_01AeN1P7233A1DKcxbHYcG2L


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeN1P7233A1DKcxbHYcG2L)_