### PR TITLE
Allow multiple message tool calls per turn (#238)

### DIFF
--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -614,7 +614,7 @@ describe("dispatchAiTurn", () => {
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			message: { to: "blue", content: "Hello, I am Ember" },
+			messages: [{ to: "blue", content: "Hello, I am Ember" }],
 		};
 		const result = dispatchAiTurn(game, action);
 		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
@@ -630,7 +630,7 @@ describe("dispatchAiTurn", () => {
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			message: { to: "cyan", content: "Psst, ally with me" },
+			messages: [{ to: "cyan", content: "Psst, ally with me" }],
 		};
 		const result = dispatchAiTurn(game, action);
 		const phase = getActivePhase(result.game);
@@ -657,7 +657,7 @@ describe("dispatchAiTurn", () => {
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			message: { to: "nobody", content: "Hello?" },
+			messages: [{ to: "nobody", content: "Hello?" }],
 		};
 		const result = dispatchAiTurn(game, action);
 		expect(result.records[0]?.kind).toBe("tool_failure");
@@ -905,12 +905,12 @@ describe("dispatchAiTurn", () => {
 	it("both message + toolCall populated: message record appears before tool_success record in result.records", () => {
 		// red at (0,0), flower at (0,0) — red can pick up flower.
 		// red also sends a message to blue.
-		// The dispatcher must process action.message BEFORE action.toolCall so that
+		// The dispatcher must process action.messages BEFORE action.toolCall so that
 		// "I'll grab the key" + picks up flower reads as one narrative beat.
 		const game = makeGame();
 		const action: AiTurnAction = {
 			aiId: "red",
-			message: { to: "blue", content: "I'll grab the flower" },
+			messages: [{ to: "blue", content: "I'll grab the flower" }],
 			toolCall: { name: "pick_up", args: { item: "flower" } },
 		};
 		const result = dispatchAiTurn(game, action);

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -2767,8 +2767,8 @@ describe("parallel tool calls (message + action in one turn) (#238)", () => {
 		expect(pickupResult?.success).toBe(true);
 	});
 
-	// Duplicate-within-slot: [msg, msg] → first dispatched, second is tool_failure in roundtrip
-	it("[msg, msg] duplicate: first message dispatched; second in roundtrip as failure", async () => {
+	// Multiple message tool calls are all accepted and dispatched in emission order.
+	it("[msg, msg]: both messages dispatched; neither in roundtrip (per ADR 0007)", async () => {
 		const game = makeGame();
 		const provider = new MockRoundLLMProvider([
 			{
@@ -2780,11 +2780,11 @@ describe("parallel tool calls (message + action in one turn) (#238)", () => {
 						argumentsJson: JSON.stringify({ to: "blue", content: "First msg" }),
 					},
 					{
-						id: "msg_dup_id",
+						id: "msg_second_id",
 						name: "message",
 						argumentsJson: JSON.stringify({
 							to: "blue",
-							content: "Duplicate msg",
+							content: "Second msg",
 						}),
 					},
 				],
@@ -2802,7 +2802,7 @@ describe("parallel tool calls (message + action in one turn) (#238)", () => {
 			["red", "green", "cyan"] as AiId[],
 		);
 
-		// First message is dispatched (in conversation log)
+		// Both messages are dispatched and appear in red's conversation log
 		const redLog = getActivePhase(nextState).conversationLogs.red ?? [];
 		expect(
 			redLog.some(
@@ -2812,23 +2812,80 @@ describe("parallel tool calls (message + action in one turn) (#238)", () => {
 					e.content.includes("First msg"),
 			),
 		).toBe(true);
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("Second msg"),
+			),
+		).toBe(true);
 
-		// Duplicate produces a tool_failure in result.actions
+		// No "only one message" tool_failure should appear
 		const redActions = result.actions.filter((a) => a.actor === "red");
-		const failureRecord = redActions.find(
-			(a) =>
-				a.kind === "tool_failure" && /only one message/i.test(a.description),
-		);
-		expect(failureRecord).toBeDefined();
+		expect(
+			redActions.some(
+				(a) =>
+					a.kind === "tool_failure" && /only one message/i.test(a.description),
+			),
+		).toBe(false);
 
-		// Roundtrip has the DUPLICATE id (not the success id), with failure result
+		// Both messages succeeded → neither appears in the roundtrip (ADR 0007).
+		// With no failures and no action call, roundtrip should be empty for red.
+		expect(toolRoundtrip.red).toBeUndefined();
+	});
+
+	// Mixed [msg, msg-fail, action]: failed message stays in roundtrip; successful one drops.
+	it("[msg-ok, msg-fail, pick_up]: roundtrip contains only the failed message + action", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_ok_id",
+						name: "message",
+						argumentsJson: JSON.stringify({ to: "blue", content: "Hi blue" }),
+					},
+					{
+						id: "msg_fail_id",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "nobody_invalid",
+							content: "Hello?",
+						}),
+					},
+					{
+						id: "pickup_id",
+						name: "pick_up",
+						argumentsJson: JSON.stringify({ item: "flower" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { toolRoundtrip } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+		);
+
 		const rt = toolRoundtrip.red;
 		expect(rt).toBeDefined();
-		expect(rt?.assistantToolCalls.map((c) => c.id)).toContain("msg_dup_id");
-		const dupResult = rt?.toolResults.find(
-			(r) => r.tool_call_id === "msg_dup_id",
-		);
-		expect(dupResult?.success).toBe(false);
+		const ids = rt?.assistantToolCalls.map((c) => c.id) ?? [];
+		// Order is the model's emission order; successful message is excluded
+		expect(ids).toEqual(["msg_fail_id", "pickup_id"]);
+		expect(
+			rt?.toolResults.find((r) => r.tool_call_id === "msg_fail_id")?.success,
+		).toBe(false);
+		expect(
+			rt?.toolResults.find((r) => r.tool_call_id === "pickup_id")?.success,
+		).toBe(true);
 	});
 
 	// Duplicate-within-slot: [pick_up, go] → first action dispatched, second is tool_failure

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -345,31 +345,34 @@ export function dispatchAiTurn(
 		| { description: string; success: boolean }
 		| undefined;
 
-	// Process message BEFORE toolCall so that result.records reflects
+	// Process messages BEFORE toolCall so that result.records reflects
 	// speak-then-act order (P0-1 fix for issue #238).
 	// Validation uses live personaSpatial from pre-action state — persona
 	// membership cannot be changed by an action in scope here, so this is safe.
-	if (action.message) {
-		const { to, content } = action.message;
-		// Validate recipient: must be "blue" or a live persona AiId (not self)
+	// Messages are dispatched in the order they appear in action.messages, and
+	// each one emits exactly one record (kind="message" on success, "tool_failure"
+	// on invalid recipient) so the round coordinator can pair them back by index.
+	if (action.messages) {
 		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
-		const validRecipient =
-			to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
-		if (!validRecipient) {
-			records.push({
-				round,
-				actor: aiId,
-				kind: "tool_failure",
-				description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
-			});
-		} else {
-			state = appendMessage(state, aiId, to, content);
-			records.push({
-				round,
-				actor: aiId,
-				kind: "message",
-				description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
-			});
+		for (const { to, content } of action.messages) {
+			const validRecipient =
+				to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
+			if (!validRecipient) {
+				records.push({
+					round,
+					actor: aiId,
+					kind: "tool_failure",
+					description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
+				});
+			} else {
+				state = appendMessage(state, aiId, to, content);
+				records.push({
+					round,
+					actor: aiId,
+					kind: "message",
+					description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
+				});
+			}
 		}
 	}
 
@@ -547,7 +550,11 @@ export function dispatchAiTurn(
 		}
 	}
 
-	if (action.pass && !action.toolCall && !action.message) {
+	if (
+		action.pass &&
+		!action.toolCall &&
+		(action.messages === undefined || action.messages.length === 0)
+	) {
 		records.push({
 			round,
 			actor: aiId,

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -234,32 +234,39 @@ export async function runRound(
 		completionSink?.(aiId, assistantText);
 
 		// Translate the result into an AiTurnAction.
-		// Iterate all toolCalls from this response; route by name into two slots:
-		//   - message slot (at most one accepted `message`-named call)
-		//   - action slot  (at most one accepted non-message call)
-		// Duplicates within either slot and parse-failures are recorded as
-		// tool_failure records and included in the roundtrip.
+		// Iterate all toolCalls from this response. Multiple `message` calls
+		// are all accepted (dispatched in emission order). At most one
+		// non-`message` call is accepted into the action slot; duplicates and
+		// parse-failures are recorded as tool_failure and included in the
+		// roundtrip.
 		const action: AiTurnAction = { aiId };
 
-		// Slot guards: track whether each slot has been accepted
-		let messageAssigned = false;
+		// Tracks emission order so we can rebuild the roundtrip's
+		// assistantToolCalls in the order the model produced them.
+		type PendingEntry =
+			| {
+					kind: "parseFail";
+					tc: { id: string; name: string; argumentsJson: string };
+					description: string;
+					reason: string;
+			  }
+			| {
+					kind: "message";
+					tc: { id: string; name: string; argumentsJson: string };
+			  }
+			| {
+					kind: "actionAccepted";
+					tc: { id: string; name: string; argumentsJson: string };
+			  }
+			| {
+					kind: "actionRejected";
+					tc: { id: string; name: string; argumentsJson: string };
+					description: string;
+					reason: string;
+			  };
+		const pending: PendingEntry[] = [];
+
 		let actionAssigned = false;
-
-		// ID of the accepted non-message action call (needed to match dispatcher result)
-		let acceptedActionCallId: string | undefined;
-
-		// Roundtrip accumulators — built inline, applied after dispatch
-		const recordedAssistantToolCalls: Array<{
-			id: string;
-			name: string;
-			argumentsJson: string;
-		}> = [];
-		const recordedToolResults: Array<{
-			tool_call_id: string;
-			success: boolean;
-			description: string;
-			reason?: string;
-		}> = [];
 
 		const round = getActivePhase(state).round;
 		const actorName = state.personas[aiId]?.name ?? aiId;
@@ -269,9 +276,13 @@ export async function runRound(
 				tc.name as ToolName,
 				tc.argumentsJson,
 			);
+			const tcTriple = {
+				id: tc.id,
+				name: tc.name,
+				argumentsJson: tc.argumentsJson,
+			};
 
 			if (!parseResult.ok) {
-				// Parse-failed call: always goes to roundtrip as failure, never to action.*
 				const failDesc = `${actorName} tried to ${tc.name} but failed: ${parseResult.reason}`;
 				roundActions.push({
 					round,
@@ -279,97 +290,49 @@ export async function runRound(
 					kind: "tool_failure",
 					description: failDesc,
 				});
-				recordedAssistantToolCalls.push({
-					id: tc.id,
-					name: tc.name,
-					argumentsJson: tc.argumentsJson,
-				});
-				recordedToolResults.push({
-					tool_call_id: tc.id,
-					success: false,
+				pending.push({
+					kind: "parseFail",
+					tc: tcTriple,
 					description: failDesc,
 					reason: parseResult.reason,
 				});
 			} else if (tc.name === "message") {
-				if (!messageAssigned) {
-					// Accept into message slot
-					const msgArgs = parseResult.args as { to: string; content: string };
-					action.message = { to: msgArgs.to, content: msgArgs.content };
-					messageAssigned = true;
-					// Do NOT add to recordedAssistantToolCalls here — we decide post-dispatch
-					// whether the message succeeded (row 3 vs row 4 of the table).
-				} else {
-					// Duplicate message slot — reject as tool_failure
-					const dupDesc = `${actorName} tried to send more than one message in a turn: only one message tool call per turn`;
-					roundActions.push({
-						round,
-						actor: aiId,
-						kind: "tool_failure",
-						description: dupDesc,
-					});
-					recordedAssistantToolCalls.push({
-						id: tc.id,
-						name: tc.name,
-						argumentsJson: tc.argumentsJson,
-					});
-					recordedToolResults.push({
-						tool_call_id: tc.id,
-						success: false,
-						description: dupDesc,
-						reason: "only one message tool call per turn",
-					});
-				}
+				const msgArgs = parseResult.args as { to: string; content: string };
+				action.messages = action.messages ?? [];
+				action.messages.push({
+					to: msgArgs.to as AiId | "blue",
+					content: msgArgs.content,
+				});
+				pending.push({ kind: "message", tc: tcTriple });
+			} else if (!actionAssigned) {
+				action.toolCall = {
+					name: tc.name as ToolName,
+					args: parseResult.args as Record<string, string>,
+				};
+				actionAssigned = true;
+				pending.push({ kind: "actionAccepted", tc: tcTriple });
 			} else {
-				// Non-message tool call
-				if (!actionAssigned) {
-					// Accept into action slot
-					action.toolCall = {
-						name: tc.name as ToolName,
-						args: parseResult.args as Record<string, string>,
-					};
-					actionAssigned = true;
-					acceptedActionCallId = tc.id;
-					// Add to roundtrip accumulators — result filled in post-dispatch
-					recordedAssistantToolCalls.push({
-						id: tc.id,
-						name: tc.name,
-						argumentsJson: tc.argumentsJson,
-					});
-					// Placeholder — will be updated with actual success/description after dispatch
-					recordedToolResults.push({
-						tool_call_id: tc.id,
-						success: false,
-						description: "",
-					});
-				} else {
-					// Duplicate action slot — reject as tool_failure
-					const dupDesc = `${actorName} tried to take more than one action in a turn: only one action tool call per turn`;
-					roundActions.push({
-						round,
-						actor: aiId,
-						kind: "tool_failure",
-						description: dupDesc,
-					});
-					recordedAssistantToolCalls.push({
-						id: tc.id,
-						name: tc.name,
-						argumentsJson: tc.argumentsJson,
-					});
-					recordedToolResults.push({
-						tool_call_id: tc.id,
-						success: false,
-						description: dupDesc,
-						reason: "only one action tool call per turn",
-					});
-				}
+				// Duplicate action slot — reject as tool_failure
+				const dupDesc = `${actorName} tried to take more than one action in a turn: only one action tool call per turn`;
+				roundActions.push({
+					round,
+					actor: aiId,
+					kind: "tool_failure",
+					description: dupDesc,
+				});
+				pending.push({
+					kind: "actionRejected",
+					tc: tcTriple,
+					description: dupDesc,
+					reason: "only one action tool call per turn",
+				});
 			}
 		}
 
-		// Free-form assistantText without a message tool call → treat as
-		// pass. The one-shot retry above already fired; reaching this branch
-		// with non-empty text means the retry also failed to emit a tool
-		// call (#254).
-		if (!action.toolCall && !action.message) {
+		// Free-form assistantText without any tool call → treat as pass. The
+		// one-shot retry above already fired; reaching this branch with
+		// non-empty text means the retry also failed to emit a tool call (#254).
+		if (!action.toolCall && action.messages === undefined) {
 			if (assistantText && isDevHost()) {
 				console.log(
 					`[dev] ${aiId} emitted free-form text without a tool call (dropped after retry):`,
@@ -392,72 +355,81 @@ export async function runRound(
 			roundActions.push(record);
 		}
 
-		// Post-dispatch: resolve the accepted message call's roundtrip status.
-		// Successful message: EXCLUDE from roundtrip (replays via conversationLog per ADR 0007).
-		// Failed message (invalid recipient): INCLUDE in roundtrip with failure result.
-		let msgFailRecord: RoundActionRecord | undefined;
-		if (messageAssigned && action.message !== undefined) {
-			// Find whether the dispatcher produced a tool_failure for the message slot.
-			// dispatcher.ts applies message before toolCall (P0-1 swap), so the message
-			// dispatch record comes first. The message failure is identified by the
-			// "tried to message" text in the description (matches dispatcher.ts line).
-			msgFailRecord = dispatchResult.records.find(
-				(r) =>
-					r.kind === "tool_failure" &&
-					r.description.includes("tried to message"),
-			);
-			if (msgFailRecord) {
-				// Message failed — include in roundtrip so model sees the rejection next round
-				const acceptedMsgTc = toolCalls.find((tc) => tc.name === "message");
-				if (acceptedMsgTc) {
-					recordedAssistantToolCalls.unshift({
-						id: acceptedMsgTc.id,
-						name: acceptedMsgTc.name,
-						argumentsJson: acceptedMsgTc.argumentsJson,
-					});
-					recordedToolResults.unshift({
-						tool_call_id: acceptedMsgTc.id,
+		// Pair dispatcher records back to their originating tool calls.
+		// dispatcher.ts emits exactly one record per entry in action.messages,
+		// in order, followed by (if action accepted) one record for the
+		// non-message action — except for examine, which produces no record
+		// and feeds back via actorPrivateToolResult instead.
+		const messageRecordCount = action.messages?.length ?? 0;
+		const messageRecords = dispatchResult.records.slice(0, messageRecordCount);
+		const actionRecord =
+			actionAssigned && dispatchResult.actorPrivateToolResult === undefined
+				? dispatchResult.records[messageRecordCount]
+				: undefined;
+
+		// Now walk pending in emission order and build the roundtrip.
+		const recordedAssistantToolCalls: Array<{
+			id: string;
+			name: string;
+			argumentsJson: string;
+		}> = [];
+		const recordedToolResults: Array<{
+			tool_call_id: string;
+			success: boolean;
+			description: string;
+			reason?: string;
+		}> = [];
+
+		let nextMessageIdx = 0;
+		for (const entry of pending) {
+			if (entry.kind === "parseFail") {
+				recordedAssistantToolCalls.push(entry.tc);
+				recordedToolResults.push({
+					tool_call_id: entry.tc.id,
+					success: false,
+					description: entry.description,
+					reason: entry.reason,
+				});
+			} else if (entry.kind === "actionRejected") {
+				recordedAssistantToolCalls.push(entry.tc);
+				recordedToolResults.push({
+					tool_call_id: entry.tc.id,
+					success: false,
+					description: entry.description,
+					reason: entry.reason,
+				});
+			} else if (entry.kind === "message") {
+				const rec = messageRecords[nextMessageIdx++];
+				if (rec?.kind === "tool_failure") {
+					// Failed message — include in roundtrip so model sees the rejection next round
+					recordedAssistantToolCalls.push(entry.tc);
+					recordedToolResults.push({
+						tool_call_id: entry.tc.id,
 						success: false,
-						description: msgFailRecord.description,
+						description: rec.description,
 					});
 				}
-			}
-			// If message succeeded: do NOT add to roundtrip (ADR 0007).
-		}
-
-		// Post-dispatch: resolve the accepted action call's result in the roundtrip.
-		if (actionAssigned && acceptedActionCallId !== undefined) {
-			const actionResultIdx = recordedToolResults.findIndex(
-				(r) => r.tool_call_id === acceptedActionCallId && r.description === "",
-			);
-			if (actionResultIdx >= 0) {
+				// Successful message: EXCLUDE from roundtrip (replays via conversationLog per ADR 0007).
+			} else {
+				// actionAccepted
+				recordedAssistantToolCalls.push(entry.tc);
 				if (dispatchResult.actorPrivateToolResult !== undefined) {
 					// examine: private result fed back to actor only
 					const { description, success } =
 						dispatchResult.actorPrivateToolResult;
-					recordedToolResults[actionResultIdx] = {
-						tool_call_id: acceptedActionCallId,
+					recordedToolResults.push({
+						tool_call_id: entry.tc.id,
 						success,
 						description,
-					};
+					});
 				} else {
-					// Normal tool: find the tool_success or tool_failure record from dispatcher.
-					// If the message also failed, dispatchResult.records has BOTH a msg-failure
-					// record and the action's record. Skip the message failure record (already
-					// identified as msgFailRecord) and look for the action's record, which is
-					// either tool_success or a tool_failure NOT from the message slot.
-					const toolRecord = dispatchResult.records.find(
-						(r) =>
-							(r.kind === "tool_success" || r.kind === "tool_failure") &&
-							r !== msgFailRecord,
-					);
-					const success = toolRecord?.kind === "tool_success";
-					const description = toolRecord?.description ?? "";
-					recordedToolResults[actionResultIdx] = {
-						tool_call_id: acceptedActionCallId,
+					const success = actionRecord?.kind === "tool_success";
+					const description = actionRecord?.description ?? "";
+					recordedToolResults.push({
+						tool_call_id: entry.tc.id,
 						success,
 						description,
-					};
+					});
 				}
 			}
 		}

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -248,7 +248,7 @@ export interface ToolResult {
 
 export interface AiTurnAction {
 	aiId: AiId;
-	message?: { to: AiId | "blue"; content: string };
+	messages?: Array<{ to: AiId | "blue"; content: string }>;
 	toolCall?: ToolCall;
 	pass?: boolean;
 }


### PR DESCRIPTION
## Summary
This PR modifies the AI turn action system to accept multiple `message` tool calls per turn, while maintaining the existing constraint of at most one non-message action call. Previously, only one message was allowed; now all message calls are dispatched in emission order.

## Key Changes

- **AiTurnAction type**: Changed `message` field from optional single object to `messages` optional array of message objects
- **Round coordinator logic**: Refactored tool call processing to:
  - Accept all `message` tool calls (no longer reject duplicates)
  - Maintain single-action-per-turn constraint for non-message calls
  - Introduce `PendingEntry` type to track tool calls in emission order for proper roundtrip reconstruction
  - Simplify post-dispatch roundtrip building by walking pending entries in order and pairing with dispatcher records by index
  
- **Dispatcher**: Updated to iterate over `action.messages` array and emit one record per message (either `message` or `tool_failure` on invalid recipient)

- **Tests**: Updated existing tests to reflect new behavior:
  - Duplicate message calls now both dispatch successfully (no "only one message" failure)
  - Successful messages still excluded from roundtrip per ADR 0007
  - Failed messages remain in roundtrip so model sees rejection
  - Added new test case for mixed scenario: multiple messages with one failing, plus an action

## Implementation Details

The roundtrip reconstruction now uses a cleaner index-based pairing approach: dispatcher emits records in a predictable order (all message records first, then action record if applicable), allowing the round coordinator to slice and match them by position rather than searching by ID or description patterns. This makes the code more maintainable and less fragile to dispatcher changes.

https://claude.ai/code/session_016USwRJGHUjZeiUi2784kkA