### PR TITLE
Retry on drift-to-silence before dropping free-form text (#254)

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -171,14 +171,16 @@ function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
 }
 
 /**
- * Creates an SSE response body that yields a single JSON action as an OpenAI delta event.
- * Used for plain-text (free-form) delta responses (e.g., pass actions).
+ * Creates an SSE response body that models a pass: no assistant text, no
+ * tool call, just the final usage chunk so the budget-deduction path sees
+ * a non-zero cost.
  *
- * Includes a final usage chunk (mimicking OpenRouter with usage:{include:true}) so
- * the budget-deduction path sees a non-zero cost.
+ * The `_jsonAction` argument is preserved for call-site readability but
+ * ignored — the SPA only reads `message` tool calls; emitting free-form
+ * text here would trigger the #254 retry rather than passing.
  */
-function makeAiSseStream(jsonAction: string): ReadableStream<Uint8Array> {
-	const deltaChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: jsonAction } }] })}\n\n`;
+function makeAiSseStream(_jsonAction: string): ReadableStream<Uint8Array> {
+	const deltaChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: "" } }] })}\n\n`;
 	const usageChunk = `data: ${JSON.stringify({ choices: [], usage: { cost: 0.01, total_tokens: 100 } })}\n\n`;
 	const sseData = `${deltaChunk}${usageChunk}data: [DONE]\n\n`;
 	return makeSSEStream([sseData]);

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -283,10 +283,49 @@ describe("GameSession — state mutation across rounds", () => {
 describe("GameSession — completions map", () => {
 	it("completions map contains the completion text for each AI", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		// Each response includes a `message` tool call so #254's retry
+		// does not fire (this test asserts completion-text routing, not
+		// retry behaviour).
 		const provider = new MockRoundLLMProvider([
-			{ assistantText: "I am Ember", toolCalls: [] },
-			{ assistantText: "I am Sage", toolCalls: [] },
-			{ assistantText: "I am Frost", toolCalls: [] },
+			{
+				assistantText: "I am Ember",
+				toolCalls: [
+					{
+						id: "msg_r",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "I am Ember",
+						}),
+					},
+				],
+			},
+			{
+				assistantText: "I am Sage",
+				toolCalls: [
+					{
+						id: "msg_g",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "I am Sage",
+						}),
+					},
+				],
+			},
+			{
+				assistantText: "I am Frost",
+				toolCalls: [
+					{
+						id: "msg_c",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "I am Frost",
+						}),
+					},
+				],
+			},
 		]);
 
 		const { completions } = await session.submitMessage("red", "hi", provider);
