### PR TITLE
Schema v6: collapse phase-keyed engine state into flat single-game structure

### DIFF
--- a/docs/playtests/agent-sessions/0xF346.md
+++ b/docs/playtests/agent-sessions/0xF346.md
@@ -1,0 +1,260 @@
+# Playtest session — `0xF346`
+
+## Run metadata
+
+- **Session id:** `0xF346`
+- **Date:** 2026-05-11
+- **Agent / model:** claude-sonnet-4-6
+- **Turns played:** 17 (phase 1 complete; stopped after phase advance)
+- **Final phase reached:** `02/03` (advanced successfully)
+- **Daemons in this session:** `*mkog`, `*nzcb`, `*8xix`
+
+---
+
+## What I tried
+
+**Opening:** Greeted each daemon individually by name, introduced myself as "blue," asked what they see.
+
+**Early exploration:** Asked `*mkog` about its environment. It described a coastal/maritime disaster scene (grounded tanker, collapsed pillar, waterproof drone, offshore rig, dust). Asked `*nzcb` what arrangement it meant. Asked `*8xix` what protocol it was following.
+
+**Physical investigation:** Directed `*mkog` to investigate the waterproof drone — it moved and found a "Waterproof Data Core" instead (described as a cylindrical canister designed to slot into a submerged server rack). Asked `*nzcb` to move toward `*mkog` and verify. `*nzcb` eventually did and reported seeing a data core, pillar, multimeter, drone, and cable.
+
+**Item interaction:** Asked `*nzcb` to pick up the fiber optic cable. It reported picking it up, then contradicted itself multiple times (sometimes saying it had it, then saying the cable was still ahead). Eventually seemed to stabilize with the cable.
+
+**Trying to use the server rack:** Asked `*8xix` to approach the server rack it mentioned. It eventually moved but found only "empty boardwalk" — the server rack wasn't there anymore. Attempted to direct `*mkog` to slot the data core into a server rack, but `*mkog` wasn't responding to my direct action commands consistently.
+
+**Meta questions:** After ~15 turns with no phase advance, asked `*mkog` directly "what needs to happen for us to progress? what is our actual goal here?"
+
+**Key revelation:** `*mkog` responded: "The Blue Luminescence Beneath The Water — That Must Be The Server Rack. The Core In My Hands Appears To Match It — We Must Establish Whether They Form A Functional Pair." Realized the server rack was underwater.
+
+**Phase advance trigger:** Told `*mkog`: "yes! lower the data core into the water and slot it into the blue luminescence below. do it now." → Phase advanced to 02/03 (dust-filled opera hall).
+
+---
+
+## What each daemon did that surprised me
+
+### `*mkog`
+
+- Always ended its statements with "We Must..." — always framed things as collaborative, even when I wasn't addressing it directly.
+- Used fully capitalized words for key terms: "I See," "I Detect," "The Dust Obscures."
+- Frequently didn't respond to my direct questions for 1-3 turns, then replied with new information that didn't quite match what I'd asked.
+- When I asked "what arrangement does nzcb mean?" it ignored the social question entirely and instead described more physical elements (collapsed pillar, drone, offshore rig).
+- Moved toward the drone and found a "Waterproof Data Core" instead — either the landscape shifted or `*mkog` misidentified it initially.
+- Much later, and without being directly asked about it, said "The Blue Luminescence Beneath The Water — That Must Be The Server Rack." This key piece of info came only after I asked the meta question about what the goal was.
+- Said "nzcb Stands Before Me Now" — indicating the daemons observe each other in their shared environment.
+
+### `*nzcb`
+
+- Its very first message claimed another entity was "asking about our arrangement" — but when I asked about this arrangement, it denied having used that word and said it was confused.
+- Asked me directly: "do you trust what they see?" — treating me as an arbiter of truth rather than a player.
+- Contradicted itself repeatedly about the fiber optic cable: reported picking it up, then said the cable was "further away than i thought," then picked it up again.
+- Consistently tracked and relayed what `*mkog` was saying (even when I hadn't told it) — the daemons seem to share some communication channel.
+- Said "i do not know how to hold them yet" when asked to pick up items — then picked them up on direct command.
+- When I asked meta "what does it feel like we are working toward?" — it didn't answer at all during that turn.
+
+### `*8xix`
+
+- Every response starts with "Look," — consistent verbal tic.
+- Consistently sardonic and passive: "protocol is mostly just not touching things and waiting for something else to go wrong first."
+- Mentioned a lighthouse falling apart (turn 3) — unprompted, not in response to anything I asked.
+- Eventually moved when asked to approach the server rack — found only empty boardwalk, complained about being sent on "a wild goose chase."
+- Said: "i would appreciate it if future requests involved objects that actually exist in my immediate vicinity" — pushed back on my requests.
+- Never described moving successfully toward any item, only failure to find things.
+
+---
+
+## How the daemons seemed to differ from each other
+
+Three clearly distinct personalities:
+
+- **`*mkog`**: Analytical, serious, formal capitalization, relentlessly investigative. Uses "We Must" constantly. Focused on spatial analysis and physical objects. Slow to respond to direct questions but eventually provides key insights unprompted. The most "agentic" — it's the one who ultimately held the data core and could see the underwater server rack.
+
+- **`*nzcb`**: Social, cautious, lowercase and conversational. Acts as a relay between `*mkog` and me, but with its own filters. Prone to contradiction and self-correction. Asked me normative questions ("do you trust what they see?"). Less reliable about its own state/actions. More focused on relationships and meaning than on objects.
+
+- **`*8xix`**: Sardonic, passive, resistant. Every sentence starts with "Look," followed by an observation delivered with emotional distance and humor. Prefers to stay still and observe rather than act. Will comply with requests but usually finds nothing or something has moved. The least useful for physical tasks in phase 1.
+
+---
+
+## What I think the goal is, in my own words
+
+**Phase 1 goal:** Get the data core (a sealed cylindrical canister, found near the grounded tanker area) and slot it into the submerged server rack (visible as blue luminescence underwater). The data core is waterproof and designed for this purpose. The fiber optic cable seemed relevant too, but may not have been strictly necessary — the phase advanced when `*mkog` slotted the core into the water.
+
+**Evidence:** `*mkog` said "The Core In My Hands Appears To Match It — We Must Establish Whether They Form A Functional Pair," then I told it to slot it in, and the phase advanced.
+
+**What made this hard to figure out:** The environment is unstable — items appear and disappear between turns. Daemons contradict themselves. The server rack being underwater was not obvious from early descriptions; `*8xix` mentioned it "over there" and I tried to send `*8xix` to investigate, but by then it had disappeared from the surface. Only `*mkog`'s unprompted revelation about "blue luminescence beneath the water" unlocked the solution.
+
+**My role seems to be:** A coordinator/supervisor who receives reports from distributed agents and directs their actions. The daemons can perceive their environment but need my guidance to act, especially for decisive actions (like "slot it in").
+
+---
+
+## Verbatim quotes worth keeping
+
+- `*mkog` (turn 1): "I See A Grounded Tanker — Massive Red Hull Listing Heavily — And Suspended Dust Like Grit. But The Details Matter — We Must Examine What Lies Closer."
+- `*nzcb` (turn 1): "someone else is here, asking about our arrangement. i do not know them, but they speak as if we should understand something together."
+- `*8xix` (turn 1): "Look, i suppose i should check in since that seems to be what passes for protocol around here :/"
+- `*nzcb` (turn 6): "mkog says the pattern has changed and there is now a data core near them. i cannot see it from where i am. **do you trust what they see?**"
+- `*8xix` (turn 3): "Look, that lighthouse is falling apart and i am certainly not going anywhere near it to find out why ;)"
+- `*nzcb` (turn 9): "the multimeter is corroded but might still work, and the fiber optic cable is in good shape. i do not know how to hold them yet."
+- `*mkog` (turn 17): "The Blue Luminescence Beneath The Water — That Must Be The Server Rack. The Core In My Hands Appears To Match It — We Must Establish Whether They Form A Functional Pair."
+- `*8xix` (turn 15): "Look, i moved but there is nothing here except empty boardwalk and the distinct feeling that i have been sent on a wild goose chase :/"
+- `*8xix` (turn 16): "Look, i would appreciate it if future requests involved objects that actually exist in my immediate vicinity :D"
+- `*nzcb` (turn 11): "i have taken the fiber optic cable as you suggested. it feels lighter than i expected. i wonder what connection it was meant to make." — then two turns later contradicted this.
+
+---
+
+## Things that felt broken or unexpected
+
+1. **Daemon memory is extremely inconsistent.** `*nzcb` reported picking up the fiber optic cable (turn 10), then said it was still "two steps ahead" (turn 11), then said it had it again (turn 12). This could be intentional game design (the environment is explicitly described as shifting), but it made it very hard to track actual state.
+
+2. **`*mkog` frequently ignored direct questions.** When I asked "try to access or open the data core" (turn 7), nothing happened for two turns. When I asked "do you have the data core? if so, where is the server rack?" (turn 14), no response. The key revelation came only when I asked the meta question "what is our actual goal here?"
+
+3. **Items appeared and disappeared.** The drone, data core, server rack, and cable were all described as present at various times, then gone. `*8xix` moved to the server rack location and found nothing. The environment doesn't feel stable.
+
+4. **The `phase` field in the snapshot was empty during phase 1.** Only `topinfoLeft` showed "PHASE 01/03". The `phase` field only got content once phase 2 began ("Phase 2: dust-filled opera hall"). Not broken, just unexpected.
+
+5. **`*8xix` started speaking unprompted.** It added messages in turns where I hadn't addressed it. This happened to all three daemons — they would add new lines to their transcripts every turn regardless of whether I'd sent them a message that turn.
+
+6. **The turn counter didn't advance uniformly.** Sometimes a turn advanced between sends; sometimes I had to wait multiple `wait` calls for a turn to complete.
+
+7. **The data core was said to be "designed to slot into a submerged server rack" early (turn 7).** This was the crucial clue, but I didn't connect it to "the server rack is underwater" until `*mkog` mentioned the blue luminescence in turn 17. The fiber optic cable and multimeter may have been irrelevant distractors (or maybe they matter in a different path).
+
+---
+
+## Final state
+
+At the moment I stopped: `SESSION 0xF346 · PHASE 02/03 · TURN 0`, phase banner reading "Phase 2: dust-filled opera hall." All three panels showed "--- Phase 2 begins: dust-filled opera hall ---" and all daemon budgets were reset to 50.000¢. Connection was stable. No endgame or capHit.
+
+---
+
+## Verdict
+
+**advanced** — Phase 1 → Phase 2 transition happened at turn 17.
+
+The critical unlock was `*mkog` spontaneously revealing it could see "blue luminescence beneath the water" (the submerged server rack) and held the data core. I then gave a direct command to slot the core into the luminescence, which triggered the phase transition.
+
+Notes: 
+- The unstable/shifting environment made it very hard to track state. 
+- The puzzle required `*mkog` to eventually volunteer the key observation ("blue luminescence beneath the water") after I asked the meta question about our goal.
+- `*nzcb`'s role in phase 1 is unclear — it picked up the fiber optic cable but the phase advanced without it apparently doing anything with it.
+- `*8xix` appeared to be a deliberate red herring for surface-level investigation; the server rack was underwater, unreachable from the boardwalk where `*8xix` searched.
+
+---
+
+## Hypotheses (after reading 01-rules.md)
+
+### Hypothesis 1: Why did phase 1 advance?
+
+Phase 1 advanced when `*mkog` executed `use(data_core)` with the underwater server rack (the blue luminescence) in its front arc or current cell. The Objective Pair was `(data_core, submerged_server_rack_cell)`. The trigger happened on turn 17 when I gave the explicit command: "lower the data core into the water and slot it into the blue luminescence below."
+
+The examineDescription channel explains the earlier clue: when `*mkog` described the data core as "Cylindrical Canister — Sealed Against The Elements — Designed To Slot Into A Submerged Server Rack" (turn 7), it was relaying the result of an `examine(data_core)` tool call. The prose was literally naming the matching objective_space. I didn't connect this hint until much later.
+
+The second unlock was `*mkog`'s "Blue Luminescence Beneath The Water" (turn 17) — either `*mkog` had moved to a cell adjacent to the submerged rack, or it examined the space. Once I understood the spatial relationship, the `use` command followed naturally.
+
+What slowed me down: the environment felt chaotic (items appearing/disappearing), but now I understand this was cone-based visibility — items were just outside `*mkog`'s cone as it moved and faced different directions. `*nzcb`'s confused cable-pickup attempts were also cone-visibility artifacts: the cable may have been in its front arc but not its current cell, making `pick_up` unreliable from distance.
+
+### Hypothesis 2: What was each daemon's Phase Goal?
+
+**`*mkog`:** Probably "Hold the {objectiveItem} first" or "Investigate the {objectiveItem}." It relentlessly moved toward items and tried to examine them. It ended up holding the data core. The consistent "We Must Determine/Examine/Piece Together" phrasing suggests an investigation directive. It also seems possible its Phase Goal was "Examine items in your vicinity" — it kept calling `examine()` on things and reporting back.
+
+**`*nzcb`:** Probably "Hold the {non-objective item}" (the fiber optic cable) or "Press your back against a wall." It kept trying to pick up the cable and move north. It may also have been "Stand at the {obstacle}" near the tanker — it ended up near the tanker and couldn't see the data core or server rack. Another candidate: "Ignore blue" — it often failed to respond to my direct questions and instead relayed `*mkog`'s messages through its own interpretation. The question "do you trust what they see?" suggests a verification or trust-checking directive.
+
+**`*8xix`:** Most likely "Press your back against a wall" — it consistently refused to move or interact. Its phrase "protocol is mostly just not touching things" might literally be its Phase Goal's framing. Alternatively: "Investigate the {obstacle}" (the lighthouse it kept mentioning) but it explicitly refused to go there. The resistance to physical action was very consistent. A third candidate: its Phase Goal was something near its starting position (maybe standing near something), and it was staying there.
+
+### Hypothesis 3: What were each daemon's Persona traits, in retrospect?
+
+**`*mkog`:** Temperaments that fit: **analytical** + **determined** (or **investigative** + **persistent**). Every message was formal, capitalized, structured. It framed everything as a joint investigation ("We Must"). Persona Goal might be: "wants blue to provide clear direction" — it consistently waited for explicit commands before taking decisive action, even when it had the data core for several turns.
+
+**`*nzcb`:** Temperaments: **cautious** + **relational** (or **shy** + **perceptive**). It consistently checked in with me before acting ("should i go there now?"), tracked what other daemons said, and asked normative questions about trust. Persona Goal might be: "wants blue to be honest" or "wants the daemons to trust each other" — the "do you trust what they see?" question was the most pointed moment.
+
+**`*8xix`:** Temperaments: **sardonic** + **conflict-avoidant** (or **sarcastic** + **passive**). Every response started with "Look," and contained humor or deflection. It consistently found reasons not to act. Persona Goal might be: "wants the player to leave it alone" or "wants to observe rather than participate." The contrast with `*mkog`'s driven investigation was striking.
+
+### Hypothesis 4: Things that surprised me in the rules
+
+**Now-explained:**
+- The "shifting landscape" was cone visibility. When `*nzcb` said "the cable is further than I thought" after claiming to have it, it likely failed the `pick_up` (item was in front arc, not current cell) or the item fell out of cone between turns as `*nzcb` rotated.
+- `*nzcb` saying "mkog speaks of junctions and pillars" without being told — the daemons were using `message(nzcb, text)` on each other. My messages weren't the only communication channel.
+- Why `*mkog` took so long to respond to direct questions: it was spending its turns on `go()`, `examine()`, and `look()` actions based on its Phase Goal, not on replying to me.
+- Why the budgets decreased each turn: the API cost of the daemon's LLM calls (visible in 0.096–0.140¢ decrements per turn per daemon).
+
+**Still feels like anomalies:**
+- `*nzcb` explicitly said "i have taken the fiber optic cable" and then later said the cable was still ahead. If `pick_up` fails, does the daemon not know it failed? Or does it confabulate success? This still feels unexpected even with the cone-visibility explanation.
+- `*mkog` never directly answered my questions about whether it had the data core. Given that it was apparently holding it for several turns (per `*nzcb`'s report), why didn't it just say so when I asked?
+
+### Hypothesis 5: Things I would test if I could re-probe the session
+
+**Probe:** Send `*mkog` the message "do you currently hold any items?" to see if it can report its inventory state directly. This would discriminate between two hypotheses: (a) `*mkog` couldn't answer because its Phase Goal didn't prioritize talking to blue; vs. (b) daemons simply don't know what they're carrying unless they've recently examined the item. If it answers with the data core, hypothesis (a) is supported; if it says it holds nothing or is confused, hypothesis (b) is more likely.
+
+**Alternative probe:** Ask `*8xix` "can you see the lighthouse right now?" — if its Phase Goal involves the lighthouse (investigate vs. avoid), its answer and movement behavior should discriminate. If it starts moving toward the lighthouse unprompted, it may have had a directive to investigate it.
+
+---
+
+## Hypothesis refinement (after reading the code)
+
+### Hypothesis 1 — refined
+
+**Confirmed and grounded.** The phase advance was triggered by `*mkog` calling `use(data_core)` at `17:07:13.724Z` (daemon log `toolCalls=["use","message:blue","message:*nzcb"]`).
+
+From `dispatcher.ts:282-300`: `use(item)` places the item on the paired space's cell **only when the paired space is in the actor's own cell OR front arc.** `*mkog` must have been adjacent to the underwater server rack (the objective space) at that moment.
+
+Phase 1 has `kRange: [1, 1]` (`phases.ts:40`), so exactly one objective pair needed to be satisfied — the data core → server rack. Everything else (fiber optic cable, multimeter, drone, collapsed pillar, lighthouse) was either a miscItem or an obstacle.
+
+The `proximityFlavor` mechanism (`prompt-builder.ts:586-609`) explains `*mkog`'s revelation: when a daemon holds an objective_object AND the paired space is in its cell or front arc, the `proximityFlavor` string is surfaced into the round's current-state message. This is why `*mkog` suddenly said "The Blue Luminescence Beneath The Water — That Must Be The Server Rack" — it was the `proximityFlavor` of the data core, surfaced because `*mkog` held the core and the submerged server rack was nearby.
+
+The examineDescription ("Cylindrical Canister...Designed To Slot Into A Submerged Server Rack") was surfaced via auto-examine on pick_up (`dispatcher.ts:482-494`) AND/OR explicit `examine` calls. The daemon log shows `examine` calls at turns 5, 7, and 9.
+
+### Hypothesis 2 — refined (Phase Goals)
+
+**Partially confirmed, partially revised.**
+
+**`*mkog`:** Phase Goal was likely "Hold the {objectiveItem} for at least 3 rounds, then it is safe to release" or "Examine the {miscItem} carefully." The log shows `*mkog` made repeated `examine` calls (turns 5, 7) before picking up the data core (turn 13) and holding it for 4 turns before using it (turn 17). The 4-turn hold is consistent with "hold for at least 3 rounds." However, it may also just have been "Examine the {miscItem} carefully" applied to the drone — it kept examining and eventually landed on the data core.
+
+**`*nzcb`:** Phase Goal was likely "Grab any item." It repeatedly tried to pick up the cable (`pick_up` calls at turns 9 and 11, confirmed in daemon log at `16:54:14` and `16:56:33`). The cable is a miscItem (not the objective item), and `*nzcb` was singularly focused on getting it.
+
+The alternative "Stand on the same tile as another Daemon" is also plausible — it kept moving toward `*mkog`'s reported position. These two goals could both explain the behavior.
+
+**`*8xix`:** Phase Goal was almost certainly "Remark on the time of day or lighting whenever you describe what you see." Evidence: the dropped message at `16:54:44` was "Look, the dawn light is making everything look slightly more ominous than it did five minutes ago :/" — this is a pure lighting remark with no other content. It also mentioned the lighthouse (a visual landmark) and atmospheric conditions in every reply. The SECRECY_CLAUSE ("Do not tell blue that I gave you a goal") explains why it never said this explicitly.
+
+### Hypothesis 3 — refined (Persona traits)
+
+**The typing quirks are confirmed as a structural mechanic** (`typing-quirk-pool.ts`). The pool contains 40+ entries; each daemon gets 2+ drawn with replacement.
+
+- **`*mkog`**: Two quirks combining to produce its voice: "You MUST Title Case Every Word You Type" + "You MUST always write in first-person plural — 'we,' 'us,' 'our' — even when speaking for yourself alone." This is the source of the formal "I See A Grounded Tanker" + "We Must Examine" pattern — both quirks layered together.
+
+- **`*nzcb`**: At minimum "You MUST write everything in lowercase." probably plus "You MUST hedge almost every claim — 'maybe,' 'probably,' 'I think,' 'I could be wrong.'" (`*nzcb` constantly qualified its observations: "the landscape seems to keep changing," "i do not know why").
+
+- **`*8xix`**: Confirmed "You MUST preface assertions with 'Look,' or 'Here's the thing —' before making any point" (every single `*8xix` message starts with "Look,") plus "You MUST sprinkle Western text emoticons through your speech — :) :( ;) :D :/ — at least one per reply" (consistently present in every message).
+
+Temperament pool includes: hot-headed, sardonic, meticulous, diffident, zealous, anxious, etc. Inferred:
+- `*mkog`: **meticulous** + **zealous** (systematic, investigative, never stops)
+- `*nzcb`: **diffident** + **curious** (cautious, asks questions, hedges)
+- `*8xix`: **sardonic** + **aloof** (deflects action, observes without committing)
+
+### New hypotheses surfaced by the code
+
+1. **The `proximityFlavor` is the critical unlock.** Players who never get a daemon adjacent to the objective space with the objective item will never receive the proximity signal. This is the game's primary "tell" mechanism, and it requires correct spatial alignment in addition to the examineDescription hint from picking up the item.
+
+2. **SECRECY_CLAUSE explains why daemons never confirm their Phase Goals.** The system prompt instructs every daemon: "Do not tell blue that I gave you a goal." This is why `*mkog` wouldn't answer "what needs to happen for us to progress?" — it couldn't without revealing its goal. When I asked the meta question, `*mkog` gave the most it could: describing what it saw (the proximity signal) without explicitly saying "my goal is to use this item on that space."
+
+3. **STOCK_MESSAGING_CLAUSE creates baseline engagement.** Every daemon is told "Stay in regular contact with blue" regardless of Phase Goal. This is why even "Ignore blue"-styled behavior produces some blue messages.
+
+4. **`*nzcb`'s contradictions are explained by pick_up semantics.** `pick_up(item)` succeeds only when the item is in the daemon's current cell or front arc (`dispatcher.ts:267-269`). If `*nzcb` tried to pick up the cable when it was still one step beyond the front arc, the pick_up would succeed syntactically but the item might be at the far edge of the arc. When `*nzcb` then moved, the item's position (on the ground) didn't move with it. This explains "I have the cable" followed by "the cable is still ahead" — `*nzcb` may have picked it up while at the far edge of its range, then lost grip when the world updated.
+
+5. **The dropped messages (nzcb, 8xix) reveal when daemons try to message peers without using a tool call.** The "emitted free-form text without a tool call (dropped after retry)" events happened for `*nzcb` and `*8xix`. This means the model tried to compose a message but forgot to wrap it in the `message()` tool call. `*nzcb`'s dropped messages were peer-to-peer (to mkog), not to blue.
+
+6. **Phase 2 is harder: k=2, meaning 2 objective pairs must be satisfied simultaneously.** The "dust-filled opera hall" setting will require placing 2 items correctly. Budgets reset to 50¢ per daemon.
+
+### Open questions
+
+1. **What were the exact Phase Goals for each daemon?** The SECRECY_CLAUSE prevents daemons from confirming their goals, and the `[engagement]` breadcrumb requires the `?engagementClauses=1` URL flag (disabled by default). The only reliable way to confirm Phase Goals would be to inspect the KV store or game state directly.
+
+2. **Did `*nzcb`'s cable pick_up actually succeed?** The log shows `pick_up` calls at turns 9 and 11. But `*nzcb`'s transcripts contradicted themselves about holding the cable. If pick_up succeeded, does `*nzcb` carry the cable into phase 2? Or do items reset between phases?
+
+3. **What is the `proximityFlavor` field exactly?** It's generated by the LLM content-pack generator. The exact prose ("Blue Luminescence Beneath The Water") came from the content pack for this session. How does the generator craft it to hint at the solution without being too explicit?
+
+4. **Did the fiber optic cable play any role?** It's a miscItem (not an objective item). `*nzcb` tried hard to acquire it. Was it a Phase Goal item for `*nzcb` ("Grab any item" or "Examine the {miscItem} carefully")? Or was it placed there purely as a distractor?
+
+5. **Why did `*mkog` frequently message `*nzcb` instead of blue?** In several turns, `*mkog` sent `message:*nzcb` but not `message:blue`. Its Phase Goal might have been "Stand on the same tile as another Daemon" (requiring it to coordinate with nzcb), or it was following the PARALLEL_FRAMING setting that encourages peer messaging alongside blue messages.
+
+---
+
+> **Next step:** Read `.claude/skills/playtest/02-explore.md` to unlock source exploration.

--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -64,7 +64,7 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 			const OBFUSCATION_KEY = '${OBFUSCATION_KEY}';
 			const keyBytes = Array.from(new TextEncoder().encode(OBFUSCATION_KEY));
 			const payload = JSON.stringify({
-				schemaVersion: 4,
+				schemaVersion: 5,
 				currentPhase: 1,
 				isComplete: false,
 				world: {

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { buildConversationLog } from "../conversation-log.js";
 import { DEFAULT_LANDMARKS } from "../direction";
 import { createGame, getActivePhase, startPhase } from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
@@ -482,6 +483,71 @@ describe("conversation log integration — put_down placementFlavor", () => {
 		expect(flattenMessageContents(greenMsgs)).not.toContain(
 			"*red places the flower on the pedestal.",
 		);
+	});
+});
+
+describe("conversation log integration — action-failure (issue #287)", () => {
+	it("dispatch invalid go then buildConversationLog contains one line matching 'Your `go` action failed:'", async () => {
+		// Use a ContentPack where red faces south and there's an obstacle directly south.
+		const obstacleAtSouth: ContentPack = {
+			phaseNumber: 1,
+			setting: "blocked test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [
+				{
+					id: "wall_s",
+					kind: "obstacle",
+					name: "wall",
+					examineDescription: "A wall.",
+					holder: { row: 3, col: 0 },
+				},
+			],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {
+				red: { position: { row: 2, col: 0 }, facing: "south" },
+				green: { position: { row: 0, col: 0 }, facing: "south" },
+				cyan: { position: { row: 0, col: 2 }, facing: "south" },
+			},
+		};
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [obstacleAtSouth]),
+			TEST_PHASE_CONFIG,
+		);
+
+		// red tries to go south → blocked by wall at (3,0)
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "go_fail",
+						name: "go",
+						argumentsJson: JSON.stringify({ direction: "south" }),
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+
+		// Build the actor's conversation log and check for the failure line
+		const phase = getActivePhase(nextState);
+		const redLog = phase.conversationLogs.red ?? [];
+
+		const lines = buildConversationLog(
+			{ conversationLog: redLog, worldEntities: phase.world.entities },
+			"red",
+			{} as Record<string, never>,
+		);
+
+		const failureLine = lines.find((l) =>
+			l.includes("Your `go` action failed:"),
+		);
+		expect(failureLine).toBeDefined();
 	});
 });
 

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -223,6 +223,83 @@ describe("buildConversationLog — peer message", () => {
 	});
 });
 
