### PR TITLE
Smoke: sessions-picker tests fail — `.session-row[data-session-id=...]` never appears

### DIFF
--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -64,7 +64,7 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 			const OBFUSCATION_KEY = '${OBFUSCATION_KEY}';
 			const keyBytes = Array.from(new TextEncoder().encode(OBFUSCATION_KEY));
 			const payload = JSON.stringify({
-				schemaVersion: 3,
+				schemaVersion: 4,
 				currentPhase: 1,
 				isComplete: false,
 				world: {


### PR DESCRIPTION
## What this fixes

The three failing specs in `e2e/sessions-picker.spec.ts` (`:148`, `:211`, `:253`) weren't rendering `.session-row[data-session-id="0xAAAA"]` with `[ load ]` / `[ dup ]` buttons because the test seed was a schema version behind production code. `src/spa/persistence/session-codec.ts` exports `SESSION_SCHEMA_VERSION = 4` (bumped 3 → 4 in commit `c60e995`, "Collapse chat + whisper into a single directional `message` primitive"), but `seedOkSessionScript` in `e2e/sessions-picker.spec.ts:67` still wrote `schemaVersion: 3`. The picker correctly classified the seeded "ok" row as `version-mismatch` and rendered only `[ rm ]`, so the load/dup button locators timed out.

The fix is a one-line edit in the test seed: `schemaVersion: 3` → `4`. Production code is unchanged. The intentional `999` in `seedVersionMismatchScript` (line ~135) is left alone.

## QA steps for the human

None — fully covered by the integration smoke. The three originally-failing specs are the QA, and they now pass.

## Automated coverage

`pnpm typecheck`, `pnpm test` (1021 tests / 52 files), and `pnpm smoke e2e/sessions-picker.spec.ts --reporter=line` (10/10 specs) all pass on this branch. Adjacent persistence/start-screen specs also green; one unrelated `witnessed-event-reload.spec.ts:485` flake observed, but the spec file is byte-identical pre/post and the failure shows an empty `conversationLog` (live-LLM zero-turn flake, not a regression from this change).

Closes #262


---
_Generated by [Claude Code](https://claude.ai/code/session_011Y1YzH7WMYaVQNsxv9GfYQ)_