@@ -438,12 +477,28 @@ describe("GameSession — onAiDelta propagation", () => {
 	it("fires onAiDelta for each delta emitted by a live provider", async () => {
 		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
 
-		// Hand-rolled provider that synchronously calls onDelta with two fragments.
+		// Hand-rolled provider that synchronously calls onDelta with two
+		// fragments and returns a `message` tool call so #254's retry does
+		// not fire (this test asserts delta routing, not retry behaviour).
+		let callIdx = 0;
 		const liveProvider: RoundLLMProvider = {
 			async streamRound(_messages, _tools, onDelta) {
 				onDelta?.("chunk1 ");
 				onDelta?.("chunk2");
-				return { assistantText: "chunk1 chunk2", toolCalls: [] };
+				const id = `msg_${callIdx++}`;
+				return {
+					assistantText: "chunk1 chunk2",
+					toolCalls: [
+						{
+							id,
+							name: "message",
+							argumentsJson: JSON.stringify({
+								to: "blue",
+								content: "chunk1 chunk2",
+							}),
+						},
+					],
+				};
 			},
 		};
 

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -136,12 +136,16 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const game = makeGame();
 
 		const provider = new MockRoundLLMProvider([
-			{ assistantText: "Hi, I am Ember.", toolCalls: [] },
+			// All-pass responses across both rounds. Text-only responses are
+			// avoided here because #254's retry would consume an extra
+			// mock slot per text-only attempt; this test cares about
+			// message construction, not retry behaviour.
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "<red round 2>", toolCalls: [] },
-			{ assistantText: "<green round 2>", toolCalls: [] },
-			{ assistantText: "<cyan round 2>", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 
 		const r1 = await runRound(
@@ -220,9 +224,9 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const game = makeGame();
 
 		const provider = new MockRoundLLMProvider([
-			{ assistantText: "<red>", toolCalls: [] },
-			{ assistantText: "<green>", toolCalls: [] },
-			{ assistantText: "<cyan>", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 
 		await runRound(game, "red", "hello red", provider, undefined, initiative);
@@ -303,7 +307,7 @@ describe("non-addressed daemon never sees a stale user message as its last turn"
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "<cyan>", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
 		]);
 
 		await runRound(game, "cyan", "hello cyan", provider, undefined, initiative);

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -531,6 +531,119 @@ describe("drift-to-silence retry (#254)", () => {
 });
 
 // ----------------------------------------------------------------------------
+// onAiTurnComplete callback
+//
+// Per-AI "turn finished" signal — fires once per AI in initiative order,
+// AFTER any drift-to-silence retry (#254). The SPA hooks this for staged
+// per-daemon spinner-strip; coordinator runs AIs serially so the fire
+// order matches the visible round progression.
+// ----------------------------------------------------------------------------
+describe("onAiTurnComplete callback", () => {
+	it("fires once per AI in initiative order", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const order: AiId[] = [];
+		await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["green", "cyan", "red"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId) => order.push(aiId),
+		);
+
+		expect(order).toEqual(["green", "cyan", "red"]);
+	});
+
+	it("fires AFTER the retry resolves, not after the first dropped attempt", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			// red: text-only first attempt → triggers retry
+			{ assistantText: "I would like to say hi.", toolCalls: [] },
+			// red retry: message
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "hi" }),
+					},
+				],
+			},
+			// green, cyan pass
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		// Track when each callback fires relative to provider call count.
+		const fireOrder: Array<{ aiId: AiId; callsAtFire: number }> = [];
+		await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId) => fireOrder.push({ aiId, callsAtFire: provider.calls.length }),
+		);
+
+		// Red's turn made 2 provider calls (initial + retry). The
+		// onAiTurnComplete for red must fire AFTER both — i.e., when the
+		// total call count has reached 2, not 1.
+		const redFire = fireOrder.find((f) => f.aiId === "red");
+		expect(redFire?.callsAtFire).toBe(2);
+	});
+
+	it("fires for locked-out AIs too (uniform per-AI signal)", async () => {
+		// Exhaust red's budget so it locks out next round.
+		let state = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
+			...TEST_PHASE_CONFIG,
+			budgetPerAi: 1,
+		});
+		state = deductBudget(state, "red" as AiId, 1);
+		expect(isAiLockedOut(state, "red" as AiId)).toBe(true);
+
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const fired: AiId[] = [];
+		await runRound(
+			state,
+			"green",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId) => fired.push(aiId),
+		);
+
+		expect(fired).toContain("red");
+		expect(fired).toHaveLength(3);
+	});
+});
+
+// ----------------------------------------------------------------------------
 // Whisper round
 // NOTE: whispers are now implemented via assistantText containing "whisper to X: ..."
 // The new coordinator maps assistantText → chat action. Whispers are no longer

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -245,6 +245,292 @@ describe("chat-only round", () => {
 });
 
 // ----------------------------------------------------------------------------
