### PR TITLE
Add isolation rail to playtest skill so agents never read other sessions

### DIFF
--- a/.claude/skills/playtest/01-rules.md
+++ b/.claude/skills/playtest/01-rules.md
@@ -7,6 +7,10 @@ section at the bottom.
 **Do not look at any source file or other documentation yet.** Code exploration
 is Stage 3.
 
+The isolation rail from `SKILL.md` still applies: do not read, list, or grep
+anything under `docs/playtests/agent-sessions/` or `docs/playtests/archive/`.
+Other playtest logs are off-limits in this stage too.
+
 ---
 
 ## The world model

--- a/.claude/skills/playtest/02-explore.md
+++ b/.claude/skills/playtest/02-explore.md
@@ -8,6 +8,13 @@ This stage is open-ended. Below is a small starting map for orientation.
 You do not have to follow it; you can also just `Grep` / `Glob` your way
 around as normal.
 
+**One exception — the isolation rail from `SKILL.md` still applies in
+Stage 3.** Do not read, list, or grep anything under
+`docs/playtests/agent-sessions/` or `docs/playtests/archive/`. Other agents'
+and humans' playtest logs remain out of bounds even now. Your hypothesis
+refinement should be grounded in the code and your own session, not in
+someone else's writeup.
+
 ---
 
 ## Useful entry points
@@ -16,14 +23,6 @@ around as normal.
   first if any vocabulary from `01-rules.md` was unclear.
 - **`AGENTS.md`** — points at the testing surfaces, prompt files, and
   domain docs.
-- **`docs/playtests/archive/`** — seven prior playtest session logs from
-  human and agent testers. Logs `0006-session.md` and `0007-session.md` are
-  particularly relevant: both are documented attempts to advance phase 1
-  against the same model that drove your session. Treat them as evidence,
-  not authority — they may corroborate or contradict your own observations,
-  and your hypotheses may be stronger than theirs.
-- **`docs/playtests/archive/README.md`** — explains the original
-  human-driven playtest discipline and infrastructure.
 - **`src/spa/game/prompt-builder.ts`** — the file that assembles each
   daemon's system prompt every round. Read this if any hypothesis touches
   what a daemon knows or sees.

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -24,6 +24,33 @@ contaminated.
 
 ---
 
+## The isolation rail (applies in every stage)
+
+**You may never read another playtest log.** Not in Stage 1, not in Stage 2,
+not in Stage 3, not even after the playtest is finished. Specifically, treat
+the following as out of bounds for the entire skill:
+
+- Any file under `docs/playtests/agent-sessions/` other than the one file you
+  create for your own session.
+- Any file under `docs/playtests/archive/`.
+- Do not `ls`, `Grep`, `Glob`, `cat`, `Read`, or otherwise enumerate the
+  contents of those directories. Listing is a spoiler too — filenames and
+  counts leak signal.
+
+The point of this skill is to produce an *independent* observation of the
+game. Reading another agent's or human's session — even "just for context",
+even "just to compare" — contaminates your read of your own playthrough and
+defeats the whole exercise. If you find yourself reaching for a prior log,
+stop; the answer is to write down what *you* saw, not to triangulate against
+what someone else saw.
+
+The only files you may write or read under `docs/playtests/` are:
+
+- `docs/playtests/_agent-observation-template.md` (read once, to copy).
+- `docs/playtests/agent-sessions/<your-sessionId>.md` (your own log).
+
+---
+
 ## Stage 1 in one paragraph
 
 You will start a local instance of hi-blue with one shell command, drive a
@@ -143,9 +170,9 @@ forget early-turn detail.
 4. Fill it in **as you go**. Don't batch everything at the end — quotes are
    easier to capture in the moment.
 
-**Do not `ls /home/user/hi-blue/docs/playtests/agent-sessions/`** — prior
-agents' observations are spoilers for you. Read only the template file and
-write only your own session file.
+Per the isolation rail above: read only the template file and write only
+your own session file. Do not `ls`, `Read`, `Grep`, or otherwise inspect
+`docs/playtests/agent-sessions/` or `docs/playtests/archive/`.
 
 ---
 
@@ -157,7 +184,9 @@ You may **not** during Stage 1:
   These contain the developer's view (HTTP requests, tool-call results) and
   would spoil the mechanics you are supposed to be discovering through play.
 - Read any source file under `src/`.
-- Read any other Markdown under `docs/` (including `docs/playtests/archive/`).
+- Read any other Markdown under `docs/`. The `docs/playtests/` subtree is
+  covered by the isolation rail above and is out of bounds for the whole
+  skill, not just Stage 1.
 - Read `CONTEXT.md`, `AGENTS.md`, or other root-level documentation.
 - Use `Grep`, `Glob`, or open codebase search of any kind.
 - Run `pnpm build`, `pnpm test`, `pnpm typecheck`, or any other repo command


### PR DESCRIPTION
Promotes the prior-agent-sessions spoiler warning into an explicit
all-stages "isolation rail" in SKILL.md, restates it in 01-rules.md and
02-explore.md, and removes the Stage 3 recommendation to read
docs/playtests/archive/0006-0007 so the rail isn't immediately
contradicted at the gate-lift. The whole point of the three-stage reveal
is an independent observation; cross-reading other agents' or humans'
session logs contaminates that, so the rail applies even after Stage 3
opens up the rest of the repo.