### PR TITLE
Smoke: witnessed-event-reload — witness's DaemonFile conversationLog stays empty after live `go` tool-call

### DIFF
--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -425,7 +425,7 @@ async function armRoute(
 		}
 
 		const sysContent = bodyParsed?.messages?.[0]?.content ?? "";
-		if (sysContent.includes(`You are *${actorName}, a Daemon.`)) {
+		if (sysContent.includes(`writing *${actorName}, a Daemon.`)) {
 			await route.fulfill({
 				status: 200,
 				headers: {
@@ -779,7 +779,7 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 			if (body && typeof body === "object") {
 				const b = body as { messages?: Array<{ content?: string }> };
 				const sysContent = b.messages?.[0]?.content ?? "";
-				if (sysContent.includes(`You are *${name}, a Daemon.`)) {
+				if (sysContent.includes(`writing *${name}, a Daemon.`)) {
 					return body as Record<string, unknown>;
 				}
 			}

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -488,6 +488,19 @@ describe("voice framing", () => {
 		);
 		expect(prompt).not.toContain("has no clue where they are");
 	});
+
+	// Regression guard: e2e SSE-stub routing uses the substring
+	// `writing *{name}, a Daemon.` to identify the per-daemon actor request.
+	// If the identity line wording changes this test catches it at unit-test
+	// time instead of silently breaking smoke routing.
+	it("identity line contains the 'writing *{name}, a Daemon.' substring that e2e SSE routing depends on (all phases)", () => {
+		for (const phase of [1, 2, 3] as const) {
+			let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+			if (phase !== 1) game = startPhase(game, makeConfig(phase));
+			const prompt = buildAiContext(game, "red").toSystemPrompt();
+			expect(prompt).toContain("writing *Ember, a Daemon.");
+		}
+	});
 });
 
 describe("<rules> block", () => {


### PR DESCRIPTION
## What this fixes

The smoke spec `e2e/witnessed-event-reload.spec.ts` routes per-daemon SSE stubs by substring-matching the system prompt: the actor request gets a `toolCallSseBody("go", …)` reply, others get a plain stub. The matcher used `` `You are *${name}, a Daemon.` ``, which stopped matching after commit `22d3415` (#241 — authorial framing) rewrote `src/spa/game/prompt-builder.ts:498–504` to emit `"You are the author writing *${name}, a Daemon."` instead. Every request fell through to the plain-stub branch, the actor never emitted a `go` tool-call, no cone projection ran, no witnessed-event was appended to the witness's `conversationLog`, and the assertion at `spec:485` saw `conversationLog: []`.

The fix updates the substring matcher in two specs to `` `writing *${name}, a Daemon.` ``, which uniquely anchors on the authorial-framing identity line:

- `e2e/witnessed-event-reload.spec.ts` — `armRoute` (route-stub dispatcher) and `findBodyForName` (post-reload body lookup)
- `e2e/whisper-tampering.spec.ts` — sibling spec with the identical brittleness

A new jsdom regression-guard in `src/spa/game/__tests__/prompt-builder.test.ts` pins the substring contract across phases 1/2/3 so any future re-wording of the identity line fails at unit-test time instead of silently breaking smoke routing.

No production code changes — the bug was entirely in test plumbing that drifted out of sync with the system prompt.

## QA steps for the human

None — fully covered by the targeted smoke spec.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 1022 unit tests pass (52 files), including the new regression guard
- `pnpm smoke e2e/witnessed-event-reload.spec.ts` — passes; the originally-failing assertion at line 485 (live `go` → cone projection → witness `conversationLog` → DaemonFile serialization → reload survival → system-prompt re-injection) now succeeds end-to-end
- Full `pnpm smoke` — 39 pass / 5 fail; the 5 failures are pre-existing on parent commit `61c1063^` and unrelated to this change. Notable: `whisper-tampering.spec.ts:29` now gets past the routing-substring failure but exposes a second pre-existing assertion-format staleness at line 143 (`expectedLine = \`*${senderId}: ${SENTINEL}\``) that doesn't match the current renderer output `[Round N] *<from> dms you: <content>` from `src/spa/game/conversation-log.ts:60`. Worth a follow-up issue.

Closes #264

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2sDqZqwDu7CYAmEuP5HnA)_