### PR TITLE
Add routing prefix to outgoing AI messages for game-wide tracking

### DIFF
--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -97,12 +97,12 @@ describe("buildOpenAiMessages", () => {
 			role: "user",
 			content: "[Round 0] blue dms you: Hello Ember!",
 		});
-		// Outgoing assistant turn renders raw entry.content — what the model
-		// actually emitted via the `message` tool. No synthetic round/routing
-		// prefix; that would misrepresent its own output back to it.
+		// Outgoing assistant turn is prefixed with "[Round N] you dm <toLabel>:"
+		// so the Daemon can track who it addressed across the whole game (not
+		// just on the round immediately after).
 		expect(messages[2]).toEqual({
 			role: "assistant",
-			content: "Hello, player!",
+			content: "[Round 0] you dm blue: Hello, player!",
 		});
 		// Trailing current-state turn
 		expect(messages[3]?.role).toBe("user");

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -980,13 +980,12 @@ describe("conversation rendering (role turns)", () => {
 		expect(userMsg).toBeDefined();
 	});
 
-	it("outgoing AI message becomes an assistant turn carrying the raw body the model emitted", () => {
-		// Outgoing turns deliberately render as `entry.content` only — no
-		// synthetic "[Round N] you dm <to>:" prefix. Showing the model that
-		// prefix as if it were its own output would (a) misrepresent its past
-		// emission, (b) risk inducing it to emit the prefix verbatim instead
-		// of using the `message` tool. Routing context for outgoing turns
-		// lives in the prior-round tool_call/tool_result pair when present.
+	it("outgoing AI message becomes an assistant turn prefixed with '[Round N] you dm <to>:'", () => {
+		// Outgoing turns carry the same "[Round N] you dm <toLabel>:" prefix
+		// renderEntry() produces, so the Daemon can track who it addressed
+		// across the whole game — not just on the round immediately after,
+		// which is the only scope the prior-round tool_call/tool_result pair
+		// covers.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "red", "blue", "Greetings");
 		const ctx = buildAiContext(game, "red");
@@ -994,7 +993,8 @@ describe("conversation rendering (role turns)", () => {
 		const asst = messages.find(
 			(m) =>
 				m.role === "assistant" &&
-				(m as { content: string | null }).content === "Greetings",
+				(m as { content: string | null }).content ===
+					"[Round 0] you dm blue: Greetings",
 		);
 		expect(asst).toBeDefined();
 	});
@@ -1020,12 +1020,13 @@ describe("conversation rendering (role turns)", () => {
 		game = appendMessage(game, "green", "red", "secret");
 		const greenCtx = buildAiContext(game, "green");
 		const messages = buildOpenAiMessages(greenCtx);
-		// Outgoing turn = raw content; see the "outgoing AI message" test above
-		// for why we don't add a synthetic round/routing prefix here.
+		// Outgoing turn carries the "[Round N] you dm <toLabel>:" prefix; see
+		// the "outgoing AI message" test above for the rationale.
 		const asst = messages.find(
 			(m) =>
 				m.role === "assistant" &&
-				(m as { content: string | null }).content === "secret",
+				(m as { content: string | null }).content ===
+					"[Round 0] you dm *red: secret",
 		);
 		expect(asst).toBeDefined();
 	});

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -8,13 +8,14 @@
  *   1. { role: "system", content: ctx.toSystemPrompt() }
  *      Stable per (persona × phase) — OpenRouter's prefix cache reuses it round-to-round.
  *   2. One turn per ConversationEntry, sorted by round ascending (stable):
- *      - kind=message, outgoing: { role: "assistant", content: entry.content }
- *        — raw body the model emitted via the `message` tool. NO synthetic
- *        prefix: showing the model `[Round N] you dm <to>:` as if it were
- *        its own output would (a) misrepresent what it actually produced,
- *        (b) risk inducing it to emit that prefix verbatim instead of using
- *        the tool. Routing context for outgoing turns lives in the
- *        prior-round tool_call/tool_result pair (block 3 below) when present.
+ *      - kind=message, outgoing: { role: "assistant", content: renderEntry(...) }
+ *        — "[Round N] you dm <to>: <content>". The routing prefix lets the
+ *        Daemon track who it addressed across the whole game (the prior-round
+ *        tool_call/tool_result pair in block 3 only covers the immediately-next
+ *        round). Tradeoff: the assistant turn no longer matches the raw body
+ *        the model emitted via the `message` tool, and the model may parrot
+ *        the prefix into future `content` — `message_tool_description` in
+ *        prompt-builder.ts is the place to defend against that if it shows up.
  *      - kind=message, incoming: { role: "user",      content: renderEntry(...) }
  *        — "[Round N] <from> dms you: <content>".
  *      - kind=witnessed-event:   { role: "user",      content: renderEntry(...) }
@@ -63,10 +64,14 @@ export function buildOpenAiMessages(
 	for (const entry of sortedLog) {
 		if (entry.kind === "message") {
 			if (entry.from === ctx.aiId) {
-				// Outgoing: assistant turn shows the raw body the model emitted
-				// via the `message` tool. No synthetic round/routing prefix —
-				// it would misrepresent the model's own output. See header.
-				messages.push({ role: "assistant", content: entry.content });
+				// Outgoing: prefix with "[Round N] you dm <toLabel>:" so the
+				// Daemon can track who it addressed across the whole game —
+				// not just on the round immediately after, which is the only
+				// scope the prior-round tool_call/tool_result pair covers.
+				messages.push({
+					role: "assistant",
+					content: renderEntry(entry, ctx.aiId, ctx.worldSnapshot.entities),
+				});
 			} else {
 				// Incoming: user turn includes "[Round N] <from> dms you:" so
 				// the model can place the message in time and identify the


### PR DESCRIPTION
## Summary
Changed outgoing AI messages in the conversation history to include a routing prefix `[Round N] you dm <toLabel>:` so the Daemon can track who the AI addressed across the entire game, not just the immediately following round.

## Key Changes
- **openai-message-builder.ts**: Modified outgoing message handling to call `renderEntry()` instead of using raw `entry.content`, adding the round and recipient context to assistant turns
- **Test updates**: Updated test expectations in both `prompt-builder.test.ts` and `openai-message-builder.test.ts` to verify the new prefixed format
- **Documentation**: Updated code comments to explain the rationale—the prior-round tool_call/tool_result pair only covers routing for the immediately-next round, so the prefix is needed for game-wide tracking

## Implementation Details
- The change trades off exact fidelity to the model's raw output for improved game state tracking across multiple rounds
- Added a note in comments that `message_tool_description` in prompt-builder.ts should defend against the model parroting the prefix into future message content if needed
- All outgoing messages now follow the same format as incoming messages and witnessed events, with consistent round/routing information

https://claude.ai/code/session_01Y8s46Ls2VV1sctWTjUUGhd