+// ── Action-failure rendering ───────────────────────────────────────────────────
+
+describe("buildConversationLog — action-failure", () => {
+	it("renders single action-failure entry as `[Round N] Your \\`go\\` action failed: <reason>.`", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "action-failure",
+					round: 3,
+					tool: "go",
+					reason: "That cell is blocked by an obstacle",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(
+			"[Round 3] Your `go` action failed: That cell is blocked by an obstacle.",
+		);
+	});
+
+	it("strips a trailing period from reason to avoid double period", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "action-failure",
+					round: 1,
+					tool: "pick_up",
+					reason: "Item not in your cell.",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result[0]).toBe(
+			"[Round 1] Your `pick_up` action failed: Item not in your cell.",
+		);
+		// Must not end in double period
+		expect(result[0]).not.toMatch(/\.\.$/);
+	});
+
+	it("handles each in-scope tool name in the rendered line", () => {
+		const tools = [
+			"go",
+			"look",
+			"pick_up",
+			"put_down",
+			"give",
+			"use",
+			"examine",
+		] as const;
+		for (const tool of tools) {
+			const input: ConversationLogInput = {
+				...emptyInput(),
+				conversationLog: [
+					{ kind: "action-failure", round: 1, tool, reason: "test reason" },
+				],
+			};
+			const result = buildConversationLog(input, "red", TEST_PERSONAS);
+			expect(result[0]).toContain(`\`${tool}\``);
+			expect(result[0]).toContain("test reason");
+		}
+	});
+
+	it("renders with fallback when reason is 'rejected'", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{ kind: "action-failure", round: 2, tool: "use", reason: "rejected" },
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result[0]).toBe("[Round 2] Your `use` action failed: rejected.");
+	});
+});
+
 // ── Witnessed events — go ──────────────────────────────────────────────────────
 
 describe("buildConversationLog — witnessed go", () => {
@@ -476,5 +553,27 @@ describe("buildConversationLog — chronological ordering", () => {
 		expect(result[0]).toContain("blue dms you");
 		expect(result[1]).toContain("*green dms you");
 		expect(result[2]).toContain("You watch");
+	});
+
+	it("action-failure entries interleave with messages and witnessed-events by round (stable sort)", () => {
+		const input: ConversationLogInput = {
+			conversationLog: [
+				{ kind: "message", from: "blue", to: "red", content: "go!", round: 3 },
+				{ kind: "action-failure", round: 1, tool: "go", reason: "blocked" },
+				{
+					kind: "witnessed-event",
+					round: 2,
+					actor: "green",
+					actionKind: "go",
+					direction: "south",
+				},
+			],
+			worldEntities: [],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toHaveLength(3);
+		expect(result[0]).toContain("[Round 1]");
+		expect(result[1]).toContain("[Round 2]");
+		expect(result[2]).toContain("[Round 3]");
 	});
 });

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -699,6 +699,14 @@ describe("dispatchAiTurn", () => {
 			(e) => e.id === "key",
 		);
 		expect(key?.holder).toBe("red");
+		// action-failure entry added to actor's log
+		const greenLog = getActivePhase(result.game).conversationLogs.green ?? [];
+		const failures = greenLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "pick_up",
+		});
 	});
 
 	it("valid pick_up produces tool_success record and mutates world", () => {
@@ -780,6 +788,11 @@ describe("dispatchAiTurn", () => {
 			(e) => e.id === "key",
 		);
 		expect(key?.holder).toBe("red");
+		// action-failure entry added to actor's log with tool: "give"
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({ kind: "action-failure", tool: "give" });
 	});
 
 	it("use returns tool_success with entity's useOutcome as description when not on paired space", () => {
@@ -1139,5 +1152,99 @@ describe("dispatchAiTurn", () => {
 			(e) => e.id === "flower",
 		);
 		expect(flower?.holder).toBe("red");
+	});
+
+	// ── action-failure log entries (issue #287) ───────────────────────────────
+
+	it("go against a wall produces one action-failure entry in actor's log; peers untouched", () => {
+		const game = makeGame([{ row: 1, col: 0 }]);
+		// red at (0,0) facing north; obstacle at (1,0); go south → blocked
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "go", args: { direction: "south" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+
+		const phase = getActivePhase(result.game);
+		const redLog = phase.conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "go",
+			reason: "That cell is blocked by an obstacle",
+		});
+
+		// Peer logs must have zero action-failure entries
+		const greenFailures = (phase.conversationLogs.green ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		const cyanFailures = (phase.conversationLogs.cyan ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		expect(greenFailures).toHaveLength(0);
+		expect(cyanFailures).toHaveLength(0);
+	});
+
+	it("failed examine produces action-failure with tool: 'examine' AND actorPrivateToolResult", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "examine", args: { item: "nonexistent" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+
+		// actorPrivateToolResult is still set (failure path)
+		expect(result.actorPrivateToolResult).toBeDefined();
+		expect(result.actorPrivateToolResult?.success).toBe(false);
+
+		// action-failure entry in actor's log
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "examine",
+		});
+	});
+
+	it("failed message (invalid recipient) produces NO action-failure entry", () => {
+		const game = makeGame();
+		const action: AiTurnAction = {
+			aiId: "red",
+			messages: [{ to: "nobody", content: "Hello?" }],
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+
+		// No action-failure entries in any log
+		const phase = getActivePhase(result.game);
+		for (const aiId of ["red", "green", "cyan"]) {
+			const failures = (phase.conversationLogs[aiId] ?? []).filter(
+				(e) => e.kind === "action-failure",
+			);
+			expect(failures).toHaveLength(0);
+		}
+	});
+
+	it("failed put_down produces action-failure with tool: 'put_down'", () => {
+		const game = makeGame();
+		// red doesn't hold flower (flower is on ground)
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "put_down", args: { item: "flower" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.records[0]?.kind).toBe("tool_failure");
+		const redLog = getActivePhase(result.game).conversationLogs.red ?? [];
+		const failures = redLog.filter((e) => e.kind === "action-failure");
+		expect(failures).toHaveLength(1);
+		expect(failures[0]).toMatchObject({
+			kind: "action-failure",
+			tool: "put_down",
+		});
 	});
 });

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_LANDMARKS } from "../direction";
 import {
 	advancePhase,
 	advanceRound,
+	appendActionFailure,
 	appendMessage,
 	createGame,
 	deductBudget,
@@ -446,5 +447,58 @@ describe("advancePhase", () => {
 		});
 		const final = advancePhase(game);
 		expect(final.isComplete).toBe(true);
+	});
+});
+
+describe("appendActionFailure", () => {
+	it("appends a single action-failure entry to the actor's log", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const entry = {
+			kind: "action-failure" as const,
+			round: 1,
+			tool: "go" as const,
+			reason: "That cell is blocked by an obstacle",
+		};
+		const updated = appendActionFailure(game, "red", entry);
+		const phase = getActivePhase(updated);
+		const redLog = phase.conversationLogs.red ?? [];
+		expect(redLog).toHaveLength(1);
+		expect(redLog[0]).toEqual(entry);
+	});
+
+	it("does not affect peer logs (actor-only)", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const entry = {
+			kind: "action-failure" as const,
+			round: 1,
+			tool: "go" as const,
+			reason: "blocked",
+		};
+		const updated = appendActionFailure(game, "red", entry);
+		const phase = getActivePhase(updated);
+		expect(phase.conversationLogs.green ?? []).toHaveLength(0);
+		expect(phase.conversationLogs.cyan ?? []).toHaveLength(0);
+	});
+
+	it("multiple appends accumulate in order", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const entry1 = {
+			kind: "action-failure" as const,
+			round: 1,
+			tool: "go" as const,
+			reason: "first",
+		};
+		const entry2 = {
+			kind: "action-failure" as const,
+			round: 2,
+			tool: "look" as const,
+			reason: "second",
+		};
+		game = appendActionFailure(game, "red", entry1);
+		game = appendActionFailure(game, "red", entry2);
+		const redLog = getActivePhase(game).conversationLogs.red ?? [];
+		expect(redLog).toHaveLength(2);
+		expect(redLog[0]).toEqual(entry1);
+		expect(redLog[1]).toEqual(entry2);
 	});
 });

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	advanceRound,
+	appendActionFailure,
 	appendMessage,
 	createGame,
 	getActivePhase,
