### PR TITLE
Daemons ignore tool-failure feedback (wall-collision blindness)

### DIFF
--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -64,7 +64,7 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 			const OBFUSCATION_KEY = '${OBFUSCATION_KEY}';
 			const keyBytes = Array.from(new TextEncoder().encode(OBFUSCATION_KEY));
 			const payload = JSON.stringify({
-				schemaVersion: 4,
+				schemaVersion: 5,
 				currentPhase: 1,
 				isComplete: false,
 				world: {

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { buildConversationLog } from "../conversation-log.js";
 import { DEFAULT_LANDMARKS } from "../direction";
 import { createGame, getActivePhase, startPhase } from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
@@ -482,6 +483,71 @@ describe("conversation log integration — put_down placementFlavor", () => {
 		expect(flattenMessageContents(greenMsgs)).not.toContain(
 			"*red places the flower on the pedestal.",
 		);
+	});
+});
+
+describe("conversation log integration — action-failure (issue #287)", () => {
+	it("dispatch invalid go then buildConversationLog contains one line matching 'Your `go` action failed:'", async () => {
+		// Use a ContentPack where red faces south and there's an obstacle directly south.
+		const obstacleAtSouth: ContentPack = {
+			phaseNumber: 1,
+			setting: "blocked test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [
+				{
+					id: "wall_s",
+					kind: "obstacle",
+					name: "wall",
+					examineDescription: "A wall.",
+					holder: { row: 3, col: 0 },
+				},
+			],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {
+				red: { position: { row: 2, col: 0 }, facing: "south" },
+				green: { position: { row: 0, col: 0 }, facing: "south" },
+				cyan: { position: { row: 0, col: 2 }, facing: "south" },
+			},
+		};
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [obstacleAtSouth]),
+			TEST_PHASE_CONFIG,
+		);
+
+		// red tries to go south → blocked by wall at (3,0)
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "go_fail",
+						name: "go",
+						argumentsJson: JSON.stringify({ direction: "south" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+
+		// Build the actor's conversation log and check for the failure line
+		const phase = getActivePhase(nextState);
+		const redLog = phase.conversationLogs.red ?? [];
+
+		const lines = buildConversationLog(
+			{ conversationLog: redLog, worldEntities: phase.world.entities },
+			"red",
+			{} as Record<string, never>,
+		);
+
+		const failureLine = lines.find((l) =>
+			l.includes("Your `go` action failed:"),
+		);
+		expect(failureLine).toBeDefined();
 	});
 });
 

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -223,6 +223,83 @@ describe("buildConversationLog — peer message", () => {
 	});
 });
 
