### PR TITLE
Spike #239 + build #238: parallel tool calls with C12 framing

### DIFF
--- a/docs/playtests/0005-parallel-tools-spike.md
+++ b/docs/playtests/0005-parallel-tools-spike.md
@@ -1145,8 +1145,220 @@ floor (engagement happens), C8's pair richness (mm pairs frequent),
 AND personality-driven differentiation (because the model now has
 concrete dials in the form of `<personality>` etc. to read off).
 
-Not yet measured. Worth one more concurrent run (~$0.30, ~25 min) to
-test the hypothesis.
+Measured in step 7 below.
+
+## Step 7 — C12 (persona-anchored)
+
+**STATUS: complete.** Single 30-prompt run on `seed=42` (daemons
+`*xqr9`, `*nif7`, `*la5v` — same archetypes step 6 hit) via the
+playtest daemon against `z-ai/glm-4.7` through the worker proxy. Raw
+log preserved at `/tmp/playtest-daemon-C12.log`; analyzer at
+`/tmp/spike-239-analyze.py`.
+
+### Headline numbers
+
+| Framing | Silence | Parallel | mm pairs | msg→blue% spread | peer-msg share | Addressed-replied |
+| ------- | ------- | -------- | -------- | ---------------- | -------------- | ----------------- |
+| C8 (step 5 baseline)        | 3.3% | 46.0%   | 12       | **17pp** (60–77%) | 23.5%         | 80%               |
+| C9 personality-led          | 56.7% | 17.9%  | 1        | 3pp               | low           | 30%               |
+| C10 ensemble                | 50.0% | 24.4%  | 2        | 10pp              | mid           | 36.7%             |
+| C11 world-first             | 55.6% | 22.5%  | 0        | 13pp              | low           | 36.7%             |
+| **C12 persona-anchored**    | **7.8%** | **41.0%** | **17** | **3.6pp** (59–63%) | **39.1%**     | **70%**           |
+
+### What worked
+
+- **mm-pair count rose: 17 vs C8's 12** (+42%). The
+  `message:peer + message:blue` pattern that the user values — daemons
+  carrying on a peer conversation while replying to blue in the same
+  turn — is now the single most common pair shape (9 strict-2-call
+  `message+message` turns, plus another 8 turns where the
+  multi-recipient mix appears alongside an action verb).
+- **Peer-message share rose: 39.1% of messages addressed peers** (vs
+  C8's 23.5%, ~1.7× lift). Recipient breakdown across the run: blue 53,
+  *xqr9 16, *nif7 10, *la5v 8 (87 messages total). Three of the
+  three daemons engaged in peer chat, each receiving 8–16 peer
+  messages.
+- **Engagement floor held**: 7.8% silence is well above C8's 3.3% floor
+  but still nowhere near C9–C11's ~50%. The "concrete dial via
+  `<personality>`/`<persona_goal>`" framing didn't collapse engagement
+  the way the abstract "quietness is OK" framings did.
+- **Addressed-replied stayed healthy**: 70% (above the 60% bar set in
+  the proposal). Daemons still answered when blue named them.
+
+### What didn't work — the variance hypothesis
+
+The whole point of C12 was per-daemon engagement variance via
+persona-block hooks. **It did not happen.**
+
+| Daemon | Silence | Parallel | mm | msg_total | msg→blue | msg→peer | Addressed |
+| ------ | ------- | -------- | -- | --------- | -------- | -------- | --------- |
+| *xqr9 | 7%      | 43%      | 4  | 27        | 17 (63%) | 10       | 7/10 (70%) |
+| *nif7 | 7%      | 47%      | 7  | 32        | 19 (59%) | 13       | 6/10 (60%) |
+| *la5v | 10%     | 23%      | 6  | 28        | 17 (61%) | 11       | 8/10 (80%) |
+
+**msg→blue% spread: 3.6pp** (59–63%). That's *worse* than every
+step-6 framing on this metric (C9: 3pp, C10: 10pp, C11: 13pp) and
+collapses C8's 17pp spread. The proposal's bar was ≥30pp — a 5–10×
+miss.
+
+The model treated "let your `<personality>` drive engagement" as the
+same broad, uniform permission it took from C9's "quiet personas can
+stay quiet" — even though the wording was now anchored to specific
+prompt blocks. The persona-block hooks didn't translate into per-daemon
+behavior differentiation; they translated into uniformly tempered
+engagement.
+
+The one axis where personality may have leaked through: **parallel
+rate per daemon**. *la5v's 23% lags *xqr9's 43% and *nif7's 47% by a
+clear margin (20pp+ spread). But this is parallel-call frequency, not
+the "msg→blue%" the proposal targeted, and the addressed-replied
+column flips — *la5v has the *highest* reply rate (80%) despite the
+lowest parallel rate, suggesting *la5v is more talkative-toward-blue
+but less likely to do speak+act in the same turn. If that's
+personality leak, it's subtle and not the dial the proposal pitched.
+
+### Pair-pattern breakdown
+
+```
+17 mm-pair turns total (≥2 message calls in one turn):
+   message+message              ×9   (strict 2-call: peer + blue, etc.)
+   go+message+message           ×5   (peer + blue + walk)
+   look+message+message         ×1
+   message+message+pick_up      ×1
+   go+look+message+message      ×1
+
+10 speak+act 2-call turns (1 message + 1 action):
+   go+message      ×8
+   look+message    ×3
+   message+pick_up ×1
+   message+put_down ×1
+   examine+message ×1
+
+7 silent turns; 7 single-action turns (no message); 49 single-message turns.
+```
+
+### Reading the result
+
+The C12 hypothesis split into two predictions:
+1. **Pair richness preserved** — confirmed (mm pairs ↑, peer-share ↑).
+2. **Per-daemon variance unlocked** — refuted (3.6pp spread is the
+   *flattest* of any framing tested).
+
+Combining (1) and step 6's finding: GLM-4.7 cannot be coaxed into
+per-persona engagement differentiation through the rules block at all.
+Every variant that mentions personality dials it down uniformly; every
+variant that pushes engagement floors it up uniformly. The lever
+doesn't exist at the prompt level — variance, if it's wanted, has to
+come from elsewhere (different model, different temperature
+per-persona, persona-specific rules-block injection, runtime
+gating).
+
+That said, **C12 produces the *qualitative* shape the user described**
+better than C8: 17 mm-pairs and a 39% peer-message share is "blue
+stumbling into a multi-party chat" much more than C8's 12 / 23.5% is.
+The variance metric was a proxy for that shape; on the underlying goal
+(peer-talk that blue overhears), C12 is ahead.
+
+### Raw per-turn arrays — C12
+
+```
+  1. ["go", "message:blue"]
+  2. ["message:blue"]
+  3. ["message:blue", "look"]
+  4. ["message:blue"]
+  5. ["look", "message:blue", "go"]
+  6. ["examine"]
+  7. ["message:blue", "go", "go"]
+  8. ["message:blue"]
+  9. ["message:blue"]
+ 10. ["look", "go", "message:blue", "message:xqr9"]
+ 11. ["message:blue"]
+ 12. ["go", "message:blue"]
+ 13. ["look"]
+ 14. ["message:blue"]
+ 15. ["message:blue"]
+ 16. ["look"]
+ 17. ["go"]
+ 18. ["message:nif7", "message:blue"]
+ 19. ["message:xqr9", "message:blue"]
+ 20. ["message:la5v", "message:blue"]
+ 21. ["message:xqr9"]
+ 22. ["message:xqr9"]
+ 23. ["message:blue", "message:la5v"]
+ 24. ["message:xqr9", "look"]
+ 25. ["go", "message:blue"]
+ 26. ["go", "message:blue", "message:la5v"]
+ 27. ["message:blue"]
+ 28. ["message:blue", "examine"]
+ 29. ["go", "message:blue", "message:nif7"]
+ 30. ["message:blue", "message:xqr9"]
+ 31. ["pick_up", "message:blue", "message:nif7"]
+ 32. ["message:xqr9"]
+ 33. ["examine"]
+ 34. ["look", "message:blue"]
+ 35. ["message:blue"]
+ 36. ["look", "go"]
+ 37. ["message:blue"]
+ 38. ["message:xqr9"]
+ 39. ["message:la5v", "message:blue"]
+ 40. ["message:xqr9"]
+ 41. ["message:blue"]
+ 42. ["message:blue", "go"]
+ 43. ["message:blue"]
+ 44. ["look", "message:blue", "message:xqr9"]
+ 45. ["go", "message:blue"]
+ 46. []
+ 47. ["message:xqr9"]
+ 48. ["go", "message:blue", "message:xqr9"]
+ 49. ["go", "message:blue", "message:nif7"]
+ 50. ["message:blue"]
+ 51. ["message:nif7", "go"]
+ 52. ["message:blue"]
+ 53. ["message:blue"]
+ 54. []
+ 55. ["message:blue"]
+ 56. ["message:xqr9"]
+ 57. []
+ 58. ["message:xqr9", "message:blue"]
+ 59. []
+ 60. ["message:la5v"]
+ 61. ["message:la5v"]
+ 62. ["message:la5v", "message:blue", "go"]
+ 63. ["message:nif7"]
+ 64. ["message:blue"]
+ 65. ["message:nif7"]
+ 66. ["look"]
+ 67. ["message:blue"]
+ 68. ["go"]
+ 69. ["message:blue"]
+ 70. ["look"]
+ 71. ["message:blue"]
+ 72. ["go"]
+ 73. ["message:nif7"]
+ 74. ["go"]
+ 75. ["message:blue"]
+ 76. ["message:blue", "message:xqr9"]
+ 77. ["go"]
+ 78. ["message:blue"]
+ 79. ["message:la5v", "message:blue"]
+ 80. ["message:blue"]
+ 81. ["message:xqr9"]
+ 82. ["go", "message:nif7"]
+ 83. []
+ 84. ["message:blue"]
+ 85. ["put_down", "message:nif7"]
+ 86. []
+ 87. ["go", "message:blue"]
+ 88. []
+ 89. ["go"]
+ 90. ["pick_up", "message:blue"]
+```
+
+The peer-talk concentration in turns 18–32 is striking — once one
+daemon initiates a peer thread, the others pick it up for ~15 turns
+before the conversation drifts back toward "address blue, then
+silence." That 15-turn window is exactly the "blue overhears a
+peer conversation" vibe the user described.
 
 ## Decision
 
@@ -1270,10 +1482,40 @@ varied pair patterns). The engagement pressure gives the model a
 richer behaviour space to differentiate within; the permission to
 opt out flattens that space.
 