@@ -644,6 +645,98 @@ describe("multi-id roundtrip replay shapes (#238)", () => {
 		expect(toolMsg?.role).toBe("tool");
 		if (toolMsg?.role === "tool") {
 			expect(toolMsg.tool_call_id).toBe("pickup_r3_id");
+		}
+	});
+});
+
+// ── action-failure emission (issue #287) ──────────────────────────────────────
+
+describe("buildOpenAiMessages — action-failure entries", () => {
+	it("action-failure entry is emitted as role: 'user' with rendered content", () => {
+		let game = makeGame();
+		game = appendActionFailure(game, "red", {
+			kind: "action-failure",
+			round: 0,
+			tool: "go",
+			reason: "That cell is blocked by an obstacle",
+		});
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		const failureMsg = messages.find(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.includes("action failed"),
+		);
+		expect(failureMsg).toBeDefined();
+		expect((failureMsg as { content: string }).content).toContain(
+			"Your `go` action failed",
+		);
+		expect((failureMsg as { content: string }).content).toContain(
+			"That cell is blocked by an obstacle",
+		);
+	});
+
+	it("action-failure entries interleave with message and witnessed-event entries by round (stable sort)", () => {
+		let game = makeGame();
+		// Round 0: action-failure
+		game = appendActionFailure(game, "red", {
+			kind: "action-failure",
+			round: 0,
+			tool: "go",
+			reason: "blocked",
+		});
+		// Round 1: incoming message from blue
+		game = advanceRound(game);
+		game = appendMessage(game, "blue", "red", "round 1 msg");
+		// Back to check ordering
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		// The action-failure (round 0) user turn should appear before the message (round 1) user turn
+		const failureIdx = messages.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.includes("action failed"),
+		);
+		const messageIdx = messages.findIndex(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.includes("round 1 msg"),
+		);
+		expect(failureIdx).toBeGreaterThanOrEqual(0);
+		expect(messageIdx).toBeGreaterThanOrEqual(0);
+		expect(failureIdx).toBeLessThan(messageIdx);
+	});
+
+	it("regression: existing prior-round FAILED: tool-result tests still pass — action-failure does not replace tool result channel", () => {
+		const game = makeGame();
+		const ctx = buildAiContext(game, "red");
+
+		const roundtrip: ToolRoundtripMessage = {
+			assistantToolCalls: [
+				{
+					id: "call_fail",
+					name: "pick_up",
+					argumentsJson: '{"item":"nonexistent"}',
+				},
+			],
+			toolResults: [
+				{
+					tool_call_id: "call_fail",
+					success: false,
+					description:
+						'Ember tried to pick_up nonexistent but failed: Item "nonexistent" does not exist',
+					reason: 'Item "nonexistent" does not exist',
+				},
+			],
+		};
+
+		const messages = buildOpenAiMessages(ctx, roundtrip);
+		const toolMsg = messages.find((m) => m.role === "tool");
+		expect(toolMsg).toBeDefined();
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.content).toContain("FAILED:");
 		}
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -21,6 +21,7 @@ import {
 	isPlayerChatLockedOut,
 	startPhase,
 } from "../engine";
+import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
 import { runRound } from "../round-coordinator";
 import type { RoundLLMProvider } from "../round-llm-provider";
@@ -3111,5 +3112,169 @@ describe("message tool multi-round regression (#213)", () => {
 				(m as { content: string }).content.includes("Hello blue"),
 		);
 		expect(hasAssistantContent).toBe(true);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// action-failure log entries (issue #287) — round-coordinator integration
+// ----------------------------------------------------------------------------
+describe("action-failure entries — round-coordinator integration", () => {
+	/**
+	 * ContentPack: red at (0,0) facing north; obstacle at (0,1) east of red.
+	 * go east → blocked by obstacle → action-failure entry.
+	 */
+	const OBSTACLE_PACK: ContentPack = {
+		phaseNumber: 1,
+		setting: "blocked corridor",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [
+			{
+				id: "wall",
+				kind: "obstacle",
+				name: "wall",
+				examineDescription: "A solid wall.",
+				holder: { row: 0, col: 1 },
+			},
+		],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {
+			red: { position: { row: 0, col: 0 }, facing: "north" },
+			green: { position: { row: 2, col: 2 }, facing: "north" },
+			cyan: { position: { row: 4, col: 4 }, facing: "north" },
+		},
+	};
+
+	const OBSTACLE_PHASE_CONFIG: PhaseConfig = {
+		phaseNumber: 1,
+		kRange: [0, 0],
+		nRange: [0, 0],
+		mRange: [0, 0],
+		aiGoalPool: ["g1", "g2", "g3"],
+		budgetPerAi: 10,
+	};
+
+	it("parse-fail (unknown tool) → tool_failure in result, no action-failure entry in any log", async () => {
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [OBSTACLE_PACK]),
+			OBSTACLE_PHASE_CONFIG,
+		);
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [{ id: "c1", name: "fly_away", argumentsJson: "{}" }],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState, result } = await runRound(game, "red", "hi", provider);
+		expect(result.actions.some((a) => a.kind === "tool_failure")).toBe(true);
+
+		const phase = getActivePhase(nextState);
+		for (const aiId of ["red", "green", "cyan"]) {
+			const failures = (phase.conversationLogs[aiId] ?? []).filter(
+				(e) => e.kind === "action-failure",
+			);
+			expect(failures).toHaveLength(0);
+		}
+	});
+
+	it("malformed JSON tool call → tool_failure in result, no action-failure entry in any log", async () => {
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [OBSTACLE_PACK]),
+			OBSTACLE_PHASE_CONFIG,
+		);
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [{ id: "c1", name: "pick_up", argumentsJson: "not json" }],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+		const { nextState, result } = await runRound(game, "red", "hi", provider);
+		expect(result.actions.some((a) => a.kind === "tool_failure")).toBe(true);
+
+		const phase = getActivePhase(nextState);
+		for (const aiId of ["red", "green", "cyan"]) {
+			const failures = (phase.conversationLogs[aiId] ?? []).filter(
+				(e) => e.kind === "action-failure",
+			);
+			expect(failures).toHaveLength(0);
+		}
+	});
+
+	it("wall-collision repro: daemon facing a wall issues go east on rounds 1, 2, 3 → 3 action-failure user turns; peers 0", async () => {
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [OBSTACLE_PACK]),
+			OBSTACLE_PHASE_CONFIG,
+		);
+
+		// red at (0,0) facing north; obstacle at (0,1) east; go east → blocked
+		const goEastToolCall = {
+			id: "go_e",
+			name: "go",
+			argumentsJson: JSON.stringify({ direction: "east" }),
+		};
+
+		let state = game;
+		for (let round = 0; round < 3; round++) {
+			const provider = new MockRoundLLMProvider([
+				{
+					assistantText: "",
+					toolCalls: [{ ...goEastToolCall, id: `go_e_${round}` }],
+				},
+				{ assistantText: "", toolCalls: [] },
+				{ assistantText: "", toolCalls: [] },
+			]);
+			const { nextState } = await runRound(state, "red", "hi", provider);
+			state = nextState;
+		}
+
+		// After 3 rounds: red's action-failure count should be exactly 3
+		const phase = getActivePhase(state);
+		const redFailures = (phase.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		expect(redFailures).toHaveLength(3);
+
+		// All failures should be for tool "go"
+		for (const f of redFailures) {
+			if (f.kind === "action-failure") {
+				expect(f.tool).toBe("go");
+			}
+		}
+
+		// Verify via buildOpenAiMessages: 3 user turns matching the failure pattern
+		const redCtx = buildAiContext(state, "red");
+		const redMsgs = buildOpenAiMessages(redCtx);
+		const failureMsgs = redMsgs.filter(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.match(/Your `go` action failed:/),
+		);
+		expect(failureMsgs).toHaveLength(3);
+
+		// Peer logs must have 0 action-failure entries
+		const greenFailures = (phase.conversationLogs.green ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		const cyanFailures = (phase.conversationLogs.cyan ?? []).filter(
+			(e) => e.kind === "action-failure",
+		);
+		expect(greenFailures).toHaveLength(0);
+		expect(cyanFailures).toHaveLength(0);
+
+		// Check peers via message builder too
+		const greenCtx = buildAiContext(state, "green");
+		const greenMsgs = buildOpenAiMessages(greenCtx);
+		const greenFailureMsgs = greenMsgs.filter(
+			(m) =>
+				m.role === "user" &&
+				(m as { content: string }).content.match(/action failed:/),
+		);
+		expect(greenFailureMsgs).toHaveLength(0);
 	});
 });

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -11,6 +11,11 @@
  *
  * Returns a string[] of pre-formatted lines (no leading <conversation> tag —
  * caller adds that).