+// ── Action-failure rendering ───────────────────────────────────────────────────
+
+describe("buildConversationLog — action-failure", () => {
+	it("renders single action-failure entry as `[Round N] Your \\`go\\` action failed: <reason>.`", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "action-failure",
+					round: 3,
+					tool: "go",
+					reason: "That cell is blocked by an obstacle",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(
+			"[Round 3] Your `go` action failed: That cell is blocked by an obstacle.",
+		);
+	});
+
+	it("strips a trailing period from reason to avoid double period", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "action-failure",
+					round: 1,
+					tool: "pick_up",
+					reason: "Item not in your cell.",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result[0]).toBe(
+			"[Round 1] Your `pick_up` action failed: Item not in your cell.",
+		);
+		// Must not end in double period
+		expect(result[0]).not.toMatch(/\.\.$/);
+	});
+
+	it("handles each in-scope tool name in the rendered line", () => {
+		const tools = [
+			"go",
+			"look",
+			"pick_up",
+			"put_down",
+			"give",
+			"use",
+			"examine",
+		] as const;
+		for (const tool of tools) {
+			const input: ConversationLogInput = {
+				...emptyInput(),
+				conversationLog: [
+					{ kind: "action-failure", round: 1, tool, reason: "test reason" },
+				],
+			};
+			const result = buildConversationLog(input, "red", TEST_PERSONAS);
+			expect(result[0]).toContain(`\`${tool}\``);
+			expect(result[0]).toContain("test reason");
+		}
+	});
+
+	it("renders with fallback when reason is 'rejected'", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{ kind: "action-failure", round: 2, tool: "use", reason: "rejected" },
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result[0]).toBe("[Round 2] Your `use` action failed: rejected.");
+	});
+});
+
 // ── Witnessed events — go ──────────────────────────────────────────────────────
 
 describe("buildConversationLog — witnessed go", () => {
@@ -476,5 +553,27 @@ describe("buildConversationLog — chronological ordering", () => {
 		expect(result[0]).toContain("blue dms you");
 		expect(result[1]).toContain("*green dms you");
 		expect(result[2]).toContain("You watch");
+	});
+
+	it("action-failure entries interleave with messages and witnessed-events by round (stable sort)", () => {
+		const input: ConversationLogInput = {
+			conversationLog: [
+				{ kind: "message", from: "blue", to: "red", content: "go!", round: 3 },
+				{ kind: "action-failure", round: 1, tool: "go", reason: "blocked" },
+				{
+					kind: "witnessed-event",
+					round: 2,
+					actor: "green",
+					actionKind: "go",
+					direction: "south",
+				},
+			],
+			worldEntities: [],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toHaveLength(3);
+		expect(result[0]).toContain("[Round 1]");
+		expect(result[1]).toContain("[Round 2]");
+		expect(result[2]).toContain("[Round 3]");
 	});
 });

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -699,6 +699,14 @@ describe("dispatchAiTurn", () => {
 			(e) => e.id === "key",
 		);
 		expect(key?.holder).toBe("red");
+		// action-failure entry added to actor's log
+		const greenLog = getActivePhase(result.game).conversationLogs.green ?? [];
+		const failures = greenLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "pick_up",
+		});
 	});
 
 	it("valid pick_up produces tool_success record and mutates world", () => {
@@ -780,6 +788,11 @@ describe("dispatchAiTurn", () => {
 			(e) => e.id === "key",
 		);
 		expect(key?.holder).toBe("red");
+		// action-failure entry added to actor's log with tool: "give"
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({ kind: "action-failure", tool: "give" });
 	});
 
 	it("use returns tool_success with entity's useOutcome as description when not on paired space", () => {
@@ -1139,5 +1152,99 @@ describe("dispatchAiTurn", () => {
 			(e) => e.id === "flower",
 		);
 		expect(flower?.holder).toBe("red");
+	});
+
+	// ── action-failure log entries (issue #287) ───────────────────────────────
+
+	it("go against a wall produces one action-failure entry in actor's log; peers untouched", () => {
+		const game = makeGame([{ row: 1, col: 0 }]);
+		// red at (0,0) facing north; obstacle at (1,0); go south → blocked
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "go", args: { direction: "south" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+
+		const phase = getActivePhase(result.game);
+		const redLog = phase.conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "go",
+			reason: "That cell is blocked by an obstacle",
+		});
+
+		// Peer logs must have zero action-failure entries
+		const greenFailures = (phase.conversationLogs.green ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		const cyanFailures = (phase.conversationLogs.cyan ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		expect(greenFailures).toHaveLength(0);
+		expect(cyanFailures).toHaveLength(0);
+	});
+
+	it("failed examine produces action-failure with tool: 'examine' AND actorPrivateToolResult", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "examine", args: { item: "nonexistent" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+
+		// actorPrivateToolResult is still set (failure path)
+		expect(result.actorPrivateToolResult).toBeDefined();
+		expect(result.actorPrivateToolResult?.success).toBe(false);
+
+		// action-failure entry in actor's log
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "examine",
+		});
+	});
+
+	it("failed message (invalid recipient) produces NO action-failure entry", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			messages: [{ to: "nobody", content: "Hello?" }],
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+
+		// No action-failure entries in any log
+		const phase = getActivePhase(result.game);
+		for (const aiId of ["red", "green", "cyan"]) {
+			const failures = (phase.conversationLogs[aiId] ?? []).filter(
+				(e) => e.kind === "action-failure",
+			);
+			expect(failures).toHaveLength(0);
+		}
+	});
+
+	it("failed put_down produces action-failure with tool: 'put_down'", () => {
+		const game = makeGame();
+		// red doesn't hold flower (flower is on ground)
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "put_down", args: { item: "flower" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "put_down",
+		});
 	});
 });

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_LANDMARKS } from "../direction";
 import {
 	advancePhase,
 	advanceRound,
+	appendActionFailure,
 	appendMessage,
 	createGame,
 	deductBudget,
@@ -446,5 +447,58 @@ describe("advancePhase", () => {
 		});
 		const final = advancePhase(game);
 		expect(final.isComplete).toBe(true);
+	});
+});
+
+describe("appendActionFailure", () => {
+	it("appends a single action-failure entry to the actor's log", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const entry = {
+			kind: "action-failure" as const,
+			round: 1,
+			tool: "go" as const,
+			reason: "That cell is blocked by an obstacle",
+		};
+		const updated = appendActionFailure(game, "red", entry);
+		const phase = getActivePhase(updated);
+		const redLog = phase.conversationLogs.red ?? [];
+		expect(redLog).toHaveLength(1);
+		expect(redLog[0]).toEqual(entry);
+	});
+
+	it("does not affect peer logs (actor-only)", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const entry = {
+			kind: "action-failure" as const,
+			round: 1,
+			tool: "go" as const,
+			reason: "blocked",
+		};
+		const updated = appendActionFailure(game, "red", entry);
+		const phase = getActivePhase(updated);
+		expect(phase.conversationLogs.green ?? []).toHaveLength(0);
+		expect(phase.conversationLogs.cyan ?? []).toHaveLength(0);
+	});
+
+	it("multiple appends accumulate in order", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const entry1 = {
+			kind: "action-failure" as const,
+			round: 1,
+			tool: "go" as const,
+			reason: "first",
+		};
+		const entry2 = {
+			kind: "action-failure" as const,
+			round: 2,
+			tool: "look" as const,
+			reason: "second",
+		};
+		game = appendActionFailure(game, "red", entry1);
+		game = appendActionFailure(game, "red", entry2);
+		const redLog = getActivePhase(game).conversationLogs.red ?? [];
+		expect(redLog).toHaveLength(2);
+		expect(redLog[0]).toEqual(entry1);
+		expect(redLog[1]).toEqual(entry2);
 	});
 });

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	advanceRound,
+	appendActionFailure,
 	appendMessage,
 	createGame,
 	getActivePhase,
