### PR TITLE
fix: validateContentPacks now enforces prose-tell check via examineMentionsPairedSpace

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -157,24 +157,14 @@ describe("validateContentPacks — prose tell contract", () => {
 		).toBe(true);
 	});
 
-	it("exposes the prose-tell omission via examineMentionsPairedSpace on a validated pack", () => {
-		// Today the validator accepts this — it is the very gap issue #253 documents.
-		// The helper, however, must flag it, so a future #248-style validator-side
-		// retry has a single source of truth to call.
-		const result = validateContentPacks(
-			buildResponse(
-				"rusted iron key, heavily corroded but still intact. The teeth are worn smooth from use",
+	it("rejects a content pack whose objective_object examine does not mention the paired space", () => {
+		expect(() =>
+			validateContentPacks(
+				buildResponse(
+					"rusted iron key, heavily corroded but still intact. The teeth are worn smooth from use",
+				),
+				input,
 			),
-			input,
-		);
-		const pair = result.packs[0]?.objectivePairs[0];
-		expect(pair).toBeDefined();
-		if (!pair) return;
-		expect(
-			examineMentionsPairedSpace(
-				pair.object.examineDescription,
-				pair.space.name,
-			),
-		).toBe(false);
+		).toThrow(/examineDescription does not mention paired space/);
 	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -302,6 +302,11 @@ export function validateContentPacks(
 					`Phase ${phaseNumber}: object ${object.id} pairsWithSpaceId "${object.pairsWithSpaceId}" does not match space id "${space.id}"`,
 				);
 			}
+			if (!examineMentionsPairedSpace(object.examineDescription, space.name)) {
+				throw new ContentPackError(
+					`Phase ${phaseNumber}: object ${object.id} examineDescription does not mention paired space "${space.name}"`,
+				);
+			}
 			objectivePairs.push({ object, space });
 		}
 


### PR DESCRIPTION
The validator accepted objective_object entries whose examineDescription
did not mention the paired space name, a gap tracked in issue #253.
Wire examineMentionsPairedSpace into the objectivePairs loop so the
validator throws when the prose-tell invariant is violated, and update
the test that was documenting the omission to assert the throw.

https://claude.ai/code/session_019LfHa4FZNuhSeKdUEGwsZq