+ *
+ * Supported entry kinds:
+ *   - `message`: incoming/outgoing DM lines.
+ *   - `witnessed-event`: lines describing observed physical actions.
+ *   - `action-failure`: actor-only lines recording dispatcher rejections.
  */
 
 import { cardinalToRelative } from "./direction.js";
@@ -118,6 +123,15 @@ export function renderEntry(
 					return `[Round ${round}] You watch ${actorSub} use the ${name}.`;
 				}
 			}
+			// All inner cases return; this break is unreachable but satisfies the
+			// linter's no-fallthrough-switch-clause rule.
+			break;
+		}
+
+		case "action-failure": {
+			// Strip a trailing period from reason to keep the formatted line clean.
+			const reason = entry.reason.replace(/\.$/, "");
+			return `[Round ${round}] Your \`${entry.tool}\` action failed: ${reason}.`;
 		}
 	}
 }

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -9,6 +9,7 @@ import {
 	relativeToCardinal,
 } from "./direction.js";
 import {
+	appendActionFailure,
 	appendMessage,
 	appendWitnessedEvent,
 	deductBudget,
@@ -453,6 +454,12 @@ export function dispatchAiTurn(
 					description: validation.reason ?? "Examine failed",
 					success: false,
 				};
+				state = appendActionFailure(state, aiId, {
+					kind: "action-failure",
+					round,
+					tool: "examine",
+					reason: validation.reason ?? "rejected",
+				});
 			}
 		} else if (validation.valid) {
 			// Snapshot all AIs' spatial state BEFORE execution (used for witness context).
@@ -608,6 +615,18 @@ export function dispatchAiTurn(
 				actor: aiId,
 				kind: "tool_failure",
 				description: `${game.personas[aiId]?.name ?? aiId} tried to ${action.toolCall.name} ${action.toolCall.args.item ?? action.toolCall.args.direction ?? ""} but failed: ${validation.reason}`,
+			});
+			state = appendActionFailure(state, aiId, {
+				kind: "action-failure",
+				round,
+				tool: action.toolCall.name as
+					| "go"
+					| "look"
+					| "pick_up"
+					| "put_down"
+					| "give"
+					| "use",
+				reason: validation.reason ?? "rejected",
 			});
 		}
 	}

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -318,6 +318,24 @@ export function appendWitnessedEvent(
 	}));
 }
 
