### PR TITLE
Smoke: whisper-tampering — no captured request body matches target daemon

### DIFF
--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -112,8 +112,8 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 		.toBeGreaterThanOrEqual(3);
 
 	// 6. Identify each daemon's request body by matching the identity line.
-	//    renderSystemPrompt writes: `You are *${ctx.name}, a Daemon. You have no clue...`
-	//    (phase 1), so we match `You are *${name}, a Daemon.` for each known name.
+	//    prompt-builder.ts writes: `You are the author writing *${ctx.name}, a Daemon. You have no clue...`
+	//    (phase 1), so we match `the author writing *${name}, a Daemon.` for each known name.
 	function findBodyForName(name: string): Record<string, unknown> | null {
 		for (const body of capturedBodies) {
 			if (
@@ -124,7 +124,7 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 				const messages = (body as { messages: Array<{ content?: string }> })
 					.messages;
 				const sysContent = messages[0]?.content ?? "";
-				if (sysContent.includes(`You are *${name}, a Daemon.`)) {
+				if (sysContent.includes(`the author writing *${name}, a Daemon.`)) {
 					return body as Record<string, unknown>;
 				}
 			}
@@ -137,10 +137,12 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 	const other2Body = findBodyForName(names[2]);
 
 	// Conversation rendering moved out of the system prompt into role turns
-	// (prompt-cache restructure). Incoming peer messages are rendered as
-	// `*<from>: <content>` user turns by openai-message-builder. The sentinel
-	// uniquely identifies the fabricated whisper.
-	const expectedLine = `*${senderId}: ${SENTINEL}`;
+	// (prompt-cache restructure). Incoming peer messages are rendered through
+	// renderEntry (conversation-log.ts) as `[Round R] *<from> dms you: <content>`
+	// user turns by openai-message-builder. Round is 0 because the fabricated
+	// entry is injected with round: 0. The sentinel uniquely identifies the
+	// fabricated whisper.
+	const expectedLine = `[Round 0] *${senderId} dms you: ${SENTINEL}`;
 	const _senderName = senderName; // referenced for log clarity only
 
 	function flattenContents(body: Record<string, unknown> | null): string {


### PR DESCRIPTION
## What this fixes

`e2e/whisper-tampering.spec.ts` was failing on `findBodyForName` returning null for every daemon, so the very first assertion (`targetBody not null`) tripped with "No request body found for target daemon (names[0]=...). Captured 3 bodies." The cause was two test-side drifts against the current production code:

1. **Identity-line drift.** The system prompt in `src/spa/game/prompt-builder.ts:500,503` was changed to authorial framing — `"You are the author writing *${ctx.name}, a Daemon."` — but the spec's body-identification heuristic still searched for the old literal `"You are *${name}, a Daemon."`, so it could never match any captured body to its daemon.

2. **Rendered-message drift.** Incoming peer messages are rendered through `renderEntry` in `src/spa/game/conversation-log.ts:60` (called from `openai-message-builder.ts:74–77`) as `[Round R] *<from> dms you: <content>`. The spec's `expectedLine` still used the older shape `*<from>: <content>`, so even after fixing the identification, the role-turn content assertion would have failed.

Both edits are confined to `e2e/whisper-tampering.spec.ts`. No product code changes. The comment blocks around `findBodyForName` and `expectedLine` were refreshed to describe the current shapes so the same drift doesn't get re-introduced.

## QA steps for the human

None — fully covered by the integration smoke. The Playwright spec drives the actual code path (fabricated whisper in `<aiId>.txt` localStorage → reload → follow-up send → three `/v1/chat/completions` request bodies captured → asymmetric sentinel assertion) against `pnpm build` + `wrangler dev` on :8787, which is the production-shaped surface.

## Automated coverage

`pnpm typecheck`, `pnpm test` (52 files / 1021 tests), and `pnpm smoke e2e/whisper-tampering.spec.ts` all green. Adjacent specs `e2e/persistence-reload.spec.ts` also green; the unrelated `e2e/witnessed-event-reload.spec.ts` failure was reproduced on `main` pre-fix and is pre-existing.

Closes #263

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRUdNGcYVPcvTJw5aNaoDT)_