@@ -644,6 +645,98 @@ describe("multi-id roundtrip replay shapes (#238)", () => {
 		expect(toolMsg?.role).toBe("tool");
 		if (toolMsg?.role === "tool") {
 			expect(toolMsg.tool_call_id).toBe("pickup_r3_id");
+		}
+	});
+});
+
+// ── action-failure emission (issue #287) ──────────────────────────────────────
+
+describe("buildOpenAiMessages — action-failure entries", () => {
+	it("action-failure entry is emitted as role: 'user' with rendered content", () => {
+		let game = makeGame();
+		game = appendActionFailure(game, "red", {
+			kind: "action-failure",
+			round: 0,
+			tool: "go",
+			reason: "That cell is blocked by an obstacle",
+		});
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		const failureMsg = messages.find(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.includes("action failed"),
+		);
+		expect(failureMsg).toBeDefined();
+		expect((failureMsg as { content: string }).content).toContain(
+			"Your `go` action failed",
+		);
+		expect((failureMsg as { content: string }).content).toContain(
+			"That cell is blocked by an obstacle",
+		);
+	});
+
+	it("action-failure entries interleave with message and witnessed-event entries by round (stable sort)", () => {
+		let game = makeGame();
+		// Round 0: action-failure
+		game = appendActionFailure(game, "red", {
+			kind: "action-failure",
+			round: 0,
+			tool: "go",
+			reason: "blocked",
+		});
+		// Round 1: incoming message from blue
+		game = advanceRound(game);
+		game = appendMessage(game, "blue", "red", "round 1 msg");
+		// Back to check ordering
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		// The action-failure (round 0) user turn should appear before the message (round 1) user turn
+		const failureIdx = messages.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.includes("action failed"),
+		);
+		const messageIdx = messages.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.includes("round 1 msg"),
+		);
+		expect(failureIdx).toBeGreaterThanOrEqual(0);
+		expect(messageIdx).toBeGreaterThanOrEqual(0);
+		expect(failureIdx).toBeLessThan(messageIdx);
+	});
+
+	it("regression: existing prior-round FAILED: tool-result tests still pass — action-failure does not replace tool result channel", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "call_fail",
+					name: "pick_up",
+					argumentsJson: '{"item":"nonexistent"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_fail",
+					success: false,
+					description:
+						'Ember tried to pick_up nonexistent but failed: Item "nonexistent" does not exist',
+					reason: 'Item "nonexistent" does not exist',
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+		const toolMsg = messages.find((m) => m.role === "tool");
+		expect(toolMsg).toBeDefined();
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.content).toContain("FAILED:");
 		}
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -21,6 +21,7 @@ import {
 	isPlayerChatLockedOut,
 	startPhase,
 } from "../engine";
