### PR TITLE
Auto-examine items on pick_up to surface details to actor

### DIFF
--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -516,6 +516,39 @@ describe("dispatchAiTurn", () => {
 		expect(flower?.holder).toBe("red");
 	});
 
+	it("pick_up auto-fires examine: actorPrivateToolResult includes examineDescription", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "pick_up", args: { item: "flower" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+		// Public tool_success record still describes the pickup
+		expect(result.records[0]?.kind).toBe("tool_success");
+		expect(result.records[0]?.description).toMatch(/picked up the flower/);
+		// Private result feeds the examineDescription back to the actor's context
+		expect(result.actorPrivateToolResult).toBeDefined();
+		expect(result.actorPrivateToolResult?.success).toBe(true);
+		expect(result.actorPrivateToolResult?.description).toMatch(
+			/picked up the flower/,
+		);
+		expect(result.actorPrivateToolResult?.description).toMatch(/A flower\./);
+	});
+
+	it("failed pick_up does not produce an auto-examine private result", () => {
+		const game = makeGame();
+		// green is at (0,1); flower is at (0,0) — not in green's cell
+		const action: AiTurnAction = {
+			aiId: "green",
+			toolCall: { name: "pick_up", args: { item: "flower" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+		expect(result.actorPrivateToolResult).toBeUndefined();
+	});
+
 	it("go produces tool_success record and updates position", () => {
 		const game = makeGame();
 		// red at (0,0), going south

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -408,13 +408,29 @@ export function dispatchAiTurn(
 							activePhase.world,
 						)
 					: null;
+			const successDescription =
+				flavorDescription ?? describeToolCall(state, aiId, action.toolCall);
 			records.push({
 				round,
 				actor: aiId,
 				kind: "tool_success",
-				description:
-					flavorDescription ?? describeToolCall(state, aiId, action.toolCall),
+				description: successDescription,
 			});
+
+			// Auto-examine on pick_up: surface the item's examineDescription privately
+			// to the actor so objective-item details land in the actor's context
+			// without requiring a separate examine call.
+			if (action.toolCall.name === "pick_up") {
+				const picked = activePhase.world.entities.find(
+					(e) => e.id === action.toolCall?.args.item,
+				);
+				if (picked?.examineDescription) {
+					actorPrivateToolResult = {
+						description: `${successDescription} ${picked.examineDescription}`,
+						success: true,
+					};
+				}
+			}
 
 			// Build and append a PhysicalActionRecord for observable physical actions.
 			// look is excluded (facing-change only, not observable); examine doesn't exist yet.


### PR DESCRIPTION
## Summary
When an AI actor successfully picks up an item, the examine description is now automatically included in the private tool result sent back to the actor. This allows objective-item details to be available in the actor's context without requiring a separate examine call.

## Changes
- **Auto-examine on successful pick_up**: When a `pick_up` action succeeds, the system now retrieves the picked item's `examineDescription` and appends it to the private tool result sent to the actor
- **Private result only on success**: The `actorPrivateToolResult` is only populated when the pick_up succeeds; failed pick_up attempts do not generate a private examine result
- **Preserved public behavior**: The public `tool_success` record continues to describe only the pickup action itself, keeping the public game record clean

## Implementation Details
- The auto-examine logic is gated to only trigger for `pick_up` tool calls
- The combined description format is: `{successDescription} {examineDescription}` (e.g., "picked up the flower A flower.")
- The feature gracefully handles items without an `examineDescription` by not creating a private result
- Added comprehensive test coverage for both successful and failed pick_up scenarios

https://claude.ai/code/session_012xyVj7iryChfpY2NJ8cri9