### PR TITLE
Improve retry message to be recipient-agnostic

### DIFF
--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -454,7 +454,7 @@ describe("drift-to-silence retry (#254)", () => {
 		);
 		expect(last2[1]?.role).toBe("user");
 		expect((last2[1] as { content: string }).content).toContain(
-			'message({to: "blue", content: ...})',
+			"message({to: <recipient>, content: ...})",
 		);
 	});
 

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -215,7 +215,7 @@ export async function runRound(
 				{
 					role: "user",
 					content:
-						'You produced text but did not emit a tool call, so blue did not see it. Re-emit your previous reply now as a `message({to: "blue", content: ...})` call.',
+						"You produced text but did not emit a tool call, so no one received it. Re-emit your previous reply now as a `message({to: <recipient>, content: ...})` tool call, addressed to whoever you originally intended to speak to.",
 				},
 			];
 			const retry = await provider.streamRound(


### PR DESCRIPTION
## Summary
Updated the retry message in the round coordinator to be more generic and not assume a specific recipient ("blue"). This makes the error message applicable to any game scenario regardless of player names or roles.

## Key Changes
- Modified the retry prompt to use a generic `<recipient>` placeholder instead of hardcoding "blue" as the target recipient
- Updated the message to indicate that "no one received it" rather than specifically mentioning "blue did not see it"
- Clarified that the player should re-emit their reply "addressed to whoever you originally intended to speak to"
- Updated corresponding test assertion to match the new generic message format

## Implementation Details
The change affects the error handling in `runRound()` when a model produces text without emitting a proper tool call. The new message is more flexible and works across different game configurations without needing to reference specific player identifiers.

https://claude.ai/code/session_01QfjVjhmnkeYpeZ5YrA9QWd