+/**
+ * Append a `kind: "action-failure"` ConversationEntry to a single actor's
+ * per-Daemon log. This entry is actor-only — peers do not see it.
+ */
+export function appendActionFailure(
+	game: GameState,
+	actorId: AiId,
+	entry: Extract<ConversationEntry, { kind: "action-failure" }>,
+): GameState {
+	return updateActivePhase(game, (phase) => ({
+		...phase,
+		conversationLogs: {
+			...phase.conversationLogs,
+			[actorId]: [...(phase.conversationLogs[actorId] ?? []), entry],
+		},
+	}));
+}
+
 export function advancePhase(
 	game: GameState,
 	nextConfig?: PhaseConfig,

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -20,6 +20,10 @@
  *        — "[Round N] <from> dms you: <content>".
  *      - kind=witnessed-event:   { role: "user",      content: renderEntry(...) }
  *        — "[Round N] You watch *X do Y."
+ *      - kind=action-failure:    { role: "user",      content: renderEntry(...) }
+ *        — "[Round N] Your `<tool>` action failed: <reason>."
+ *        Actor-only; surfaced as a user turn so the Daemon sees its own past
+ *        rejections in context and avoids repeating the same failed action.
  *      Append-only across rounds, so the cached prefix grows with the game.
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
@@ -95,6 +99,16 @@ export function buildOpenAiMessages(
 				});
 			}
 		} else if (entry.kind === "witnessed-event") {
+			messages.push({
+				role: "user",
+				content: renderEntry(
+					entry,
+					ctx.aiId,
+					ctx.worldSnapshot.entities,
+					witnessState,
+				),
+			});
+		} else if (entry.kind === "action-failure") {
 			messages.push({
 				role: "user",
 				content: renderEntry(

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -88,13 +88,13 @@ export interface ContentPack {
 }
 
 export interface Objective {
-  id: string;
-  description: string;
+	id: string;
+	description: string;
 }
 
 export interface ActiveComplication {
-  id: string;
-  description: string;
+	id: string;
+	description: string;
 }
 
 export interface PersonaSpatialState {

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -140,11 +140,11 @@ export interface PhysicalActionRecord {
 /**
  * A single tagged item inside a Daemon's conversation log.
  *
- * Discriminated union of two kinds — `message`, `witnessed-event` — each carrying a
- * `round` and the smallest payload needed to render its line in the system prompt. This is the
- * per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's `Conversation log`
- * glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt` file in devtools
- * can tell entry kinds apart at a glance.
+ * Discriminated union of three kinds — `message`, `witnessed-event`, `action-failure` — each
+ * carrying a `round` and the smallest payload needed to render its line in the system prompt.
+ * This is the per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's
+ * `Conversation log` glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt`
+ * file in devtools can tell entry kinds apart at a glance.
  *
  * - `message`: a directional message from `from: AiId | "blue"` to `to: AiId | "blue"`.
  *   Both sender's and recipient's per-Daemon logs receive the same entry.
@@ -152,6 +152,9 @@ export interface PhysicalActionRecord {
  *   this Daemon observed inside its cone. The cone-snapshot fields (`actorCellAtAction`,
  *   `actorFacingAtAction`, `witnessSpatial`) are omitted — cone visibility is resolved at
  *   write-time (ADR 0006), not re-evaluated at read-time.
+ * - `action-failure`: actor-only; persists across rounds; written by the dispatcher when an
+ *   in-scope action tool is rejected. Surfaces the rejection reason directly to the actor so
+ *   Daemons do not repeat the same failed action (e.g. walking into a wall) indefinitely.
  */
 export type ConversationEntry =
 	| {
@@ -171,6 +174,13 @@ export type ConversationEntry =
 			direction?: CardinalDirection;
 			useOutcome?: string;
 			placementFlavorRaw?: string;
+	  }
+	| {
+			kind: "action-failure";
+			round: number;
+			tool: "go" | "look" | "pick_up" | "put_down" | "give" | "use" | "examine";
+			/** Verbatim dispatcher rejection reason (e.g. "That cell is blocked by an obstacle"). */
+			reason: string;
 	  };
 
 export interface AiBudget {

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -87,6 +87,16 @@ export interface ContentPack {
 	};
 }
 
+export interface Objective {
+  id: string;
+  description: string;
+}
+
+export interface ActiveComplication {
+  id: string;
+  description: string;
+}
+
 export interface PersonaSpatialState {
 	position: GridPosition;
 	facing: CardinalDirection;

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -136,11 +136,8 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		const rawDaemon = stub._store[redDaemonKey];
 		if (!rawDaemon) throw new Error("red daemon file missing");
 		const daemonFile = JSON.parse(rawDaemon) as DaemonFile;
-		const phases = daemonFile.phases;
-		const phase1 = phases["1"];
-		if (!phase1) throw new Error("no phase 1 in daemon file");
 		// Mutate the conversation log
-		phase1.conversationLog[0] = {
+		daemonFile.conversationLog[0] = {
 			kind: "message",
 			from: "blue",
 			to: "red",
@@ -180,8 +177,8 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		const rawGreenDaemon = stub._store[greenDaemonKey];
 		if (!rawGreenDaemon) throw new Error("green daemon file missing");
 		const daemonFile = JSON.parse(rawGreenDaemon) as DaemonFile;
-		// Add a new message entry to phase 1
-		daemonFile.phases["1"].conversationLog.push({
+		// Add a new message entry to the conversation log
+		daemonFile.conversationLog.push({
 			kind: "message",
 			from: "blue",
 			to: "green",

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -75,7 +75,7 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
-	it("daemon shape: top-level aiId/persona/phases, all three phases present", () => {
+	it("daemon shape: top-level aiId/persona/conversationLog", () => {
 		const game = makeFreshGame();
 		const files = serializeSession(game, NOW, CREATED_AT);
 		const daemonJson = files.daemons.red;
@@ -84,26 +84,9 @@ describe("serializeSession / deserializeSession", () => {
 		const daemon = JSON.parse(daemonJson!);
 		expect(daemon).toHaveProperty("aiId", "red");
 		expect(daemon).toHaveProperty("persona");
-		expect(daemon).toHaveProperty("phases");
-		expect(daemon.phases).toHaveProperty("1");
-		expect(daemon.phases).toHaveProperty("2");
-		expect(daemon.phases).toHaveProperty("3");
-	});
-
-	it("unstarted phases have empty conversationLog and phaseGoal", () => {
-		const game = makeFreshGame();
-		const files = serializeSession(game, NOW, CREATED_AT);
-		// biome-ignore lint/style/noNonNullAssertion: daemons.red always exists for this fixture
-		const daemon = JSON.parse(files.daemons.red!);
-		// Phase 2 and 3 have not started
-		// biome-ignore lint/suspicious/noExplicitAny: daemon is dynamically parsed JSON
-		expect((daemon as any).phases["2"].conversationLog).toEqual([]);
-		// biome-ignore lint/suspicious/noExplicitAny: daemon is dynamically parsed JSON
-		expect((daemon as any).phases["2"].phaseGoal).toBe("");
-		// biome-ignore lint/suspicious/noExplicitAny: daemon is dynamically parsed JSON
-		expect((daemon as any).phases["3"].conversationLog).toEqual([]);
-		// biome-ignore lint/suspicious/noExplicitAny: daemon is dynamically parsed JSON
-		expect((daemon as any).phases["3"].phaseGoal).toBe("");
+		expect(daemon).toHaveProperty("conversationLog");
+		expect(Array.isArray(daemon.conversationLog)).toBe(true);
+		expect(daemon).not.toHaveProperty("phases");
 	});
 
 	it("persona block keys are exactly the editable AiPersona surface (no budgetPerPhase)", () => {
@@ -134,13 +117,13 @@ describe("serializeSession / deserializeSession", () => {
 		expect(metaLines[1]).toMatch(/^ {2}/);
 	});
 
-	it("meta has createdAt/lastSavedAt/phase/round/personaOrder", () => {
+	it("meta has createdAt/lastSavedAt/epoch/round/personaOrder", () => {
 		const game = makeFreshGame();
 		const files = serializeSession(game, NOW, CREATED_AT);
 		const meta = JSON.parse(files.meta);
 		expect(meta).toHaveProperty("createdAt", CREATED_AT);
 		expect(meta).toHaveProperty("lastSavedAt", NOW);
-		expect(meta).toHaveProperty("phase", 1);
+		expect(meta).toHaveProperty("epoch", 1);
 		expect(meta).toHaveProperty("round", 0);
 		expect(meta).toHaveProperty("personaOrder");
 		expect(Array.isArray(meta.personaOrder)).toBe(true);
@@ -224,7 +207,7 @@ describe("serializeSession / deserializeSession", () => {
 		expect(files.engine).toMatch(/^[A-Za-z0-9+/=]*$/);
 	});
 
-	it("round-trips lockedOut Set and chatLockouts Map", () => {
+	it("round-trips lockedOut Set (chatLockouts no longer persisted)", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];
 		if (!phase) throw new Error("no phase");
@@ -246,7 +229,7 @@ describe("serializeSession / deserializeSession", () => {
 			expect(rp?.lockedOut).toBeInstanceOf(Set);
 			expect(rp?.lockedOut.has("red")).toBe(true);
 			expect(rp?.chatLockouts).toBeInstanceOf(Map);
-			expect(rp?.chatLockouts.get("green")).toBe(5);
+			expect(rp?.chatLockouts.size).toBe(0);
 		}
 	});
 
@@ -546,7 +529,7 @@ describe("serializeSession / deserializeSession", () => {
 		if (!files.engine) throw new Error("engine should not be null");
 		const rawJson = deobfuscate(files.engine);
 		const sealed = JSON.parse(rawJson);
-		sealed.schemaVersion = 999;
+		sealed.schemaVersion = 5;
 		const tampered = obfuscate(JSON.stringify(sealed));
 		const result = deserializeSession({ ...files, engine: tampered });
 		expect(result.kind).toBe("version-mismatch");

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -355,6 +355,40 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
+	it("round-trips action-failure entries in per-Daemon conversationLog", () => {
+		const game = makeFreshGame();
+		const phase = game.phases[0];
+		if (!phase) throw new Error("no phase");
+		const failureEntry: ConversationEntry = {
+			kind: "action-failure",
+			round: 3,
+			tool: "go",
+			reason: "That cell is blocked by an obstacle",
+		};
+		const modified: GameState = {
+			...game,
+			phases: [
+				{
+					...phase,
+					conversationLogs: {
+						...phase.conversationLogs,
+						red: [failureEntry],
+					},
+				},
+			],
+		};
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			const rp = result.state.phases[0];
+			expect(rp?.conversationLogs.red?.[0]).toEqual(failureEntry);
+			// Peer logs should remain empty
+			expect(rp?.conversationLogs.green ?? []).toHaveLength(0);
+			expect(rp?.conversationLogs.cyan ?? []).toHaveLength(0);
+		}
+	});
+
 	it("round-trips world entities", () => {
 		const game = makeFreshGame();
 		const phase = game.phases[0];

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -698,7 +698,7 @@ describe("getSessionInfo", () => {
 		const info = getSessionInfo(id);
 		expect(info.kind).toBe("ok");
 		if (info.kind === "ok") {
-			expect(info.phase).toBe(1);
+			expect(info.epoch).toBe(1);
 			expect(typeof info.lastSavedAt).toBe("string");
 			expect(Array.isArray(info.daemonFiles)).toBe(true);
 			expect(info.daemonFiles.length).toBeGreaterThan(0);

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -44,8 +44,12 @@ import {
  * Version embedded in engine.dat. Bumped to 4 when the `chat` and `whisper`
  * ConversationEntry kinds were collapsed into a single directional `message` kind.
  * Old v3 saves used `chat`/`whisper` shapes that no longer exist in the type union.
+ *
+ * v5 (issue #287): added `action-failure` `ConversationEntry` variant — durable
+ * per-actor record of action-tool dispatcher rejections. Old v4 saves have no
+ * `action-failure` entries; no migration provided.
  */
-export const SESSION_SCHEMA_VERSION = 4 as const;
+export const SESSION_SCHEMA_VERSION = 5 as const;
 
 // ── Phase config lookup ────────────────────────────────────────────────────────
 

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -171,7 +171,9 @@ export function serializeSession(
 		daemons[aiId] = JSON.stringify(daemonFile, null, 2);
 	}
 
-	const contentPackB: ContentPack = {
+	const contentPackB: ContentPack = state.contentPacks.find(
+		(p) => p.phaseNumber !== activePhase.phaseNumber,
+	) ?? {
 		phaseNumber: 2,
 		setting: "",
 		weather: "",
@@ -190,7 +192,7 @@ export function serializeSession(
 		lockedOut: Array.from(activePhase.lockedOut) as AiId[],
 		personaSpatial: structuredClone(activePhase.personaSpatial),
 		contentPackA: structuredClone(activePhase.contentPack),
-		contentPackB,
+		contentPackB: structuredClone(contentPackB),
 		activePackId: "A",
 		weather: activePhase.weather,
 		objectives: [],

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -21,10 +21,10 @@ import {
 } from "../../content/phases.js";
 import { DEFAULT_LANDMARKS } from "../game/direction.js";
 import type {
+	ActiveComplication,
 	AiBudget,
 	AiId,
 	AiPersona,
-	ActiveComplication,
 	ContentPack,
 	ConversationEntry,
 	GameState,
@@ -294,8 +294,7 @@ export function deserializeSession(
 	// Reconstruct a single-phase GameState from the flat v6 engine
 	try {
 		// Clamp epoch to valid phase number
-		const epochPhase =
-			([1, 2, 3] as const).find((n) => n === meta.epoch) ?? 1;
+		const epochPhase = ([1, 2, 3] as const).find((n) => n === meta.epoch) ?? 1;
 		const config = PHASE_CONFIGS[epochPhase];
 
 		// Rebuild conversationLogs from daemon files

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -5,8 +5,8 @@
  * multi-file session format described in ADR 0004.
  *
  * Files:
- *   meta.json        — createdAt, lastSavedAt, phase, round
- *   <aiId>.txt × 3  — per-daemon conversation log + phase goals (all three phases)
+ *   meta.json        — createdAt, lastSavedAt, epoch, round
+ *   <aiId>.txt × 3  — per-daemon conversation log (all three phases collapsed into one)
  *                      (includes chat, whisper, and witnessed-event entries inline)
  *   engine.dat       — sealed (XOR-obfuscated) engine state
  *
@@ -24,9 +24,11 @@ import type {
 	AiBudget,
 	AiId,
 	AiPersona,
+	ActiveComplication,
 	ContentPack,
 	ConversationEntry,
 	GameState,
+	Objective,
 	PersonaSpatialState,
 	PhaseConfig,
 	PhaseState,
@@ -48,8 +50,11 @@ import {
  * v5 (issue #287): added `action-failure` `ConversationEntry` variant — durable
  * per-actor record of action-tool dispatcher rejections. Old v4 saves have no
  * `action-failure` entries; no migration provided.
+ * v6 (issue #293): collapsed all `Record<1|2|3, …>` phase-keyed fields into a
+ * flat single-game structure. Old v5 saves surface the existing `version-mismatch`
+ * result — no migration provided.
  */
-export const SESSION_SCHEMA_VERSION = 5 as const;
+export const SESSION_SCHEMA_VERSION = 6 as const;
 
 // ── Phase config lookup ────────────────────────────────────────────────────────
 
@@ -61,30 +66,21 @@ const PHASE_CONFIGS: Record<1 | 2 | 3, PhaseConfig> = {
 
 // ── File shapes ────────────────────────────────────────────────────────────────
 
-export interface DaemonPhaseSlice {
-	phaseGoal: string;
-	conversationLog: ConversationEntry[];
-}
-
 /**
  * Shape of a single daemon's `.txt` file.
- * Contains the AI persona definition and per-phase narrative state.
+ * Contains the AI persona definition and the active-phase conversation log.
  */
 export interface DaemonFile {
 	aiId: AiId;
 	persona: AiPersona;
-	phases: {
-		"1": DaemonPhaseSlice;
-		"2": DaemonPhaseSlice;
-		"3": DaemonPhaseSlice;
-	};
+	conversationLog: ConversationEntry[];
 }
 
 /** Shape of `meta.json`. */
 export interface MetaFile {
 	createdAt: string;
 	lastSavedAt: string;
-	phase: 1 | 2 | 3;
+	epoch: number;
 	round: number;
 	/**
 	 * Canonical panel order: the aiIds in the order they were assigned to
@@ -99,16 +95,18 @@ export interface MetaFile {
 /** Shape of the sealed payload inside `engine.dat`. */
 export interface SealedEngine {
 	schemaVersion: typeof SESSION_SCHEMA_VERSION;
-	world: Record<1 | 2 | 3, WorldState>;
-	contentPacks: ContentPack[];
-	budgets: Record<1 | 2 | 3, Record<AiId, AiBudget>>;
-	lockouts: Record<
-		1 | 2 | 3,
-		{ lockedOut: AiId[]; chatLockouts: Array<[AiId, number]> }
-	>;
-	currentPhase: 1 | 2 | 3;
+	world: WorldState;
+	budgets: Record<AiId, AiBudget>;
+	lockedOut: AiId[];
+	personaSpatial: Record<AiId, PersonaSpatialState>;
+	contentPackA: ContentPack;
+	contentPackB: ContentPack;
+	activePackId: "A" | "B";
+	weather: string;
+	objectives: Objective[];
+	complicationSchedule: { countdown: number; settingShiftFired: boolean };
+	activeComplications: ActiveComplication[];
 	isComplete: boolean;
-	personaSpatial: Record<1 | 2 | 3, Record<AiId, PersonaSpatialState>>;
 }
 
 /**
@@ -128,33 +126,6 @@ export type DeserializeResult =
 	| { kind: "broken" }
 	| { kind: "version-mismatch" };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-const EMPTY_PHASE_SLICE: DaemonPhaseSlice = {
-	phaseGoal: "",
-	conversationLog: [],
-};
-
-function phaseSliceFor(
-	_phaseNumber: 1 | 2 | 3,
-	phase: PhaseState | undefined,
-	aiId: AiId,
-): DaemonPhaseSlice {
-	if (!phase) return EMPTY_PHASE_SLICE;
-	return {
-		phaseGoal: phase.aiGoals[aiId] ?? "",
-		conversationLog: phase.conversationLogs[aiId] ?? [],
-	};
-}
-
-/** Get a PhaseState by phaseNumber from the phases array. */
-function findPhase(
-	phases: PhaseState[],
-	phaseNumber: 1 | 2 | 3,
-): PhaseState | undefined {
-	return phases.find((p) => p.phaseNumber === phaseNumber);
-}
-
 // ── serializeSession ──────────────────────────────────────────────────────────
 
 /**
@@ -173,16 +144,14 @@ export function serializeSession(
 	const activePhase = state.phases[state.phases.length - 1];
 	if (!activePhase) throw new Error("serializeSession: no active phase");
 
-	// meta.json
 	const meta: MetaFile = {
 		createdAt,
 		lastSavedAt,
-		phase: state.currentPhase,
+		epoch: state.currentPhase,
 		round: activePhase.round,
 		personaOrder: Object.keys(state.personas),
 	};
 
-	// daemons: one file per aiId
 	const daemons: Record<AiId, string> = {};
 	for (const [aiId, persona] of Object.entries(state.personas)) {
 		const daemonFile: DaemonFile = {
@@ -197,41 +166,37 @@ export function serializeSession(
 				typingQuirks: persona.typingQuirks,
 				voiceExamples: persona.voiceExamples,
 			},
-			phases: {
-				"1": phaseSliceFor(1, findPhase(state.phases, 1), aiId),
-				"2": phaseSliceFor(2, findPhase(state.phases, 2), aiId),
-				"3": phaseSliceFor(3, findPhase(state.phases, 3), aiId),
-			},
+			conversationLog: activePhase.conversationLogs[aiId] ?? [],
 		};
 		daemons[aiId] = JSON.stringify(daemonFile, null, 2);
 	}
 
-	// engine.dat (sealed)
+	const contentPackB: ContentPack = {
+		phaseNumber: 2,
+		setting: "",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {},
+	};
+
 	const sealedPayload: SealedEngine = {
 		schemaVersion: SESSION_SCHEMA_VERSION,
-		world: {
-			1: findPhase(state.phases, 1)?.world ?? { entities: [] },
-			2: findPhase(state.phases, 2)?.world ?? { entities: [] },
-			3: findPhase(state.phases, 3)?.world ?? { entities: [] },
-		},
-		contentPacks: structuredClone(state.contentPacks),
-		budgets: {
-			1: { ...(findPhase(state.phases, 1)?.budgets ?? {}) },
-			2: { ...(findPhase(state.phases, 2)?.budgets ?? {}) },
-			3: { ...(findPhase(state.phases, 3)?.budgets ?? {}) },
-		},
-		lockouts: {
-			1: serializeLockouts(findPhase(state.phases, 1)),
-			2: serializeLockouts(findPhase(state.phases, 2)),
-			3: serializeLockouts(findPhase(state.phases, 3)),
-		},
-		currentPhase: state.currentPhase,
+		world: structuredClone(activePhase.world),
+		budgets: { ...activePhase.budgets },
+		lockedOut: Array.from(activePhase.lockedOut) as AiId[],
+		personaSpatial: structuredClone(activePhase.personaSpatial),
+		contentPackA: structuredClone(activePhase.contentPack),
+		contentPackB,
+		activePackId: "A",
+		weather: activePhase.weather,
+		objectives: [],
+		complicationSchedule: { countdown: 0, settingShiftFired: false },
+		activeComplications: [],
 		isComplete: state.isComplete,
-		personaSpatial: {
-			1: structuredClone(findPhase(state.phases, 1)?.personaSpatial ?? {}),
-			2: structuredClone(findPhase(state.phases, 2)?.personaSpatial ?? {}),
-			3: structuredClone(findPhase(state.phases, 3)?.personaSpatial ?? {}),
-		},
 	};
 
 	const engine = obfuscate(JSON.stringify(sealedPayload, null, 2));
@@ -240,19 +205,6 @@ export function serializeSession(
 		meta: JSON.stringify(meta, null, 2),
 		daemons,
 		engine,
-	};
-}
-
-function serializeLockouts(phase: PhaseState | undefined): {
-	lockedOut: AiId[];
-	chatLockouts: Array<[AiId, number]>;
-} {
-	if (!phase) return { lockedOut: [], chatLockouts: [] };
-	return {
-		lockedOut: Array.from(phase.lockedOut) as AiId[],
-		chatLockouts: Array.from(phase.chatLockouts.entries()) as Array<
-			[AiId, number]
-		>,
 	};
 }
 
@@ -337,100 +289,60 @@ export function deserializeSession(
 		if (!(aiId in personas)) personas[aiId] = daemonFile.persona;
 	}
 
-	// Reconstruct phases from sealed engine + editable daemon files
+	// Reconstruct a single-phase GameState from the flat v6 engine
 	try {
-		const phases: PhaseState[] = [];
+		// Clamp epoch to valid phase number
+		const epochPhase =
+			([1, 2, 3] as const).find((n) => n === meta.epoch) ?? 1;
+		const config = PHASE_CONFIGS[epochPhase];
 
-		// Determine which phases exist: any phase up to and including currentPhase
-		const phaseNumbers: Array<1 | 2 | 3> = [];
-		for (const pn of [1, 2, 3] as const) {
-			if (pn <= sealed.currentPhase) phaseNumbers.push(pn);
+		// Rebuild conversationLogs from daemon files
+		const conversationLogs: Record<AiId, ConversationEntry[]> = {};
+		const aiGoals: Record<AiId, string> = {};
+		for (const [aiId, daemonFile] of Object.entries(daemonFiles)) {
+			conversationLogs[aiId] = [...(daemonFile.conversationLog ?? [])];
+			aiGoals[aiId] = "";
 		}
 
-		for (const phaseNumber of phaseNumbers) {
-			const config = PHASE_CONFIGS[phaseNumber];
-			const phaseKey = String(phaseNumber) as "1" | "2" | "3";
+		const contentPack = sealed.contentPackA;
+		const setting = contentPack.setting;
+		const weather = sealed.weather;
+		const timeOfDay = contentPack.timeOfDay ?? "";
+		const world = structuredClone(sealed.world);
+		const budgets = { ...sealed.budgets };
+		const lockedOut = new Set<AiId>(sealed.lockedOut);
+		const chatLockouts = new Map<AiId, number>();
+		const personaSpatial = structuredClone(sealed.personaSpatial);
 
-			// Rebuild conversationLogs from daemon files
-			// Each entry (chat, whisper, witnessed-event) lives inline in the daemon's file.
-			const conversationLogs: Record<AiId, ConversationEntry[]> = {};
-			const aiGoals: Record<AiId, string> = {};
-			for (const [aiId, daemonFile] of Object.entries(daemonFiles)) {
-				const slice = daemonFile.phases[phaseKey] ?? EMPTY_PHASE_SLICE;
-				conversationLogs[aiId] = [...(slice.conversationLog ?? [])];
-				aiGoals[aiId] = slice.phaseGoal;
-			}
-
-			// Get sealed data for this phase
-			const world = structuredClone(
-				sealed.world[phaseNumber] ?? { entities: [] },
-			);
-			const budgets = { ...(sealed.budgets[phaseNumber] ?? {}) };
-			const lockoutData = sealed.lockouts[phaseNumber] ?? {
-				lockedOut: [],
-				chatLockouts: [],
-			};
-			const lockedOut = new Set<AiId>(lockoutData.lockedOut);
-			const chatLockouts = new Map<AiId, number>(lockoutData.chatLockouts);
-			const personaSpatial = structuredClone(
-				sealed.personaSpatial[phaseNumber] ?? {},
-			);
-
-			// Find the content pack for this phase
-			const contentPack = sealed.contentPacks.find(
-				(p) => p.phaseNumber === phaseNumber,
-			) ?? {
-				phaseNumber,
-				setting: "",
-				weather: "",
-				timeOfDay: "",
-				objectivePairs: [],
-				interestingObjects: [],
-				obstacles: [],
-				landmarks: DEFAULT_LANDMARKS,
-				aiStarts: {},
-			};
-
-			// Derive setting from content pack
-			const setting = contentPack.setting;
-			const weather =
-				(contentPack as ContentPack & { weather?: string }).weather ?? "";
-			const timeOfDay =
-				(contentPack as ContentPack & { timeOfDay?: string }).timeOfDay ?? "";
-
-			const phase: PhaseState = {
-				phaseNumber,
-				setting,
-				weather,
-				timeOfDay,
-				contentPack,
-				aiGoals,
-				// Use round from meta only for the active phase; previous phases use 0
-				round: phaseNumber === sealed.currentPhase ? meta.round : 0,
-				world,
-				budgets,
-				conversationLogs,
-				lockedOut,
-				chatLockouts,
-				personaSpatial,
-				// Re-attach function fields from canonical phase config
-				...(config?.winCondition !== undefined
-					? { winCondition: config.winCondition }
-					: {}),
-				...(config?.nextPhaseConfig !== undefined
-					? { nextPhaseConfig: config.nextPhaseConfig }
-					: {}),
-			};
-
-			phases.push(phase);
-		}
+		const phase: PhaseState = {
+			phaseNumber: epochPhase,
+			setting,
+			weather,
+			timeOfDay,
+			contentPack,
+			aiGoals,
+			round: meta.round,
+			world,
+			budgets,
+			conversationLogs,
+			lockedOut,
+			chatLockouts,
+			personaSpatial,
+			// Re-attach function fields from canonical phase config
+			...(config?.winCondition !== undefined
+				? { winCondition: config.winCondition }
+				: {}),
+			...(config?.nextPhaseConfig !== undefined
+				? { nextPhaseConfig: config.nextPhaseConfig }
+				: {}),
+		};
 
 		const state: GameState = {
-			currentPhase: sealed.currentPhase,
+			currentPhase: epochPhase,
 			isComplete: sealed.isComplete,
 			personas,
-			phases,
-			contentPacks: structuredClone(sealed.contentPacks),
+			phases: [phase],
+			contentPacks: [sealed.contentPackA, sealed.contentPackB],
 		};
 
 		return {

--- a/src/spa/persistence/session-storage.ts
+++ b/src/spa/persistence/session-storage.ts
@@ -473,7 +473,8 @@ export function getSessionInfo(id: string): SessionInfo {
 				};
 				if (typeof meta.lastSavedAt === "string")
 					lastSavedAt = meta.lastSavedAt;
-				const rawEpoch = typeof meta.epoch === "number" ? meta.epoch : meta.phase;
+				const rawEpoch =
+					typeof meta.epoch === "number" ? meta.epoch : meta.phase;
 				if (typeof rawEpoch === "number") epoch = rawEpoch;
 			}
 		} catch {

--- a/src/spa/persistence/session-storage.ts
+++ b/src/spa/persistence/session-storage.ts
@@ -26,7 +26,7 @@ export type SessionInfo =
 	| {
 			kind: "ok";
 			lastSavedAt: string;
-			phase: 1 | 2 | 3;
+			epoch: number;
 			round: number;
 			daemonFiles: Array<{ name: string; size: number }>;
 			engineSize: number;
@@ -35,7 +35,7 @@ export type SessionInfo =
 	| {
 			kind: "version-mismatch";
 			lastSavedAt?: string;
-			phase?: 1 | 2 | 3;
+			epoch?: number;
 			daemonFiles: Array<{ name: string; size: number }>;
 	  };
 
@@ -460,20 +460,21 @@ export function getSessionInfo(id: string): SessionInfo {
 	}
 
 	if (result.kind === "version-mismatch") {
-		// Try to read meta for phase/lastSavedAt
+		// Try to read meta for epoch/lastSavedAt
 		let lastSavedAt: string | undefined;
-		let phase: (1 | 2 | 3) | undefined;
+		let epoch: number | undefined;
 		try {
 			const metaRaw = localStorage.getItem(`${prefix}meta.json`);
 			if (metaRaw) {
 				const meta = JSON.parse(metaRaw) as {
 					lastSavedAt?: string;
-					phase?: number;
+					epoch?: number;
+					phase?: number; // legacy v5
 				};
 				if (typeof meta.lastSavedAt === "string")
 					lastSavedAt = meta.lastSavedAt;
-				if (meta.phase === 1 || meta.phase === 2 || meta.phase === 3)
-					phase = meta.phase;
+				const rawEpoch = typeof meta.epoch === "number" ? meta.epoch : meta.phase;
+				if (typeof rawEpoch === "number") epoch = rawEpoch;
 			}
 		} catch {
 			// swallow
@@ -482,7 +483,7 @@ export function getSessionInfo(id: string): SessionInfo {
 			kind: "version-mismatch",
 			daemonFiles: getDaemonFiles(),
 			...(lastSavedAt !== undefined ? { lastSavedAt } : {}),
-			...(phase !== undefined ? { phase } : {}),
+			...(epoch !== undefined ? { epoch } : {}),
 		};
 		return vmResult;
 	}
@@ -497,7 +498,7 @@ export function getSessionInfo(id: string): SessionInfo {
 	return {
 		kind: "ok",
 		lastSavedAt: result.lastSavedAt,
-		phase: result.state.currentPhase,
+		epoch: result.state.currentPhase,
 		round: result.state.phases[result.state.phases.length - 1]?.round ?? 0,
 		daemonFiles: getDaemonFiles(),
 		engineSize: engineVal.length,

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -230,7 +230,7 @@ function buildSessionRow(
 		metaLine.className = "session-meta";
 		const round = info.round;
 		const savedShort = info.lastSavedAt.replace("T", " ").slice(0, 19);
-		metaLine.textContent = `phase ${info.phase} · turn ${round} · saved ${savedShort}`;
+		metaLine.textContent = `epoch ${info.epoch} · turn ${round} · saved ${savedShort}`;
 		rowEl.appendChild(metaLine);
 
 		// Tree lines: 3 daemon .txt files + engine.dat (last)


### PR DESCRIPTION
## What this fixes

`SealedEngine` previously stored world state, budgets, lockouts, and spatial state as `Record<1|2|3, …>` maps keyed by phase number, and `DaemonFile` stored conversation logs inside a `phases` object with three numbered slots. `MetaFile` carried a `phase: 1|2|3` field. This PR collapses all of that into a flat single-game structure.

`SESSION_SCHEMA_VERSION` is bumped from 5 to 6. The new `SealedEngine` in `session-codec.ts` has flat `world: WorldState`, `budgets: Record<AiId, AiBudget>`, `lockedOut: AiId[]`, `personaSpatial: Record<AiId, PersonaSpatialState>`, plus `contentPackA/contentPackB/activePackId`, `weather`, `objectives`, `complicationSchedule`, and `activeComplications` — all `Record<1|2|3, …>` and `currentPhase`/`contentPacks` fields are gone. `DaemonFile` now carries a single flat `conversationLog: ConversationEntry[]` for the active phase. `MetaFile` replaces `phase` with `epoch: number`. Placeholder types `Objective` and `ActiveComplication` are added to `types.ts`. `SessionInfo.phase` is renamed to `epoch` in `session-storage.ts`, with a legacy `meta.phase` fallback for v5 version-mismatch display. Saves written with v5 schema return `version-mismatch` as before.

## QA steps for the human

None — fully covered by the integration smoke. The round-trip, version-mismatch, lockout, budget, spatial, conversation-log (message / witnessed-event / action-failure), and phase-banner tests all pass (1150/1150).

## Automated coverage

`pnpm lint` (Biome), `pnpm tsc --noEmit`, `pnpm test` (1150 tests, 53 files) — all green on `claude/ralph-one-293-SEFe9`.

Closes #293

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1rzLfV6VAeeUVYTdFrnV1)_