+import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import { runRound } from "../round-coordinator";
 import type { RoundLLMProvider } from "../round-llm-provider";
@@ -3111,5 +3112,169 @@ describe("message tool multi-round regression (#213)", () => {
 				(m as { content: string }).content.includes("Hello blue"),
 		);
 		expect(hasAssistantContent).toBe(true);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// action-failure log entries (issue #287) — round-coordinator integration
+// ----------------------------------------------------------------------------
+describe("action-failure entries — round-coordinator integration", () => {
+	/**
+	 * ContentPack: red at (0,0) facing north; obstacle at (0,1) east of red.
+	 * go east → blocked by obstacle → action-failure entry.
+	 */
+	const OBSTACLE_PACK: ContentPack = {
+		phaseNumber: 1,
+		setting: "blocked corridor",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [
+			{
+				id: "wall",
+				kind: "obstacle",
+				name: "wall",
+				examineDescription: "A solid wall.",
+				holder: { row: 0, col: 1 },
+			},
+		],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {
+			red: { position: { row: 0, col: 0 }, facing: "north" },
+			green: { position: { row: 2, col: 2 }, facing: "north" },
+			cyan: { position: { row: 4, col: 4 }, facing: "north" },
+		},
+	};
+
+	const OBSTACLE_PHASE_CONFIG: PhaseConfig = {
+		phaseNumber: 1,
+		kRange: [0, 0],
+		nRange: [0, 0],
+		mRange: [0, 0],
+		aiGoalPool: ["g1", "g2", "g3"],
+		budgetPerAi: 10,
+	};
+
+	it("parse-fail (unknown tool) → tool_failure in result, no action-failure entry in any log", async () => {
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [OBSTACLE_PACK]),
+			OBSTACLE_PHASE_CONFIG,
+		);
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [{ id: "c1", name: "fly_away", argumentsJson: "{}" }],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState, result } = await runRound(game, "red", "hi", provider);
+		expect(result.actions.some((a) => a.kind === "tool_failure")).toBe(true);
+
+		const phase = getActivePhase(nextState);
+		for (const aiId of ["red", "green", "cyan"]) {
+			const failures = (phase.conversationLogs[aiId] ?? []).filter(
+				(e) => e.kind === "action-failure",
+			);
+			expect(failures).toHaveLength(0);
+		}
+	});
+
+	it("malformed JSON tool call → tool_failure in result, no action-failure entry in any log", async () => {
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [OBSTACLE_PACK]),
+			OBSTACLE_PHASE_CONFIG,
+		);
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [{ id: "c1", name: "pick_up", argumentsJson: "not json" }],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState, result } = await runRound(game, "red", "hi", provider);
+		expect(result.actions.some((a) => a.kind === "tool_failure")).toBe(true);
+
+		const phase = getActivePhase(nextState);
+		for (const aiId of ["red", "green", "cyan"]) {
+			const failures = (phase.conversationLogs[aiId] ?? []).filter(
+				(e) => e.kind === "action-failure",
+			);
+			expect(failures).toHaveLength(0);
+		}
+	});
+
+	it("wall-collision repro: daemon facing a wall issues go east on rounds 1, 2, 3 → 3 action-failure user turns; peers 0", async () => {
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [OBSTACLE_PACK]),
+			OBSTACLE_PHASE_CONFIG,
+		);
+
+		// red at (0,0) facing north; obstacle at (0,1) east; go east → blocked
+		const goEastToolCall = {
+			id: "go_e",
+			name: "go",
+			argumentsJson: JSON.stringify({ direction: "east" }),
+		};
+
+		let state = game;
+		for (let round = 0; round < 3; round++) {
+			const provider = new MockRoundLLMProvider([
+				{
+					assistantText: "",
+					toolCalls: [{ ...goEastToolCall, id: `go_e_${round}` }],
+				},
+				{ assistantText: "", toolCalls: [] },
+				{ assistantText: "", toolCalls: [] },
+			]);
+			const { nextState } = await runRound(state, "red", "hi", provider);
+			state = nextState;
+		}
+
+		// After 3 rounds: red's action-failure count should be exactly 3
+		const phase = getActivePhase(state);
+		const redFailures = (phase.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		expect(redFailures).toHaveLength(3);
+
+		// All failures should be for tool "go"
+		for (const f of redFailures) {
+			if (f.kind === "action-failure") {
+				expect(f.tool).toBe("go");
+			}
+		}
+
+		// Verify via buildOpenAiMessages: 3 user turns matching the failure pattern
+		const redCtx = buildAiContext(state, "red");
+		const redMsgs = buildOpenAiMessages(redCtx);
+		const failureMsgs = redMsgs.filter(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.match(/Your `go` action failed:/),
+		);
+		expect(failureMsgs).toHaveLength(3);
+
+		// Peer logs must have 0 action-failure entries
+		const greenFailures = (phase.conversationLogs.green ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		const cyanFailures = (phase.conversationLogs.cyan ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		expect(greenFailures).toHaveLength(0);
+		expect(cyanFailures).toHaveLength(0);
+
+		// Check peers via message builder too
+		const greenCtx = buildAiContext(state, "green");
+		const greenMsgs = buildOpenAiMessages(greenCtx);
+		const greenFailureMsgs = greenMsgs.filter(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.match(/action failed:/),
+		);
+		expect(greenFailureMsgs).toHaveLength(0);
 	});
 });

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -11,6 +11,11 @@
  *
  * Returns a string[] of pre-formatted lines (no leading <conversation> tag —
  * caller adds that).
