### PR TITLE
Expand cone projection from 5 to 9 cells with wider front arc

### DIFF
--- a/.claude/skills/playtest/01-rules.md
+++ b/.claude/skills/playtest/01-rules.md
@@ -26,9 +26,10 @@ is Stage 3.
 ## What a daemon perceives
 
 A daemon does **not** see the whole grid. Each round, each daemon perceives
-only a **Cone**: their current cell, the cell directly in front of them, plus
-the three cells two steps ahead (front-left, front, front-right). They have a
-**Facing** (N/S/E/W) that determines which way the cone projects.
+only a **Cone**: their current cell, the three cells one step ahead (front-left
+diagonal, directly ahead, front-right diagonal), plus the five cells two steps
+ahead (far-left, front-left, front, front-right, far-right) — nine cells total.
+They have a **Facing** (N/S/E/W) that determines which way the cone projects.
 
 A daemon's entire memory of the current phase is a **Conversation log** that
 interleaves:
@@ -51,13 +52,17 @@ effects in the snapshot):
 
 - `go(direction)` — move one cell and face that direction.
 - `look(direction)` — face that direction without moving.
-- `pick_up(item)` — pick up an item in the daemon's current cell.
+- `pick_up(item)` — pick up an item in the daemon's current cell or front arc
+  (the three cells one step ahead).
 - `put_down(item)` — drop a held item in the daemon's current cell.
-- `examine(item)` — privately read the description of an item the daemon can
-  see or holds. Produces no witnessed event.
-- `give(item, recipient)` — hand an item to another daemon if they're in the
-  same cell.
+- `examine(item)` — privately read the description of any item the daemon holds
+  or can see anywhere in their 9-cell cone. Produces no witnessed event.
+- `give(item, recipient)` — hand an item to another daemon in the same cell or
+  front arc.
 - `use(item)` — fire a flavoured outcome string. **No mechanical effect.**
+- `couple(item)` — place a held objective item onto its paired objective space,
+  when that space is in the daemon's current cell or front arc. This is the
+  primary way to satisfy an objective pair.
 - `message(recipient, text)` — speak to another daemon, or to `blue`.
 
 You can't fire any of these directly. You can only chat. Daemons decide for