+// Drift-to-silence retry (#254)
+//
+// When the model returns free-form text with no tool call, the coordinator
+// retries the turn once with a tightening nudge before falling through to
+// drop-to-pass. The retry's nudge and the dropped first attempt must NOT
+// land in game state, the conversation log, or the persisted tool
+// roundtrip — only the retry's response flows through normal dispatch.
+// ----------------------------------------------------------------------------
+describe("drift-to-silence retry (#254)", () => {
+	it("retry that returns a message tool call lands in the conversation log", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			// red: text-only first attempt → triggers retry
+			{ assistantText: "I'd say hello to blue.", toolCalls: [] },
+			// red retry: emits the message
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Hello blue!",
+						}),
+					},
+				],
+			},
+			// green, cyan: pass
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("Hello blue!"),
+			),
+		).toBe(true);
+	});
+
+	it("retry's nudge does NOT leak into the conversation log", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "dropped first attempt text", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "recovered reply",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		const allLogContent = (
+			Object.values(
+				getActivePhase(nextState).conversationLogs,
+			).flat() as Array<{
+				kind: string;
+				content?: string;
+			}>
+		)
+			.map((e) => e.content ?? "")
+			.join("\n");
+
+		// The dropped first attempt and the nudge user-message must never
+		// appear in any AI's conversation log.
+		expect(allLogContent).not.toContain("dropped first attempt text");
+		expect(allLogContent).not.toContain("did not emit a tool call");
+		expect(allLogContent).not.toContain("Re-emit your previous reply");
+	});
+
+	it("retry that also drops falls through to pass; no message in the log", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I think I should say something.", toolCalls: [] },
+			// retry also drops
+			{ assistantText: "still no tool call here.", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
+		const redMsgs = redLog.filter(
+			(e) => e.kind === "message" && e.from === "red",
+		);
+		expect(redMsgs).toHaveLength(0);
+	});
+
+	it("does NOT retry when first attempt is a true pass (empty text, no tool calls)", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		await runRound(game, "red", "hi", provider, undefined, [
+			"red",
+			"green",
+			"cyan",
+		] as AiId[]);
+
+		// One call per AI — no retries fired.
+		expect(provider.calls).toHaveLength(3);
+	});
+
+	it("does NOT retry when first attempt already has a tool call", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "I will take the flower",
+				toolCalls: [
+					{
+						id: "call_1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		await runRound(game, "red", "hi", provider, undefined, [
+			"red",
+			"green",
+			"cyan",
+		] as AiId[]);
+
+		expect(provider.calls).toHaveLength(3);
+	});
+
+	it("retry sees the nudge appended after the dropped first attempt", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I would like to say hi.", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "hi blue",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		await runRound(game, "red", "hi", provider, undefined, [
+			"red",
+			"green",
+			"cyan",
+		] as AiId[]);
+
+		// Red's retry is provider.calls[1]; its messages should include the
+		// dropped first attempt as an assistant turn and the nudge as a
+		// user turn after the original messages.
+		const retryMessages = provider.calls[1]?.messages ?? [];
+		const last2 = retryMessages.slice(-2);
+		expect(last2[0]?.role).toBe("assistant");
+		expect((last2[0] as { content: string }).content).toBe(
+			"I would like to say hi.",
+		);
+		expect(last2[1]?.role).toBe("user");
+		expect((last2[1] as { content: string }).content).toContain(
+			'message({to: "blue", content: ...})',
+		);
+	});
+
+	it("retry sums costUsd from both LLM calls into the budget deduction", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "drift", toolCalls: [], costUsd: 0.4 },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "ok",
+						}),
+					},
+				],
+				costUsd: 0.5,
+			},
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+		]);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		const phase = getActivePhase(nextState);
+		// Budget starts at 5; red spent 0.4 + 0.5 = 0.9, leaving 4.1
+		expect(phase.budgets.red?.remaining).toBeCloseTo(4.1, 10);
+	});
+
+	it("retry that yields msg-success keeps the tool roundtrip empty (no first-attempt leak)", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "drifted", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "ok blue",
+						}),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
+		// msg-success excluded from roundtrip per ADR 0007; the dropped
+		// first attempt must not slip in either.
+		expect(toolRoundtrip.red).toBeUndefined();
+	});
+});
+
+// ----------------------------------------------------------------------------
 // Whisper round
 // NOTE: whispers are now implemented via assistantText containing "whisper to X: ..."
 // The new coordinator maps assistantText → chat action. Whispers are no longer
