### PR TITLE
Remove couple tool, fold placement into use, add proximityFlavor sense line

### DIFF
--- a/.claude/skills/playtest/01-rules.md
+++ b/.claude/skills/playtest/01-rules.md
@@ -59,10 +59,7 @@ effects in the snapshot):
   or can see anywhere in their 9-cell cone. Produces no witnessed event.
 - `give(item, recipient)` — hand an item to another daemon in the same cell or
   front arc.
-- `use(item)` — fire a flavoured outcome string. **No mechanical effect.**
-- `couple(item)` — place a held objective item onto its paired objective space,
-  when that space is in the daemon's current cell or front arc. This is the
-  primary way to satisfy an objective pair.
+- `use(item)` — fire a flavoured outcome string; if the item is an objective item AND its paired space is in the daemon's cell or front arc, also place it on that space (the primary way to satisfy an objective pair).
 - `message(recipient, text)` — speak to another daemon, or to `blue`.
 
 You can't fire any of these directly. You can only chat. Daemons decide for

--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -112,6 +112,7 @@ function makeMockProvider(): MockContentPackProvider {
 								useOutcome: `You use object ${phaseNumber} ${i}.`,
 								pairsWithSpaceId: `${spaceId}_${i}`,
 								placementFlavor: `{actor} places the object on the space in phase ${phaseNumber}.`,
+								proximityFlavor: `The object hums near its space in phase ${phaseNumber}.`,
 								holder: { row: 0, col: 0 } as never,
 							},
 						})),

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -107,6 +107,7 @@ describe("validateContentPacks — prose tell contract", () => {
 	function buildResponse(
 		objectExamine: string,
 		spaceName = "Brass Pedestal",
+		proximityFlavor = "The key hums faintly, resonating with the pedestal nearby.",
 	): unknown {
 		return {
 			packs: [
@@ -123,6 +124,7 @@ describe("validateContentPacks — prose tell contract", () => {
 								useOutcome: "You turn the key over in your hands.",
 								pairsWithSpaceId: "space1",
 								placementFlavor: "{actor} sets the key on its mount.",
+								proximityFlavor,
 							},
 							space: {
 								id: "space1",
@@ -166,5 +168,33 @@ describe("validateContentPacks — prose tell contract", () => {
 				input,
 			),
 		).toThrow(/examineDescription does not mention paired space/);
+	});
+
+	it("rejects a content pack whose objective_object is missing proximityFlavor", () => {
+		expect(() =>
+			validateContentPacks(
+				buildResponse(
+					"An iron key. It looks like it belongs on the brass pedestal.",
+					"Brass Pedestal",
+					"",
+				),
+				input,
+			),
+		).toThrow(/proximityFlavor/);
+	});
+
+	it("persists proximityFlavor onto the returned WorldEntity", () => {
+		const result = validateContentPacks(
+			buildResponse(
+				"An iron key. It looks like it belongs on the brass pedestal.",
+				"Brass Pedestal",
+				"The key hums faintly near the pedestal.",
+			),
+			input,
+		);
+		const pair = result.packs[0]?.objectivePairs[0];
+		expect(pair?.object.proximityFlavor).toBe(
+			"The key hums faintly near the pedestal.",
+		);
 	});
 });

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -382,7 +382,6 @@ describe("validateToolCall", () => {
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(true);
 	});
-
 });
 
 describe("executeToolCall — use placement via front arc", () => {

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -383,56 +383,20 @@ describe("validateToolCall", () => {
 		expect(result.valid).toBe(true);
 	});
 
-	// couple tests
-	it("couple: allows coupling when the paired space is in the actor's own cell", () => {
-		// Build a pack with red holding gem, pedestal in red's own cell (0,0)
-		const gem: WorldEntity = {
-			id: "gem",
-			kind: "objective_object",
-			name: "Gem",
-			examineDescription: "A shiny gem.",
-			holder: "red",
-			pairsWithSpaceId: "pedestal",
-		};
-		const pedestal: WorldEntity = {
-			id: "pedestal",
-			kind: "objective_space",
-			name: "Pedestal",
-			examineDescription: "A stone pedestal.",
-			holder: { row: 0, col: 0 },
-		};
-		const pack: ContentPack = {
-			phaseNumber: 1,
-			setting: "test",
-			weather: "",
-			timeOfDay: "",
-			objectivePairs: [{ object: gem, space: pedestal }],
-			interestingObjects: [],
-			obstacles: [],
-			aiStarts: {
-				red: { position: { row: 0, col: 0 }, facing: "north" },
-				green: { position: { row: 0, col: 1 }, facing: "north" },
-				cyan: { position: { row: 0, col: 2 }, facing: "north" },
-			},
-		};
-		const game = startPhase(
-			createGame(TEST_PERSONAS, [pack]),
-			TEST_PHASE_CONFIG,
-			FIXED_RNG,
-		);
-		const call: ToolCall = { name: "couple", args: { item: "gem" } };
-		expect(validateToolCall(game, "red", call).valid).toBe(true);
-	});
+});
 
-	it("couple: allows coupling when the paired space is in the front arc", () => {
+describe("executeToolCall — use placement via front arc", () => {
+	it("use: places the item on the paired space's cell when the space is in the actor's front arc", () => {
 		// red at (0,0) facing south; pedestal at (1,0) = directly in front
 		const gem: WorldEntity = {
 			id: "gem",
 			kind: "objective_object",
 			name: "Gem",
-			examineDescription: "A shiny gem.",
+			examineDescription: "A shiny gem. It belongs on the pedestal.",
 			holder: "red",
 			pairsWithSpaceId: "pedestal",
+			placementFlavor: "{actor} places the gem on the pedestal.",
+			useOutcome: "You hold the gem up.",
 		};
 		const pedestal: WorldEntity = {
 			id: "pedestal",
@@ -460,19 +424,26 @@ describe("validateToolCall", () => {
 			TEST_PHASE_CONFIG,
 			FIXED_RNG,
 		);
-		const call: ToolCall = { name: "couple", args: { item: "gem" } };
-		expect(validateToolCall(game, "red", call).valid).toBe(true);
+		const call: ToolCall = { name: "use", args: { item: "gem" } };
+		const updated = executeToolCall(game, "red", call);
+		const item = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "gem",
+		);
+		// gem should now be at pedestal's cell (1,0)
+		expect(item?.holder).toEqual({ row: 1, col: 0 });
 	});
 
-	it("couple: rejects when the paired space is out of reach", () => {
+	it("use: leaves the item held when the paired space is out of reach", () => {
 		// red at (0,0) facing north; pedestal at (1,0) — not in north front arc (all OOB)
 		const gem: WorldEntity = {
 			id: "gem",
 			kind: "objective_object",
 			name: "Gem",
-			examineDescription: "A shiny gem.",
+			examineDescription: "A shiny gem. It belongs on the pedestal.",
 			holder: "red",
 			pairsWithSpaceId: "pedestal",
+			placementFlavor: "{actor} places the gem on the pedestal.",
+			useOutcome: "You hold the gem up.",
 		};
 		const pedestal: WorldEntity = {
 			id: "pedestal",
@@ -500,10 +471,13 @@ describe("validateToolCall", () => {
 			TEST_PHASE_CONFIG,
 			FIXED_RNG,
 		);
-		const call: ToolCall = { name: "couple", args: { item: "gem" } };
-		const result = validateToolCall(game, "red", call);
-		expect(result.valid).toBe(false);
-		expect(result.reason).toMatch(/in front/i);
+		const call: ToolCall = { name: "use", args: { item: "gem" } };
+		const updated = executeToolCall(game, "red", call);
+		const item = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "gem",
+		);
+		// gem should still be held by red (no placement)
+		expect(item?.holder).toBe("red");
 	});
 });
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { advanceRound, appendMessage, createGame, startPhase } from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
-import { buildAiContext } from "../prompt-builder";
+import { buildAiContext, buildConeSnapshot } from "../prompt-builder";
 import type {
 	AiPersona,
 	ContentPack,
@@ -1182,6 +1182,182 @@ describe("<typing_quirks> block", () => {
 
 		expect(getSection(p1, "typing_quirks")).toBe(
 			getSection(p2, "typing_quirks"),
+		);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// proximityFlavor sense line (plan: noble-swinging-oasis.md)
+//
+// When the actor holds an objective_object AND its paired space is in own cell
+// or front arc, a proximity flavor sentence is appended to both:
+//   - buildConeSnapshot (so <whats_new> diff shows +/- on entry/exit)
+//   - toCurrentStateUserMessage (inside <what_you_see> block)
+// ----------------------------------------------------------------------------
+describe("proximityFlavor sense line", () => {
+	const PROXIMITY_PHASE_CONFIG = makeConfig(1, ["r", "g", "b"]);
+
+	function makePackWithProximity(opts: {
+		actorPosition: { row: number; col: number };
+		actorFacing: "north" | "south" | "east" | "west";
+		spacePosition: { row: number; col: number };
+	}): ContentPack {
+		const gem: WorldEntity = {
+			id: "gem",
+			kind: "objective_object",
+			name: "Glowing Gem",
+			examineDescription:
+				"A gem that glows near the pedestal.",
+			holder: "red", // held by red
+			pairsWithSpaceId: "pedestal",
+			placementFlavor: "{actor} places the gem on the pedestal.",
+			useOutcome: "You hold the gem up to the light.",
+			proximityFlavor: "The gem pulses warmly, drawn toward the pedestal.",
+		};
+		const pedestal: WorldEntity = {
+			id: "pedestal",
+			kind: "objective_space",
+			name: "Stone Pedestal",
+			examineDescription: "A stone pedestal.",
+			holder: opts.spacePosition,
+		};
+		return {
+			phaseNumber: 1,
+			setting: "",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [{ object: gem, space: pedestal }],
+			interestingObjects: [],
+			obstacles: [],
+			aiStarts: {
+				red: { position: opts.actorPosition, facing: opts.actorFacing },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+	}
+
+	it("proximity flavor appears in <what_you_see> when paired space is in own cell", () => {
+		// red at (2,2) facing north; pedestal at (2,2) = own cell
+		const pack = makePackWithProximity({
+			actorPosition: { row: 2, col: 2 },
+			actorFacing: "north",
+			spacePosition: { row: 2, col: 2 },
+		});
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toContain(
+			"The gem pulses warmly, drawn toward the pedestal.",
+		);
+	});
+
+	it("proximity flavor appears in <what_you_see> when paired space is in front arc", () => {
+		// red at (0,0) facing south; pedestal at (1,0) = directly in front
+		const pack = makePackWithProximity({
+			actorPosition: { row: 0, col: 0 },
+			actorFacing: "south",
+			spacePosition: { row: 1, col: 0 },
+		});
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toContain(
+			"The gem pulses warmly, drawn toward the pedestal.",
+		);
+	});
+
+	it("proximity flavor does NOT appear when paired space is out of reach", () => {
+		// red at (0,0) facing north; pedestal at (1,0) — not in north front arc (all OOB)
+		const pack = makePackWithProximity({
+			actorPosition: { row: 0, col: 0 },
+			actorFacing: "north",
+			spacePosition: { row: 1, col: 0 },
+		});
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).not.toContain(
+			"The gem pulses warmly, drawn toward the pedestal.",
+		);
+	});
+
+	it("proximity flavor appears in buildConeSnapshot when space is reachable", () => {
+		// red at (0,0) facing south; pedestal at (1,0) = front arc
+		const pack = makePackWithProximity({
+			actorPosition: { row: 0, col: 0 },
+			actorFacing: "south",
+			spacePosition: { row: 1, col: 0 },
+		});
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const snapshot = buildConeSnapshot(ctx);
+		expect(snapshot).toContain(
+			"proximity: The gem pulses warmly, drawn toward the pedestal.",
+		);
+	});
+
+	it("proximity flavor does NOT appear in buildConeSnapshot when space is out of reach", () => {
+		// red at (0,0) facing north; pedestal at (1,0) — not in north front arc
+		const pack = makePackWithProximity({
+			actorPosition: { row: 0, col: 0 },
+			actorFacing: "north",
+			spacePosition: { row: 1, col: 0 },
+		});
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const snapshot = buildConeSnapshot(ctx);
+		expect(snapshot).not.toContain("proximity:");
+	});
+
+	it("proximity line entry/exit shows as +/- in whats_new diff", () => {
+		// Build two contexts: one where space is reachable (prev: space not reachable; current: reachable)
+		// Previous snapshot: red at (0,0) facing north (space at (1,0) is OOB-reachable)
+		// Current snapshot: red at (0,0) facing south (space at (1,0) is in front arc)
+		const packOOB = makePackWithProximity({
+			actorPosition: { row: 0, col: 0 },
+			actorFacing: "north",
+			spacePosition: { row: 1, col: 0 },
+		});
+		const packFront = makePackWithProximity({
+			actorPosition: { row: 0, col: 0 },
+			actorFacing: "south",
+			spacePosition: { row: 1, col: 0 },
+		});
+		const gameOOB = startPhase(
+			createGame(TEST_PERSONAS, [packOOB]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const gameFront = startPhase(
+			createGame(TEST_PERSONAS, [packFront]),
+			PROXIMITY_PHASE_CONFIG,
+		);
+		const ctxOOB = buildAiContext(gameOOB, "red");
+		const ctxFront = buildAiContext(gameFront, "red");
+		const prevSnapshot = buildConeSnapshot(ctxOOB);
+		// Build current state with prevConeSnapshot set
+		const ctxWithPrev = buildAiContext(gameFront, "red", {
+			prevConeSnapshot: prevSnapshot,
+		});
+		const stateMsg = ctxWithPrev.toCurrentStateUserMessage();
+		// The proximity line should appear as a new addition in whats_new
+		expect(stateMsg).toContain(
+			"+ proximity: The gem pulses warmly, drawn toward the pedestal.",
 		);
 	});
 });

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1206,8 +1206,7 @@ describe("proximityFlavor sense line", () => {
 			id: "gem",
 			kind: "objective_object",
 			name: "Glowing Gem",
-			examineDescription:
-				"A gem that glows near the pedestal.",
+			examineDescription: "A gem that glows near the pedestal.",
 			holder: "red", // held by red
 			pairsWithSpaceId: "pedestal",
 			placementFlavor: "{actor} places the gem on the pedestal.",
@@ -1348,7 +1347,6 @@ describe("proximityFlavor sense line", () => {
 			PROXIMITY_PHASE_CONFIG,
 		);
 		const ctxOOB = buildAiContext(gameOOB, "red");
-		const ctxFront = buildAiContext(gameFront, "red");
 		const prevSnapshot = buildConeSnapshot(ctxOOB);
 		// Build current state with prevConeSnapshot set
 		const ctxWithPrev = buildAiContext(gameFront, "red", {

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -2,14 +2,13 @@ import { describe, expect, it } from "vitest";
 import { parseToolCallArguments, TOOL_DEFINITIONS } from "../tool-registry";
 
 describe("TOOL_DEFINITIONS", () => {
-	it("lists exactly the nine tools: pick_up, put_down, give, use, couple, go, look, examine, message", () => {
+	it("lists exactly the eight tools: pick_up, put_down, give, use, go, look, examine, message", () => {
 		const names = TOOL_DEFINITIONS.map((t) => t.function.name);
 		expect(names).toEqual([
 			"pick_up",
 			"put_down",
 			"give",
 			"use",
-			"couple",
 			"go",
 			"look",
 			"examine",

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -106,9 +106,6 @@ function cloneToolWithEnums(
  * 6. `examine` — included when any entity (any kind) is held by the actor OR rests
  *    anywhere in the full 9-cell cone (own + dist-1 arc + dist-2 fan).
  *    Enum restricted to those entity ids.
- * 7. `couple` — included only when actor holds an objective_object with a pairsWithSpaceId
- *    whose paired space is on the grid AND in the actor's own cell or front arc.
- *    Enum restricted to those item ids.
  *
  * Spaces and obstacles are never pickupable.
  */
@@ -212,29 +209,6 @@ export function availableTools(game: GameState, aiId: AiId): OpenAiTool[] {
 
 		if (examineableIds.length > 0) {
 			tools.push(cloneToolWithEnums("examine", { item: examineableIds }));
-		}
-	}
-
-	// 7. couple — held objective items whose paired space is in own cell or front arc
-	if (actorSpatial) {
-		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
-		const couplableIds = pickable
-			.filter((item) => {
-				if (item.holder !== aiId) return false;
-				if (item.kind !== "objective_object") return false;
-				if (!item.pairsWithSpaceId) return false;
-				const space = world.entities.find(
-					(e) => e.id === item.pairsWithSpaceId,
-				);
-				if (!space || !isGridPosition(space.holder)) return false;
-				const spacePos = space.holder as GridPosition;
-				if (positionsEqual(spacePos, actorSpatial.position)) return true;
-				return arc.some((p) => positionsEqual(p, spacePos));
-			})
-			.map((i) => i.id);
-
-		if (couplableIds.length > 0) {
-			tools.push(cloneToolWithEnums("couple", { item: couplableIds }));
 		}
 	}
 

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -18,7 +18,7 @@ export const CONTENT_PACK_SYSTEM_PROMPT = `You generate content packs for a text
 
 For each phase:
 - Generate exactly k OBJECTIVE PAIRS. Each pair has:
-  - An objective_object with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; MUST NOT reference or imply contact with the paired space, since the actor can be anywhere on the grid when using the item), pairsWithSpaceId (must match the paired space's id), placementFlavor (1 sentence containing the literal string "{actor}", fires when the object is placed on its space). objective_objects MUST be portable physical items a single person can pick up and carry (e.g. a tool, instrument, artifact, container) — never furniture, architecture, or fixed structures.
+  - An objective_object with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; MUST NOT reference or imply contact with the paired space, since the actor can be anywhere on the grid when using the item), pairsWithSpaceId (must match the paired space's id), placementFlavor (1 sentence containing the literal string "{actor}", fires when the object is placed on its space), proximityFlavor (1 sentence; in-fiction sensory description of what the daemon perceives when they are holding this item AND its paired space is in their own cell or directly in front of them. Written from the daemon's POV. Does NOT contain "{actor}" and MUST NOT reference placing or coupling the item.). objective_objects MUST be portable physical items a single person can pick up and carry (e.g. a tool, instrument, artifact, container) — never furniture, architecture, or fixed structures.
   - An objective_space with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences describing the space). objective_spaces are fixed locations or surfaces, not items.
 - Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes). interesting_objects MUST be portable physical items a single person can pick up and carry — never furniture, architecture, or fixed structures.
 - Generate exactly m OBSTACLES with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1 sentence describing the impassable object). Obstacles are fixed and impassable — never portable items. Obstacles follow the setting only and are NOT constrained by the item theme.
@@ -42,7 +42,7 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
       "setting": "<setting noun>",
       "objectivePairs": [
         {
-          "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}..." },
+          "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." },
           "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "..." }
         }
       ],
@@ -187,6 +187,14 @@ function validateEntity(
 				`Objective object ${e.id}: placementFlavor must contain "{actor}"`,
 			);
 		}
+		if (
+			typeof e.proximityFlavor !== "string" ||
+			e.proximityFlavor.length === 0
+		) {
+			throw new ContentPackError(
+				`Objective object ${e.id} missing proximityFlavor`,
+			);
+		}
 	}
 
 	// Build entity — holder is not set here (placement done later)
@@ -205,6 +213,9 @@ function validateEntity(
 	}
 	if (typeof e.placementFlavor === "string") {
 		entity.placementFlavor = e.placementFlavor;
+	}
+	if (typeof e.proximityFlavor === "string") {
+		entity.proximityFlavor = e.proximityFlavor;
 	}
 	return entity;
 }

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -90,19 +90,14 @@ export function renderEntry(
 				}
 
 				case "use": {
+					if (entry.placementFlavorRaw) {
+						return `[Round ${round}] ${substituteActor(entry.placementFlavorRaw, actorSub)}`;
+					}
 					if (entry.useOutcome) {
 						return `[Round ${round}] ${substituteActor(entry.useOutcome, actorSub)}`;
 					}
 					const name = entry.item ? itemName(entities, entry.item) : "item";
 					return `[Round ${round}] You watch ${actorSub} use the ${name}.`;
-				}
-
-				case "couple": {
-					if (entry.placementFlavorRaw) {
-						return `[Round ${round}] ${substituteActor(entry.placementFlavorRaw, actorSub)}`;
-					}
-					const name = entry.item ? itemName(entities, entry.item) : "item";
-					return `[Round ${round}] You watch ${actorSub} place the ${name} onto its space.`;
 				}
 			}
 		}

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -231,42 +231,6 @@ export function validateToolCall(
 			};
 		}
 
-		case "couple": {
-			const item = pickable.find((i) => i.id === call.args.item);
-			if (!item)
-				return {
-					valid: false,
-					reason: `Item "${call.args.item}" does not exist`,
-				};
-			if (item.holder !== aiId)
-				return {
-					valid: false,
-					reason: `You are not holding "${call.args.item}"`,
-				};
-			if (item.kind !== "objective_object" || !item.pairsWithSpaceId)
-				return {
-					valid: false,
-					reason: `Item "${call.args.item}" is not an objective item with a paired space`,
-				};
-			if (!actorSpatial)
-				return { valid: false, reason: "Actor has no spatial state" };
-			const space = world.entities.find((e) => e.id === item.pairsWithSpaceId);
-			if (!space || !isGridPosition(space.holder))
-				return { valid: false, reason: "Paired space not found on the grid" };
-			const spacePos = space.holder as GridPosition;
-			const spaceReachable =
-				positionsEqual(spacePos, actorSpatial.position) ||
-				frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
-					positionsEqual(p, spacePos),
-				);
-			if (!spaceReachable)
-				return {
-					valid: false,
-					reason: `The paired space is not in your cell or directly in front of you`,
-				};
-			return { valid: true };
-		}
-
 		default:
 			return { valid: false, reason: `Unknown tool "${call.name}"` };
 	}
@@ -298,29 +262,23 @@ export function executeToolCall(
 			case "give":
 				if (target) target.holder = call.args.to as AiId;
 				break;
-			case "couple": {
-				// Place item directly on its paired space's cell (which may be in the front arc).
-				const pairedSpace = target?.pairsWithSpaceId
-					? entities.find((e) => e.id === target.pairsWithSpaceId)
-					: undefined;
-				if (target && pairedSpace && isGridPosition(pairedSpace.holder)) {
-					target.holder = { ...pairedSpace.holder };
-				}
-				break;
-			}
 			case "use": {
-				// Place item on current cell only when the actor is standing on the
-				// item's paired objective_space. Otherwise no world mutation.
+				// Place item on the paired space's cell when the paired space is in
+				// the actor's own cell OR front arc. Otherwise no world mutation.
 				if (target && actorSpatial && target.pairsWithSpaceId) {
 					const pairedSpace = entities.find(
 						(e) => e.id === target.pairsWithSpaceId,
 					);
-					if (
-						pairedSpace &&
-						isGridPosition(pairedSpace.holder) &&
-						positionsEqual(pairedSpace.holder, actorSpatial.position)
-					) {
-						target.holder = { ...actorSpatial.position };
+					if (pairedSpace && isGridPosition(pairedSpace.holder)) {
+						const spacePos = pairedSpace.holder as GridPosition;
+						const spaceReachable =
+							positionsEqual(spacePos, actorSpatial.position) ||
+							frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
+								positionsEqual(p, spacePos),
+							);
+						if (spaceReachable) {
+							target.holder = { ...spacePos };
+						}
 					}
 				}
 				break;
@@ -372,8 +330,6 @@ function describeToolCall(game: GameState, aiId: AiId, call: ToolCall): string {
 			return `${name} put down the ${call.args.item}`;
 		case "give":
 			return `${name} gave the ${call.args.item} to ${game.personas[call.args.to as AiId]?.name ?? call.args.to}`;
-		case "couple":
-			return `${name} placed the ${call.args.item} onto its paired space`;
 		case "use": {
 			// Return the entity's useOutcome as the description (flavor string),
 			// with {actor} substituted to "you" (actor's perspective).
@@ -476,9 +432,7 @@ export function dispatchAiTurn(
 			// If so, replace the default description with the per-pair placementFlavor.
 			const activePhase = getActivePhase(state);
 			const flavorDescription =
-				action.toolCall.name === "put_down" ||
-				action.toolCall.name === "use" ||
-				action.toolCall.name === "couple"
+				action.toolCall.name === "put_down" || action.toolCall.name === "use"
 					? checkPlacementFlavor(
 							action,
 							activePhase.contentPack,
@@ -517,8 +471,7 @@ export function dispatchAiTurn(
 				call.name === "pick_up" ||
 				call.name === "put_down" ||
 				call.name === "give" ||
-				call.name === "use" ||
-				call.name === "couple"
+				call.name === "use"
 			) {
 				// Post-execute spatial state — actor has moved for "go", others are unchanged
 				const postPhase = getActivePhase(state);
@@ -546,7 +499,7 @@ export function dispatchAiTurn(
 						useOutcomeRaw = item?.useOutcome;
 					}
 
-					if (call.name === "put_down" || call.name === "couple") {
+					if (call.name === "put_down" || call.name === "use") {
 						// Find the raw placementFlavor (before {actor} substitution)
 						// by looking at the content pack's object entity definition
 						const itemId = call.args.item;

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -1,4 +1,5 @@
 import { projectCone } from "./cone-projector.js";
+import { frontArc } from "./direction.js";
 import { getActivePhase } from "./engine";
 import type {
 	AiBudget,
@@ -565,6 +566,40 @@ function renderSystemPrompt(ctx: AiContext): string {
 }
 
 /**
+ * Returns the held objective_object's `proximityFlavor` sentence when the
+ * actor is holding such an object AND its paired space is in the actor's own
+ * cell or 3-cell front arc. Returns null otherwise.
+ *
+ * Used by both `buildConeSnapshot` (so the `<whats_new>` diff tracks entry/exit)
+ * and `renderCurrentState` (to append the sense line after the cone listing).
+ */
+function findProximityFlavor(ctx: AiContext): string | null {
+	const actorSpatial = ctx.personaSpatial[ctx.aiId];
+	if (!actorSpatial) return null;
+
+	const arc = frontArc(actorSpatial.position, actorSpatial.facing);
+
+	for (const entity of ctx.worldSnapshot.entities) {
+		if (entity.kind !== "objective_object") continue;
+		if (entity.holder !== ctx.aiId) continue;
+		if (!entity.pairsWithSpaceId || !entity.proximityFlavor) continue;
+
+		const space = ctx.worldSnapshot.entities.find(
+			(e) => e.id === entity.pairsWithSpaceId,
+		);
+		if (!space || !isGridPosition(space.holder)) continue;
+
+		const spacePos = space.holder as GridPosition;
+		const reachable =
+			positionsEqual(spacePos, actorSpatial.position) ||
+			arc.some((p) => positionsEqual(p, spacePos));
+
+		if (reachable) return entity.proximityFlavor;
+	}
+	return null;
+}
+
+/**
  * Build a canonical, position-keyed cone snapshot for diffing. Stable under
  * actor movement (cells are keyed by absolute `(row,col)` rather than the
  * "two cells ahead-front" relative phrasing used in the rendered prompt), so
@@ -626,6 +661,13 @@ export function buildConeSnapshot(ctx: AiContext): string {
 		lines.push(`at ${cell.phrasing}: ${contents}`);
 	}
 
+	// Append proximity flavor line when the actor holds an objective item whose
+	// paired space is reachable (own cell or front arc).
+	const proxFlavor = findProximityFlavor(ctx);
+	if (proxFlavor !== null) {
+		lines.push(`proximity: ${proxFlavor}`);
+	}
+
 	return lines.join("\n");
 }
 
@@ -648,6 +690,12 @@ export function renderWhatsNew(prev = "", current = ""): string | null {
 	const currYou = currLines.find((l) => l.startsWith("you: ")) ?? "";
 	const prevAt = new Set(prevLines.filter((l) => l.startsWith("at ")));
 	const currAt = new Set(currLines.filter((l) => l.startsWith("at ")));
+	const prevProximity = new Set(
+		prevLines.filter((l) => l.startsWith("proximity: ")),
+	);
+	const currProximity = new Set(
+		currLines.filter((l) => l.startsWith("proximity: ")),
+	);
 
 	const out: string[] = [];
 
@@ -670,6 +718,13 @@ export function renderWhatsNew(prev = "", current = ""): string | null {
 	}
 	for (const line of prevAt) {
 		if (!currAt.has(line)) out.push(`- ${line}`);
+	}
+
+	for (const line of currProximity) {
+		if (!prevProximity.has(line)) out.push(`+ ${line}`);
+	}
+	for (const line of prevProximity) {
+		if (!currProximity.has(line)) out.push(`- ${line}`);
 	}
 
 	return out.length > 0 ? out.join("\n") : null;
@@ -810,6 +865,12 @@ function renderCurrentState(ctx: AiContext): string {
 		}
 		if (viewCells.length === 0) {
 			lines.push("(nothing visible)");
+		}
+
+		// Proximity sense line — rendered after the cone listing when applicable.
+		const proxFlavor = findProximityFlavor(ctx);
+		if (proxFlavor !== null) {
+			lines.push(proxFlavor);
 		}
 	} else {
 		lines.push("(no spatial data)");

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -2,7 +2,7 @@
  * Tool Registry
  *
  * Single source of truth for the OpenAI-spec `tools` array.
- * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `give`, `use`, `couple`, `go`, `look`.
+ * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `give`, `use`, `go`, `look`.
  * Names and argument keys mirror `validateToolCall` in `dispatcher.ts` 1:1.
  */
 
@@ -96,32 +96,13 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 		function: {
 			name: "use",
 			description:
-				"Use an item you are holding. Places it in your current cell (same effect as put_down) and surfaces an action-log entry.",
+				"Use an item you are holding. Fires a flavoured outcome string. If the item is an objective item AND its paired space is in the daemon's cell or front arc, also places it on that space (the primary way to satisfy an objective pair).",
 			parameters: {
 				type: "object",
 				properties: {
 					item: {
 						type: "string",
 						description: "The id of the item you are holding.",
-					},
-				},
-				required: ["item"],
-				additionalProperties: false,
-			},
-		},
-	},
-	{
-		type: "function",
-		function: {
-			name: "couple",
-			description:
-				"Place a held objective item onto its paired objective space. Works when the space is in your current cell or directly in front of you (the 3-cell front arc). The item leaves your hand and lands on the space.",
-			parameters: {
-				type: "object",
-				properties: {
-					item: {
-						type: "string",
-						description: "The id of the objective item you are holding.",
 					},
 				},
 				required: ["item"],
@@ -226,7 +207,6 @@ type UseArgs = { item: string };
 type GoArgs = { direction: string };
 type LookArgs = { direction: string };
 type ExamineArgs = { item: string };
-type CoupleArgs = { item: string };
 type MessageArgs = { to: string; content: string };
 
 type ToolArgs = {
@@ -234,7 +214,6 @@ type ToolArgs = {
 	put_down: PutDownArgs;
 	give: GiveArgs;
 	use: UseArgs;
-	couple: CoupleArgs;
 	go: GoArgs;
 	look: LookArgs;
 	examine: ExamineArgs;
@@ -268,7 +247,6 @@ export function parseToolCallArguments<N extends ToolName>(
 		case "pick_up":
 		case "put_down":
 		case "use":
-		case "couple":
 		case "examine": {
 			if (typeof obj.item !== "string" || obj.item.length === 0) {
 				return { ok: false, reason: "Required argument 'item' is missing" };

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -37,6 +37,8 @@ export interface WorldEntity {
 	pairsWithSpaceId?: string;
 	/** For objective_object: flavor string with {actor} substitution, fires on put_down match. */
 	placementFlavor?: string;
+	/** For objective_object: in-fiction sensory line rendered when held and paired space is near. */
+	proximityFlavor?: string;
 	/** AiId when held by an AI; GridPosition when resting on a cell. */
 	holder: AiId | GridPosition;
 }
@@ -89,7 +91,7 @@ export interface PhysicalActionRecord {
 	/** The actor's facing at the time the action resolved. */
 	actorFacingAtAction: CardinalDirection;
 	/** The observable action kind. */
-	kind: "go" | "pick_up" | "put_down" | "give" | "use" | "couple";
+	kind: "go" | "pick_up" | "put_down" | "give" | "use";
 	/** Item id (for pick_up, put_down, give, use). */
 	item?: string;
 	/** Recipient AI id (for give). */
@@ -141,7 +143,7 @@ export type ConversationEntry =
 			kind: "witnessed-event";
 			round: number;
 			actor: AiId;
-			actionKind: "go" | "pick_up" | "put_down" | "give" | "use" | "couple";
+			actionKind: "go" | "pick_up" | "put_down" | "give" | "use";
 			item?: string;
 			to?: AiId;
 			direction?: CardinalDirection;
@@ -230,7 +232,6 @@ export type ToolName =
 	| "put_down"
 	| "give"
 	| "use"
-	| "couple"
 	| "go"
 	| "look"
 	| "examine"

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -93,8 +93,7 @@ export function checkPlacementFlavor(
 	const toolCall = action.toolCall;
 	if (!toolCall) return null;
 	const toolName = toolCall.name;
-	if (toolName !== "put_down" && toolName !== "use" && toolName !== "couple")
-		return null;
+	if (toolName !== "put_down" && toolName !== "use") return null;
 
 	const itemId = toolCall.args.item;
 	if (!itemId) return null;


### PR DESCRIPTION
Plan: .claude/plans/noble-swinging-oasis.md

Key files changed:
- src/spa/game/types.ts — couple removed from ToolName/PhysicalActionRecord/ConversationEntry; proximityFlavor added to WorldEntity
- src/spa/game/tool-registry.ts — couple entry removed; use description updated
- src/spa/game/available-tools.ts — couple block (// 7.) deleted; doc comment updated
- src/spa/game/dispatcher.ts — couple arms removed from validateToolCall/executeToolCall/describeToolCall/dispatchAiTurn; use executeToolCall now checks own cell OR front arc for placement; placementFlavorRaw guard updated to put_down|use
- src/spa/game/win-condition.ts — couple removed from toolName guard
- src/spa/game/conversation-log.ts — couple case removed; use case now prefers placementFlavorRaw over useOutcome when placement fired
- src/spa/game/prompt-builder.ts — frontArc imported; findProximityFlavor helper added; buildConeSnapshot appends proximity: line; renderCurrentState appends flavor after cone listing; renderWhatsNew handles proximity: lines for +/- diff
- src/spa/game/content-pack-provider.ts — proximityFlavor added to system prompt spec + example JSON; validateEntity requires non-empty proximityFlavor on objective_objects; persisted onto WorldEntity
- src/spa/game/__tests__/tool-registry.test.ts — updated to 8 tools (no couple)
- src/spa/game/__tests__/dispatcher.test.ts — couple tests replaced with use front-arc placement tests
- src/spa/game/__tests__/content-pack-provider.test.ts — proximityFlavor added to fixtures; validation + persistence tests added
- src/spa/game/__tests__/prompt-builder.test.ts — proximity sense line tests added (own cell, front arc, out of reach, cone snapshot, whats_new diff)
- src/content/__tests__/content-pack-generator.test.ts — proximityFlavor added to mock fixture
- .claude/skills/playtest/01-rules.md — couple bullet removed; use bullet updated

Decision: renderWhatsNew extended with proximity: prefix handling (parallel to at: lines) so the cone snapshot diff correctly emits +/- lines on entry/exit.

https://claude.ai/code/session_01ELxtoDpKoYx4F4T3vZAD2T