### PR TITLE
Strip direct grid coordinates from daemon prompts

### DIFF
--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -311,7 +311,7 @@ describe("prompt-builder — spatial 'Where you are' section (current-state user
 		);
 		const ctx = buildAiContext(game, "red");
 		const stateMsg = ctx.toCurrentStateUserMessage();
-		expect(stateMsg).toMatch(/row 0.*col 0/i);
+		expect(stateMsg).toMatch(/facing/i);
 		expect(stateMsg).toMatch(/north/i);
 	});
 
@@ -826,7 +826,7 @@ describe("<what_you_see> (cone)", () => {
 		const ctx = buildAiContext(game, "red");
 		const stateMsg = ctx.toCurrentStateUserMessage();
 		// flower at (1,0) is directly in front of red (facing south)
-		expect(stateMsg).toContain("Directly in front (row 1, col 0): flower");
+		expect(stateMsg).toContain("Directly in front: flower");
 	});
 
 	it("AIs visible in cone are rendered with their id, facing, and held items", () => {
@@ -890,7 +890,7 @@ describe("<what_you_see> (cone)", () => {
 		const ctx = buildAiContext(game, "red");
 		const stateMsg = ctx.toCurrentStateUserMessage();
 		// Obstacle at (1,0) is directly in front of red (facing south)
-		expect(stateMsg).toContain("Directly in front (row 1, col 0):");
+		expect(stateMsg).toContain("Directly in front:");
 		expect(stateMsg).toContain("col1");
 	});
 

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -806,9 +806,7 @@ function renderCurrentState(ctx: AiContext): string {
 
 			// Capitalise the phrasing for display
 			const label = phrasing.charAt(0).toUpperCase() + phrasing.slice(1);
-			lines.push(
-				`- ${label}: ${contents}`,
-			);
+			lines.push(`- ${label}: ${contents}`);
 		}
 		if (viewCells.length === 0) {
 			lines.push("(nothing visible)");

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -1,5 +1,4 @@
 import { projectCone } from "./cone-projector.js";
-import { formatPosition } from "./direction.js";
 import { getActivePhase } from "./engine";
 import type {
 	AiBudget,
@@ -592,7 +591,7 @@ export function buildConeSnapshot(ctx: AiContext): string {
 		.map((i) => i.name)
 		.sort();
 	lines.push(
-		`you: pos=(${actorSpatial.position.row},${actorSpatial.position.col}) facing=${actorSpatial.facing} holding=[${heldItems.join(", ") || "nothing"}] cell=[${ownCellItems.join(", ") || "nothing"}]`,
+		`you: facing=${actorSpatial.facing} holding=[${heldItems.join(", ") || "nothing"}] cell=[${ownCellItems.join(", ") || "nothing"}]`,
 	);
 
 	const coneCells = projectCone(actorSpatial.position, actorSpatial.facing);
@@ -624,7 +623,7 @@ export function buildConeSnapshot(ctx: AiContext): string {
 
 		const contents =
 			contentParts.length > 0 ? [...contentParts].sort().join(", ") : "nothing";
-		lines.push(`at (${position.row},${position.col}): ${contents}`);
+		lines.push(`at ${cell.phrasing}: ${contents}`);
 	}
 
 	return lines.join("\n");
@@ -716,9 +715,7 @@ function renderCurrentState(ctx: AiContext): string {
 
 	lines.push("<where_you_are>");
 	if (actorSpatial) {
-		lines.push(
-			`Position: ${formatPosition(actorSpatial.position)}, facing ${facingLabel(actorSpatial.facing)}`,
-		);
+		lines.push(`Facing: ${facingLabel(actorSpatial.facing)}`);
 
 		// Held items
 		const heldItems = items.filter((item) => item.holder === ctx.aiId);
@@ -810,7 +807,7 @@ function renderCurrentState(ctx: AiContext): string {
 			// Capitalise the phrasing for display
 			const label = phrasing.charAt(0).toUpperCase() + phrasing.slice(1);
 			lines.push(
-				`- ${label} (row ${position.row}, col ${position.col}): ${contents}`,
+				`- ${label}: ${contents}`,
 			);
 		}
 		if (viewCells.length === 0) {


### PR DESCRIPTION
Daemons no longer receive raw (row, col) numbers anywhere in their
per-round context. <where_you_are> now shows facing direction only;
<what_you_see> uses ConePhrasing labels only; <whats_new> diffs key
on phrasing instead of coordinates.

https://claude.ai/code/session_012DHZxqbnQXnqhSrXmBDou8