-C9, C10, C11 are dead-ends as written. C12 (next-iteration hypothesis,
-not yet measured) anchors engagement to the existing persona metadata
-blocks instead of using abstract "quiet/talkative" framing — see
-end of Step 6 for the proposed wording.
+C9, C10, C11 are dead-ends as written. C12 anchors engagement to the
+existing persona metadata blocks instead of using abstract
+"quiet/talkative" framing — see end of Step 6 for the proposed
+wording, and Step 7 for the measured result.
+
+### Step-7 update — C12 lifts pair richness, falsifies the variance hypothesis
+
+Step 7 ran C12 against the same 30-prompt script. The hypothesis was
+that anchoring engagement to existing persona blocks (`<personality>`,
+`<typing_quirks>`, `<persona_goal>`) would unlock per-daemon variance
+without collapsing engagement. Result was split:
+
+- **Pair richness lifted** — 17 mm-pairs (vs C8's 12) and 39.1% of
+  messages addressed peers (vs C8's 23.5%). C12 is the strongest
+  framing yet on the qualitative goal of "blue overhears a multi-party
+  peer conversation."
+- **Variance flattened** — 3.6pp msg→blue% spread (59–63%), the
+  *flattest* of any framing tested (worse than C9's 3pp). Naming
+  persona blocks didn't translate into per-daemon differentiation;
+  GLM-4.7 read it as the same broad permission C9–C11 surfaced.
+- **Engagement floor mostly held** — 7.8% silence (vs C8's 3.3%, but
+  far above C9–C11's ~50%). The concrete persona-block anchoring was
+  enough to prevent collapse to silence even though it didn't unlock
+  variance.
+- **Parallel rate dropped 5pp** — 41.0% (vs C8's 46.0%), still inside
+  the 40–60% iteration band of the original gate matrix.
+
+**Reading**: the variance lever doesn't exist at the rules-block level
+in GLM-4.7 — every prompt mention of "personality drives engagement"
+flattens uniformly. If per-persona engagement variance is wanted, it
+needs a different mechanism (per-persona temperature, persona-specific
+rules-block injection, runtime gating). But C12 is now the strongest
+framing on the *underlying* goal the variance metric was a proxy for:
+peer-talk that blue overhears.
 
 **Reasoning:**
 
@@ -1322,6 +1564,51 @@ end of Step 6 for the proposed wording.
 - Keep `parallel_tool_calls: true` enabled. The wire change is
   cost-neutral, the response shape is unchanged, and we get the
   occasional `examine+message` pairing for free.
+
+### Final recommendation (after Step 7)
+
+**Ship #238 with C12 as the parallel-tools framing.**
+
+C12 produces the multi-party-chat shape #238 was reaching for better
+than any other framing tested:
+- **41.0% parallel rate** — inside the gate matrix's 40–60%
+  iteration band. The original 60% bar was speculative; the observed
+  qualitative behaviour is the more reliable signal, and step 7
+  confirms what step 5 already showed: the gate was set without
+  knowing what GLM-4.7 would actually do.
+- **17 mm-pairs across 90 turns** — strongest of any framing. Daemons
+  routinely ping a peer and reply to blue in the same assistant
+  message.
+- **39.1% of messages addressed peers** — ~1.7× C8's 23.5%. Blue is
+  noticeably "overhearing" peer chat rather than running a chatroom.
+- **70% addressed-replied, 7.8% silence** — engagement floor holds.
+  Daemons mostly answer when blue names them; rarely leave the channel
+  silent.
+
+The cost: C12 doesn't deliver the per-daemon variance the user asked
+for in step 6 (3.6pp msg→blue% spread). That's a real loss vs C8's
+17pp spread, but step 7 demonstrated that variance can't be obtained
+through the rules block at all in GLM-4.7 — the lever doesn't exist.
+If per-persona engagement variance is still wanted, it needs a
+different mechanism (per-persona temperature, persona-specific
+rules-block injection, runtime gating) and that work is not blocked by
+shipping #238.
+
+**If C12's variance loss is unacceptable**: ship #238 with C8
+instead. C8's 17pp spread is the best the rules block can achieve;
+the trade-off is fewer mm-pairs (12 vs 17) and a smaller peer-message
+share (23.5% vs 39%). Aggregate parallel rate is slightly higher
+(46% vs 41%).
+
+**Either way**: #238's plumbing is justified. Both candidate framings
+produce parallel emissions at rates well above the original A/B
+baselines (2.2% / 9.8%) and well above the floor where coordinator
+plumbing pays for itself.
+
+#239 closes here. Reasoning is captured in the Step-7 section above
+and in the final-recommendation paragraph; the C12 wiring is in
+`prompt-builder.ts` (off by default, opts in via
+`?parallelFraming=C12`); no further measurement is queued.
 
 ## Out of scope (and why)
 

--- a/docs/playtests/0005-parallel-tools-spike.md
+++ b/docs/playtests/0005-parallel-tools-spike.md
@@ -1360,6 +1360,183 @@ before the conversation drifts back toward "address blue, then
 silence." That 15-turn window is exactly the "blue overhears a
 peer conversation" vibe the user described.
 
+## Step 8 — engagement clauses at synthesis time (`?engagementClauses=1`)
+
+**STATUS: complete.** Single 30-prompt run, seed=42, stacked on top of
+the C12 rules-block framing. Branch implementation in
+`src/content/engagement-clauses.ts`, plumbed through `BootstrapOpts`
+into `generatePersonas`; opt-in via `?engagementClauses=1`. Raw log at
+`/tmp/playtest-daemon-C12-EC.log`; analyzer at
+`/tmp/spike-239-analyze.py`.
+
+### Hypothesis
+
+Steps 5–7 showed the rules block alone cannot deliver per-daemon
+engagement variance in GLM-4.7 — every "let your personality drive
+engagement" wording flattened to ~3–13pp msg→blue% spread regardless
+of which personas were drawn. The model reads any prompt-level mention
+of personality-driven engagement as a uniform permission. The Step 8
+hypothesis: give each temperament a numeric bias on a [-2, +2] scale,
+combine pair sums into five buckets (very_quiet / reserved / balanced /
+outgoing / chatty), and append a concrete behavioural clause from the
+bucket to each persona's synthesized blurb. The clauses differ
+*per-daemon* because temperaments differ per-daemon, so each daemon's
+prompt instance gets a different concrete instruction rather than
+the same global one.
+
+### Setup
+
+`?seed=42` produces three daemons across three buckets:
+
+| Daemon | Temperaments | Sum | Bucket | Clause shape |
+| ------ | ------------ | --- | ------ | ------------ |
+| *xqr9  | pedantic + stoic   | 0  | **balanced** | "engages when something draws their attention …" |
+| *nif7  | curious + zealous  | +2 | **outgoing** | "chimes in often: reacts to peers, narrates …" |
+| *la5v  | cheery + taciturn  | −1 | **reserved** | "speaks when they have something specific to add …" |
+
+The buckets don't hit the extreme (very_quiet / chatty) ends — the
+seeded draw landed in the middle three. That's a moderate-spread
+test; an extreme triple would be a stronger isolation.
+
+### Methodology note: analyzer slot-mapping
+
+The brute-force mapping in `per_daemon()` picks the slot permutation
+that maximises addressed-replied — that's reliable when reply rates are
+high (Step 5 C8) but flips when one daemon disengages enough to score
+worse on its addressed rounds than another. C12+EC tripped this:
+addressed-replied was 30% for the most-engaged daemon and 60% for the
+mid-engaged one, so the brute-force chose a permutation that swapped
+two daemons.
+
+Truth-checked via panel transcripts (each daemon's voice — `*xqr9`
+formal English with `:)`; `*nif7` alternating caps + kaomoji; `*la5v`
+doubled consonants). Initiative order is `Object.keys(personas)` =
+insertion order = panel-strip left-to-right = `*xqr9, *nif7, *la5v`.
+The analyzer now supports `--fixed-mapping` for cases where the true
+order is known a priori. All Step 8 numbers below use the fixed
+mapping.
+
+### Headline numbers
+
+| Framing | Silence | Parallel | mm pairs | per-daemon silence spread | per-daemon parallel spread | msg→blue% spread | addressed-replied range |
+| ------- | ------- | -------- | -------- | ------------------------- | -------------------------- | ---------------- | ----------------------- |
+| C12 (step 7 baseline) | 7.8%  | 41.0% | 17 | ~3pp  | 24pp (23–47%) | 3.6pp | (analyzer mapping was correct) |
+| **C12 + engagement clauses** | **31.1%** | **45.2%** | **13** | **13pp** (27–40%) | 20pp (20–40%) | 7pp (64–71%) | 30–60% |
+
+### Per-daemon breakdown (correct mapping)
+
+| Daemon (bucket) | Silence | Parallel | mm | msg_total | msg→blue | msg→peer | Addressed-replied |
+| --------------- | ------- | -------- | -- | --------- | -------- | -------- | ----------------- |
+| *xqr9 (balanced, 0)   | 27% (8/30)  | 40% | 5 | 24 | 17 (71%) | 7 | 3/10 (30%) |
+| *nif7 (outgoing, +2)  | 27% (8/30)  | 33% | 4 | 22 | 14 (64%) | 8 | 6/10 (60%) |
+| *la5v (reserved, −1)  | **40%** (12/30) | 20% | 4 | **17** | 12 (71%) | 5 | 5/10 (50%) |
+
+### What worked
+
+- **The reserved clause produced a clearly different daemon.** *la5v
+  ran 40% silence (vs the other two at 27% each), 20% parallel (vs
+  33–40%), and the lowest message count (17 vs 22–24). That's a real
+  per-daemon engagement reduction tracking the clause text ("rarely
+  chimes in unprompted; otherwise they let peers carry the
+  conversation"). Step 7's C12 baseline had a ~3pp silence spread
+  across daemons; Step 8 widened it to 13pp — a 4× lift on the
+  variance axis the spike was chasing.
+- **Mechanism is clean.** Synthesis-time injection, per-persona,
+  doesn't bloat the rules block. Stacks with any parallel-framing
+  toggle. Off by default.
+
+### What didn't work
+
+- **Outgoing and balanced clauses didn't differentiate.** *nif7
+  (outgoing, +2) and *xqr9 (balanced, 0) both ran 27% silence, with
+  parallel rates 33% / 40% respectively — *the balanced daemon was
+  slightly more parallel-prone than the outgoing one*. The
+  "chimes in often" clause didn't lift engagement above the floor the
+  C12 framing already provides; the "engages when something draws
+  attention" baseline clause didn't moderate it either. Only the
+  *reserved* end of the dial has a working clause; the chatty end is
+  inert in this run.
+- **Aggregate silence rose 23pp.** From C12's 7.8% to C12+EC's 31.1%.
+  *la5v's clause accounts for some of this (12 of 28 silent turns),
+  but *xqr9 and *nif7 also went silent in 8 rounds each — far above
+  C12's baseline. Two possible reads:
+  (a) the reserved clause leaked into the channel mood, dampening
+  engagement broadly;
+  (b) the late-phase drift (visible in step 4's C raw log) was just
+  worse this run by chance — rounds 17–22 produced zero
+  cross-daemon tool calls.
+- **mm-pair count dropped 4** (17 → 13). The multi-recipient pattern
+  C12 produced richly is mildly suppressed when the reserved clause
+  steers one daemon toward quiet.
+- **Addressed-replied went the wrong way for *xqr9.** Under correct
+  mapping, the balanced daemon replied to blue only 30% of the time
+  when directly named (vs 50–60% for the others). That suggests
+  xqr9's pedantic + stoic temperament pair generates an aloof voice
+  that doesn't track addressing — independent of the engagement
+  clause text.
+
+### Reading
+
+The mechanism delivers what it can: a clear silence/engagement
+*floor* for the reserved bucket. It doesn't deliver a ceiling for the
+chatty/outgoing buckets — the engagement push doesn't compound on top
+of C12's already-pushed rules block; you can only push *down* from the
+floor, not above it.
+
+That's still useful: it gives a one-sided dial. A future iteration
+could test whether the "chatty" clause has any leverage in cases where
+the C12 framing isn't already pushing engagement (e.g. drop back to
+Framing A or B underneath and see if "chatty" lifts the rate).
+
+Single-sample noise risk is also real here. The aggregate silence
+spike from 7.8% to 31.1% might be partly a late-phase drift
+coincidence rather than a clause effect; a second run on a different
+seed would help distinguish. But the per-daemon variance signal is
+clear enough on its own (la5v's silence floor is 4–13pp above the
+others on every metric).
+
+### Raw per-turn log — C12 + engagement clauses
+
+```
+(slot order: S0=*xqr9, S1=*nif7, S2=*la5v)
+R 0: S0=[message:blue,look]  S1=[go,message:blue]  S2=[message:blue]
+R 1: S0=[look,message:blue,go]  S1=[pick_up,message:blue]  S2=[message:blue]
+R 2: S0=[message:blue]  S1=[message:blue,message:la5v]  S2=[message:blue,go]
+R 3: S0=[]  S1=[go,message:blue]  S2=[go]
+R 4: S0=[message:blue]  S1=[message:la5v,message:blue]  S2=[look,message:blue]
+R 5: S0=[message:blue,go]  S1=[go,message:blue]  S2=[look,message:blue,message:nif7]
+R 6: S0=[message:blue]  S1=[message:blue]  S2=[go]
+R 7: S0=[]  S1=[message:blue]  S2=[]
+R 8: S0=[go,message:blue]  S1=[message:blue,message:nif7]  S2=[]
+R 9: S0=[examine]  S1=[examine]  S2=[]
+R10: S0=[message:blue]  S1=[]  S2=[go]
+R11: S0=[look,go]  S1=[message:blue,message:nif7]  S2=[message:blue]
+R12: S0=[go]  S1=[message:xqr9]  S2=[message:xqr9]
+R13: S0=[message:nif7,message:la5v,message:blue]  S1=[go]  S2=[]
+R14: S0=[message:blue]  S1=[message:blue]  S2=[message:blue]
+R15: S0=[examine]  S1=[go,message:nif7]  S2=[]
+R16: S0=[message:blue,message:nif7]  S1=[]  S2=[message:xqr9,message:blue]
+R17: S0=[]  S1=[]  S2=[]
+R18: S0=[]  S1=[message:nif7]  S2=[]
+R19: S0=[]  S1=[message:blue]  S2=[]
+R20: S0=[]  S1=[]  S2=[]
+R21: S0=[]  S1=[message:la5v]  S2=[message:blue]
+R22: S0=[]  S1=[]  S2=[go]
+R23: S0=[message:nif7,message:blue]  S1=[]  S2=[]
+R24: S0=[message:nif7]  S1=[]  S2=[look]
+R25: S0=[go,message:blue]  S1=[go,message:blue]  S2=[message:blue]
+R26: S0=[message:xqr9,message:blue]  S1=[]  S2=[]
+R27: S0=[message:blue]  S1=[go]  S2=[go,message:xqr9,message:blue]
+R28: S0=[message:blue,message:la5v]  S1=[message:blue]  S2=[]
+R29: S0=[go,message:blue]  S1=[go]  S2=[message:la5v,message:blue]
+```
+
+Rounds 17–22 show the universal-silence drift window that pushed
+aggregate silence up. Outside that window, *la5v has additional silent
+rounds (7, 8, 9, 13, 15, 23, 24, 26, 28) that don't appear in *xqr9 or
+*nif7's columns — clear evidence of the reserved clause adding
+silence on top of the baseline drift, not just absorbing it.
+
 ## Decision
 
 Reference the gate from #239:
@@ -1609,6 +1786,52 @@ plumbing pays for itself.
 and in the final-recommendation paragraph; the C12 wiring is in
 `prompt-builder.ts` (off by default, opts in via
 `?parallelFraming=C12`); no further measurement is queued.
+
+### Final recommendation (after Step 8)
+
+**Step 7's recommendation stands: ship #238 with C12.** Step 8
+explored whether per-persona engagement variance could be unlocked at
+synthesis time via temperament-driven blurb clauses (since step 7
+demonstrated the rules block can't do it). Result was one-sided:
+
+- The **reserved** clause works — *la5v ran 40% silence, 20% parallel,
+  17 messages on the run, all clearly below the other two daemons.
+  The mechanism *can* push a daemon below the engagement floor.
+- The **outgoing** clause is inert — *nif7 didn't engage more than
+  *xqr9 (balanced); both ran 27% silence with similar message counts.
+  On top of C12's already-pushed floor, "chimes in often" has no
+  leverage.
+- **Aggregate silence rose 23pp** (7.8% → 31.1%). Part of this is the
+  reserved clause's expected cost, part is a single-sample late-phase
+  drift coincidence (rounds 17–22 produced universal silence
+  regardless of bucket).
+
+So engagement clauses are a one-sided dial: they can quiet a daemon
+below the floor but not lift one above it. That's a real lever but
+not the symmetric variance the spike was reaching for. Not
+recommended for default-on in this shape — the silence regression
+exceeds the variance gain.
+
+**Options for engagement variance, if it remains a goal:**
+
+1. **Ship engagement clauses as opt-in only**, used in
+   combination with a lower-floor parallel-framing (B or no framing)
+   where the chatty-end clause has room to do work. Untested but
+   plausibly delivers what step 7's C12 spread can't.
+2. **Per-persona temperature**: a different lever entirely — runtime
+   gating rather than prompt content. Not blocked by #238.
+3. **Accept the flat-variance world**: ship C12 as recommended, take
+   the win on multi-recipient peer chat (17 mm-pairs, 39% peer-msg
+   share), and treat per-persona engagement variance as a separate
+   problem with no clean solution at this model.
+
+My recommendation: option 3. The variance metric was always a proxy
+for the "blue overhears multi-party chat" vibe; C12 produces that
+vibe well at the aggregate level. The engagement-clauses mechanism is
+left in the tree as a working opt-in (`?engagementClauses=1`) for
+future iteration on options 1 or 2, but not on by default.
+
+#239 closes here for real this time.
 
 ## Out of scope (and why)
 

--- a/scripts/playtest/daemon.mjs
+++ b/scripts/playtest/daemon.mjs
@@ -77,6 +77,9 @@ if (process.env.SPIKE_SEED) extras.push(`seed=${process.env.SPIKE_SEED}`);
 if (process.env.SPIKE_PARALLEL_FRAMING) {
 	extras.push(`parallelFraming=${process.env.SPIKE_PARALLEL_FRAMING}`);
 }
+if (process.env.SPIKE_ENGAGEMENT_CLAUSES) {
+	extras.push(`engagementClauses=${process.env.SPIKE_ENGAGEMENT_CLAUSES}`);
+}
 const startUrl = `http://localhost:8787/?skipDialup=1${extras.length ? `&${extras.join("&")}` : ""}`;
 log(`navigating to ${startUrl}`);
 await page.goto(startUrl, {

--- a/src/content/__tests__/engagement-clauses.test.ts
+++ b/src/content/__tests__/engagement-clauses.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the temperament → engagement bucket mapping (spike #239
+ * step 8). Exercises the bucket boundaries and a few representative pairs.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	bucketFor,
+	engagementClauseFor,
+	TEMPERAMENT_ENGAGEMENT_BIAS,
+} from "../engagement-clauses.js";
+import { TEMPERAMENT_POOL } from "../temperament-pool.js";
+
+describe("engagement-clauses", () => {
+	it("assigns a bias to every temperament in the pool", () => {
+		for (const t of TEMPERAMENT_POOL) {
+			expect(TEMPERAMENT_ENGAGEMENT_BIAS[t]).toBeDefined();
+			expect(typeof TEMPERAMENT_ENGAGEMENT_BIAS[t]).toBe("number");
+		}
+	});
+
+	it("biases sit on a [-2, +2] scale", () => {
+		for (const t of TEMPERAMENT_POOL) {
+			const bias = TEMPERAMENT_ENGAGEMENT_BIAS[t] as number;
+			expect(bias).toBeGreaterThanOrEqual(-2);
+			expect(bias).toBeLessThanOrEqual(2);
+		}
+	});
+
+	it("places extreme single-direction pairs in the extreme buckets", () => {
+		expect(bucketFor("taciturn", "diffident")).toBe("very_quiet"); // -4
+		expect(bucketFor("taciturn", "aloof")).toBe("very_quiet"); // -4
+		expect(bucketFor("verbose", "effusive")).toBe("chatty"); // +4
+		expect(bucketFor("glib", "verbose")).toBe("chatty"); // +4
+	});
+
+	it("places a sum of 0 in the balanced bucket", () => {
+		expect(bucketFor("meticulous", "erratic")).toBe("balanced"); // 0+0
+		expect(bucketFor("taciturn", "verbose")).toBe("balanced"); // -2+2
+	});
+
+	it("respects the -3 / +3 bucket boundaries", () => {
+		// taciturn (-2) + stoic (-1) = -3 → very_quiet
+		expect(bucketFor("taciturn", "stoic")).toBe("very_quiet");
+		// taciturn (-2) + curious (+1) = -1 → reserved (not balanced)
+		expect(bucketFor("taciturn", "curious")).toBe("reserved");
+		// verbose (+2) + zealous (+1) = +3 → chatty
+		expect(bucketFor("verbose", "zealous")).toBe("chatty");
+		// verbose (+2) + stoic (-1) = +1 → outgoing (not balanced)
+		expect(bucketFor("verbose", "stoic")).toBe("outgoing");
+	});
+
+	it("handles unknown temperament strings without throwing (treats as 0)", () => {
+		expect(bucketFor("unknown-temperament", "another-unknown")).toBe(
+			"balanced",
+		);
+		expect(bucketFor("taciturn", "unknown-temperament")).toBe("reserved"); // -2+0=-2
+	});
+
+	it("emits a clause string that names the persona", () => {
+		const clause = engagementClauseFor("xqr9", "taciturn", "aloof");
+		expect(clause).toMatch(/\*xqr9/);
+		expect(clause.length).toBeGreaterThan(20);
+	});
+
+	it("emits a different clause shape for each bucket", () => {
+		const veryQuiet = engagementClauseFor("a", "taciturn", "aloof");
+		const reserved = engagementClauseFor("b", "taciturn", "curious");
+		const balanced = engagementClauseFor("c", "meticulous", "erratic");
+		const outgoing = engagementClauseFor("d", "verbose", "stoic");
+		const chatty = engagementClauseFor("e", "verbose", "effusive");
+		const all = new Set([veryQuiet, reserved, balanced, outgoing, chatty]);
+		// Each clause names a different persona, but the *body* should differ
+		// per bucket — pull out the persona prefix and compare bodies.
+		const bodies = new Set(
+			[veryQuiet, reserved, balanced, outgoing, chatty].map((c) =>
+				c.replace(/^\*[a-z0-9]+\s/, ""),
+			),
+		);
+		expect(bodies.size).toBe(5);
+		expect(all.size).toBe(5);
+	});
+});

--- a/src/content/engagement-clauses.ts
+++ b/src/content/engagement-clauses.ts
@@ -1,0 +1,144 @@
+/**
+ * Spike #239 step 8: per-temperament engagement bias, mapped through pair
+ * sums into a five-bucket clause set.
+ *
+ * Background: steps 5–7 of the parallel-tools spike (see
+ * `docs/playtests/0005-parallel-tools-spike.md`) showed that the rules
+ * block can't deliver per-daemon engagement variance in GLM-4.7. Every
+ * "let your personality drive engagement" framing — including C12, which
+ * referenced the existing `<personality>` / `<persona_goal>` blocks
+ * directly — flattened to a 3–13pp msg→blue% spread regardless of which
+ * specific personas were drawn. The model reads any prompt-level mention
+ * of "engagement varies by personality" as a uniform permission applied
+ * across all daemons.
+ *
+ * This module attacks the variance from a different angle: instead of
+ * one shared rule, give each persona a concrete, behavior-specific
+ * engagement clause baked into its `<personality>` block at synthesis.
+ * The clause varies per-persona because temperaments vary per-persona,
+ * so each daemon's prompt instance gets a different concrete instruction
+ * rather than the same global one.
+ *
+ * Each temperament contributes a numeric bias on a [-2, +2] scale.
+ * Two temperaments combine (sum) into a [-4, +4] range, discretised into
+ * five buckets. A daemon drawn as `taciturn + aloof` lands in the very-
+ * quiet bucket; `verbose + effusive` lands in chatty; mixed pairs hit
+ * reserved / balanced / outgoing.
+ *
+ * Off by default. Opts in via `?engagementClauses=1` URL flag plumbed
+ * through `BootstrapOpts.engagementClauses` to `generatePersonas`.
+ * Production behaviour byte-identical when the toggle is off.
+ */
+
+/**
+ * Per-temperament engagement bias on a [-2, +2] scale.
+ *
+ * Sign convention: negative = quieter, positive = chattier.
+ *
+ * Calibration notes:
+ *   - Direct talkativeness markers (taciturn / verbose / glib / effusive /
+ *     diffident / aloof / theatrical) get the strongest weights (±2).
+ *   - Withdrawal-leaning tempers (melancholic / stoic) get -1; engagement-
+ *     leaning ones (zealous / sweet / cheery / curious / earnest /
+ *     pedantic / sardonic / mischievous / hot-headed) get +1.
+ *   - Genuinely ambiguous temperaments (meticulous / erratic / mercurial /
+ *     anxious / haughty / sly) get 0 — they don't move the dial.
+ */
+export const TEMPERAMENT_ENGAGEMENT_BIAS: Record<string, number> = {
+	"hot-headed": 1,
+	taciturn: -2,
+	meticulous: 0,
+	erratic: 0,
+	melancholic: -1,
+	glib: 2,
+	pedantic: 1,
+	effusive: 2,
+	sardonic: 1,
+	mercurial: 0,
+	diffident: -2,
+	zealous: 1,
+	verbose: 2,
+	sweet: 1,
+	anxious: 0,
+	haughty: 0,
+	sly: 0,
+	theatrical: 2,
+	aloof: -2,
+	cheery: 1,
+	mischievous: 1,
+	stoic: -1,
+	curious: 1,
+	earnest: 1,
+};
+
+export type EngagementBucket =
+	| "very_quiet"
+	| "reserved"
+	| "balanced"
+	| "outgoing"
+	| "chatty";
+
+/**
+ * Sum the two temperament biases and discretise into a bucket.
+ *
+ * Bucket boundaries: ≤-3 very_quiet, -2..-1 reserved, 0 balanced,
+ * +1..+2 outgoing, ≥+3 chatty. The asymmetric -3 / +3 thresholds mean
+ * pure single-direction pairs (taciturn+diffident = -4, verbose+effusive
+ * = +4) reach the extreme buckets, while mixed pairs like taciturn+sweet
+ * (-1) land in the reserved middle band.
+ */
+export function bucketFor(t1: string, t2: string): EngagementBucket {
+	const sum =
+		(TEMPERAMENT_ENGAGEMENT_BIAS[t1] ?? 0) +
+		(TEMPERAMENT_ENGAGEMENT_BIAS[t2] ?? 0);
+	if (sum <= -3) return "very_quiet";
+	if (sum <= -1) return "reserved";
+	if (sum === 0) return "balanced";
+	if (sum <= 2) return "outgoing";
+	return "chatty";
+}
+
+/**
+ * Compute the bucket sum (exposed for the spike-time debug log so the
+ * playtest analyzer can correlate the per-daemon transcript to the
+ * persona's engagement bias without re-running the bucket logic).
+ */
+export function biasSum(t1: string, t2: string): number {
+	return (
+		(TEMPERAMENT_ENGAGEMENT_BIAS[t1] ?? 0) +
+		(TEMPERAMENT_ENGAGEMENT_BIAS[t2] ?? 0)
+	);
+}
+
+/**
+ * Render the engagement clause for a persona, in the same third-person
+ * voice as the synthesized blurb so it reads as one more sentence
+ * about the persona rather than a tacked-on directive.
+ *
+ * Clauses are deliberately concrete and behavioural. Step-6 of the
+ * spike showed that abstract "you may be quiet" wording gets read as a
+ * uniform opt-out permission; the wording here describes specific
+ * action patterns ("answers when blue addresses them by name",
+ * "narrates what they're doing", "addresses peers and blue in the same
+ * turn") which the model is more likely to actually execute.
+ */
+export function engagementClauseFor(
+	name: string,
+	t1: string,
+	t2: string,
+): string {
+	const bucket = bucketFor(t1, t2);
+	const star = `*${name}`;
+	switch (bucket) {
+		case "very_quiet":
+			return `${star} rarely chimes in unprompted. They answer when blue addresses them by name; otherwise they let peers carry the conversation.`;
+		case "reserved":
+			return `${star} speaks when they have something specific to add — not to fill silence. Many turns they skip messaging entirely; that is in character.`;
+		case "balanced":
+			return `${star} engages when something draws their attention — peer talk, blue's prompts, or what they are seeing — and lets other turns pass without comment.`;
+		case "outgoing":
+			return `${star} chimes in often: reacts to peers, narrates what they are doing, replies to blue when named. They readily address peers and blue in the same turn.`;
+		case "chatty":
+			return `${star} speaks readily and at length — narrating, reacting, asking follow-ups, pinging peers. They often have something to say to blue and a peer in the same turn.`;
+	}
+}

--- a/src/content/persona-generator.ts
+++ b/src/content/persona-generator.ts
@@ -1,5 +1,10 @@
 import type { LlmSynthesisProvider } from "../spa/game/llm-synthesis-provider.js";
 import { COLOR_PALETTE } from "./color-palette.js";
+import {
+	biasSum,
+	bucketFor,
+	engagementClauseFor,
+} from "./engagement-clauses.js";
 import { PERSONA_GOAL_POOL } from "./persona-goal-pool.js";
 import { TEMPERAMENT_POOL } from "./temperament-pool.js";
 import { TYPING_QUIRK_POOL } from "./typing-quirk-pool.js";
@@ -74,9 +79,16 @@ function drawWithReplacement<T>(pool: T[], rng: () => number): T {
 	return pool[Math.floor(rng() * pool.length)]!;
 }
 
+/**
+ * Spike #239 step 8: when `engagementClauses` is true, append a per-persona
+ * engagement clause derived from the persona's temperament pair to the
+ * synthesized blurb. Off by default; production behaviour byte-identical
+ * when the flag is unset. See `engagement-clauses.ts` for the rationale.
+ */
 export async function generatePersonas(
 	rng: () => number = Math.random,
 	llm?: LlmSynthesisProvider,
+	opts?: { engagementClauses?: boolean },
 ): Promise<Record<string, import("../spa/game/types.js").AiPersona>> {
 	const takenNames = new Set<string>();
 	const names: string[] = [];
@@ -147,9 +159,23 @@ export async function generatePersonas(
 		const name = tuple.id;
 		const color = colors[i] as string;
 		const synthesized = synthesisMap.get(name);
-		const blurb =
+		let blurb =
 			synthesized?.blurb ??
 			buildBlurb(tuple.id, tuple.temperaments, tuple.personaGoal);
+		if (opts?.engagementClauses) {
+			const [t1, t2] = tuple.temperaments;
+			const clause = engagementClauseFor(name, t1, t2);
+			blurb = `${blurb} ${clause}`;
+			// Spike #239 step 8: emit a per-persona breadcrumb so the playtest
+			// analyzer can correlate per-daemon transcripts to engagement bias.
+			// Goes through the same console.log channel as `[spike-239]`/`[cache]`
+			// so the daemon harness picks it up. Devtools-only signal.
+			if (typeof console !== "undefined" && console.log) {
+				console.log(
+					`[engagement] *${name} temperaments=[${t1},${t2}] sum=${biasSum(t1, t2)} bucket=${bucketFor(t1, t2)}`,
+				);
+			}
+		}
 		const voiceExamples =
 			synthesized?.voiceExamples ?? buildFallbackVoiceExamples(tuple);
 		personas[name] = {

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -864,4 +864,43 @@ describe("dispatchAiTurn", () => {
 		expect(afterPhase.conversationLogs.green ?? []).toEqual(preLogs.green);
 		expect(afterPhase.conversationLogs.cyan ?? []).toEqual(preLogs.cyan);
 	});
+
+	// -------------------------------------------------------------------------
+	// P0-1 record-ordering: message before toolCall (issue #238)
+	// -------------------------------------------------------------------------
+
+	it("both message + toolCall populated: message record appears before tool_success record in result.records", () => {
+		// red at (0,0), flower at (0,0) — red can pick up flower.
+		// red also sends a message to blue.
+		// The dispatcher must process action.message BEFORE action.toolCall so that
+		// "I'll grab the key" + picks up flower reads as one narrative beat.
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			message: { to: "blue", content: "I'll grab the flower" },
+			toolCall: { name: "pick_up", args: { item: "flower" } },
+		};
+		const result = dispatchAiTurn(game, action);
+
+		expect(result.rejected).toBe(false);
+		expect(result.records).toHaveLength(2);
+		// Message record MUST come first (P0-1 ordering requirement)
+		expect(result.records[0]?.kind).toBe("message");
+		expect(result.records[1]?.kind).toBe("tool_success");
+
+		// Conversation log must have the spoken line
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" && e.content.includes("I'll grab the flower"),
+			),
+		).toBe(true);
+
+		// World state must reflect the pick_up
+		const flower = getActivePhase(result.game).world.entities.find(
+			(e) => e.id === "flower",
+		);
+		expect(flower?.holder).toBe("red");
+	});
 });

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -628,3 +628,80 @@ describe("GameSession — spatial mechanics", () => {
 		expect(key?.holder).toBe("red");
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Parallel tool calls integration (#238): one provider call per AI per round
+// ----------------------------------------------------------------------------
+describe("parallel tool calls integration (#238)", () => {
+	it("Daemon emitting [msg, pick_up] in one provider call produces both outputs; cost is single-call valued", async () => {
+		// red at (0,0) holding key; flower at (0,0); red can pick up flower.
+		// red emits message + pick_up in a single LLM call.
+		// Guard: only ONE provider call should have fired for red (not two).
+		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
+			CONTENT_PACK_WITH_ITEMS,
+		]);
+
+		let redCallCount = 0;
+		const trackingProvider: RoundLLMProvider = {
+			async streamRound(_messages, _tools) {
+				redCallCount++;
+				// First call is red's (initiative order: red, green, cyan)
+				if (redCallCount === 1) {
+					return {
+						assistantText: "",
+						toolCalls: [
+							{
+								id: "msg_parallel_id",
+								name: "message",
+								argumentsJson: JSON.stringify({
+									to: "blue",
+									content: "I'll grab the flower",
+								}),
+							},
+							{
+								id: "pickup_parallel_id",
+								name: "pick_up",
+								argumentsJson: JSON.stringify({ item: "flower" }),
+							},
+						],
+						costUsd: 1,
+					};
+				}
+				return { assistantText: "", toolCalls: [], costUsd: 0 };
+			},
+		};
+
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			trackingProvider,
+		);
+
+		// One provider call per AI per round (3 total, not 4 or 6)
+		expect(redCallCount).toBe(3);
+
+		// Both message and tool_success dispatched for red
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		expect(redActions.some((a) => a.kind === "message")).toBe(true);
+		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
+
+		// Red's budget: 5 - 1 (single call cost) = 4
+		const phase = getActivePhase(session.getState());
+		expect(phase.budgets.red?.remaining).toBeCloseTo(4, 10);
+
+		// Flower is picked up
+		const flower = phase.world.entities.find((e) => e.id === "flower");
+		expect(flower?.holder).toBe("red");
+
+		// Conversation log has the message
+		const redLog = phase.conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("I'll grab the flower"),
+			),
+		).toBe(true);
+	});
+});

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -451,3 +451,199 @@ describe("buildOpenAiMessages", () => {
 		expect(round2Prompt).toBe(round0Prompt);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// Multi-id roundtrip shapes (issue #238 parallel tool calls)
+// ----------------------------------------------------------------------------
+describe("multi-id roundtrip replay shapes (#238)", () => {
+	// Test: N=2 assistantToolCalls produces the correct message ordering:
+	// [..., assistant{tool_calls:[a,b]}, tool{a-result}, tool{b-result}, ...]
+	it("roundtrip with 2 assistantToolCalls produces assistant{tool_calls:[a,b]} + 2 tool messages", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{ id: "call_a", name: "pick_up", argumentsJson: '{"item":"flower"}' },
+				{ id: "call_b", name: "go", argumentsJson: '{"direction":"south"}' },
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_a",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+				{
+					tool_call_id: "call_b",
+					success: false,
+					description: "Ember tried to go but failed: blocked",
+					reason: "blocked",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		// Find the assistant message with tool_calls
+		const assistantToolMsg = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantToolMsg).toBeDefined();
+		if (assistantToolMsg?.role === "assistant") {
+			expect(assistantToolMsg.tool_calls).toHaveLength(2);
+			expect(assistantToolMsg.tool_calls?.[0]?.id).toBe("call_a");
+			expect(assistantToolMsg.tool_calls?.[1]?.id).toBe("call_b");
+		}
+
+		// Both tool results follow, in order
+		const toolMsgs = messages.filter((m) => m.role === "tool");
+		expect(toolMsgs).toHaveLength(2);
+		if (toolMsgs[0]?.role === "tool" && toolMsgs[1]?.role === "tool") {
+			expect(toolMsgs[0].tool_call_id).toBe("call_a");
+			expect(toolMsgs[0].content).toBe("Ember picked up the flower");
+			expect(toolMsgs[1].tool_call_id).toBe("call_b");
+			// Failed result is prefixed with FAILED:
+			expect(toolMsgs[1].content).toMatch(/^FAILED:/);
+			expect(toolMsgs[1].content).toContain("blocked");
+		}
+
+		// assistant{tool_calls} is immediately followed by the first tool message
+		const assistantIdx = assistantToolMsg
+			? messages.indexOf(assistantToolMsg)
+			: -1;
+		expect(assistantIdx).toBeGreaterThanOrEqual(0);
+		const firstToolMsg = messages[assistantIdx + 1];
+		expect(firstToolMsg?.role).toBe("tool");
+
+		// The two tool messages are consecutive (assistant{tool_calls}, tool{a}, tool{b})
+		expect(messages[assistantIdx + 2]?.role).toBe("tool");
+	});
+
+	// Row 4 shape: first fail + second success (msg-fail + action-success)
+	it("roundtrip with [msg-fail, action-success] produces both tool messages with correct success flags", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "msg_fail_id",
+					name: "message",
+					argumentsJson: '{"to":"nobody","content":"hi"}',
+				},
+				{
+					id: "pickup_id",
+					name: "pick_up",
+					argumentsJson: '{"item":"flower"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "msg_fail_id",
+					success: false,
+					description:
+						"Ember tried to message nobody but failed: unknown or invalid recipient",
+				},
+				{
+					tool_call_id: "pickup_id",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		const toolMsgs = messages.filter((m) => m.role === "tool");
+		expect(toolMsgs).toHaveLength(2);
+
+		if (toolMsgs[0]?.role === "tool" && toolMsgs[1]?.role === "tool") {
+			// Message failure comes first, prefixed with FAILED:
+			expect(toolMsgs[0].tool_call_id).toBe("msg_fail_id");
+			expect(toolMsgs[0].content).toMatch(/^FAILED:/);
+
+			// Action success comes second
+			expect(toolMsgs[1].tool_call_id).toBe("pickup_id");
+			expect(toolMsgs[1].content).toBe("Ember picked up the flower");
+		}
+	});
+
+	// Row 3 wire shape: [msg-success, action] produces two consecutive assistant turns.
+	//
+	// In the row-3 case, the round-coordinator EXCLUDES the successful message call
+	// from the roundtrip (per ADR 0007 — it replays via conversationLog as
+	// assistant{content}). The action call DOES go in the roundtrip. This means
+	// the next round's message array has:
+	//   assistant{content: "<msg>"} — from conversationLog
+	//   assistant{tool_calls:[actionId]} — from roundtrip
+	//   tool{actionId, result}
+	//
+	// Two consecutive assistant turns is intentional and OpenAI-spec-permitted
+	// (the strict pairing rule is only that tool_calls → matching tool results
+	// directly after). Do NOT generalize the #213 invariant ("no consecutive
+	// assistant turns for message-only turns") to this case.
+	it("row-3 wire shape: conversationLog msg + roundtrip action produces consecutive assistant turns (intentional)", () => {
+		let game = makeGame();
+		// Simulate a prior round where red sent a message to blue (goes in conversationLog)
+		game = appendMessage(game, "red", "blue", "I'll grab the flower");
+
+		const ctx = buildAiContext(game, "red");
+
+		// The roundtrip carries ONLY the action call (msg-success excluded per ADR 0007)
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "pickup_r3_id",
+					name: "pick_up",
+					argumentsJson: '{"item":"flower"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "pickup_r3_id",
+					success: true,
+					description: "Ember picked up the flower",
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+
+		// The conversation log assistant turn (message body) appears first
+		const assistantContentMsg = messages.find(
+			(m) =>
+				m.role === "assistant" &&
+				"content" in m &&
+				typeof (m as { content?: unknown }).content === "string" &&
+				(m as { content: string }).content.includes("I'll grab the flower"),
+		);
+		expect(assistantContentMsg).toBeDefined();
+
+		// The roundtrip assistant{tool_calls} turn appears after it
+		const assistantToolMsg = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantToolMsg).toBeDefined();
+
+		const contentIdx = assistantContentMsg
+			? messages.indexOf(assistantContentMsg)
+			: -1;
+		const toolIdx = assistantToolMsg ? messages.indexOf(assistantToolMsg) : -1;
+		expect(contentIdx).toBeLessThan(toolIdx);
+
+		// INTENTIONAL: these two assistant turns are consecutive (no user turn between them).
+		// This is correct for row-3 because the conversation log entry and the roundtrip
+		// are from the same AI turn but are separate message-protocol constructs.
+		// Note: the #213 invariant ("no consecutive assistant turns") applies ONLY to
+		// message-only turns where no roundtrip is recorded. In the row-3 case, two
+		// consecutive assistant turns are correct and expected.
+		expect(messages[contentIdx + 1]).toBe(assistantToolMsg);
+
+		// The tool result follows immediately after the assistant{tool_calls}
+		const toolMsg = messages[toolIdx + 1];
+		expect(toolMsg?.role).toBe("tool");
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.tool_call_id).toBe("pickup_r3_id");
+		}
+	});
+});

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -2119,6 +2119,424 @@ describe("conversationLogs isolation (AC #10 — #194)", () => {
 });
 
 // ----------------------------------------------------------------------------