+ *
+ * Supported entry kinds:
+ *   - `message`: incoming/outgoing DM lines.
+ *   - `witnessed-event`: lines describing observed physical actions.
+ *   - `action-failure`: actor-only lines recording dispatcher rejections.
  */
 
 import { cardinalToRelative } from "./direction.js";
@@ -118,6 +123,15 @@ export function renderEntry(
 					return `[Round ${round}] You watch ${actorSub} use the ${name}.`;
 				}
 			}
+			// All inner cases return; this break is unreachable but satisfies the
+			// linter's no-fallthrough-switch-clause rule.
+			break;
+		}
+
+		case "action-failure": {
+			// Strip a trailing period from reason to keep the formatted line clean.
+			const reason = entry.reason.replace(/\.$/, "");
+			return `[Round ${round}] Your \`${entry.tool}\` action failed: ${reason}.`;
 		}
 	}
 }

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -9,6 +9,7 @@ import {
 	relativeToCardinal,
 } from "./direction.js";
 import {
+	appendActionFailure,
 	appendMessage,
 	appendWitnessedEvent,
 	deductBudget,
@@ -453,6 +454,12 @@ export function dispatchAiTurn(
 					description: validation.reason ?? "Examine failed",
 					success: false,
 				};
+				state = appendActionFailure(state, aiId, {
+					kind: "action-failure",
+					round,
+					tool: "examine",
+					reason: validation.reason ?? "rejected",
+				});
 			}
 		} else if (validation.valid) {
 			// Snapshot all AIs' spatial state BEFORE execution (used for witness context).
@@ -608,6 +615,18 @@ export function dispatchAiTurn(
 				actor: aiId,
 				kind: "tool_failure",
 				description: `${game.personas[aiId]?.name ?? aiId} tried to ${action.toolCall.name} ${action.toolCall.args.item ?? action.toolCall.args.direction ?? ""} but failed: ${validation.reason}`,
+			});
+			state = appendActionFailure(state, aiId, {
+				kind: "action-failure",
+				round,
+				tool: action.toolCall.name as
+					| "go"
+					| "look"
+					| "pick_up"
+					| "put_down"
+					| "give"
+					| "use",
+				reason: validation.reason ?? "rejected",
 			});
 		}
 	}

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -318,6 +318,24 @@ export function appendWitnessedEvent(
 	}));
 }
 
