### PR TITLE
Strip leading asterisk from 'to' field in give and message tools

### DIFF
--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -177,6 +177,85 @@ describe("parseToolCallArguments", () => {
 		}
 	});
 
+	it("strips a leading '*' from give.to (conversation log renders ids as *foo)", () => {
+		const result = parseToolCallArguments(
+			"give",
+			'{"item":"flower","to":"*cyan"}',
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ item: "flower", to: "cyan" });
+		}
+	});
+
+	it("returns ok:false when give.to is just '*' (empty after strip)", () => {
+		const result = parseToolCallArguments("give", '{"item":"flower","to":"*"}');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+
+	it("parses valid message arguments", () => {
+		const result = parseToolCallArguments(
+			"message",
+			'{"to":"cyan","content":"hi"}',
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ to: "cyan", content: "hi" });
+		}
+	});
+
+	it("strips a leading '*' from message.to (conversation log renders ids as *foo)", () => {
+		const result = parseToolCallArguments(
+			"message",
+			'{"to":"*6nho","content":"hi"}',
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ to: "6nho", content: "hi" });
+		}
+	});
+
+	it("only strips a single leading '*' from message.to", () => {
+		const result = parseToolCallArguments(
+			"message",
+			'{"to":"**foo","content":"hi"}',
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.args).toEqual({ to: "*foo", content: "hi" });
+		}
+	});
+
+	it("returns ok:false when message.to is just '*' (empty after strip)", () => {
+		const result = parseToolCallArguments(
+			"message",
+			'{"to":"*","content":"hi"}',
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+
+	it("returns ok:false with /required/i reason when 'to' is missing for message", () => {
+		const result = parseToolCallArguments("message", '{"content":"hi"}');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+
+	it("returns ok:false with /required/i reason when 'content' is missing for message", () => {
+		const result = parseToolCallArguments("message", '{"to":"cyan"}');
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toMatch(/required/i);
+		}
+	});
+
 	it("parses valid go arguments", () => {
 		const result = parseToolCallArguments("go", '{"direction":"north"}');
 		expect(result.ok).toBe(true);

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -257,12 +257,18 @@ export function parseToolCallArguments<N extends ToolName>(
 			if (typeof obj.item !== "string" || obj.item.length === 0) {
 				return { ok: false, reason: "Required argument 'item' is missing" };
 			}
-			if (typeof obj.to !== "string" || obj.to.length === 0) {
+			if (typeof obj.to !== "string") {
+				return { ok: false, reason: "Required argument 'to' is missing" };
+			}
+			// Strip a leading `*` — the conversation log renders AI ids as `*foo`,
+			// and the model occasionally parrots that prefix into the structured arg.
+			const to = obj.to.startsWith("*") ? obj.to.slice(1) : obj.to;
+			if (to.length === 0) {
 				return { ok: false, reason: "Required argument 'to' is missing" };
 			}
 			return {
 				ok: true,
-				args: { item: obj.item, to: obj.to } as ToolArgs[N],
+				args: { item: obj.item, to } as ToolArgs[N],
 			};
 		}
 		case "go":
@@ -276,7 +282,13 @@ export function parseToolCallArguments<N extends ToolName>(
 			return { ok: true, args: { direction: obj.direction } as ToolArgs[N] };
 		}
 		case "message": {
-			if (typeof obj.to !== "string" || obj.to.length === 0) {
+			if (typeof obj.to !== "string") {
+				return { ok: false, reason: "Required argument 'to' is missing" };
+			}
+			// Strip a leading `*` — the conversation log renders AI ids as `*foo`,
+			// and the model occasionally parrots that prefix into the structured arg.
+			const to = obj.to.startsWith("*") ? obj.to.slice(1) : obj.to;
+			if (to.length === 0) {
 				return { ok: false, reason: "Required argument 'to' is missing" };
 			}
 			if (typeof obj.content !== "string" || obj.content.length === 0) {
@@ -284,7 +296,7 @@ export function parseToolCallArguments<N extends ToolName>(
 			}
 			return {
 				ok: true,
-				args: { to: obj.to, content: obj.content } as ToolArgs[N],
+				args: { to, content: obj.content } as ToolArgs[N],
 			};
 		}
 		default:


### PR DESCRIPTION
## Summary
Updated the `parseToolCallArguments` function to strip a leading asterisk (`*`) from the `to` field in both the `give` and `message` tool calls. This handles cases where the AI model parrots back the asterisk prefix that the conversation log uses to render AI entity IDs.

## Key Changes
- **give tool**: Added logic to strip a single leading `*` from the `to` argument before validation
- **message tool**: Added logic to strip a single leading `*` from the `to` argument before validation
- Both implementations validate that the `to` field is not empty after stripping the asterisk
- Added comprehensive test coverage for the new behavior, including:
  - Valid cases with and without the asterisk prefix
  - Edge cases where `to` is just `*` (invalid after stripping)
  - Cases with multiple leading asterisks (only the first is stripped)
  - Missing required fields for the message tool

## Implementation Details
- The asterisk stripping is applied after type checking but before length validation
- Only a single leading asterisk is removed (e.g., `**foo` becomes `*foo`)
- If the field becomes empty after stripping, it's treated as a missing required argument
- The implementation is consistent across both `give` and `message` tools

https://claude.ai/code/session_017cVSeFYcLeE2asT9XDHAbs