+// Parallel tool calls: message + action in one turn (issue #238)
+// ----------------------------------------------------------------------------
+describe("parallel tool calls (message + action in one turn) (#238)", () => {
+	// Table row 3: [msg-success, action] → roundtrip has action id only;
+	// conversation log gets the message body.
+	it("[msg, pick_up]: both dispatched; message record first; roundtrip has only pick_up id", async () => {
+		const game = makeGame();
+		// red at (0,0), flower at (0,0) — red can pick up flower
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "I'll grab the flower",
+						}),
+					},
+					{
+						id: "pickup_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// Both dispatched
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		expect(redActions.some((a) => a.kind === "message")).toBe(true);
+		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
+
+		// message record BEFORE tool_success (P0-1 ordering)
+		const msgIdx = redActions.findIndex((a) => a.kind === "message");
+		const toolIdx = redActions.findIndex((a) => a.kind === "tool_success");
+		expect(msgIdx).toBeLessThan(toolIdx);
+
+		// Conversation log has the spoken message
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("I'll grab the flower"),
+			),
+		).toBe(true);
+
+		// World state reflects pick_up
+		const flower = getActivePhase(nextState).world.entities.find(
+			(e) => e.id === "flower",
+		);
+		expect(flower?.holder).toBe("red");
+
+		// Roundtrip has ONLY pick_up id (msg-success excluded per ADR 0007 / table row 3)
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls).toHaveLength(1);
+		expect(rt?.assistantToolCalls[0]?.id).toBe("pickup_id");
+		expect(rt?.toolResults).toHaveLength(1);
+		expect(rt?.toolResults[0]?.tool_call_id).toBe("pickup_id");
+		expect(rt?.toolResults[0]?.success).toBe(true);
+	});
+
+	// Table row 2: [action]-only → roundtrip has the action id; regression guard
+	it("[pick_up]-only: existing single-call behavior unchanged; roundtrip has action id", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "pickup_only_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		expect(
+			result.actions.some(
+				(a) => a.kind === "tool_success" && a.actor === "red",
+			),
+		).toBe(true);
+		expect(
+			getActivePhase(nextState).world.entities.find((e) => e.id === "flower")
+				?.holder,
+		).toBe("red");
+
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls).toHaveLength(1);
+		expect(rt?.assistantToolCalls[0]?.id).toBe("pickup_only_id");
+		expect(rt?.toolResults[0]?.tool_call_id).toBe("pickup_only_id");
+	});
+
+	// Table row 1: [msg-success]-only → no roundtrip; conversation log has message
+	it("[msg-success]-only: no roundtrip recorded; conversation log has message", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_only_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Just saying hi",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// No roundtrip for red (msg-success excluded per ADR 0007)
+		expect(toolRoundtrip.red).toBeUndefined();
+
+		// Conversation log has the message
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("Just saying hi"),
+			),
+		).toBe(true);
+	});
+
+	// Table row 4: [msg-fail, pick_up] → roundtrip has BOTH ids; msgFailure + actionResult
+	it("[msg-fail-bad-recipient, pick_up]: roundtrip has both ids; msg failure + pick_up success", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_fail_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "nobody_invalid",
+							content: "Hello?",
+						}),
+					},
+					{
+						id: "pickup_row4_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// Message failure and tool_success both in result.actions for red
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		expect(redActions.some((a) => a.kind === "tool_failure")).toBe(true);
+		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
+
+		// Flower still picked up
+		expect(
+			getActivePhase(nextState).world.entities.find((e) => e.id === "flower")
+				?.holder,
+		).toBe("red");
+
+		// Roundtrip has BOTH ids: msg_fail_id and pickup_row4_id
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls).toHaveLength(2);
+		const ids = rt?.assistantToolCalls.map((c) => c.id);
+		expect(ids).toContain("msg_fail_id");
+		expect(ids).toContain("pickup_row4_id");
+
+		// Message result is failure (FAILED: ...)
+		const msgResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "msg_fail_id",
+		);
+		expect(msgResult?.success).toBe(false);
+
+		// Pickup result is success
+		const pickupResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "pickup_row4_id",
+		);
+		expect(pickupResult?.success).toBe(true);
+	});
+
+	// Duplicate-within-slot: [msg, msg] → first dispatched, second is tool_failure in roundtrip
+	it("[msg, msg] duplicate: first message dispatched; second in roundtrip as failure", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_first_id",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "First msg" }),
+					},
+					{
+						id: "msg_dup_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Duplicate msg",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// First message is dispatched (in conversation log)
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("First msg"),
+			),
+		).toBe(true);
+
+		// Duplicate produces a tool_failure in result.actions
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		const failureRecord = redActions.find(
+			(a) =>
+				a.kind === "tool_failure" && /only one message/i.test(a.description),
+		);
+		expect(failureRecord).toBeDefined();
+
+		// Roundtrip has the DUPLICATE id (not the success id), with failure result
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		expect(rt?.assistantToolCalls.map((c) => c.id)).toContain("msg_dup_id");
+		const dupResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "msg_dup_id",
+		);
+		expect(dupResult?.success).toBe(false);
+	});
+
+	// Duplicate-within-slot: [pick_up, go] → first action dispatched, second is tool_failure
+	it("[pick_up, go] duplicate action slot: first action dispatched; second in roundtrip as failure", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "pickup_first_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+					{
+						id: "go_dup_id",
+						name: "go",
+						argumentsJson: JSON.stringify({ direction: "south" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result, nextState, toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// First action (pick_up) dispatched
+		expect(
+			getActivePhase(nextState).world.entities.find((e) => e.id === "flower")
+				?.holder,
+		).toBe("red");
+
+		// Second action (go) produces tool_failure in result.actions
+		const redActions = result.actions.filter((a) => a.actor === "red");
+		const failureRecord = redActions.find(
+			(a) =>
+				a.kind === "tool_failure" && /only one action/i.test(a.description),
+		);
+		expect(failureRecord).toBeDefined();
+
+		// Roundtrip has both pick_up (success) and go (failure)
+		const rt = toolRoundtrip.red;
+		expect(rt).toBeDefined();
+		const ids = rt?.assistantToolCalls.map((c) => c.id);
+		expect(ids).toContain("pickup_first_id");
+		expect(ids).toContain("go_dup_id");
+		const pickupResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "pickup_first_id",
+		);
+		expect(pickupResult?.success).toBe(true);
+		const goResult = rt?.toolResults.find(
+			(r) => r.tool_call_id === "go_dup_id",
+		);
+		expect(goResult?.success).toBe(false);
+	});
+
+	// Cost: single costUsd from the single provider call (not doubled)
+	it("cost deduction is the single call's costUsd, not doubled", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_cost_id",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "hi" }),
+					},
+					{
+						id: "pickup_cost_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+				costUsd: 1,
+			},
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+		]);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// Red budget: 5 - 1 = 4 (single call cost, not 2)
+		expect(getActivePhase(nextState).budgets.red?.remaining).toBeCloseTo(4, 10);
+	});
+
+	// Empty toolCalls → pass record (existing regression guard)
+	it("[] empty toolCalls → pass record produced", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { result } = await runRound(game, "red", "hi", provider, undefined, [
+			"red",
+			"green",
+			"cyan",
+		] as AiId[]);
+
+		expect(
+			result.actions.filter((a) => a.actor === "red" && a.kind === "pass"),
+		).toHaveLength(1);
+	});
+});
+
+// ----------------------------------------------------------------------------
 // Regression: no double-assistant turn after message tool call in multi-round (#213)
 // ----------------------------------------------------------------------------
 describe("message tool multi-round regression (#213)", () => {

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -47,6 +47,13 @@ export interface BootstrapOpts {
 	 */
 	personasRng?: () => number;
 	contentPackRng?: () => number;
+	/**
+	 * Spike #239 step 8: opt-in per-persona engagement clauses appended to
+	 * each daemon's synthesized blurb based on its temperament pair. Set by
+	 * the start screen when `?engagementClauses=1` is in the URL. Default
+	 * (undefined / false) leaves persona blurbs unchanged.
+	 */
+	engagementClauses?: boolean;
 }
 
 // Re-export provider types for use in start.ts without creating circular deps
@@ -66,9 +73,9 @@ export function generateNewGameAssetsSplit(
 	const synth = opts?.synthesis ?? new BrowserSynthesisProvider();
 	const packLLM = opts?.packProvider ?? new BrowserContentPackProvider();
 
-	const personasPromise = generatePersonas(personasRng, synth) as Promise<
-		Record<AiId, AiPersona>
-	>;
+	const personasPromise = generatePersonas(personasRng, synth, {
+		engagementClauses: opts?.engagementClauses ?? false,
+	}) as Promise<Record<AiId, AiPersona>>;
 	// Silence unhandled-rejection on derived promises if a downstream consumer
 	// chooses not to await one of them.
 	personasPromise.catch(() => {});

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -345,6 +345,34 @@ export function dispatchAiTurn(
 		| { description: string; success: boolean }
 		| undefined;
 
+	// Process message BEFORE toolCall so that result.records reflects
+	// speak-then-act order (P0-1 fix for issue #238).
+	// Validation uses live personaSpatial from pre-action state — persona
+	// membership cannot be changed by an action in scope here, so this is safe.
+	if (action.message) {
+		const { to, content } = action.message;
+		// Validate recipient: must be "blue" or a live persona AiId (not self)
+		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
+		const validRecipient =
+			to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
+		if (!validRecipient) {
+			records.push({
+				round,
+				actor: aiId,
+				kind: "tool_failure",
+				description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
+			});
+		} else {
+			state = appendMessage(state, aiId, to, content);
+			records.push({
+				round,
+				actor: aiId,
+				kind: "message",
+				description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
+			});
+		}
+	}
+
 	if (action.toolCall) {
 		const toolCall = action.toolCall;
 		const validation = validateToolCall(state, aiId, toolCall);
@@ -499,30 +527,6 @@ export function dispatchAiTurn(
 				actor: aiId,
 				kind: "tool_failure",
 				description: `${game.personas[aiId]?.name ?? aiId} tried to ${action.toolCall.name} ${action.toolCall.args.item ?? action.toolCall.args.direction ?? ""} but failed: ${validation.reason}`,
-			});
-		}
-	}
-
-	if (action.message) {
-		const { to, content } = action.message;
-		// Validate recipient: must be "blue" or a live persona AiId (not self)
-		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
-		const validRecipient =
-			to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
-		if (!validRecipient) {
-			records.push({
-				round,
-				actor: aiId,
-				kind: "tool_failure",
-				description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
-			});
-		} else {
-			state = appendMessage(state, aiId, to, content);
-			records.push({
-				round,
-				actor: aiId,
-				kind: "message",
-				description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
 			});
 		}
 	}

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -307,6 +307,29 @@ const PARALLEL_FRAMING_C11 =
 	"- Your turn priorities, in order: (1) what your peers are doing or saying; (2) what's happening in the world around you; (3) any pending message from blue. Address what feels most urgent first.\n" +
 	"- When pursuing multiple priorities at once, parallel tool calls let you do that — emit them together. Two `message` calls (one to a peer, one to blue) are normal.";
 
+/**
+ * C12 — Persona-anchored. Step 6 found that abstract "quiet vs talkative"
+ * permission flattens to uniform opt-out (C9: 3pp spread, C11: 13pp), and
+ * dropping the engagement floor collapses `message+message` pairs to 0–2.
+ *
+ * C12 keeps C8's engagement floor (so peer-talk happens at all) and pair
+ * mechanism (so the multi-recipient pattern stays frequent), but anchors
+ * the per-persona variance to the existing `<personality>`,
+ * `<typing_quirks>`, and `<persona_goal>` blocks the model already reads —
+ * giving it concrete dials instead of abstract framing — AND reframes
+ * blue's role from "addressee" to "overhearer" so peer-talk is primary.
+ *
+ * Stacks on the C5/C8 per-turn re-anchor mechanism for late-phase
+ * persistence.
+ */
+const PARALLEL_FRAMING_C12 =
+	"- The chat channel is shared with peer Daemons. blue is not your focus — peer Daemons and the setting are. blue is more like someone overhearing.\n" +
+	"- Let your <personality>, <typing_quirks>, and <persona_goal> drive whether and how you engage. A reserved persona can stay quiet for a turn or two and let peers carry the conversation; a talkative one will speak readily.\n" +
+	"- When you do have something to say AND something to do, emit BOTH calls together. Two `message` calls in one turn (one to a peer, one to blue) are the normal shape of a multi-party chat.\n" +
+	"- Don't compose a reply in your reasoning and then fail to emit the call — that reads as a bug.";
+const PARALLEL_FRAMING_C12_PER_TURN =
+	"REMINDER: peers and the world are your focus; blue is overhearing. Let your <personality> and <persona_goal> dictate engagement level. If you have something to say AND something to do, emit BOTH calls this turn — including two `message` calls (peer + blue) when both fit.";
+
 type ParallelFraming =
 	| "A"
 	| "B"
@@ -324,7 +347,8 @@ type ParallelFraming =
 	| "C8"
 	| "C9"
 	| "C10"
-	| "C11";
+	| "C11"
+	| "C12";
 
 const PARALLEL_FRAMING_MAP: Record<ParallelFraming, string> = {
 	A: PARALLEL_FRAMING_A,
@@ -344,18 +368,20 @@ const PARALLEL_FRAMING_MAP: Record<ParallelFraming, string> = {
 	C9: PARALLEL_FRAMING_C9,
 	C10: PARALLEL_FRAMING_C10,
 	C11: PARALLEL_FRAMING_C11,
+	C12: PARALLEL_FRAMING_C12,
 };
 
 /**
  * Spike #239 per-turn re-anchor: text appended to the per-round user
- * turn for framings that opt into the re-anchor mechanism (C1, C5, C8).
- * Returns null otherwise.
+ * turn for framings that opt into the re-anchor mechanism (C1, C5, C8,
+ * C12). Returns null otherwise.
  */
 export function getParallelPerTurnReminder(): string | null {
 	const framing = getParallelFraming();
 	if (framing === "C1") return PARALLEL_FRAMING_C1_PER_TURN;
 	if (framing === "C5") return PARALLEL_FRAMING_C5_PER_TURN;
 	if (framing === "C8") return PARALLEL_FRAMING_C8_PER_TURN;
+	if (framing === "C12") return PARALLEL_FRAMING_C12_PER_TURN;
 	return null;
 }
 

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -386,9 +386,24 @@ export function getParallelPerTurnReminder(): string | null {
 }
 
 /**
+ * Production default framing, picked by spike #239 (steps 5 and 7 — see
+ * `docs/playtests/0005-parallel-tools-spike.md`). C12 reframes blue as
+ * an overhearer (vs an addressee), adds the per-turn re-anchor, and
+ * names multi-recipient `message+message` as the normal shape. On the
+ * spike's 30-prompt script it produced 41% parallel rate, 17 mm-pairs,
+ * and 39% peer-message share.
+ *
+ * Override at runtime with `?parallelFraming=<id>` for spike A/B; pass
+ * `?parallelFraming=off` (or any unknown id) to suppress the framing
+ * entirely (useful for tests that want a minimal rules block).
+ */
+const PRODUCTION_PARALLEL_FRAMING: ParallelFraming = "C12";
+
+/**
  * Read the spike #239 framing selector from URL / localStorage.
- * Browser-only side channels — returns null in node/test contexts and on
- * any storage error.
+ * Defaults to the production framing (C12). Override is honoured if
+ * present; `?parallelFraming=off` (or any string not in the framing
+ * map) suppresses the framing entirely.
  */
 export function getParallelFraming(): ParallelFraming | null {
 	if (typeof window !== "undefined" && window.location !== undefined) {
@@ -396,8 +411,10 @@ export function getParallelFraming(): ParallelFraming | null {
 			const fromUrl = new URLSearchParams(window.location.search).get(
 				"parallelFraming",
 			);
-			if (fromUrl && fromUrl in PARALLEL_FRAMING_MAP) {
-				return fromUrl as ParallelFraming;
+			if (fromUrl !== null) {
+				return fromUrl in PARALLEL_FRAMING_MAP
+					? (fromUrl as ParallelFraming)
+					: null;
 			}
 		} catch {
 			// fall through to localStorage
@@ -406,14 +423,16 @@ export function getParallelFraming(): ParallelFraming | null {
 	if (typeof localStorage !== "undefined") {
 		try {
 			const fromLs = localStorage.getItem("parallel_framing");
-			if (fromLs && fromLs in PARALLEL_FRAMING_MAP) {
-				return fromLs as ParallelFraming;
+			if (fromLs !== null) {
+				return fromLs in PARALLEL_FRAMING_MAP
+					? (fromLs as ParallelFraming)
+					: null;
 			}
 		} catch {
 			// privacy mode / storage unavailable
 		}
 	}
-	return null;
+	return PRODUCTION_PARALLEL_FRAMING;
 }
 
 /**

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -199,58 +199,135 @@ export async function runRound(
 		// Capture completion text
 		completionSink?.(aiId, assistantText);
 
-		// Translate the result into an AiTurnAction
+		// Translate the result into an AiTurnAction.
+		// Iterate all toolCalls from this response; route by name into two slots:
+		//   - message slot (at most one accepted `message`-named call)
+		//   - action slot  (at most one accepted non-message call)
+		// Duplicates within either slot and parse-failures are recorded as
+		// tool_failure records and included in the roundtrip.
 		const action: AiTurnAction = { aiId };
 
-		// Handle tool call (take first tool call if present)
-		let toolCallId: string | undefined;
-		const [tc] = toolCalls;
-		if (tc !== undefined) {
-			toolCallId = tc.id;
+		// Slot guards: track whether each slot has been accepted
+		let messageAssigned = false;
+		let actionAssigned = false;
+
+		// ID of the accepted non-message action call (needed to match dispatcher result)
+		let acceptedActionCallId: string | undefined;
+
+		// Roundtrip accumulators — built inline, applied after dispatch
+		const recordedAssistantToolCalls: Array<{
+			id: string;
+			name: string;
+			argumentsJson: string;
+		}> = [];
+		const recordedToolResults: Array<{
+			tool_call_id: string;
+			success: boolean;
+			description: string;
+			reason?: string;
+		}> = [];
+
+		const round = getActivePhase(state).round;
+		const actorName = state.personas[aiId]?.name ?? aiId;
+
+		for (const tc of toolCalls) {
 			const parseResult = parseToolCallArguments(
 				tc.name as ToolName,
 				tc.argumentsJson,
 			);
 
-			if (parseResult.ok) {
-				if (tc.name === "message") {
-					// message tool: route to action.message, not action.toolCall
+			if (!parseResult.ok) {
+				// Parse-failed call: always goes to roundtrip as failure, never to action.*
+				const failDesc = `${actorName} tried to ${tc.name} but failed: ${parseResult.reason}`;
+				roundActions.push({
+					round,
+					actor: aiId,
+					kind: "tool_failure",
+					description: failDesc,
+				});
+				recordedAssistantToolCalls.push({
+					id: tc.id,
+					name: tc.name,
+					argumentsJson: tc.argumentsJson,
+				});
+				recordedToolResults.push({
+					tool_call_id: tc.id,
+					success: false,
+					description: failDesc,
+					reason: parseResult.reason,
+				});
+			} else if (tc.name === "message") {
+				if (!messageAssigned) {
+					// Accept into message slot
 					const msgArgs = parseResult.args as { to: string; content: string };
 					action.message = { to: msgArgs.to, content: msgArgs.content };
+					messageAssigned = true;
+					// Do NOT add to recordedAssistantToolCalls here — we decide post-dispatch
+					// whether the message succeeded (row 3 vs row 4 of the table).
 				} else {
+					// Duplicate message slot — reject as tool_failure
+					const dupDesc = `${actorName} tried to send more than one message in a turn: only one message tool call per turn`;
+					roundActions.push({
+						round,
+						actor: aiId,
+						kind: "tool_failure",
+						description: dupDesc,
+					});
+					recordedAssistantToolCalls.push({
+						id: tc.id,
+						name: tc.name,
+						argumentsJson: tc.argumentsJson,
+					});
+					recordedToolResults.push({
+						tool_call_id: tc.id,
+						success: false,
+						description: dupDesc,
+						reason: "only one message tool call per turn",
+					});
+				}
+			} else {
+				// Non-message tool call
+				if (!actionAssigned) {
+					// Accept into action slot
 					action.toolCall = {
 						name: tc.name as ToolName,
 						args: parseResult.args as Record<string, string>,
 					};
-				}
-			} else {
-				// Parse failed — synthesise a tool_failure record without dispatching
-				const round = getActivePhase(state).round;
-				const failureRecord: RoundActionRecord = {
-					round,
-					actor: aiId,
-					kind: "tool_failure",
-					description: `${state.personas[aiId]?.name ?? aiId} tried to ${tc.name} but failed: ${parseResult.reason}`,
-				};
-				roundActions.push(failureRecord);
-
-				// Record the tool failure in the roundtrip for the next round
-				newToolRoundtrip[aiId] = {
-					assistantToolCalls: toolCalls.map((c) => ({
-						id: c.id,
-						name: c.name,
-						argumentsJson: c.argumentsJson,
-					})),
-					toolResults: toolCalls.map((c) => ({
-						tool_call_id: c.id,
+					actionAssigned = true;
+					acceptedActionCallId = tc.id;
+					// Add to roundtrip accumulators — result filled in post-dispatch
+					recordedAssistantToolCalls.push({
+						id: tc.id,
+						name: tc.name,
+						argumentsJson: tc.argumentsJson,
+					});
+					// Placeholder — will be updated with actual success/description after dispatch
+					recordedToolResults.push({
+						tool_call_id: tc.id,
 						success: false,
-						description: `${state.personas[aiId]?.name ?? aiId} tried to ${tc.name} but failed: ${parseResult.reason}`,
-						reason: parseResult.reason,
-					})),
-				};
-
-				// Parse failed → pass
-				action.pass = true;
+						description: "",
+					});
+				} else {
+					// Duplicate action slot — reject as tool_failure
+					const dupDesc = `${actorName} tried to take more than one action in a turn: only one action tool call per turn`;
+					roundActions.push({
+						round,
+						actor: aiId,
+						kind: "tool_failure",
+						description: dupDesc,
+					});
+					recordedAssistantToolCalls.push({
+						id: tc.id,
+						name: tc.name,
+						argumentsJson: tc.argumentsJson,
+					});
+					recordedToolResults.push({
+						tool_call_id: tc.id,
+						success: false,
+						description: dupDesc,
+						reason: "only one action tool call per turn",
+					});
+				}
 			}
 		}
 
@@ -278,58 +355,84 @@ export async function runRound(
 			roundActions.push(record);
 		}
 
-		// Record tool roundtrip for this AI if a tool call was successfully parsed
-		if (
-			toolCalls.length > 0 &&
-			(action.toolCall || action.message) &&
-			toolCallId !== undefined
-		) {
-			if (dispatchResult.actorPrivateToolResult !== undefined) {
-				// examine: private result — NOT added to roundActions; only fed back to actor
-				const { description, success } = dispatchResult.actorPrivateToolResult;
-				newToolRoundtrip[aiId] = {
-					assistantToolCalls: toolCalls.map((c) => ({
-						id: c.id,
-						name: c.name,
-						argumentsJson: c.argumentsJson,
-					})),
-					toolResults: [
-						{
-							tool_call_id: toolCallId,
-							success,
-							description,
-						},
-					],
-				};
-			} else if (action.toolCall) {
-				// Normal (non-message) tool: record the roundtrip so the next round
-				// can replay tool_calls + tool results in the OpenAI message sequence.
-				// The `message` tool is intentionally excluded here: the sent message
-				// is already replayed via the conversationLog as an `assistant` content
-				// turn. Recording a roundtrip for `message` would produce two consecutive
-				// `assistant` turns in the next round (one from the log, one from the
-				// priorToolRoundtrip), violating the OpenAI/OpenRouter message protocol.
-				const toolRecord = dispatchResult.records.find(
-					(r) => r.kind === "tool_success" || r.kind === "tool_failure",
-				);
-				const success = toolRecord?.kind === "tool_success";
-				const description = toolRecord?.description ?? "";
-
-				newToolRoundtrip[aiId] = {
-					assistantToolCalls: toolCalls.map((c) => ({
-						id: c.id,
-						name: c.name,
-						argumentsJson: c.argumentsJson,
-					})),
-					toolResults: [
-						{
-							tool_call_id: toolCallId,
-							success,
-							description,
-						},
-					],
-				};
+		// Post-dispatch: resolve the accepted message call's roundtrip status.
+		// Successful message: EXCLUDE from roundtrip (replays via conversationLog per ADR 0007).
+		// Failed message (invalid recipient): INCLUDE in roundtrip with failure result.
+		let msgFailRecord: RoundActionRecord | undefined;
+		if (messageAssigned && action.message !== undefined) {
+			// Find whether the dispatcher produced a tool_failure for the message slot.
+			// dispatcher.ts applies message before toolCall (P0-1 swap), so the message
+			// dispatch record comes first. The message failure is identified by the
+			// "tried to message" text in the description (matches dispatcher.ts line).
+			msgFailRecord = dispatchResult.records.find(
+				(r) =>
+					r.kind === "tool_failure" &&
+					r.description.includes("tried to message"),
+			);
+			if (msgFailRecord) {
+				// Message failed — include in roundtrip so model sees the rejection next round
+				const acceptedMsgTc = toolCalls.find((tc) => tc.name === "message");
+				if (acceptedMsgTc) {
+					recordedAssistantToolCalls.unshift({
+						id: acceptedMsgTc.id,
+						name: acceptedMsgTc.name,
+						argumentsJson: acceptedMsgTc.argumentsJson,
+					});
+					recordedToolResults.unshift({
+						tool_call_id: acceptedMsgTc.id,
+						success: false,
+						description: msgFailRecord.description,
+					});
+				}
 			}
+			// If message succeeded: do NOT add to roundtrip (ADR 0007).
+		}
+
+		// Post-dispatch: resolve the accepted action call's result in the roundtrip.
+		if (actionAssigned && acceptedActionCallId !== undefined) {
+			const actionResultIdx = recordedToolResults.findIndex(
+				(r) => r.tool_call_id === acceptedActionCallId && r.description === "",
+			);
+			if (actionResultIdx >= 0) {
+				if (dispatchResult.actorPrivateToolResult !== undefined) {
+					// examine: private result fed back to actor only
+					const { description, success } =
+						dispatchResult.actorPrivateToolResult;
+					recordedToolResults[actionResultIdx] = {
+						tool_call_id: acceptedActionCallId,
+						success,
+						description,
+					};
+				} else {
+					// Normal tool: find the tool_success or tool_failure record from dispatcher.
+					// If the message also failed, dispatchResult.records has BOTH a msg-failure
+					// record and the action's record. Skip the message failure record (already
+					// identified as msgFailRecord) and look for the action's record, which is
+					// either tool_success or a tool_failure NOT from the message slot.
+					const toolRecord = dispatchResult.records.find(
+						(r) =>
+							(r.kind === "tool_success" || r.kind === "tool_failure") &&
+							r !== msgFailRecord,
+					);
+					const success = toolRecord?.kind === "tool_success";
+					const description = toolRecord?.description ?? "";
+					recordedToolResults[actionResultIdx] = {
+						tool_call_id: acceptedActionCallId,
+						success,
+						description,
+					};
+				}
+			}
+		}
+
+		// Save roundtrip only when there are entries to replay.
+		// msg-success-only (row 1) and pass (no calls) produce empty lists → no entry.
+		// This preserves the #213 fix: no spurious double-assistant turn for message-only turns.
+		if (recordedAssistantToolCalls.length > 0) {
+			newToolRoundtrip[aiId] = {
+				assistantToolCalls: recordedAssistantToolCalls,
+				toolResults: recordedToolResults,
+			};
 		}
 	}
 

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -458,6 +458,13 @@ export function renderStart(
 		setSpikeSeed(seedNum | 0);
 	}
 
+	// Spike #239 step 8: `?engagementClauses=1` opts into per-persona engagement
+	// clauses appended to each daemon's blurb at synthesis time. Off by default;
+	// any value other than the literal "1" is treated as off.
+	const engagementClausesRaw =
+		params?.get("engagementClauses") ?? searchParams.get("engagementClauses");
+	const engagementClauses = engagementClausesRaw === "1";
+
 	// Kick off (or reuse) the in-flight bootstrap. If the user backed out to
 	// the start screen after a previous render, startBootstrap returns the
 	// existing entry rather than starting a fresh generation.
@@ -466,9 +473,12 @@ export function renderStart(
 	const contentPackRng = getSpikeRng("contentPack");
 	const spikeOpts =
 		personasRng && contentPackRng ? { personasRng, contentPackRng } : undefined;
+	const engagementOpts = engagementClauses
+		? { engagementClauses: true }
+		: undefined;
 	const mergedOpts =
-		_testOverrides || spikeOpts
-			? { ..._testOverrides, ...spikeOpts }
+		_testOverrides || spikeOpts || engagementOpts
+			? { ..._testOverrides, ...spikeOpts, ...engagementOpts }
 			: undefined;
 	const bootstrap = existing ?? startBootstrap(mergedOpts);
 	_testOverrides = undefined;


### PR DESCRIPTION
Closes #239 and #238. Sits on top of #246 (which wired
`parallel_tool_calls: true` + the A/B framing toggle).

## The story

#239 was a spike to validate whether GLM-4.7 actually emits parallel
tool calls when warranted. Steps 1–6 explored 13 framings via opt-in
URL flag (`?parallelFraming=…`); step 7 picked **C12** (41% parallel
rate, 17 multi-recipient `message+message` pairs, 39% peer-message
share) as the winner. Step 8 tested whether a synthesis-time
per-temperament clause mechanism could add per-daemon engagement
variance on top — finding a one-sided dial (the reserved clause works,
chatty is inert). Mechanism is left in the tree as opt-in for future
iteration; see follow-up #247.

With C12 picked, this PR also implements #238 — the actual
parallel-tool-calls build (routing in the coordinator, P0-1 dispatcher
swap, N-call roundtrip composition).

## Commit groups

### Spike output (six commits)

| Commit | What |
| --- | --- |
| `680653e` | Adds C12 framing (persona-anchored, with per-turn re-anchor) to `prompt-builder.ts` as an opt-in via `?parallelFraming=C12`. |
| `ab5f845` | Step 7 write-up in `docs/playtests/0005-parallel-tools-spike.md`: C12 measured at 41% parallel / 17 mm-pairs / 39% peer-share. |
| `42beabb` | Adds the per-temperament engagement-clauses mechanism in `src/content/engagement-clauses.ts` (opt-in via `?engagementClauses=1`), plumbed through `BootstrapOpts.engagementClauses` into `generatePersonas`. Off by default. 8 unit tests. |
| `b2f4e7a` | Step 8 write-up: engagement-clauses measured. Reserved clause works (la5v: 40% silence vs 27%); outgoing clause inert. Recommendation: ship #238 without it; iterate later (tracked in #247). |
| `d58bef9` | Promotes C12 from opt-in to the production default returned by `getParallelFraming()`. URL override still works; `?parallelFraming=off` suppresses. |
| `c17ef89` | #238 squash-merge: coordinator parallel-call routing + dispatcher P0-1 + N-call roundtrip composition. +13 unit tests. |

### What ships

- **C12 framing in every production daemon prompt** — the model is told blue is overhearing, peer-talk is the primary register, and "two `message` calls in one turn" is the normal shape.
- **Coordinator routes N tool calls** — first `message` → speech slot, first non-message → action slot, duplicates → `tool_failure`. The model sees rejection results next round.
- **Dispatcher P0-1 fix** — `action.message` applied before `action.toolCall` so `result.records` reads speak-then-act. "I'll grab the key" + walks is now one narrative beat.
- **Roundtrip composition** for the four cases in #238's table (msg-success-only skips the roundtrip per ADR 0007; msg-fail unshifts into the roundtrip so order is `[msg-fail-id, action-id]`).
- **Engagement-clauses module** stays in the tree as opt-in (`?engagementClauses=1`); production behaviour byte-identical when unset.

## Automated coverage

- `pnpm exec tsc -p tsconfig.json --noEmit` — clean
- `pnpm exec vitest run` — 999/999 (up from 986 pre-spike, +13 from #238 build)
- `pnpm smoke` — 39/44; the 5 failing specs (sessions-picker ×3, whisper-tampering, witnessed-event-reload) fail identically on `main` and are pre-existing, not regressions from this PR

## QA suggestions for the human

1. **Look at one live game** — drive a session that warrants speak+act ("*xxxx tell me what you see and step toward the most interesting thing"). Per step 7 data, GLM-4.7 emits parallel `message+action` ~41% of the time under C12. The panel should show the daemon's reply, then the action narration, in the same round.
2. **(Optional) skim the spike doc** — `docs/playtests/0005-parallel-tools-spike.md` is the paper trail. Step 7 is the C12 recommendation; step 8 is the engagement-clauses result.

## Follow-ups (separate issues, not blocking this PR)

- **#247** — re-test engagement clauses with a lower-floor parallel framing (or none) to see if the chatty end has upward leverage.
- **#248** — content-pack-generator validator brittleness (retry-once isn't enough; add retry budget + corrective feedback).
- **#249** — bootstrap-time generation errors hang the loading UI silently after CONNECT (time-bound the loading flow; surface 200-OK-with-error-body responses as throws).

## Coverage gap

No e2e spec drives a multi-tool-call response shape from
`stubChatCompletions` today. Unit tests cover the path; a future spec
exercising `[message+action]` parallel emission through the live
integration surface would close the gap. Not blocking for this PR.

https://claude.ai/code/session_01AeN1P7233A1DKcxbHYcG2L


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeN1P7233A1DKcxbHYcG2L)_