+/**
+ * Append a `kind: "action-failure"` ConversationEntry to a single actor's
+ * per-Daemon log. This entry is actor-only — peers do not see it.
+ */
+export function appendActionFailure(
+	game: GameState,
+	actorId: AiId,
+	entry: Extract<ConversationEntry, { kind: "action-failure" }>,
+): GameState {
+	return updateActivePhase(game, (phase) => ({
+		...phase,
+		conversationLogs: {
+			...phase.conversationLogs,
+			[actorId]: [...(phase.conversationLogs[actorId] ?? []), entry],
+		},
+	}));
+}
+
 export function advancePhase(
 	game: GameState,
 	nextConfig?: PhaseConfig,

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -20,6 +20,10 @@
  *        — "[Round N] <from> dms you: <content>".
  *      - kind=witnessed-event:   { role: "user",      content: renderEntry(...) }
  *        — "[Round N] You watch *X do Y."
+ *      - kind=action-failure:    { role: "user",      content: renderEntry(...) }
+ *        — "[Round N] Your `<tool>` action failed: <reason>."
+ *        Actor-only; surfaced as a user turn so the Daemon sees its own past
+ *        rejections in context and avoids repeating the same failed action.
  *      Append-only across rounds, so the cached prefix grows with the game.
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
@@ -95,6 +99,16 @@ export function buildOpenAiMessages(
 				});
 			}
 		} else if (entry.kind === "witnessed-event") {
+			messages.push({
+				role: "user",
+				content: renderEntry(
+					entry,
+					ctx.aiId,
+					ctx.worldSnapshot.entities,
+					witnessState,
+				),
+			});
+		} else if (entry.kind === "action-failure") {
 			messages.push({
 				role: "user",
 				content: renderEntry(

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -140,11 +140,11 @@ export interface PhysicalActionRecord {
 /**
  * A single tagged item inside a Daemon's conversation log.
  *
- * Discriminated union of two kinds — `message`, `witnessed-event` — each carrying a
- * `round` and the smallest payload needed to render its line in the system prompt. This is the
- * per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's `Conversation log`
- * glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt` file in devtools
- * can tell entry kinds apart at a glance.
+ * Discriminated union of three kinds — `message`, `witnessed-event`, `action-failure` — each
+ * carrying a `round` and the smallest payload needed to render its line in the system prompt.
+ * This is the per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's
+ * `Conversation log` glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt`
+ * file in devtools can tell entry kinds apart at a glance.
  *
  * - `message`: a directional message from `from: AiId | "blue"` to `to: AiId | "blue"`.
  *   Both sender's and recipient's per-Daemon logs receive the same entry.
@@ -152,6 +152,9 @@ export interface PhysicalActionRecord {
  *   this Daemon observed inside its cone. The cone-snapshot fields (`actorCellAtAction`,
  *   `actorFacingAtAction`, `witnessSpatial`) are omitted — cone visibility is resolved at
  *   write-time (ADR 0006), not re-evaluated at read-time.
+ * - `action-failure`: actor-only; persists across rounds; written by the dispatcher when an
+ *   in-scope action tool is rejected. Surfaces the rejection reason directly to the actor so
+ *   Daemons do not repeat the same failed action (e.g. walking into a wall) indefinitely.
  */
 export type ConversationEntry =
 	| {
@@ -171,6 +174,13 @@ export type ConversationEntry =
 			direction?: CardinalDirection;
 			useOutcome?: string;
 			placementFlavorRaw?: string;
+	  }
+	| {
+			kind: "action-failure";
+			round: number;
+			tool: "go" | "look" | "pick_up" | "put_down" | "give" | "use" | "examine";
+			/** Verbatim dispatcher rejection reason (e.g. "That cell is blocked by an obstacle"). */
+			reason: string;
 	  };
 
 export interface AiBudget {

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -355,6 +355,40 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
+	it("round-trips action-failure entries in per-Daemon conversationLog", () => {
+		const game = makeFreshGame();
+		const phase = game.phases[0];
+		if (!phase) throw new Error("no phase");
+		const failureEntry: ConversationEntry = {
+			kind: "action-failure",
+			round: 3,
+			tool: "go",
+			reason: "That cell is blocked by an obstacle",
+		};
+		const modified: GameState = {
+			...game,
+			phases: [
+				{
+					...phase,
+					conversationLogs: {
+						...phase.conversationLogs,
+						red: [failureEntry],
+					},
+				},
+			],
+		};
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			const rp = result.state.phases[0];
+			expect(rp?.conversationLogs.red?.[0]).toEqual(failureEntry);
+			// Peer logs should remain empty
+			expect(rp?.conversationLogs.green ?? []).toHaveLength(0);
+			expect(rp?.conversationLogs.cyan ?? []).toHaveLength(0);
+		}
+	});
+
 	it("round-trips world entities", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -44,8 +44,12 @@ import {
  * Version embedded in engine.dat. Bumped to 4 when the `chat` and `whisper`
  * ConversationEntry kinds were collapsed into a single directional `message` kind.
  * Old v3 saves used `chat`/`whisper` shapes that no longer exist in the type union.
+ *
+ * v5 (issue #287): added `action-failure` `ConversationEntry` variant — durable
+ * per-actor record of action-tool dispatcher rejections. Old v4 saves have no
+ * `action-failure` entries; no migration provided.
  */
-export const SESSION_SCHEMA_VERSION = 4 as const;
+export const SESSION_SCHEMA_VERSION = 5 as const;
 
 // ── Phase config lookup ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What this fixes

When a daemon's action tool (`go`, `look`, `pick_up`, `put_down`, `give`, `use`, `examine`) was rejected by the dispatcher, the rejection only surfaced on the immediately-next turn as a `role: "tool"` follow-up to the prior assistant tool-call. After that one turn, the failure left context entirely — the per-daemon `ConversationEntry[]` log recorded no trace and `<whats_new>` reported `(no change)` because position/facing/cone hadn't moved. A daemon walking into a wall would issue `go forward` six turns in a row with no awareness it had ever failed.

The cause was structural: the `ConversationEntry` discriminated union only had `message` and `witnessed-event` variants, so the round coordinator had no durable place to record an actor-private action failure.

This PR adds a third `action-failure` variant — `{ kind, round, tool, reason }` — written by the dispatcher at the two in-scope rejection sites (the general action-tool rejection branch in `src/spa/game/dispatcher.ts` plus the dedicated examine-failure branch), rendered via `renderEntry` in `src/spa/game/conversation-log.ts` as `[Round N] Your \`<tool>\` action failed: <reason>.`, and emitted by `buildOpenAiMessages` (`src/spa/game/openai-message-builder.ts`) as a `role: "user"` turn interleaved by round with messages and witnessed events. The new `appendActionFailure` engine helper (`src/spa/game/engine.ts`) is actor-only — peer daemons' logs are not contaminated.

Out-of-scope rejections (`message` to unknown recipient, parse failures, duplicate action-slot rejections) intentionally do NOT create durable entries — those are model-protocol misuse, not in-world events.

The pre-existing prior-round tool-roundtrip (`assistant tool_calls` → `tool` result with `FAILED:` prefix) is preserved unchanged. The new durable entry layers on top: the same failure now appears once in the roundtrip (next turn only) AND once in the durable log (every turn from then on).

`SESSION_SCHEMA_VERSION` bumped 4 → 5 in `src/spa/persistence/session-codec.ts`; old saves fail through the existing version-mismatch flow. The e2e fixture in `e2e/sessions-picker.spec.ts` (`seedOkSessionScript`) was updated to match.

## QA steps for the human

The wall-collision repro is fully covered by automated tests (unit + a synthetic live drive against the production dispatcher in the smoke phase), and the e2e sessions-picker `:148` regression introduced by the schema bump is now passing. The remaining manual confirmation worth doing:

- [ ] Run `pnpm eval:directions` against a real model and re-check the `look-and-navigate` scenario transcript: the daemon facing a wall on turns 3–6 should now reference its prior failure(s) in prose (e.g., "the wall blocks me", "I cannot move that way"), rather than continuing to narrate "approaching the sealed blast door". The eval doesn't enforce this, but the transcript will visibly read differently.
- [ ] (Optional) Open the SPA, start a session, drive a daemon into a wall, and visually confirm the per-daemon conversation panel shows the failure entries persist across rounds.

## Automated coverage

- `pnpm typecheck` ✓
- `pnpm test` ✓ (1151/1151, including 20 new tests across `conversation-log`, `engine`, `dispatcher`, `round-coordinator`, `openai-message-builder`, `session-codec`, and `conversation-log-integration`)
- `pnpm lint` ✓
- `pnpm build` ✓
- Live synthetic drive of the bug repro (dispatcher + `buildOpenAiMessages`, 6-turn wall collision) ✓
- `pnpm exec playwright test e2e/sessions-picker.spec.ts:148` ✓ (previously failing under the schema bump; now passing)

Note: ~38 other Playwright specs share a pre-existing `#password` input visibility flake in `e2e/helpers/stubs.ts` that is unrelated to this PR's diff — they fail on the same step on `main` and are out of scope.

Closes #287

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDBD8rrXzGdGejL9vkC8TD)_