@@ -1294,12 +1580,28 @@ describe("runRound — onAiDelta callback", () => {
 	it("fires onAiDelta with (aiId, text) for each delta from a live provider", async () => {
 		const game = makeGame();
 
-		// Hand-rolled provider that synchronously calls onDelta with two fragments.
+		// Hand-rolled provider that synchronously calls onDelta with two
+		// fragments and returns a `message` tool call so #254's retry does
+		// not fire (this test asserts delta routing, not retry behaviour).
+		let callIdx = 0;
 		const liveProvider: RoundLLMProvider = {
 			async streamRound(_messages, _tools, onDelta) {
 				onDelta?.("frag1 ");
 				onDelta?.("frag2");
-				return { assistantText: "frag1 frag2", toolCalls: [] };
+				const id = `msg_${callIdx++}`;
+				return {
+					assistantText: "frag1 frag2",
+					toolCalls: [
+						{
+							id,
+							name: "message",
+							argumentsJson: JSON.stringify({
+								to: "blue",
+								content: "frag1 frag2",
+							}),
+						},
+					],
+				};
 			},
 		};
 

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -115,6 +115,7 @@ export class GameSession {
 		chatLockoutConfig?: ChatLockoutConfig,
 		initiative?: AiId[],
 		onAiDelta?: (aiId: AiId, text: string) => void,
+		onAiTurnComplete?: (aiId: AiId) => void,
 	): Promise<SubmitMessageResult> {
 		let effectiveConfig = chatLockoutConfig;
 		if (!effectiveConfig && this.armedChatLockout) {
@@ -147,6 +148,7 @@ export class GameSession {
 			completionSink,
 			onAiDelta,
 			this.coneSnapshots,
+			onAiTurnComplete,
 		);
 
 		// Fill in empty string for AIs whose completions weren't captured

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -30,7 +30,7 @@ import {
 } from "./engine";
 import { buildOpenAiMessages } from "./openai-message-builder";
 import { buildAiContext, buildConeSnapshot } from "./prompt-builder";
-import type { RoundLLMProvider } from "./round-llm-provider";
+import type { OpenAiMessage, RoundLLMProvider } from "./round-llm-provider";
 import { parseToolCallArguments } from "./tool-registry";
 import type {
 	AiId,
@@ -190,11 +190,39 @@ export async function runRound(
 		const tools = availableTools(state, aiId);
 
 		// Call the provider
-		const { assistantText, toolCalls, costUsd } = await provider.streamRound(
+		let { assistantText, toolCalls, costUsd } = await provider.streamRound(
 			messages,
 			tools,
 			onAiDelta ? (text) => onAiDelta(aiId, text) : undefined,
 		);
+
+		// Drift-to-silence recovery (#254): if the model returned free-form
+		// text with no tool call, retry once with a tightening nudge before
+		// falling through to the drop-to-pass branch below. The retry's
+		// input — the dropped first attempt and the nudge — stays in
+		// `retryMessages` only; it never enters game state, the
+		// conversation log, or the persisted tool roundtrip.
+		if (assistantText && toolCalls.length === 0) {
+			const retryMessages: OpenAiMessage[] = [
+				...messages,
+				{ role: "assistant", content: assistantText },
+				{
+					role: "user",
+					content:
+						'You produced text but did not emit a tool call, so blue did not see it. Re-emit your previous reply now as a `message({to: "blue", content: ...})` call.',
+				},
+			];
+			const retry = await provider.streamRound(
+				retryMessages,
+				tools,
+				onAiDelta ? (text) => onAiDelta(aiId, text) : undefined,
+			);
+			assistantText = retry.assistantText;
+			toolCalls = retry.toolCalls;
+			if (retry.costUsd !== undefined) {
+				costUsd = (costUsd ?? 0) + retry.costUsd;
+			}
+		}
 
 		// Capture completion text
 		completionSink?.(aiId, assistantText);
@@ -331,11 +359,14 @@ export async function runRound(
 			}
 		}
 
-		// Free-form assistantText without a message tool call → treat as pass (drop the text)
+		// Free-form assistantText without a message tool call → treat as
+		// pass. The one-shot retry above already fired; reaching this branch
+		// with non-empty text means the retry also failed to emit a tool
+		// call (#254).
 		if (!action.toolCall && !action.message) {
 			if (assistantText && isDevHost()) {
 				console.log(
-					`[dev] ${aiId} emitted free-form text without a tool call (dropped):`,
+					`[dev] ${aiId} emitted free-form text without a tool call (dropped after retry):`,
 					assistantText,
 				);
 			}

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -108,6 +108,10 @@ export interface RunRoundResult {
  * @param onAiDelta  Optional per-AI live-delta callback. Fires synchronously
  *   inside the SSE parser loop for each text chunk arriving from the wire.
  *   Never called for locked-out AIs or mock providers that ignore onDelta.
+ * @param onAiTurnComplete  Optional per-AI "turn finished" callback. Fires
+ *   exactly once per AI in initiative order, AFTER any drift-to-silence
+ *   retry (#254) has resolved and after dispatch. Fires for locked-out
+ *   AIs too (so callers can clear per-AI UI state uniformly).
  */
 export async function runRound(
 	game: GameState,
@@ -120,6 +124,7 @@ export async function runRound(
 	completionSink?: (aiId: AiId, text: string) => void,
 	onAiDelta?: (aiId: AiId, text: string) => void,
 	priorConeSnapshots?: Partial<Record<AiId, string>>,
+	onAiTurnComplete?: (aiId: AiId) => void,
 ): Promise<RunRoundResult> {
 	const aiOrder = Object.keys(game.personas);
 
@@ -165,6 +170,7 @@ export async function runRound(
 			});
 			// Sink gets empty string for locked AI
 			completionSink?.(aiId, "");
+			onAiTurnComplete?.(aiId);
 			continue;
 		}
 
@@ -465,6 +471,12 @@ export async function runRound(
 				toolResults: recordedToolResults,
 			};
 		}
+
+		// Per-AI "turn finished" signal — fires after dispatch, after any
+		// drift-to-silence retry (#254). Callers use this for per-daemon UI
+		// state that should track the coordinator's serial progress through
+		// the initiative order (e.g., stripping panel spinners staged).
+		onAiTurnComplete?.(aiId);
 	}
 
 	// 3. Advance the round counter

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1222,24 +1222,6 @@ export function renderGame(
 		// Round-local ended flag (distinct from module-level gameEnded)
 		let roundGameEnded = false;
 
-		// Track first-delta-seen per AI to strip the spinner exactly once.
-		const firstDeltaSeen = new Set<AiId>();
-
-		const onAiDelta = (aiId: AiId, _text: string): void => {
-			if (!firstDeltaSeen.has(aiId)) {
-				firstDeltaSeen.add(aiId);
-				// Strip this daemon's spinner on its first live delta.
-				// Post-#213, free-form assistantText is dropped by the engine; actual
-				// panel content comes from ConversationEntry message events emitted
-				// by the encoder after the round completes. We keep the spinner-strip
-				// side-effect here but no longer paint tokens or the AI prefix live.
-				stripSpinner(aiId);
-			}
-			// Free-form delta text is intentionally NOT painted. Panel content is
-			// driven by encoder "message" events (conversationLog-based) after the
-			// round, ensuring the DM-thread filter (AC #1/2) is always applied.
-		};
-
 		try {
 			const provider = new BrowserLLMProvider({
 				disableReasoning: !enableReasoning,
@@ -1250,12 +1232,7 @@ export function renderGame(
 				provider,
 				undefined,
 				initiative,
-				onAiDelta,
 			);
-
-			// Safety-net strip: if no live deltas arrived (mock provider, all AIs
-			// locked out, or first delta hasn't fired yet), strip every spinner now.
-			stripAllSpinners();
 
 			const phaseAfter = getActivePhase(nextState);
 			const events = encodeRoundResult(
@@ -1268,8 +1245,13 @@ export function renderGame(
 			for (const event of events) {
 				switch (event.type) {
 					case "ai_start":
-						// Track the current daemon for budget/lockout events.
-						// Panel content is now driven by "message" events, not prefixes.
+						// Strip this daemon's spinner as the encoder reaches its
+						// turn block. Spinners persist through the entire round
+						// — including any drift-to-silence retry (#254) — and
+						// strip in initiative order here at round-resolve time.
+						// The finally block also calls stripAllSpinners() as a
+						// safety net on early exit / error.
+						stripSpinner(event.aiId);
 						break;
 
 					case "token":

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1226,12 +1226,19 @@ export function renderGame(
 			const provider = new BrowserLLMProvider({
 				disableReasoning: !enableReasoning,
 			});
+			// Strip each daemon's spinner as the coordinator finishes its
+			// turn (post-retry per #254). Coordinator awaits AIs serially in
+			// initiative order, so this fires staged in real time —
+			// preserving the "spinners stop one by one" feel from before
+			// #254 while correctly covering the retry window.
 			const { result, completions, nextState } = await session.submitMessage(
 				addressed,
 				message,
 				provider,
 				undefined,
 				initiative,
+				undefined,
+				(aiId) => stripSpinner(aiId),
 			);
 
 			const phaseAfter = getActivePhase(nextState);
@@ -1245,13 +1252,9 @@ export function renderGame(
 			for (const event of events) {
 				switch (event.type) {
 					case "ai_start":
-						// Strip this daemon's spinner as the encoder reaches its
-						// turn block. Spinners persist through the entire round
-						// — including any drift-to-silence retry (#254) — and
-						// strip in initiative order here at round-resolve time.
-						// The finally block also calls stripAllSpinners() as a
-						// safety net on early exit / error.
-						stripSpinner(event.aiId);
+						// Per-daemon spinner-strip happens live via the
+						// onAiTurnComplete callback (see above); panel content
+						// is driven by "message" events, not prefixes.
 						break;
 
 					case "token":


### PR DESCRIPTION
When a daemon returns free-form text with no tool call, the SPA used to
silently coerce it to pass and discard the content (~30-43% of GLM-4.7
turns per playtests 0006/0007). Add one-shot retry that re-prompts the
model to re-emit the same reply as a `message` tool call. The retry's
nudge user message and the dropped first attempt stay ephemeral — they
never enter game state, the conversation log, or the persisted tool
roundtrip. Falls through to the existing drop-to-pass branch only when
the retry also fails to emit a tool call.