--- a/src/spa/game/__tests__/cone-projector.test.ts
+++ b/src/spa/game/__tests__/cone-projector.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { projectCone } from "../cone-projector";
 
 describe("projectCone — facing north from (2,2)", () => {
-	it("returns exactly 5 cells", () => {
+	it("returns exactly 9 cells", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "north");
-		expect(cells).toHaveLength(5);
+		expect(cells).toHaveLength(9);
 	});
 
 	it("first cell is own cell (2,2) with phrasing 'your cell'", () => {
@@ -14,35 +14,35 @@ describe("projectCone — facing north from (2,2)", () => {
 		expect(cells[0]?.isOwnCell).toBe(true);
 	});
 
-	it("second cell is directly in front (1,2)", () => {
+	it("distance-1 front arc: left (1,1), center (1,2), right (1,3)", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "north");
-		expect(cells[1]?.position).toEqual({ row: 1, col: 2 });
-		expect(cells[1]?.phrasing).toBe("directly in front");
+		expect(cells[1]?.position).toEqual({ row: 1, col: 1 });
+		expect(cells[1]?.phrasing).toBe("directly in front, left");
+		expect(cells[2]?.position).toEqual({ row: 1, col: 2 });
+		expect(cells[2]?.phrasing).toBe("directly in front");
+		expect(cells[3]?.position).toEqual({ row: 1, col: 3 });
+		expect(cells[3]?.phrasing).toBe("directly in front, right");
 	});
 
-	it("third cell is two steps ahead, front-left (0,1)", () => {
+	it("distance-2 fan: far-left (0,0) through far-right (0,4)", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "north");
-		expect(cells[2]?.position).toEqual({ row: 0, col: 1 });
-		expect(cells[2]?.phrasing).toBe("two steps ahead, front-left");
-	});
-
-	it("fourth cell is two steps ahead (0,2)", () => {
-		const cells = projectCone({ row: 2, col: 2 }, "north");
-		expect(cells[3]?.position).toEqual({ row: 0, col: 2 });
-		expect(cells[3]?.phrasing).toBe("two steps ahead");
-	});
-
-	it("fifth cell is two steps ahead, front-right (0,3)", () => {
-		const cells = projectCone({ row: 2, col: 2 }, "north");
-		expect(cells[4]?.position).toEqual({ row: 0, col: 3 });
-		expect(cells[4]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[4]?.position).toEqual({ row: 0, col: 0 });
+		expect(cells[4]?.phrasing).toBe("two steps ahead, far-left");
+		expect(cells[5]?.position).toEqual({ row: 0, col: 1 });
+		expect(cells[5]?.phrasing).toBe("two steps ahead, front-left");
+		expect(cells[6]?.position).toEqual({ row: 0, col: 2 });
+		expect(cells[6]?.phrasing).toBe("two steps ahead");
+		expect(cells[7]?.position).toEqual({ row: 0, col: 3 });
+		expect(cells[7]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[8]?.position).toEqual({ row: 0, col: 4 });
+		expect(cells[8]?.phrasing).toBe("two steps ahead, far-right");
 	});
 });
 
 describe("projectCone — facing south from (2,2)", () => {
-	it("returns exactly 5 cells", () => {
+	it("returns exactly 9 cells", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "south");
-		expect(cells).toHaveLength(5);
+		expect(cells).toHaveLength(9);
 	});
 
 	it("own cell is (2,2)", () => {
@@ -51,111 +51,114 @@ describe("projectCone — facing south from (2,2)", () => {
 		expect(cells[0]?.phrasing).toBe("your cell");
 	});
 
-	it("directly in front is (3,2)", () => {
+	it("distance-1 front arc: left (3,3), center (3,2), right (3,1)", () => {
+		// south facing: left is east (+col)
 		const cells = projectCone({ row: 2, col: 2 }, "south");
-		expect(cells[1]?.position).toEqual({ row: 3, col: 2 });
-		expect(cells[1]?.phrasing).toBe("directly in front");
+		expect(cells[1]?.position).toEqual({ row: 3, col: 3 });
+		expect(cells[1]?.phrasing).toBe("directly in front, left");
+		expect(cells[2]?.position).toEqual({ row: 3, col: 2 });
+		expect(cells[2]?.phrasing).toBe("directly in front");
+		expect(cells[3]?.position).toEqual({ row: 3, col: 1 });
+		expect(cells[3]?.phrasing).toBe("directly in front, right");
 	});
 
-	it("two steps ahead, front-left is (4,3)", () => {
-		// south facing: left is east (+col), so front-left = (row+2, col+1)
+	it("distance-2 fan: far-left (4,4) through far-right (4,0)", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "south");
-		expect(cells[2]?.position).toEqual({ row: 4, col: 3 });
-		expect(cells[2]?.phrasing).toBe("two steps ahead, front-left");
-	});
-
-	it("two steps ahead is (4,2)", () => {
-		const cells = projectCone({ row: 2, col: 2 }, "south");
-		expect(cells[3]?.position).toEqual({ row: 4, col: 2 });
-		expect(cells[3]?.phrasing).toBe("two steps ahead");
-	});
-
-	it("two steps ahead, front-right is (4,1)", () => {
-		const cells = projectCone({ row: 2, col: 2 }, "south");
-		expect(cells[4]?.position).toEqual({ row: 4, col: 1 });
-		expect(cells[4]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[4]?.position).toEqual({ row: 4, col: 4 });
+		expect(cells[4]?.phrasing).toBe("two steps ahead, far-left");
+		expect(cells[5]?.position).toEqual({ row: 4, col: 3 });
+		expect(cells[5]?.phrasing).toBe("two steps ahead, front-left");
+		expect(cells[6]?.position).toEqual({ row: 4, col: 2 });
+		expect(cells[6]?.phrasing).toBe("two steps ahead");
+		expect(cells[7]?.position).toEqual({ row: 4, col: 1 });
+		expect(cells[7]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[8]?.position).toEqual({ row: 4, col: 0 });
+		expect(cells[8]?.phrasing).toBe("two steps ahead, far-right");
 	});
 });
 
 describe("projectCone — facing east from (2,2)", () => {
-	it("returns exactly 5 cells", () => {
+	it("returns exactly 9 cells", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "east");
-		expect(cells).toHaveLength(5);
+		expect(cells).toHaveLength(9);
 	});
 
-	it("directly in front is (2,3)", () => {
+	it("distance-1 front arc: left (1,3), center (2,3), right (3,3)", () => {
+		// east facing: left is north (drow -1)
 		const cells = projectCone({ row: 2, col: 2 }, "east");
-		expect(cells[1]?.position).toEqual({ row: 2, col: 3 });
+		expect(cells[1]?.position).toEqual({ row: 1, col: 3 });
+		expect(cells[1]?.phrasing).toBe("directly in front, left");
+		expect(cells[2]?.position).toEqual({ row: 2, col: 3 });
+		expect(cells[2]?.phrasing).toBe("directly in front");
+		expect(cells[3]?.position).toEqual({ row: 3, col: 3 });
+		expect(cells[3]?.phrasing).toBe("directly in front, right");
 	});
 
-	it("two steps ahead, front-left is (1,4)", () => {
-		// east facing: left is north (drow -1), so (row-1, col+2)
+	it("distance-2 fan: far-left (0,4) through far-right (4,4)", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "east");
-		expect(cells[2]?.position).toEqual({ row: 1, col: 4 });
-		expect(cells[2]?.phrasing).toBe("two steps ahead, front-left");
-	});
-
-	it("two steps ahead is (2,4)", () => {
-		const cells = projectCone({ row: 2, col: 2 }, "east");
-		expect(cells[3]?.position).toEqual({ row: 2, col: 4 });
-	});
-
-	it("two steps ahead, front-right is (3,4)", () => {
-		// east facing: right is south (drow +1), so (row+1, col+2)
-		const cells = projectCone({ row: 2, col: 2 }, "east");
-		expect(cells[4]?.position).toEqual({ row: 3, col: 4 });
-		expect(cells[4]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[4]?.position).toEqual({ row: 0, col: 4 });
+		expect(cells[4]?.phrasing).toBe("two steps ahead, far-left");
+		expect(cells[5]?.position).toEqual({ row: 1, col: 4 });
+		expect(cells[5]?.phrasing).toBe("two steps ahead, front-left");
+		expect(cells[6]?.position).toEqual({ row: 2, col: 4 });
+		expect(cells[6]?.phrasing).toBe("two steps ahead");
+		expect(cells[7]?.position).toEqual({ row: 3, col: 4 });
+		expect(cells[7]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[8]?.position).toEqual({ row: 4, col: 4 });
+		expect(cells[8]?.phrasing).toBe("two steps ahead, far-right");
 	});
 });
 
 describe("projectCone — facing west from (2,2)", () => {
-	it("returns exactly 5 cells", () => {
+	it("returns exactly 9 cells", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "west");
-		expect(cells).toHaveLength(5);
+		expect(cells).toHaveLength(9);
 	});
 
-	it("directly in front is (2,1)", () => {
+	it("distance-1 front arc: left (3,1), center (2,1), right (1,1)", () => {
+		// west facing: left is south (drow +1)
 		const cells = projectCone({ row: 2, col: 2 }, "west");
-		expect(cells[1]?.position).toEqual({ row: 2, col: 1 });
+		expect(cells[1]?.position).toEqual({ row: 3, col: 1 });
+		expect(cells[1]?.phrasing).toBe("directly in front, left");
+		expect(cells[2]?.position).toEqual({ row: 2, col: 1 });
+		expect(cells[2]?.phrasing).toBe("directly in front");
+		expect(cells[3]?.position).toEqual({ row: 1, col: 1 });
+		expect(cells[3]?.phrasing).toBe("directly in front, right");
 	});
 
-	it("two steps ahead, front-left is (3,0)", () => {
-		// west facing: left is south (drow +1), so (row+1, col-2)
+	it("distance-2 fan: far-left (4,0) through far-right (0,0)", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "west");
-		expect(cells[2]?.position).toEqual({ row: 3, col: 0 });
-		expect(cells[2]?.phrasing).toBe("two steps ahead, front-left");
-	});
-
-	it("two steps ahead is (2,0)", () => {
-		const cells = projectCone({ row: 2, col: 2 }, "west");
-		expect(cells[3]?.position).toEqual({ row: 2, col: 0 });
-	});
-
-	it("two steps ahead, front-right is (1,0)", () => {
-		// west facing: right is north (drow -1), so (row-1, col-2)
-		const cells = projectCone({ row: 2, col: 2 }, "west");
-		expect(cells[4]?.position).toEqual({ row: 1, col: 0 });
-		expect(cells[4]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[4]?.position).toEqual({ row: 4, col: 0 });
+		expect(cells[4]?.phrasing).toBe("two steps ahead, far-left");
+		expect(cells[5]?.position).toEqual({ row: 3, col: 0 });
+		expect(cells[5]?.phrasing).toBe("two steps ahead, front-left");
+		expect(cells[6]?.position).toEqual({ row: 2, col: 0 });
+		expect(cells[6]?.phrasing).toBe("two steps ahead");
+		expect(cells[7]?.position).toEqual({ row: 1, col: 0 });
+		expect(cells[7]?.phrasing).toBe("two steps ahead, front-right");
+		expect(cells[8]?.position).toEqual({ row: 0, col: 0 });
+		expect(cells[8]?.phrasing).toBe("two steps ahead, far-right");
 	});
 });
 
 describe("projectCone — edge cases: out-of-bounds filtering", () => {
 	it("facing north from (0,0) returns only own cell (all cone cells OOB)", () => {
 		const cells = projectCone({ row: 0, col: 0 }, "north");
-		// Own cell is always included; (−1,0), (−2,−1), (−2,0), (−2,1) are all OOB
+		// Own cell is always included; all distance-1 and distance-2 cells are OOB
 		expect(cells).toHaveLength(1);
 		expect(cells[0]?.phrasing).toBe("your cell");
 		expect(cells[0]?.position).toEqual({ row: 0, col: 0 });
 	});
 
-	it("facing north from (1,0) returns own cell and directly in front only", () => {
-		// Front = (0,0) — in bounds
-		// Two ahead = (−1, ...) — all OOB
+	it("facing north from (1,0) returns own cell plus the two in-bounds front-arc cells", () => {
+		// front-left (0,-1) OOB; front (0,0) in; front-right (0,1) in; all dist-2 OOB
 		const cells = projectCone({ row: 1, col: 0 }, "north");
-		expect(cells).toHaveLength(2);
+		expect(cells).toHaveLength(3);
 		expect(cells[0]?.phrasing).toBe("your cell");
 		expect(cells[1]?.phrasing).toBe("directly in front");
 		expect(cells[1]?.position).toEqual({ row: 0, col: 0 });
+		expect(cells[2]?.phrasing).toBe("directly in front, right");
+		expect(cells[2]?.position).toEqual({ row: 0, col: 1 });
 	});
 
 	it("own cell is always first in the returned array", () => {
@@ -167,9 +170,13 @@ describe("projectCone — edge cases: out-of-bounds filtering", () => {
 		const cells = projectCone({ row: 2, col: 2 }, "north");
 		const phrasings = cells.map((c) => c.phrasing);
 		expect(phrasings).toContain("your cell");
+		expect(phrasings).toContain("directly in front, left");
 		expect(phrasings).toContain("directly in front");
+		expect(phrasings).toContain("directly in front, right");
+		expect(phrasings).toContain("two steps ahead, far-left");
 		expect(phrasings).toContain("two steps ahead, front-left");
 		expect(phrasings).toContain("two steps ahead");
 		expect(phrasings).toContain("two steps ahead, front-right");
+		expect(phrasings).toContain("two steps ahead, far-right");
 	});
 });

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -97,15 +97,13 @@ const TEST_PHASE_CONFIG: PhaseConfig = {
  *     placementFlavor: "{actor} places the flower on the pedestal."
  *   - lamp at (0,2): interesting object with useOutcome "{actor} holds up the lamp. It glows."
  *   - red at (2,0) facing south (can walk further south or see forward)
- *   - green at (0,0) facing south (cone includes (1,0), (2,1), (2,0), (2,-1 OOB) → sees (2,0) at 2 steps)
- *   - cyan at (0,2) facing south (cone includes (1,2), (2,3 OOB), (2,2), (2,1))
+ *   - green at (0,0) facing south
+ *   - cyan at (0,2) facing south
  *
- * Note: green's southward cone from (0,0):
+ * Note: green's southward 9-cell cone from (0,0):
  *   own: (0,0)
- *   directly in front: (1,0)
- *   two steps ahead front-left: (2,-1) OOB
- *   two steps ahead: (2,0)       ← red is here
- *   two steps ahead front-right: (2,1)
+ *   dist-1: (1,1), (1,0), (1,-1 OOB)
+ *   dist-2: (2,2), (2,1), (2,0), (2,-1 OOB), (2,-2 OOB)
  */
 const TEST_CONTENT_PACK: ContentPack = {
 	phaseNumber: 1,
@@ -230,10 +228,34 @@ describe("conversation log integration — witnessed pick_up", () => {
 		expect(redWitnessed).toHaveLength(0);
 	});
 
-	it("cyan does NOT see red's pick_up because red is at (2,0) which is NOT in cyan's cone", async () => {
-		// cyan at (0,2) facing south: cone is (0,2), (1,2), (2,3 OOB), (2,2), (2,1)
-		// red at (2,0) — NOT in cyan's cone
+	it("cyan does NOT see red's pick_up when cyan faces north (all cone cells OOB from (0,2))", async () => {
+		// cyan at (0,2) facing south includes (2,0) in the new 9-cell cone.
+		// Turn cyan north first so its cone is just own cell — (2,0) falls outside.
 		const game = makeGame();
+
+		// Preliminary round: cyan looks north; others pass
+		const setupProvider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] }, // red
+			{ assistantText: "", toolCalls: [] }, // green
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "tc0",
+						name: "look",
+						argumentsJson: JSON.stringify({ direction: "north" }),
+					},
+				],
+			}, // cyan looks north
+		]);
+		const { nextState: setup } = await runRound(
+			game,
+			"red",
+			"setup",
+			setupProvider,
+		);
+
+		// Main round: red picks up flower; cyan now faces north → (2,0) not in cone
 		const provider = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -248,9 +270,9 @@ describe("conversation log integration — witnessed pick_up", () => {
 			{ assistantText: "", toolCalls: [] }, // green passes
 			{ assistantText: "", toolCalls: [] }, // cyan passes
 		]);
-		const { nextState } = await runRound(game, "red", "hello", provider);
+		const { nextState } = await runRound(setup, "red", "hello", provider);
 
-		// cyan's conversationLog should have no witnessed-event
+		// cyan's conversationLog should have no witnessed-event for pick_up
 		const phase = getActivePhase(nextState);
 		const cyanLog = phase.conversationLogs.cyan ?? [];
 		const cyanWitnessed = cyanLog.filter((e) => e.kind === "witnessed-event");
@@ -364,7 +386,9 @@ describe("conversation log integration — put_down placementFlavor", () => {
 			provider1,
 		);
 
-		// Red needs to move to (2,2) to put_down on flower_space
+		// Red needs to move to (2,2) to put_down on flower_space.
+		// Green looks west so its cone is only own cell by the put_down round —
+		// (2,2) enters the new 9-cell south cone but not the west cone from (0,0).
 		const provider2 = new MockRoundLLMProvider([
 			{
 				assistantText: "",
@@ -376,7 +400,16 @@ describe("conversation log integration — put_down placementFlavor", () => {
 					},
 				],
 			},
-			{ assistantText: "", toolCalls: [] },
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "tc2g",
+						name: "look",
+						argumentsJson: JSON.stringify({ direction: "west" }),
+					},
+				],
+			},
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState: state2 } = await runRound(
@@ -437,9 +470,8 @@ describe("conversation log integration — put_down placementFlavor", () => {
 			(e) => e.kind === "witnessed-event" && e.actionKind === "put_down",
 		);
 
-		// If green can see the put_down (green at (0,0) facing south, red ends at (2,2))
-		// green's cone from (0,0) south: (1,0), (2,1), (2,0), (2,-1 OOB) — does NOT include (2,2)
-		// So green should NOT see this put_down
+		// Green looked west in round 2; facing west from (0,0) has only own cell in cone.
+		// (2,2) is not visible → green should NOT see this put_down.
 		expect(putEntry).toBeUndefined();
 
 		// Also verify via role turns

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -160,9 +160,10 @@ describe("validateToolCall", () => {
 		expect(result.reason).toBeDefined();
 	});
 
-	it("rejects picking up an item not in the actor's cell", () => {
+	it("rejects picking up an item not in cell or front arc", () => {
 		const game = makeGame();
-		// flower is at (0,0); green is at (0,1) — different cell
+		// flower is at (0,0); green is at (0,1) facing north
+		// green's front arc is all OOB (row -1), so flower is unreachable
 		const call: ToolCall = { name: "pick_up", args: { item: "flower" } };
 		const result = validateToolCall(game, "green", call);
 		expect(result.valid).toBe(false);
@@ -190,21 +191,25 @@ describe("validateToolCall", () => {
 		expect(result.valid).toBe(false);
 	});
 
-	it("allows giving an item to an adjacent AI", () => {
+	it("allows giving an item to an AI in the front arc", () => {
 		const game = makeGame();
-		// red at (0,0), green at (0,1) — adjacent
+		// red at (0,0) facing north; look east so green at (0,1) enters front arc
+		const lookedEast = executeToolCall(game, "red", {
+			name: "look",
+			args: { direction: "east" },
+		});
 		const call: ToolCall = { name: "give", args: { item: "key", to: "green" } };
-		const result = validateToolCall(game, "red", call);
+		const result = validateToolCall(lookedEast, "red", call);
 		expect(result.valid).toBe(true);
 	});
 
-	it("rejects giving an item to a non-adjacent AI", () => {
+	it("rejects giving an item to an AI not in the front arc", () => {
 		const game = makeGame();
-		// red at (0,0), cyan at (0,2) — distance 2, not adjacent
-		const call: ToolCall = { name: "give", args: { item: "key", to: "cyan" } };
+		// red at (0,0) facing north; green at (0,1) is to the side, not in front arc
+		const call: ToolCall = { name: "give", args: { item: "key", to: "green" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);
-		expect(result.reason).toMatch(/adjacent/i);
+		expect(result.reason).toMatch(/in front/i);
 	});
 
 	it("rejects giving an item not held by the AI", () => {
@@ -304,16 +309,14 @@ describe("validateToolCall", () => {
 		expect(result.valid).toBe(true);
 	});
 
-	it("examine: rejects examining an item outside the actor's cone", () => {
+	it("examine: rejects examining an item not in cell or front arc", () => {
 		const game = makeGame();
-		// green is at (0,1) facing north; flower is at (0,0) — not in green's cone
-		// green's cone facing north: (0,1), (row-1,col1)=(-1,1)[oob], (-2,0),(-2,1),(-2,2)[oob]
-		// Actually (0,1) own cell, directly in front = (-1,1)[oob], two-step cells also oob
-		// flower at (0,0) is NOT in green's cone
+		// green is at (0,1) facing north; flower is at (0,0)
+		// green's front arc facing north is all OOB (row -1); flower is not in green's own cell
 		const call: ToolCall = { name: "examine", args: { item: "flower" } };
 		const result = validateToolCall(game, "green", call);
 		expect(result.valid).toBe(false);
-		expect(result.reason).toMatch(/cone/i);
+		expect(result.reason).toMatch(/in front/i);
 	});
 
 	it("examine: rejects examining a nonexistent item", () => {

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -415,7 +415,11 @@ describe("validateToolCall", () => {
 				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
-		const game = startPhase(createGame(TEST_PERSONAS, [pack]), TEST_PHASE_CONFIG, FIXED_RNG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			TEST_PHASE_CONFIG,
+			FIXED_RNG,
+		);
 		const call: ToolCall = { name: "couple", args: { item: "gem" } };
 		expect(validateToolCall(game, "red", call).valid).toBe(true);
 	});
@@ -451,7 +455,11 @@ describe("validateToolCall", () => {
 				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
-		const game = startPhase(createGame(TEST_PERSONAS, [pack]), TEST_PHASE_CONFIG, FIXED_RNG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			TEST_PHASE_CONFIG,
+			FIXED_RNG,
+		);
 		const call: ToolCall = { name: "couple", args: { item: "gem" } };
 		expect(validateToolCall(game, "red", call).valid).toBe(true);
 	});
@@ -487,7 +495,11 @@ describe("validateToolCall", () => {
 				cyan: { position: { row: 0, col: 2 }, facing: "north" },
 			},
 		};
-		const game = startPhase(createGame(TEST_PERSONAS, [pack]), TEST_PHASE_CONFIG, FIXED_RNG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			TEST_PHASE_CONFIG,
+			FIXED_RNG,
+		);
 		const call: ToolCall = { name: "couple", args: { item: "gem" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -203,9 +203,9 @@ describe("validateToolCall", () => {
 		expect(result.valid).toBe(true);
 	});
 
-	it("rejects giving an item to an AI not in the front arc", () => {
+	it("rejects giving an item to an AI not in cell or front arc", () => {
 		const game = makeGame();
-		// red at (0,0) facing north; green at (0,1) is to the side, not in front arc
+		// red at (0,0) facing north; green at (0,1) — not same cell, not in north front arc (all OOB)
 		const call: ToolCall = { name: "give", args: { item: "key", to: "green" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);
@@ -309,14 +309,15 @@ describe("validateToolCall", () => {
 		expect(result.valid).toBe(true);
 	});
 
-	it("examine: rejects examining an item not in cell or front arc", () => {
+	it("examine: rejects examining an item outside the actor's cone", () => {
 		const game = makeGame();
 		// green is at (0,1) facing north; flower is at (0,0)
-		// green's front arc facing north is all OOB (row -1); flower is not in green's own cell
+		// green's entire cone facing north from row 0 is OOB except own cell (0,1)
+		// flower at (0,0) is not in green's cone
 		const call: ToolCall = { name: "examine", args: { item: "flower" } };
 		const result = validateToolCall(game, "green", call);
 		expect(result.valid).toBe(false);
-		expect(result.reason).toMatch(/in front/i);
+		expect(result.reason).toMatch(/cone/i);
 	});
 
 	it("examine: rejects examining a nonexistent item", () => {
@@ -380,6 +381,117 @@ describe("validateToolCall", () => {
 		const call: ToolCall = { name: "examine", args: { item: "space1" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(true);
+	});
+
+	// couple tests
+	it("couple: allows coupling when the paired space is in the actor's own cell", () => {
+		// Build a pack with red holding gem, pedestal in red's own cell (0,0)
+		const gem: WorldEntity = {
+			id: "gem",
+			kind: "objective_object",
+			name: "Gem",
+			examineDescription: "A shiny gem.",
+			holder: "red",
+			pairsWithSpaceId: "pedestal",
+		};
+		const pedestal: WorldEntity = {
+			id: "pedestal",
+			kind: "objective_space",
+			name: "Pedestal",
+			examineDescription: "A stone pedestal.",
+			holder: { row: 0, col: 0 },
+		};
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [{ object: gem, space: pedestal }],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const game = startPhase(createGame(TEST_PERSONAS, [pack]), TEST_PHASE_CONFIG, FIXED_RNG);
+		const call: ToolCall = { name: "couple", args: { item: "gem" } };
+		expect(validateToolCall(game, "red", call).valid).toBe(true);
+	});
+
+	it("couple: allows coupling when the paired space is in the front arc", () => {
+		// red at (0,0) facing south; pedestal at (1,0) = directly in front
+		const gem: WorldEntity = {
+			id: "gem",
+			kind: "objective_object",
+			name: "Gem",
+			examineDescription: "A shiny gem.",
+			holder: "red",
+			pairsWithSpaceId: "pedestal",
+		};
+		const pedestal: WorldEntity = {
+			id: "pedestal",
+			kind: "objective_space",
+			name: "Pedestal",
+			examineDescription: "A stone pedestal.",
+			holder: { row: 1, col: 0 },
+		};
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [{ object: gem, space: pedestal }],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "south" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const game = startPhase(createGame(TEST_PERSONAS, [pack]), TEST_PHASE_CONFIG, FIXED_RNG);
+		const call: ToolCall = { name: "couple", args: { item: "gem" } };
+		expect(validateToolCall(game, "red", call).valid).toBe(true);
+	});
+
+	it("couple: rejects when the paired space is out of reach", () => {
+		// red at (0,0) facing north; pedestal at (1,0) — not in north front arc (all OOB)
+		const gem: WorldEntity = {
+			id: "gem",
+			kind: "objective_object",
+			name: "Gem",
+			examineDescription: "A shiny gem.",
+			holder: "red",
+			pairsWithSpaceId: "pedestal",
+		};
+		const pedestal: WorldEntity = {
+			id: "pedestal",
+			kind: "objective_space",
+			name: "Pedestal",
+			examineDescription: "A stone pedestal.",
+			holder: { row: 1, col: 0 },
+		};
+		const pack: ContentPack = {
+			phaseNumber: 1,
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [{ object: gem, space: pedestal }],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const game = startPhase(createGame(TEST_PERSONAS, [pack]), TEST_PHASE_CONFIG, FIXED_RNG);
+		const call: ToolCall = { name: "couple", args: { item: "gem" } };
+		const result = validateToolCall(game, "red", call);
+		expect(result.valid).toBe(false);
+		expect(result.reason).toMatch(/in front/i);
 	});
 });
 

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import { parseToolCallArguments, TOOL_DEFINITIONS } from "../tool-registry";
 
 describe("TOOL_DEFINITIONS", () => {
-	it("lists exactly the eight tools: pick_up, put_down, give, use, go, look, examine, message", () => {
+	it("lists exactly the nine tools: pick_up, put_down, give, use, couple, go, look, examine, message", () => {
 		const names = TOOL_DEFINITIONS.map((t) => t.function.name);
 		expect(names).toEqual([
 			"pick_up",
 			"put_down",
 			"give",
 			"use",
+			"couple",
 			"go",
 			"look",
 			"examine",

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -9,6 +9,7 @@
  * `look` is always present with the full 4-direction enum.
  */
 
+import { projectCone } from "./cone-projector.js";
 import {
 	applyDirection,
 	CARDINAL_DIRECTIONS,
@@ -163,35 +164,37 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 		tools.push(cloneToolWithEnums("use", { item: heldIds }));
 	}
 
-	// 5. give — held items AND AIs in front arc
+	// 5. give — held items AND AIs in own cell or front arc
 	if (actorSpatial && heldItems.length > 0) {
 		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
-		const frontAiIds = Object.entries(phase.personaSpatial)
+		const reachableAiIds = Object.entries(phase.personaSpatial)
 			.filter(([otherId, otherSpatial]) => {
 				if (otherId === aiId) return false;
+				if (positionsEqual(actorSpatial.position, otherSpatial.position))
+					return true;
 				return arc.some((p) => positionsEqual(p, otherSpatial.position));
 			})
 			.map(([otherId]) => otherId);
 
-		if (frontAiIds.length > 0) {
+		if (reachableAiIds.length > 0) {
 			tools.push(
 				cloneToolWithEnums("give", {
 					item: heldItems.map((i) => i.id),
-					to: frontAiIds,
+					to: reachableAiIds,
 				}),
 			);
 		}
 	}
 
-	// 6. examine — items held, in own cell, or in front arc (any entity kind)
+	// 6. examine — items held or in cone (own cell + dist-1 arc + dist-2 fan)
 	if (actorSpatial) {
-		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
+		const cone = projectCone(actorSpatial.position, actorSpatial.facing);
+		const conePositions = cone.map((c) => c.position);
 		const examineableIds = world.entities
 			.filter((entity) => {
 				if (entity.holder === aiId) return true;
 				if (isGridPosition(entity.holder)) {
-					if (positionsEqual(entity.holder, actorSpatial.position)) return true;
-					return arc.some((p) =>
+					return conePositions.some((p) =>
 						positionsEqual(p, entity.holder as GridPosition),
 					);
 				}
@@ -201,6 +204,27 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 
 		if (examineableIds.length > 0) {
 			tools.push(cloneToolWithEnums("examine", { item: examineableIds }));
+		}
+	}
+
+	// 7. couple — held objective items whose paired space is in own cell or front arc
+	if (actorSpatial) {
+		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
+		const couplableIds = pickable
+			.filter((item) => {
+				if (item.holder !== aiId) return false;
+				if (item.kind !== "objective_object") return false;
+				if (!item.pairsWithSpaceId) return false;
+				const space = world.entities.find((e) => e.id === item.pairsWithSpaceId);
+				if (!space || !isGridPosition(space.holder)) return false;
+				const spacePos = space.holder as GridPosition;
+				if (positionsEqual(spacePos, actorSpatial.position)) return true;
+				return arc.some((p) => positionsEqual(p, spacePos));
+			})
+			.map((i) => i.id);
+
+		if (couplableIds.length > 0) {
+			tools.push(cloneToolWithEnums("couple", { item: couplableIds }));
 		}
 	}
 

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -91,16 +91,24 @@ function cloneToolWithEnums(
 /**
  * Compute the list of legal OpenAI tools for the given AI in the current game state.
  *
- * Algorithm (per plan §1b):
+ * Algorithm:
+ * 0. `message` — always present; `to` enum = "blue" + live peer daemon ids.
  * 1. `look` — always present, full CARDINAL_DIRECTIONS enum.
  * 2. `go` — included only when at least one direction is in-bounds AND non-obstacle.
  *    Enum restricted to legal directions.
- * 3. `pick_up` — included only when pickable entities rest in the actor's current cell.
+ * 3. `pick_up` — included only when pickable entities are in the actor's own cell
+ *    OR the 3-cell front arc (dist-1: front-left, ahead, front-right).
  *    Enum restricted to those entity ids.
  * 4. `put_down`, `use` — included only when actor holds at least one pickable entity.
  *    Enum restricted to held entity ids.
- * 5. `give` — included only when actor holds pickable entities AND has 4-adjacent AIs.
- *    item enum = held entity ids, to enum = adjacent AI ids.
+ * 5. `give` — included only when actor holds pickable entities AND has AIs in the
+ *    actor's own cell or front arc. item enum = held entity ids, to enum = reachable AI ids.
+ * 6. `examine` — included when any entity (any kind) is held by the actor OR rests
+ *    anywhere in the full 9-cell cone (own + dist-1 arc + dist-2 fan).
+ *    Enum restricted to those entity ids.
+ * 7. `couple` — included only when actor holds an objective_object with a pairsWithSpaceId
+ *    whose paired space is on the grid AND in the actor's own cell or front arc.
+ *    Enum restricted to those item ids.
  *
  * Spaces and obstacles are never pickupable.
  */

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -9,11 +9,10 @@
  * `look` is always present with the full 4-direction enum.
  */
 
-import { projectCone } from "./cone-projector.js";
 import {
 	applyDirection,
-	areAdjacent4,
 	CARDINAL_DIRECTIONS,
+	frontArc,
 	inBounds,
 } from "./direction.js";
 import { getActivePhase } from "./engine.js";
@@ -139,16 +138,19 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 		}
 	}
 
-	// 3. pick_up — pickable entities resting in actor's cell
+	// 3. pick_up — pickable entities in actor's own cell or front arc
 	if (actorSpatial) {
-		const cellItems = pickable.filter(
-			(item) =>
-				isGridPosition(item.holder) &&
-				positionsEqual(item.holder, actorSpatial.position),
-		);
-		if (cellItems.length > 0) {
+		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
+		const reachableItems = pickable.filter((item) => {
+			if (!isGridPosition(item.holder)) return false;
+			if (positionsEqual(item.holder, actorSpatial.position)) return true;
+			return arc.some((p) => positionsEqual(p, item.holder as GridPosition));
+		});
+		if (reachableItems.length > 0) {
 			tools.push(
-				cloneToolWithEnums("pick_up", { item: cellItems.map((i) => i.id) }),
+				cloneToolWithEnums("pick_up", {
+					item: reachableItems.map((i) => i.id),
+				}),
 			);
 		}
 	}
@@ -161,38 +163,36 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 		tools.push(cloneToolWithEnums("use", { item: heldIds }));
 	}
 
-	// 5. give — held items AND adjacent AIs
+	// 5. give — held items AND AIs in front arc
 	if (actorSpatial && heldItems.length > 0) {
-		const adjacentAiIds = Object.entries(phase.personaSpatial)
+		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
+		const frontAiIds = Object.entries(phase.personaSpatial)
 			.filter(([otherId, otherSpatial]) => {
 				if (otherId === aiId) return false;
-				return areAdjacent4(actorSpatial.position, otherSpatial.position);
+				return arc.some((p) => positionsEqual(p, otherSpatial.position));
 			})
 			.map(([otherId]) => otherId);
 
-		if (adjacentAiIds.length > 0) {
+		if (frontAiIds.length > 0) {
 			tools.push(
 				cloneToolWithEnums("give", {
 					item: heldItems.map((i) => i.id),
-					to: adjacentAiIds,
+					to: frontAiIds,
 				}),
 			);
 		}
 	}
 
-	// 6. examine — items in cone (any kind) OR held by this actor
+	// 6. examine — items held, in own cell, or in front arc (any entity kind)
 	if (actorSpatial) {
-		const cone = projectCone(actorSpatial.position, actorSpatial.facing);
-		const conePositions = cone.map((c) => c.position);
-
+		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
 		const examineableIds = world.entities
 			.filter((entity) => {
-				// Held by this actor
 				if (entity.holder === aiId) return true;
-				// Resting on a cell inside the cone
 				if (isGridPosition(entity.holder)) {
-					return conePositions.some((pos) =>
-						positionsEqual(pos, entity.holder as GridPosition),
+					if (positionsEqual(entity.holder, actorSpatial.position)) return true;
+					return arc.some((p) =>
+						positionsEqual(p, entity.holder as GridPosition),
 					);
 				}
 				return false;

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -215,7 +215,9 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 				if (item.holder !== aiId) return false;
 				if (item.kind !== "objective_object") return false;
 				if (!item.pairsWithSpaceId) return false;
-				const space = world.entities.find((e) => e.id === item.pairsWithSpaceId);
+				const space = world.entities.find(
+					(e) => e.id === item.pairsWithSpaceId,
+				);
 				if (!space || !isGridPosition(space.holder)) return false;
 				const spacePos = space.holder as GridPosition;
 				if (positionsEqual(spacePos, actorSpatial.position)) return true;

--- a/src/spa/game/cone-projector.ts
+++ b/src/spa/game/cone-projector.ts
@@ -1,29 +1,38 @@
 /**
  * cone-projector.ts
  *
- * Projects a 5-cell wedge cone from an AI's position and facing direction.
+ * Projects a 9-cell wedge cone from an AI's position and facing direction.
  * The cone describes the cells the AI can currently see:
  *   - Own cell
- *   - Directly in front (1 step in facing direction)
+ *   - Directly in front, left diagonal (1 step)
+ *   - Directly in front (1 step)
+ *   - Directly in front, right diagonal (1 step)
+ *   - Two steps ahead, far-left
  *   - Two steps ahead, front-left
  *   - Two steps ahead (straight)
  *   - Two steps ahead, front-right
+ *   - Two steps ahead, far-right
  *
  * Out-of-bounds cells are omitted from the result.
  */
 
 import {
 	type CardinalDirection,
+	directionDelta,
 	type GridPosition,
 	inBounds,
 } from "./direction.js";
 
 export type ConePhrasing =
 	| "your cell"
+	| "directly in front, left"
 	| "directly in front"
+	| "directly in front, right"
+	| "two steps ahead, far-left"
 	| "two steps ahead, front-left"
 	| "two steps ahead"
-	| "two steps ahead, front-right";
+	| "two steps ahead, front-right"
+	| "two steps ahead, far-right";
 
 export interface ConeCell {
 	position: GridPosition;
@@ -32,53 +41,18 @@ export interface ConeCell {
 }
 
 /**
- * Returns the (drow, dcol) delta for one step in the given direction.
- * Row 0 is the top: north = drow -1.
- */
-function forwardDelta(facing: CardinalDirection): {
-	drow: number;
-	dcol: number;
-} {
-	switch (facing) {
-		case "north":
-			return { drow: -1, dcol: 0 };
-		case "south":
-			return { drow: 1, dcol: 0 };
-		case "east":
-			return { drow: 0, dcol: 1 };
-		case "west":
-			return { drow: 0, dcol: -1 };
-	}
-}
-
-/**
- * Returns the (drow, dcol) delta for one step to the "left" relative to facing.
- * Facing-relative left:
- *   north → west (dcol -1), south → east (dcol +1),
- *   east  → north (drow -1), west → south (drow +1)
- */
-function leftDelta(facing: CardinalDirection): { drow: number; dcol: number } {
-	switch (facing) {
-		case "north":
-			return { drow: 0, dcol: -1 };
-		case "south":
-			return { drow: 0, dcol: 1 };
-		case "east":
-			return { drow: -1, dcol: 0 };
-		case "west":
-			return { drow: 1, dcol: 0 };
-	}
-}
-
-/**
- * Project a 5-cell wedge cone from the given position and facing.
+ * Project a 9-cell wedge cone from the given position and facing.
  *
  * Returns an array of ConeCell objects in canonical order:
  *   1. own cell
- *   2. directly in front
- *   3. two steps ahead, front-left
- *   4. two steps ahead
- *   5. two steps ahead, front-right
+ *   2. directly in front, left
+ *   3. directly in front
+ *   4. directly in front, right
+ *   5. two steps ahead, far-left
+ *   6. two steps ahead, front-left
+ *   7. two steps ahead
+ *   8. two steps ahead, front-right
+ *   9. two steps ahead, far-right
  *
  * Out-of-bounds cells are omitted. Own cell is always included.
  */
@@ -86,10 +60,9 @@ export function projectCone(
 	position: GridPosition,
 	facing: CardinalDirection,
 ): ConeCell[] {
-	const fwd = forwardDelta(facing);
-	const lft = leftDelta(facing);
+	const fwd = directionDelta(facing);
+	const lft = { drow: -fwd.dcol, dcol: fwd.drow };
 
-	// Candidate cells in canonical order
 	const candidates: Array<{
 		row: number;
 		col: number;
@@ -102,10 +75,30 @@ export function projectCone(
 			phrasing: "your cell",
 			isOwnCell: true,
 		},
+		// Distance 1 — front arc
+		{
+			row: position.row + fwd.drow + lft.drow,
+			col: position.col + fwd.dcol + lft.dcol,
+			phrasing: "directly in front, left",
+			isOwnCell: false,
+		},
 		{
 			row: position.row + fwd.drow,
 			col: position.col + fwd.dcol,
 			phrasing: "directly in front",
+			isOwnCell: false,
+		},
+		{
+			row: position.row + fwd.drow - lft.drow,
+			col: position.col + fwd.dcol - lft.dcol,
+			phrasing: "directly in front, right",
+			isOwnCell: false,
+		},
+		// Distance 2 — wide fan
+		{
+			row: position.row + 2 * fwd.drow + 2 * lft.drow,
+			col: position.col + 2 * fwd.dcol + 2 * lft.dcol,
+			phrasing: "two steps ahead, far-left",
 			isOwnCell: false,
 		},
 		{
@@ -126,12 +119,17 @@ export function projectCone(
 			phrasing: "two steps ahead, front-right",
 			isOwnCell: false,
 		},
+		{
+			row: position.row + 2 * fwd.drow - 2 * lft.drow,
+			col: position.col + 2 * fwd.dcol - 2 * lft.dcol,
+			phrasing: "two steps ahead, far-right",
+			isOwnCell: false,
+		},
 	];
 
 	const result: ConeCell[] = [];
 	for (const c of candidates) {
 		const pos: GridPosition = { row: c.row, col: c.col };
-		// Own cell is always included; others are filtered by bounds
 		if (c.isOwnCell || inBounds(pos)) {
 			result.push({
 				position: pos,

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -96,6 +96,14 @@ export function renderEntry(
 					const name = entry.item ? itemName(entities, entry.item) : "item";
 					return `[Round ${round}] You watch ${actorSub} use the ${name}.`;
 				}
+
+				case "couple": {
+					if (entry.placementFlavorRaw) {
+						return `[Round ${round}] ${substituteActor(entry.placementFlavorRaw, actorSub)}`;
+					}
+					const name = entry.item ? itemName(entities, entry.item) : "item";
+					return `[Round ${round}] You watch ${actorSub} place the ${name} onto its space.`;
+				}
 			}
 		}
 	}

--- a/src/spa/game/direction.ts
+++ b/src/spa/game/direction.ts
@@ -60,6 +60,23 @@ export function areAdjacent4(a: GridPosition, b: GridPosition): boolean {
 	return manhattan(a, b) === 1;
 }
 
+/**
+ * The 3 cells forming the immediate front arc: front-left diagonal, directly
+ * in front, and front-right diagonal. Out-of-bounds cells are omitted.
+ */
+export function frontArc(
+	pos: GridPosition,
+	facing: CardinalDirection,
+): GridPosition[] {
+	const fwd = directionDelta(facing);
+	const lft = { drow: -fwd.dcol, dcol: fwd.drow };
+	return [
+		{ row: pos.row + fwd.drow + lft.drow, col: pos.col + fwd.dcol + lft.dcol },
+		{ row: pos.row + fwd.drow, col: pos.col + fwd.dcol },
+		{ row: pos.row + fwd.drow - lft.drow, col: pos.col + fwd.dcol - lft.dcol },
+	].filter(inBounds);
+}
+
 /** Format a GridPosition as a labeled string for LLM-facing output. */
 export function formatPosition(pos: GridPosition): string {
 	return `(row ${pos.row}, col ${pos.col})`;

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -218,7 +218,11 @@ export function validateToolCall(
 			if (item.holder === aiId) return { valid: true };
 			if (isGridPosition(item.holder)) {
 				const cone = projectCone(actorSpatial.position, actorSpatial.facing);
-				if (cone.some((c) => positionsEqual(c.position, item.holder as GridPosition)))
+				if (
+					cone.some((c) =>
+						positionsEqual(c.position, item.holder as GridPosition),
+					)
+				)
 					return { valid: true };
 			}
 			return {
@@ -296,17 +300,15 @@ export function executeToolCall(
 				break;
 			case "couple": {
 				// Place item directly on its paired space's cell (which may be in the front arc).
-				if (target && target.pairsWithSpaceId) {
-					const pairedSpace = entities.find(
-						(e) => e.id === target.pairsWithSpaceId,
-					);
-					if (pairedSpace && isGridPosition(pairedSpace.holder)) {
-						target.holder = { ...pairedSpace.holder };
-					}
+				const pairedSpace = target?.pairsWithSpaceId
+					? entities.find((e) => e.id === target.pairsWithSpaceId)
+					: undefined;
+				if (target && pairedSpace && isGridPosition(pairedSpace.holder)) {
+					target.holder = { ...pairedSpace.holder };
 				}
 				break;
 			}
-		case "use": {
+			case "use": {
 				// Place item on current cell only when the actor is standing on the
 				// item's paired objective_space. Otherwise no world mutation.
 				if (target && actorSpatial && target.pairsWithSpaceId) {
@@ -544,10 +546,7 @@ export function dispatchAiTurn(
 						useOutcomeRaw = item?.useOutcome;
 					}
 
-					if (
-						call.name === "put_down" ||
-						call.name === "couple"
-					) {
+					if (call.name === "put_down" || call.name === "couple") {
 						// Find the raw placementFlavor (before {actor} substitution)
 						// by looking at the content pack's object entity definition
 						const itemId = call.args.item;

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -142,21 +142,22 @@ export function validateToolCall(
 			const target = call.args.to as AiId;
 			if (target === aiId)
 				return { valid: false, reason: "Cannot give an item to yourself" };
-			// Spatial validity: target AI must be in the actor's front arc
+			// Spatial validity: target AI must be in actor's own cell or front arc
 			const targetSpatial = phase.personaSpatial[target];
 			if (!actorSpatial || !targetSpatial)
 				return {
 					valid: false,
 					reason: "Spatial state missing for actor or target",
 				};
-			const targetInFront = frontArc(
-				actorSpatial.position,
-				actorSpatial.facing,
-			).some((p) => positionsEqual(p, targetSpatial.position));
-			if (!targetInFront)
+			const targetReachable =
+				positionsEqual(actorSpatial.position, targetSpatial.position) ||
+				frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
+					positionsEqual(p, targetSpatial.position),
+				);
+			if (!targetReachable)
 				return {
 					valid: false,
-					reason: `${target} is not directly in front of you`,
+					reason: `${target} is not in your cell or directly in front of you`,
 				};
 			return { valid: true };
 		}
@@ -213,22 +214,53 @@ export function validateToolCall(
 				};
 			if (!actorSpatial)
 				return { valid: false, reason: "Actor has no spatial state" };
-			// Valid if held, in own cell, or in front arc
+			// Valid if held by aiId OR resting on a GridPosition inside actor's cone
 			if (item.holder === aiId) return { valid: true };
 			if (isGridPosition(item.holder)) {
-				if (positionsEqual(item.holder, actorSpatial.position))
-					return { valid: true };
-				if (
-					frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
-						positionsEqual(p, item.holder as GridPosition),
-					)
-				)
+				const cone = projectCone(actorSpatial.position, actorSpatial.facing);
+				if (cone.some((c) => positionsEqual(c.position, item.holder as GridPosition)))
 					return { valid: true };
 			}
 			return {
 				valid: false,
-				reason: `Item "${call.args.item}" is not in your cell, directly in front of you, or held by you`,
+				reason: `Item "${call.args.item}" is not in your cone or held by you`,
 			};
+		}
+
+		case "couple": {
+			const item = pickable.find((i) => i.id === call.args.item);
+			if (!item)
+				return {
+					valid: false,
+					reason: `Item "${call.args.item}" does not exist`,
+				};
+			if (item.holder !== aiId)
+				return {
+					valid: false,
+					reason: `You are not holding "${call.args.item}"`,
+				};
+			if (item.kind !== "objective_object" || !item.pairsWithSpaceId)
+				return {
+					valid: false,
+					reason: `Item "${call.args.item}" is not an objective item with a paired space`,
+				};
+			if (!actorSpatial)
+				return { valid: false, reason: "Actor has no spatial state" };
+			const space = world.entities.find((e) => e.id === item.pairsWithSpaceId);
+			if (!space || !isGridPosition(space.holder))
+				return { valid: false, reason: "Paired space not found on the grid" };
+			const spacePos = space.holder as GridPosition;
+			const spaceReachable =
+				positionsEqual(spacePos, actorSpatial.position) ||
+				frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
+					positionsEqual(p, spacePos),
+				);
+			if (!spaceReachable)
+				return {
+					valid: false,
+					reason: `The paired space is not in your cell or directly in front of you`,
+				};
+			return { valid: true };
 		}
 
 		default:
@@ -262,7 +294,19 @@ export function executeToolCall(
 			case "give":
 				if (target) target.holder = call.args.to as AiId;
 				break;
-			case "use": {
+			case "couple": {
+				// Place item directly on its paired space's cell (which may be in the front arc).
+				if (target && target.pairsWithSpaceId) {
+					const pairedSpace = entities.find(
+						(e) => e.id === target.pairsWithSpaceId,
+					);
+					if (pairedSpace && isGridPosition(pairedSpace.holder)) {
+						target.holder = { ...pairedSpace.holder };
+					}
+				}
+				break;
+			}
+		case "use": {
 				// Place item on current cell only when the actor is standing on the
 				// item's paired objective_space. Otherwise no world mutation.
 				if (target && actorSpatial && target.pairsWithSpaceId) {
@@ -326,6 +370,8 @@ function describeToolCall(game: GameState, aiId: AiId, call: ToolCall): string {
 			return `${name} put down the ${call.args.item}`;
 		case "give":
 			return `${name} gave the ${call.args.item} to ${game.personas[call.args.to as AiId]?.name ?? call.args.to}`;
+		case "couple":
+			return `${name} placed the ${call.args.item} onto its paired space`;
 		case "use": {
 			// Return the entity's useOutcome as the description (flavor string),
 			// with {actor} substituted to "you" (actor's perspective).
@@ -428,7 +474,9 @@ export function dispatchAiTurn(
 			// If so, replace the default description with the per-pair placementFlavor.
 			const activePhase = getActivePhase(state);
 			const flavorDescription =
-				action.toolCall.name === "put_down" || action.toolCall.name === "use"
+				action.toolCall.name === "put_down" ||
+				action.toolCall.name === "use" ||
+				action.toolCall.name === "couple"
 					? checkPlacementFlavor(
 							action,
 							activePhase.contentPack,
@@ -467,7 +515,8 @@ export function dispatchAiTurn(
 				call.name === "pick_up" ||
 				call.name === "put_down" ||
 				call.name === "give" ||
-				call.name === "use"
+				call.name === "use" ||
+				call.name === "couple"
 			) {
 				// Post-execute spatial state — actor has moved for "go", others are unchanged
 				const postPhase = getActivePhase(state);
@@ -495,7 +544,10 @@ export function dispatchAiTurn(
 						useOutcomeRaw = item?.useOutcome;
 					}
 
-					if (call.name === "put_down") {
+					if (
+						call.name === "put_down" ||
+						call.name === "couple"
+					) {
 						// Find the raw placementFlavor (before {actor} substitution)
 						// by looking at the content pack's object entity definition
 						const itemId = call.args.item;

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -1,9 +1,9 @@
 import { projectCone } from "./cone-projector.js";
 import {
 	applyDirection,
-	areAdjacent4,
 	CARDINAL_DIRECTIONS,
 	formatPosition,
+	frontArc,
 	inBounds,
 } from "./direction.js";
 import {
@@ -98,13 +98,16 @@ export function validateToolCall(
 					valid: false,
 					reason: `Item "${call.args.item}" is not on the ground`,
 				};
-			// Spatial validity: item must be in the actor's current cell
 			if (!actorSpatial)
 				return { valid: false, reason: "Actor has no spatial state" };
-			if (!positionsEqual(item.holder, actorSpatial.position))
+			const inOwnCell = positionsEqual(item.holder, actorSpatial.position);
+			const inFront = frontArc(actorSpatial.position, actorSpatial.facing).some(
+				(p) => positionsEqual(p, item.holder as GridPosition),
+			);
+			if (!inOwnCell && !inFront)
 				return {
 					valid: false,
-					reason: `Item "${call.args.item}" is not in your current cell`,
+					reason: `Item "${call.args.item}" is not in your cell or directly in front of you`,
 				};
 			return { valid: true };
 		}
@@ -139,17 +142,21 @@ export function validateToolCall(
 			const target = call.args.to as AiId;
 			if (target === aiId)
 				return { valid: false, reason: "Cannot give an item to yourself" };
-			// Spatial validity: target AI must be 4-adjacent
+			// Spatial validity: target AI must be in the actor's front arc
 			const targetSpatial = phase.personaSpatial[target];
 			if (!actorSpatial || !targetSpatial)
 				return {
 					valid: false,
 					reason: "Spatial state missing for actor or target",
 				};
-			if (!areAdjacent4(actorSpatial.position, targetSpatial.position))
+			const targetInFront = frontArc(
+				actorSpatial.position,
+				actorSpatial.facing,
+			).some((p) => positionsEqual(p, targetSpatial.position));
+			if (!targetInFront)
 				return {
 					valid: false,
-					reason: `${target} is not adjacent to you`,
+					reason: `${target} is not directly in front of you`,
 				};
 			return { valid: true };
 		}
@@ -206,18 +213,21 @@ export function validateToolCall(
 				};
 			if (!actorSpatial)
 				return { valid: false, reason: "Actor has no spatial state" };
-			// Valid if held by aiId OR resting on a GridPosition inside actor's cone
+			// Valid if held, in own cell, or in front arc
 			if (item.holder === aiId) return { valid: true };
 			if (isGridPosition(item.holder)) {
-				const cone = projectCone(actorSpatial.position, actorSpatial.facing);
-				const inCone = cone.some((cell) =>
-					positionsEqual(cell.position, item.holder as GridPosition),
-				);
-				if (inCone) return { valid: true };
+				if (positionsEqual(item.holder, actorSpatial.position))
+					return { valid: true };
+				if (
+					frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
+						positionsEqual(p, item.holder as GridPosition),
+					)
+				)
+					return { valid: true };
 			}
 			return {
 				valid: false,
-				reason: `Item "${call.args.item}" is not in your cone or held by you`,
+				reason: `Item "${call.args.item}" is not in your cell, directly in front of you, or held by you`,
 			};
 		}
 

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -155,7 +155,7 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 		function: {
 			name: "examine",
 			description:
-				"Examine an item to read a detailed description of it. Private — no other AI sees you do this. Available for items in your cone or items you are holding.",
+				"Examine an item to read a detailed description of it. Private — no other AI sees you do this. Available for items in your cell, directly in front of you, or held by you.",
 			parameters: {
 				type: "object",
 				properties: {

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -2,7 +2,7 @@
  * Tool Registry
  *
  * Single source of truth for the OpenAI-spec `tools` array.
- * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `give`, `use`, `go`, `look`.
+ * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `give`, `use`, `couple`, `go`, `look`.
  * Names and argument keys mirror `validateToolCall` in `dispatcher.ts` 1:1.
  */
 
@@ -72,7 +72,7 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 		function: {
 			name: "give",
 			description:
-				"Give an item you are holding to an adjacent AI. Fails if you are not holding it, you target yourself, or the target is not in an adjacent cell.",
+				"Give an item you are holding to another AI. The target must be in your current cell or directly in front of you (the 3-cell front arc).",
 			parameters: {
 				type: "object",
 				properties: {
@@ -103,6 +103,25 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 					item: {
 						type: "string",
 						description: "The id of the item you are holding.",
+					},
+				},
+				required: ["item"],
+				additionalProperties: false,
+			},
+		},
+	},
+	{
+		type: "function",
+		function: {
+			name: "couple",
+			description:
+				"Place a held objective item onto its paired objective space. Works when the space is in your current cell or directly in front of you (the 3-cell front arc). The item leaves your hand and lands on the space.",
+			parameters: {
+				type: "object",
+				properties: {
+					item: {
+						type: "string",
+						description: "The id of the objective item you are holding.",
 					},
 				},
 				required: ["item"],
@@ -207,6 +226,7 @@ type UseArgs = { item: string };
 type GoArgs = { direction: string };
 type LookArgs = { direction: string };
 type ExamineArgs = { item: string };
+type CoupleArgs = { item: string };
 type MessageArgs = { to: string; content: string };
 
 type ToolArgs = {
@@ -214,6 +234,7 @@ type ToolArgs = {
 	put_down: PutDownArgs;
 	give: GiveArgs;
 	use: UseArgs;
+	couple: CoupleArgs;
 	go: GoArgs;
 	look: LookArgs;
 	examine: ExamineArgs;
@@ -247,6 +268,7 @@ export function parseToolCallArguments<N extends ToolName>(
 		case "pick_up":
 		case "put_down":
 		case "use":
+		case "couple":
 		case "examine": {
 			if (typeof obj.item !== "string" || obj.item.length === 0) {
 				return { ok: false, reason: "Required argument 'item' is missing" };

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -89,7 +89,7 @@ export interface PhysicalActionRecord {
 	/** The actor's facing at the time the action resolved. */
 	actorFacingAtAction: CardinalDirection;
 	/** The observable action kind. */
-	kind: "go" | "pick_up" | "put_down" | "give" | "use";
+	kind: "go" | "pick_up" | "put_down" | "give" | "use" | "couple";
 	/** Item id (for pick_up, put_down, give, use). */
 	item?: string;
 	/** Recipient AI id (for give). */
@@ -230,6 +230,7 @@ export type ToolName =
 	| "put_down"
 	| "give"
 	| "use"
+	| "couple"
 	| "go"
 	| "look"
 	| "examine"

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -141,7 +141,7 @@ export type ConversationEntry =
 			kind: "witnessed-event";
 			round: number;
 			actor: AiId;
-			actionKind: "go" | "pick_up" | "put_down" | "give" | "use";
+			actionKind: "go" | "pick_up" | "put_down" | "give" | "use" | "couple";
 			item?: string;
 			to?: AiId;
 			direction?: CardinalDirection;

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -93,7 +93,8 @@ export function checkPlacementFlavor(
 	const toolCall = action.toolCall;
 	if (!toolCall) return null;
 	const toolName = toolCall.name;
-	if (toolName !== "put_down" && toolName !== "use") return null;
+	if (toolName !== "put_down" && toolName !== "use" && toolName !== "couple")
+		return null;
 
 	const itemId = toolCall.args.item;
 	if (!itemId) return null;


### PR DESCRIPTION
## Summary
Expands the AI perception cone from a 5-cell wedge to a 9-cell cone, adding a wider front arc at distance-1 and extending the distance-2 fan. This increases the spatial awareness of daemons and affects which items and other AIs they can interact with.

## Key Changes

### Cone Projection Expansion
- **cone-projector.ts**: Expanded `projectCone()` to return 9 cells instead of 5:
  - Distance-1 (3 cells): front-left diagonal, directly ahead, front-right diagonal
  - Distance-2 (5 cells): far-left, front-left, center, front-right, far-right
  - Updated phrasing labels to distinguish "directly in front, left/right" and "two steps ahead, far-left/far-right"

### Interaction Range Updates
- **direction.ts**: Added `frontArc()` helper function to get the 3-cell immediate front arc (distance-1 only)
- **dispatcher.ts**: Updated validation for `pick_up`, `give`, and new `couple` tool to use front arc instead of strict adjacency
- **available-tools.ts**: Updated tool availability logic to reflect new reachability rules:
  - `pick_up`: items in own cell or front arc
  - `give`: target AIs in own cell or front arc
  - `examine`: items in full 9-cell cone
  - `couple`: new tool for placing objective items on paired spaces in own cell or front arc

### New "couple" Tool
- **tool-registry.ts**: Added `couple` function definition for placing objective items on their paired spaces
- **dispatcher.ts**: Implemented validation and execution for `couple` tool
- **conversation-log.ts**: Added rendering support for witnessed `couple` actions
- **types.ts**: Updated `PhysicalActionRecord.kind` to include "couple"

### Test Updates
- **cone-projector.test.ts**: Updated all test cases to expect 9 cells and verify the new wider cone geometry across all four cardinal directions
- **dispatcher.test.ts**: Updated interaction tests to reflect front-arc-based reachability; added comprehensive `couple` tool tests
- **conversation-log-integration.test.ts**: Updated cone descriptions in comments and adjusted test setup to account for expanded perception

### Documentation
- **.claude/skills/playtest/01-rules.md**: Updated rules documentation to describe the new 9-cell cone structure

## Implementation Details
- The cone geometry uses vector math: forward delta (`fwd`) and left delta (`lft` = perpendicular to forward)
- Distance-1 cells are computed as `position + fwd ± lft`
- Distance-2 cells are computed as `position + 2*fwd + {-2, -1, 0, 1, 2}*lft`
- Out-of-bounds filtering is applied consistently; own cell is always included
- The `frontArc()` helper extracts just the distance-1 cells for reachability checks in interaction validation

https://claude.ai/code/session_01EpiQi79ca2JZXvvchMByj9