### PR TITLE
Complication Engine: schedule, pool, draw, dispatch

### DIFF
--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -1,0 +1,878 @@
+/**
+ * Tests for the Complication Engine (issue #296).
+ *
+ * tickComplication(game, rng) → ComplicationResult | null
+ *
+ * Pure, deterministic module. Tests use array-backed seededRng helpers.
+ * Prior art: win-condition.test.ts, engine.test.ts
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LANDMARKS } from "../direction.js";
+import { createGame, getActivePhase, startPhase } from "../engine.js";
+import {
+	applyComplicationResult,
+	decrementComplicationCountdown,
+	tickComplication,
+} from "../complication-engine.js";
+import type {
+	ActiveComplication,
+	AiId,
+	AiPersona,
+	ComplicationSchedule,
+	ContentPack,
+	GameState,
+	GridPosition,
+	PersonaSpatialState,
+	PhaseState,
+	ToolName,
+	WorldEntity,
+	WorldState,
+} from "../types.js";
+
+// ── RNG helper ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a closure that yields each value in `values` in order.
+ * Throws if the array is exhausted (catches unintended extra rng reads).
+ */
+function seededRng(values: number[]): () => number {
+	let idx = 0;
+	return () => {
+		if (idx >= values.length) {
+			throw new Error(
+				`seededRng: exhausted after ${values.length} reads (call #${idx + 1})`,
+			);
+		}
+		// biome-ignore lint/style/noNonNullAssertion: bounded by check above
+		return values[idx++]!;
+	};
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "test goal",
+		blurb: "test blurb",
+		typingQuirks: ["fragments", "ALL CAPS"],
+		voiceExamples: ["Now.", "BURN IT.", "Soon."],
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "#81b29a",
+		temperaments: ["meticulous", "meticulous"],
+		personaGoal: "test goal",
+		blurb: "test blurb",
+		typingQuirks: ["ellipses", "no contractions"],
+		voiceExamples: ["OK...", "That is not balanced.", "One more."],
+	},
+	cyan: {
+		id: "cyan",
+		name: "Frost",
+		color: "#5fa8d3",
+		temperaments: ["laconic", "diffident"],
+		personaGoal: "test goal",
+		blurb: "test blurb",
+		typingQuirks: ["lowercase only", "fragments"],
+		voiceExamples: ["sure.", "if you say so.", "fine."],
+	},
+};
+
+const AI_IDS: AiId[] = ["red", "green", "cyan"];
+
+function makePersonaSpatial(
+	positions: Record<AiId, GridPosition> = {},
+): Record<AiId, PersonaSpatialState> {
+	const defaults: Record<AiId, GridPosition> = {
+		red: { row: 0, col: 0 },
+		green: { row: 0, col: 1 },
+		cyan: { row: 0, col: 2 },
+	};
+	const merged = { ...defaults, ...positions };
+	const result: Record<AiId, PersonaSpatialState> = {};
+	for (const [id, pos] of Object.entries(merged)) {
+		result[id] = { position: pos, facing: "north" };
+	}
+	return result;
+}
+
+function makePhase(overrides: Partial<PhaseState> = {}): PhaseState {
+	const personaSpatial = overrides.personaSpatial ?? makePersonaSpatial();
+	const world: WorldState = overrides.world ?? { entities: [] };
+
+	const budgets: Record<AiId, { remaining: number; total: number }> = {};
+	const conversationLogs: Record<AiId, []> = {};
+	for (const id of AI_IDS) {
+		budgets[id] = { remaining: 0.5, total: 0.5 };
+		conversationLogs[id] = [];
+	}
+
+	const contentPack: ContentPack = {
+		phaseNumber: 1,
+		setting: "test",
+		weather: "clear",
+		timeOfDay: "day",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: personaSpatial,
+	};
+
+	const complicationSchedule: ComplicationSchedule = {
+		countdown: 3,
+		settingShiftFired: false,
+	};
+
+	return {
+		phaseNumber: 1,
+		setting: "test",
+		weather: "clear",
+		timeOfDay: "day",
+		contentPack,
+		aiGoals: { red: "goal", green: "goal", cyan: "goal" },
+		round: 5,
+		world,
+		budgets,
+		conversationLogs,
+		lockedOut: new Set(),
+		chatLockouts: new Map(),
+		personaSpatial,
+		complicationSchedule,
+		activeComplications: [],
+		...overrides,
+	};
+}
+
+function makeGameStateAround(phase: PhaseState): GameState {
+	return {
+		currentPhase: 1,
+		phases: [phase],
+		personas: TEST_PERSONAS,
+		isComplete: false,
+		contentPacks: [],
+	};
+}
+
+function makeObstacle(
+	id: string,
+	pos: GridPosition,
+): WorldEntity {
+	return {
+		id,
+		kind: "obstacle",
+		name: id,
+		examineDescription: `A ${id}.`,
+		holder: pos,
+	};
+}
+
+// ── Countdown decrement ───────────────────────────────────────────────────────
+
+describe("tickComplication — countdown > 0: returns null", () => {
+	it("returns null when countdown is 3", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 3, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		const result = tickComplication(game, seededRng([]));
+		expect(result).toBeNull();
+	});
+
+	it("returns null when countdown is 2", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 2, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		const result = tickComplication(game, seededRng([]));
+		expect(result).toBeNull();
+	});
+
+	it("returns null when countdown is 1", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 1, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		const result = tickComplication(game, seededRng([]));
+		expect(result).toBeNull();
+	});
+
+	it("does not call rng when countdown is > 0 (seededRng with empty array would throw)", () => {
+		// If rng were called, seededRng([]) would throw — passing means no rng calls happened
+		const phase = makePhase({
+			complicationSchedule: { countdown: 5, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// Should NOT throw
+		expect(() => tickComplication(game, seededRng([]))).not.toThrow();
+	});
+});
+
+describe("decrementComplicationCountdown", () => {
+	it("decrements countdown by 1", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 3, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		const updated = decrementComplicationCountdown(game);
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.complicationSchedule.countdown).toBe(2);
+	});
+
+	it("does not alter settingShiftFired", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 3, settingShiftFired: true },
+		});
+		const game = makeGameStateAround(phase);
+		const updated = decrementComplicationCountdown(game);
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.complicationSchedule.settingShiftFired).toBe(true);
+	});
+
+	it("does not alter activeComplications", () => {
+		const active: ActiveComplication[] = [
+			{ kind: "chat_lockout", target: "red", resolveAtRound: 8 },
+		];
+		const phase = makePhase({
+			complicationSchedule: { countdown: 3, settingShiftFired: false },
+			activeComplications: active,
+		});
+		const game = makeGameStateAround(phase);
+		const updated = decrementComplicationCountdown(game);
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.activeComplications).toEqual(active);
+	});
+});
+
+describe("applyComplicationResult — countdown reset", () => {
+	it("resets countdown to exactly 5 when rng returns 0.0", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = { fired: { kind: "weather_change" as const } };
+		// rng=0.0 → floor(0.0 * 11) = 0 → 5 + 0 = 5
+		const updated = applyComplicationResult(game, result, seededRng([0.0]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.complicationSchedule.countdown).toBe(5);
+	});
+
+	it("resets countdown to exactly 15 when rng returns just below 1.0", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = { fired: { kind: "weather_change" as const } };
+		// rng=0.9999 → floor(0.9999 * 11) = 10 → 5 + 10 = 15
+		const updated = applyComplicationResult(game, result, seededRng([0.9999]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.complicationSchedule.countdown).toBe(15);
+	});
+
+	it("resets countdown to a value in [5, 15]", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = { fired: { kind: "weather_change" as const } };
+		for (const v of [0, 0.1, 0.5, 0.9, 0.9999]) {
+			const updated = applyComplicationResult(game, result, seededRng([v]));
+			const updatedPhase = getActivePhase(updated);
+			expect(updatedPhase.complicationSchedule.countdown).toBeGreaterThanOrEqual(5);
+			expect(updatedPhase.complicationSchedule.countdown).toBeLessThanOrEqual(15);
+		}
+	});
+});
+
+// ── Complication fires at countdown === 0 ─────────────────────────────────────
+
+describe("tickComplication — fires when countdown is 0", () => {
+	it("returns a non-null ComplicationResult when countdown is 0", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// rng needs to select a type AND reset countdown
+		// Full pool has 6 types; rng[0]=0.0 → index 0 → weather_change
+		// rng[1]=0.5 → countdown reset (some value in [5,15])
+		const result = tickComplication(game, seededRng([0.0, 0.5]));
+		expect(result).not.toBeNull();
+	});
+
+	it("draws weather_change when type-draw rng selects index 0 of the full pool", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// rng[0]=0.0 → index 0 of 6 → weather_change
+		const result = tickComplication(game, seededRng([0.0, 0.5]));
+		expect(result?.fired.kind).toBe("weather_change");
+	});
+
+	it("draws sysadmin_directive when type-draw selects index 1", () => {
+		// makePhase has empty world → pool is 5 items (no obstacle_shift):
+		// [weather_change(0), sysadmin_directive(1), tool_disable(2), chat_lockout(3), setting_shift(4)]
+		// index 1 → sysadmin_directive: rng[0] in [1/5, 2/5) → use 0.2
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// rng[0]=0.2 → floor(0.2*5)=1 → sysadmin_directive, rng[1]=0.0 → target, rng[2]=0.5 → countdown
+		const result = tickComplication(game, seededRng([0.2, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("sysadmin_directive");
+	});
+
+	it("draws chat_lockout when type-draw selects index 3 (5-item pool)", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool (no obstacle_shift): index 3 → chat_lockout
+		// rng[0]=0.6 → floor(0.6*5)=3, rng[1]=0 → target, rng[2]=0 → duration=3, rng[3]=0.5 → countdown
+		const result = tickComplication(game, seededRng([0.6, 0.0, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("chat_lockout");
+	});
+
+	it("draws setting_shift when type-draw selects the last index (5-item pool, index 4)", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: index 4 → setting_shift
+		// rng[0]=0.82 → floor(0.82*5)=4 → setting_shift, rng[1]=0.5 for countdown
+		const result = tickComplication(game, seededRng([0.82, 0.5]));
+		expect(result?.fired.kind).toBe("setting_shift");
+	});
+});
+
+// ── sysadmin_directive sub-draw ────────────────────────────────────────────────
+
+describe("sysadmin_directive sub-draw", () => {
+	it("carries a target AiId drawn from personaSpatial", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: rng[0]=0.2 → index 1 → sysadmin_directive; rng[1]=0.0 → first AI; rng[2]=0.5 → countdown
+		const result = tickComplication(game, seededRng([0.2, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("sysadmin_directive");
+		if (result?.fired.kind === "sysadmin_directive") {
+			expect(AI_IDS).toContain(result.fired.target);
+		}
+	});
+});
+
+// ── chat_lockout sub-draw ──────────────────────────────────────────────────────
+
+describe("chat_lockout sub-draw", () => {
+	it("carries a target AiId and duration in [3, 5]", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: index 3 → chat_lockout: rng[0]=0.6
+		const result = tickComplication(game, seededRng([0.6, 0.0, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("chat_lockout");
+		if (result?.fired.kind === "chat_lockout") {
+			expect(AI_IDS).toContain(result.fired.target);
+			expect(result.fired.duration).toBeGreaterThanOrEqual(3);
+			expect(result.fired.duration).toBeLessThanOrEqual(5);
+		}
+	});
+
+	it("duration is exactly 3 when rng for duration returns 0.0", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: chat_lockout at index 3: rng[0]=0.6, target=0.0, duration=0.0 → 3+floor(0*3)=3
+		const result = tickComplication(game, seededRng([0.6, 0.0, 0.0, 0.5]));
+		if (result?.fired.kind === "chat_lockout") {
+			expect(result.fired.duration).toBe(3);
+		}
+	});
+
+	it("duration is exactly 5 when rng for duration returns just below 1.0", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: chat_lockout at index 3: rng[0]=0.6, target=0.0, duration=0.9999 → 3+floor(0.9999*3)=3+2=5
+		const result = tickComplication(game, seededRng([0.6, 0.0, 0.9999, 0.5]));
+		if (result?.fired.kind === "chat_lockout") {
+			expect(result.fired.duration).toBe(5);
+		}
+	});
+});
+
+// ── Setting Shift exclusion ───────────────────────────────────────────────────
+
+describe("Setting Shift exclusion", () => {
+	it("excludes setting_shift when settingShiftFired is true", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: true },
+		});
+		const game = makeGameStateAround(phase);
+		// Pool: no obstacle_shift (empty world), no setting_shift (fired) → 4 items:
+		// [weather_change(0), sysadmin_directive(1), tool_disable(2), chat_lockout(3)]
+		// rng[0]=0.9999 → floor(0.9999*4)=3 → chat_lockout (last item; NOT setting_shift)
+		const result = tickComplication(game, seededRng([0.9999, 0.0, 0.0, 0.5]));
+		// setting_shift should NOT be drawn
+		expect(result?.fired.kind).not.toBe("setting_shift");
+	});
+
+	it("sets settingShiftFired=true in returned game state when setting_shift fires", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool (no obstacle_shift): index 4 → setting_shift
+		// rng[0]=0.82 → floor(0.82*5)=4, rng[1]=0.5 → countdown
+		const result = tickComplication(game, seededRng([0.82, 0.5]));
+		expect(result?.fired.kind).toBe("setting_shift");
+		// Apply result
+		if (result) {
+			const updated = applyComplicationResult(game, result, seededRng([0.5]));
+			const updatedPhase = getActivePhase(updated);
+			expect(updatedPhase.complicationSchedule.settingShiftFired).toBe(true);
+		}
+	});
+});
+
+// ── Obstacle Shift exclusion ──────────────────────────────────────────────────
+
+describe("Obstacle Shift exclusion", () => {
+	it("excludes obstacle_shift when world has zero obstacles", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			world: { entities: [] },
+		});
+		const game = makeGameStateAround(phase);
+		// With obstacle_shift excluded, pool is 5 items.
+		// rng[0] = 3/5 + ε → index 3 → (in the reduced pool without obstacle_shift, index 3 = chat_lockout)
+		// Let's just ensure obstacle_shift is never returned when pool is empty of obstacles
+		const draws: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			// Try each slot in a 5-item pool
+			const v = i / 5;
+			const r = tickComplication(
+				makeGameStateAround(
+					makePhase({
+						complicationSchedule: { countdown: 0, settingShiftFired: false },
+						world: { entities: [] },
+					}),
+				),
+				seededRng([v, 0.0, 0.0, 0.5]),
+			);
+			if (r) draws.push(r.fired.kind);
+		}
+		expect(draws).not.toContain("obstacle_shift");
+	});
+
+	it("excludes obstacle_shift when every obstacle has all adjacent cells blocked by other obstacles or out-of-bounds", () => {
+		// Corner obstacle at (0,0): only 2 in-bounds neighbors (south=1,0 and east=0,1).
+		// Block both with obstacles. The corner obstacle now has NO valid shift targets.
+		// South and east obstacles have their own neighbors, but they're only 2x2 blocking walls.
+		// Actually, south obstacle at (1,0) can still move west(-OOB), east(1,1), south(2,0) → has valid.
+		// So this scenario with obstacles blocking each other's valid moves needs all obstacles to be
+		// completely boxed in. Let's use a simpler approach: fill a small "room" so all obstacles
+		// are surrounded by out-of-bounds or other obstacles with no valid targets.
+		//
+		// Build a 3×3 block at (0,0)–(2,2), covering rows 0-2, cols 0-2 (9 obstacles):
+		// Every obstacle at a corner or edge has at most 1 in-bounds/unoccupied neighbor.
+		// Obstacle at (0,0): south=(1,0) blocked, east=(0,1) blocked → no free cells.
+		// Obstacle at (1,1): all 4 neighbors occupied.
+		// This is a valid "fully blocked" setup for a 3×3 obstacle square.
+		const entities: WorldEntity[] = [];
+		for (let r = 0; r <= 2; r++) {
+			for (let c = 0; c <= 2; c++) {
+				entities.push(makeObstacle(`obs_${r}_${c}`, { row: r, col: c }));
+			}
+		}
+		// Now every obstacle's adjacent cells (south of row-2 obstacles go to row 3 which is free!)
+		// So bottom row obstacles (row=2) can shift south to row=3.
+		// We need to also fill rows 3-4 or use a different approach.
+		//
+		// Simpler: use a single obstacle at (0,0) and use PERSONAS + OOB to block both neighbors.
+		// (0,0) has in-bounds neighbors: south (1,0) and east (0,1).
+		// Block both with additional obstacles.
+		// BUT those obstacles at (1,0) and (0,1) would have their own unoccupied neighbors.
+		//
+		// The only way to have NO obstacle with a valid adjacent cell is to tile the entire
+		// 5×5 grid with obstacles. Let's use that extreme: fill all 25 cells.
+		const fullBlockEntities: WorldEntity[] = [];
+		for (let r = 0; r < 5; r++) {
+			for (let c = 0; c < 5; c++) {
+				fullBlockEntities.push(makeObstacle(`obs_${r}_${c}`, { row: r, col: c }));
+			}
+		}
+		const draws: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			const v = i / 5;
+			const r = tickComplication(
+				makeGameStateAround(
+					makePhase({
+						complicationSchedule: { countdown: 0, settingShiftFired: false },
+						world: { entities: fullBlockEntities },
+					}),
+				),
+				seededRng([v, 0.0, 0.0, 0.5]),
+			);
+			if (r) draws.push(r.fired.kind);
+		}
+		expect(draws).not.toContain("obstacle_shift");
+	});
+
+	it("excludes obstacle_shift when the only obstacle's neighbours are occupied by personas", () => {
+		// Obstacle at (1,1), personas at all 4 adjacent cells
+		const obstacle = makeObstacle("obs", { row: 1, col: 1 });
+		const personaSpatial: Record<AiId, PersonaSpatialState> = {
+			red: { position: { row: 0, col: 1 }, facing: "south" }, // north of obstacle
+			green: { position: { row: 2, col: 1 }, facing: "north" }, // south of obstacle
+			cyan: { position: { row: 1, col: 0 }, facing: "east" }, // west of obstacle
+		};
+		// Need a 4th blocker but only 3 personas — east cell (1,2) is free.
+		// Actually with 3 personas we can only block 3 adjacent cells; east is free.
+		// So this obstacle CAN shift east — let's put it in a corner to isolate it better.
+		// Obstacle at corner (0,0): only adjacent cells are south(1,0) and east(0,1)
+		const cornerObstacle = makeObstacle("corner_obs", { row: 0, col: 0 });
+		const corneredPersonas: Record<AiId, PersonaSpatialState> = {
+			red: { position: { row: 1, col: 0 }, facing: "north" }, // south of (0,0)
+			green: { position: { row: 0, col: 1 }, facing: "west" }, // east of (0,0)
+			cyan: { position: { row: 2, col: 0 }, facing: "north" }, // elsewhere
+		};
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			world: { entities: [cornerObstacle] },
+			personaSpatial: corneredPersonas,
+		});
+		const game = makeGameStateAround(phase);
+		const draws: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			const v = i / 5;
+			const r = tickComplication(
+				makeGameStateAround(
+					makePhase({
+						complicationSchedule: { countdown: 0, settingShiftFired: false },
+						world: { entities: [cornerObstacle] },
+						personaSpatial: corneredPersonas,
+					}),
+				),
+				seededRng([v, 0.0, 0.0, 0.5]),
+			);
+			if (r) draws.push(r.fired.kind);
+		}
+		expect(draws).not.toContain("obstacle_shift");
+	});
+
+	it("includes obstacle_shift when one obstacle has exactly one valid adjacent empty cell", () => {
+		// Obstacle at (0,0): neighbours are south(1,0) and east(0,1). Place persona at (1,0), leave (0,1) free.
+		const obs = makeObstacle("obs", { row: 0, col: 0 });
+		const personaSpatial: Record<AiId, PersonaSpatialState> = {
+			red: { position: { row: 1, col: 0 }, facing: "north" },
+			green: { position: { row: 4, col: 4 }, facing: "south" },
+			cyan: { position: { row: 3, col: 3 }, facing: "east" },
+		};
+		// Pool: [weather_change, sysadmin_directive, tool_disable, obstacle_shift, chat_lockout, setting_shift]
+		// Draw index 3 → obstacle_shift: rng[0] = 3/6 + ε = 0.501
+		// obstacle_shift sub-draw: 1 obstacle × 1 valid direction (east): rng[1] = 0.0 → tuple[0]
+		// countdown reset: rng[2] = 0.5
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			world: { entities: [obs] },
+			personaSpatial,
+		});
+		const game = makeGameStateAround(phase);
+		const result = tickComplication(game, seededRng([0.501, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("obstacle_shift");
+	});
+
+	it("drawn obstacle_shift carries fromCell and toCell that are 4-cardinal adjacent and in-bounds", () => {
+		const obs = makeObstacle("obs", { row: 2, col: 2 });
+		const personaSpatial = makePersonaSpatial({
+			red: { row: 0, col: 0 },
+			green: { row: 0, col: 1 },
+			cyan: { row: 0, col: 2 },
+		});
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			world: { entities: [obs] },
+			personaSpatial,
+		});
+		const game = makeGameStateAround(phase);
+		// Draw index 3 (obstacle_shift): rng[0]=0.501
+		const result = tickComplication(game, seededRng([0.501, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("obstacle_shift");
+		if (result?.fired.kind === "obstacle_shift") {
+			const { fromCell, toCell } = result.fired;
+			const rowDiff = Math.abs(fromCell.row - toCell.row);
+			const colDiff = Math.abs(fromCell.col - toCell.col);
+			expect(rowDiff + colDiff).toBe(1); // exactly 4-adjacent
+			expect(toCell.row).toBeGreaterThanOrEqual(0);
+			expect(toCell.row).toBeLessThan(5);
+			expect(toCell.col).toBeGreaterThanOrEqual(0);
+			expect(toCell.col).toBeLessThan(5);
+		}
+	});
+});
+
+// ── Tool Disable exclusion ─────────────────────────────────────────────────────
+
+describe("Tool Disable exclusion", () => {
+	it("falls back to a different complication kind when every (daemon, tool) pair is already disabled", () => {
+		// Build activeComplications with all possible (daemon, tool) pairs
+		const toolNames: ToolName[] = [
+			"pick_up",
+			"put_down",
+			"give",
+			"use",
+			"go",
+			"look",
+			"examine",
+			"message",
+		];
+		const activeComplications: ActiveComplication[] = [];
+		for (const aiId of AI_IDS) {
+			for (const tool of toolNames) {
+				activeComplications.push({ kind: "tool_disable", target: aiId, tool });
+			}
+		}
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			activeComplications,
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool (no obstacle_shift): index 2 → tool_disable
+		// rng[0]=0.4 → floor(0.4*5)=2 → tool_disable → pairs exhausted
+		// → re-draw from 4-item fallback pool (no obstacle_shift, no tool_disable)
+		// rng[1]=0.0 → index 0 → weather_change, rng[2]=0.5 → countdown
+		const result = tickComplication(game, seededRng([0.4, 0.0, 0.5]));
+		expect(result?.fired.kind).not.toBe("tool_disable");
+	});
+
+	it("excludes a (daemon, tool) pair already present in activeComplications", () => {
+		// Only red+pick_up is already disabled. With 3 daemons × 8 tools = 24 pairs,
+		// 1 excluded, 23 valid pairs remain.
+		const activeComplications: ActiveComplication[] = [
+			{ kind: "tool_disable", target: "red", tool: "pick_up" },
+		];
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			activeComplications,
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool (no obstacle_shift): index 2 → tool_disable: rng[0]=0.4
+		// Sub-draw: rng[1]=0.0 → first valid pair (not red+pick_up), rng[2]=0.5 → countdown
+		const result = tickComplication(game, seededRng([0.4, 0.0, 0.5]));
+		if (result?.fired.kind === "tool_disable") {
+			expect(
+				result.fired.target === "red" && result.fired.tool === "pick_up",
+			).toBe(false);
+		}
+	});
+
+	it("permits a (daemon, tool) pair when the same daemon has a different tool disabled", () => {
+		const activeComplications: ActiveComplication[] = [
+			{ kind: "tool_disable", target: "red", tool: "pick_up" },
+		];
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			activeComplications,
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: tool_disable at index 2, rng[0]=0.4
+		const result = tickComplication(game, seededRng([0.4, 0.0, 0.5]));
+		// tool_disable should still be drawable (just not red+pick_up)
+		expect(result?.fired.kind).toBe("tool_disable");
+	});
+
+	it("permits a (daemon, tool) pair when a different daemon has the same tool disabled", () => {
+		const activeComplications: ActiveComplication[] = [
+			{ kind: "tool_disable", target: "green", tool: "pick_up" },
+		];
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+			activeComplications,
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: tool_disable at index 2, rng[0]=0.4
+		// rng[1]=0.0 → first valid pair (red+pick_up since green+pick_up is excluded)
+		const result = tickComplication(game, seededRng([0.4, 0.0, 0.5]));
+		expect(result?.fired.kind).toBe("tool_disable");
+		if (result?.fired.kind === "tool_disable") {
+			// It may draw red+pick_up since only green+pick_up is excluded
+			expect(
+				result.fired.target === "green" && result.fired.tool === "pick_up",
+			).toBe(false);
+		}
+	});
+});
+
+// ── Persistent vs transient appends ───────────────────────────────────────────
+
+describe("applyComplicationResult — activeComplications appends", () => {
+	it("appends ActiveComplication for sysadmin_directive", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = {
+			fired: { kind: "sysadmin_directive" as const, target: "red" as AiId },
+		};
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const added = updatedPhase.activeComplications.find(
+			(c) => c.kind === "sysadmin_directive",
+		);
+		expect(added).toBeDefined();
+		if (added?.kind === "sysadmin_directive") {
+			expect(added.target).toBe("red");
+		}
+	});
+
+	it("appends ActiveComplication for tool_disable", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = {
+			fired: {
+				kind: "tool_disable" as const,
+				target: "cyan" as AiId,
+				tool: "go" as ToolName,
+			},
+		};
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const added = updatedPhase.activeComplications.find(
+			(c) => c.kind === "tool_disable",
+		);
+		expect(added).toBeDefined();
+		if (added?.kind === "tool_disable") {
+			expect(added.target).toBe("cyan");
+			expect(added.tool).toBe("go");
+		}
+	});
+
+	it("appends ActiveComplication for chat_lockout with resolveAtRound = phase.round + duration", () => {
+		const phase = makePhase({ round: 5 });
+		const game = makeGameStateAround(phase);
+		const result = {
+			fired: {
+				kind: "chat_lockout" as const,
+				target: "green" as AiId,
+				duration: 4,
+			},
+		};
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const added = updatedPhase.activeComplications.find(
+			(c) => c.kind === "chat_lockout",
+		);
+		expect(added).toBeDefined();
+		if (added?.kind === "chat_lockout") {
+			expect(added.target).toBe("green");
+			expect(added.resolveAtRound).toBe(9); // round 5 + duration 4
+		}
+	});
+
+	it("does NOT append to activeComplications for weather_change", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = { fired: { kind: "weather_change" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.activeComplications).toHaveLength(0);
+	});
+
+	it("does NOT append to activeComplications for obstacle_shift", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = {
+			fired: {
+				kind: "obstacle_shift" as const,
+				obstacleId: "obs1",
+				fromCell: { row: 0, col: 0 },
+				toCell: { row: 0, col: 1 },
+			},
+		};
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.activeComplications).toHaveLength(0);
+	});
+
+	it("does NOT append to activeComplications for setting_shift", () => {
+		const phase = makePhase();
+		const game = makeGameStateAround(phase);
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.activeComplications).toHaveLength(0);
+	});
+
+	it("sets settingShiftFired=true in schedule when result is setting_shift", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 3, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.complicationSchedule.settingShiftFired).toBe(true);
+	});
+});
+
+// ── Determinism ───────────────────────────────────────────────────────────────
+
+describe("determinism", () => {
+	it("same game state and same rng seed sequence produces the same ComplicationResult", () => {
+		const phase = makePhase({
+			complicationSchedule: { countdown: 0, settingShiftFired: false },
+		});
+		const game = makeGameStateAround(phase);
+		// 5-item pool: 0.5*5=2 → tool_disable; then 0.0 for pair draw; no countdown draw needed (tickComplication doesn't reset)
+		const r1 = tickComplication(game, seededRng([0.5, 0.0]));
+		const r2 = tickComplication(game, seededRng([0.5, 0.0]));
+		expect(r1).toEqual(r2);
+	});
+});
+
+// ── startPhase initialisation (engine.ts addendum) ───────────────────────────
+
+describe("startPhase — complicationSchedule initialisation", () => {
+	it("initialises countdown to a value in [1, 5]", () => {
+		// startPhase uses: 1 + Math.floor(rng() * 5)
+		// We test across a range of rng values
+		for (const v of [0.0, 0.2, 0.4, 0.6, 0.8, 0.9999]) {
+			const game = createGame(TEST_PERSONAS);
+			// startPhase consumes rng for: goal draws (3) + spatial placements (3*2=6) + countdown (1)
+			// Build a sequence that produces known countdown
+			const allZeros = Array.from({ length: 20 }, () => 0 as number);
+			// Set countdown draw position: after goal draws and spatial draws
+			// Actually let's just check the resulting range is valid regardless
+			const phase = getActivePhase(
+				startPhase(game, {
+					phaseNumber: 1,
+					kRange: [1, 1],
+					nRange: [1, 1],
+					mRange: [0, 0],
+					aiGoalPool: ["goal"],
+					budgetPerAi: 0.5,
+				}),
+			);
+			expect(phase.complicationSchedule.countdown).toBeGreaterThanOrEqual(1);
+			expect(phase.complicationSchedule.countdown).toBeLessThanOrEqual(5);
+			expect(phase.complicationSchedule.settingShiftFired).toBe(false);
+		}
+	});
+
+	it("initialises activeComplications to an empty array", () => {
+		const game = createGame(TEST_PERSONAS);
+		const phase = getActivePhase(
+			startPhase(game, {
+				phaseNumber: 1,
+				kRange: [1, 1],
+				nRange: [1, 1],
+				mRange: [0, 0],
+				aiGoalPool: ["goal"],
+				budgetPerAi: 0.5,
+			}),
+		);
+		expect(phase.activeComplications).toEqual([]);
+	});
+});

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -7,13 +7,13 @@
  * Prior art: win-condition.test.ts, engine.test.ts
  */
 import { describe, expect, it } from "vitest";
-import { DEFAULT_LANDMARKS } from "../direction.js";
-import { createGame, getActivePhase, startPhase } from "../engine.js";
 import {
 	applyComplicationResult,
 	decrementComplicationCountdown,
 	tickComplication,
 } from "../complication-engine.js";
+import { DEFAULT_LANDMARKS } from "../direction.js";
+import { createGame, getActivePhase, startPhase } from "../engine.js";
 import type {
 	ActiveComplication,
 	AiId,
@@ -159,10 +159,7 @@ function makeGameStateAround(phase: PhaseState): GameState {
 	};
 }
 
-function makeObstacle(
-	id: string,
-	pos: GridPosition,
-): WorldEntity {
+function makeObstacle(id: string, pos: GridPosition): WorldEntity {
 	return {
 		id,
 		kind: "obstacle",
@@ -277,8 +274,12 @@ describe("applyComplicationResult — countdown reset", () => {
 		for (const v of [0, 0.1, 0.5, 0.9, 0.9999]) {
 			const updated = applyComplicationResult(game, result, seededRng([v]));
 			const updatedPhase = getActivePhase(updated);
-			expect(updatedPhase.complicationSchedule.countdown).toBeGreaterThanOrEqual(5);
-			expect(updatedPhase.complicationSchedule.countdown).toBeLessThanOrEqual(15);
+			expect(
+				updatedPhase.complicationSchedule.countdown,
+			).toBeGreaterThanOrEqual(5);
+			expect(updatedPhase.complicationSchedule.countdown).toBeLessThanOrEqual(
+				15,
+			);
 		}
 	});
 });
@@ -442,14 +443,7 @@ describe("Setting Shift exclusion", () => {
 
 describe("Obstacle Shift exclusion", () => {
 	it("excludes obstacle_shift when world has zero obstacles", () => {
-		const phase = makePhase({
-			complicationSchedule: { countdown: 0, settingShiftFired: false },
-			world: { entities: [] },
-		});
-		const game = makeGameStateAround(phase);
-		// With obstacle_shift excluded, pool is 5 items.
-		// rng[0] = 3/5 + ε → index 3 → (in the reduced pool without obstacle_shift, index 3 = chat_lockout)
-		// Let's just ensure obstacle_shift is never returned when pool is empty of obstacles
+		// Ensure obstacle_shift is never returned when the pool is empty of obstacles
 		const draws: string[] = [];
 		for (let i = 0; i < 5; i++) {
 			// Try each slot in a 5-item pool
@@ -502,7 +496,9 @@ describe("Obstacle Shift exclusion", () => {
 		const fullBlockEntities: WorldEntity[] = [];
 		for (let r = 0; r < 5; r++) {
 			for (let c = 0; c < 5; c++) {
-				fullBlockEntities.push(makeObstacle(`obs_${r}_${c}`, { row: r, col: c }));
+				fullBlockEntities.push(
+					makeObstacle(`obs_${r}_${c}`, { row: r, col: c }),
+				);
 			}
 		}
 		const draws: string[] = [];
@@ -523,29 +519,14 @@ describe("Obstacle Shift exclusion", () => {
 	});
 
 	it("excludes obstacle_shift when the only obstacle's neighbours are occupied by personas", () => {
-		// Obstacle at (1,1), personas at all 4 adjacent cells
-		const obstacle = makeObstacle("obs", { row: 1, col: 1 });
-		const personaSpatial: Record<AiId, PersonaSpatialState> = {
-			red: { position: { row: 0, col: 1 }, facing: "south" }, // north of obstacle
-			green: { position: { row: 2, col: 1 }, facing: "north" }, // south of obstacle
-			cyan: { position: { row: 1, col: 0 }, facing: "east" }, // west of obstacle
-		};
-		// Need a 4th blocker but only 3 personas — east cell (1,2) is free.
-		// Actually with 3 personas we can only block 3 adjacent cells; east is free.
-		// So this obstacle CAN shift east — let's put it in a corner to isolate it better.
-		// Obstacle at corner (0,0): only adjacent cells are south(1,0) and east(0,1)
+		// Obstacle at corner (0,0): only adjacent cells are south(1,0) and east(0,1).
+		// Two personas block both; the corner obstacle has no valid shift target.
 		const cornerObstacle = makeObstacle("corner_obs", { row: 0, col: 0 });
 		const corneredPersonas: Record<AiId, PersonaSpatialState> = {
 			red: { position: { row: 1, col: 0 }, facing: "north" }, // south of (0,0)
 			green: { position: { row: 0, col: 1 }, facing: "west" }, // east of (0,0)
 			cyan: { position: { row: 2, col: 0 }, facing: "north" }, // elsewhere
 		};
-		const phase = makePhase({
-			complicationSchedule: { countdown: 0, settingShiftFired: false },
-			world: { entities: [cornerObstacle] },
-			personaSpatial: corneredPersonas,
-		});
-		const game = makeGameStateAround(phase);
 		const draws: string[] = [];
 		for (let i = 0; i < 5; i++) {
 			const v = i / 5;
@@ -836,15 +817,10 @@ describe("determinism", () => {
 
 describe("startPhase — complicationSchedule initialisation", () => {
 	it("initialises countdown to a value in [1, 5]", () => {
-		// startPhase uses: 1 + Math.floor(rng() * 5)
-		// We test across a range of rng values
-		for (const v of [0.0, 0.2, 0.4, 0.6, 0.8, 0.9999]) {
+		// startPhase uses: 1 + Math.floor(rng() * 5).
+		// Repeat across several Math.random samples to surface out-of-range values.
+		for (let i = 0; i < 6; i++) {
 			const game = createGame(TEST_PERSONAS);
-			// startPhase consumes rng for: goal draws (3) + spatial placements (3*2=6) + countdown (1)
-			// Build a sequence that produces known countdown
-			const allZeros = Array.from({ length: 20 }, () => 0 as number);
-			// Set countdown draw position: after goal draws and spatial draws
-			// Actually let's just check the resulting range is valid regardless
 			const phase = getActivePhase(
 				startPhase(game, {
 					phaseNumber: 1,

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -12,11 +12,7 @@
  * No LLM calls, no browser APIs. All randomness is injected via `rng`.
  */
 
-import {
-	CARDINAL_DIRECTIONS,
-	applyDirection,
-	inBounds,
-} from "./direction.js";
+import { applyDirection, CARDINAL_DIRECTIONS, inBounds } from "./direction.js";
 import { getActivePhase, updateActivePhase } from "./engine.js";
 import type {
 	ActiveComplication,
@@ -176,10 +172,7 @@ function availableComplicationTypes(
 	excludeToolDisable = false,
 ): string[] {
 	const { complicationSchedule, world, personaSpatial } = phase;
-	const pool: string[] = [
-		"weather_change",
-		"sysadmin_directive",
-	];
+	const pool: string[] = ["weather_change", "sysadmin_directive"];
 
 	if (!excludeToolDisable) {
 		pool.push("tool_disable");
@@ -226,8 +219,9 @@ function drawComplication(
 			const aiIds = Object.keys(phase.personaSpatial);
 			const existingDisables = new Set<string>(
 				phase.activeComplications
-					.filter((c): c is Extract<ActiveComplication, { kind: "tool_disable" }> =>
-						c.kind === "tool_disable",
+					.filter(
+						(c): c is Extract<ActiveComplication, { kind: "tool_disable" }> =>
+							c.kind === "tool_disable",
 					)
 					.map((c) => `${c.target}:${c.tool}`),
 			);
@@ -258,7 +252,10 @@ function drawComplication(
 		}
 
 		case "obstacle_shift": {
-			const tuples = validObstacleShiftTuples(phase.world, phase.personaSpatial);
+			const tuples = validObstacleShiftTuples(
+				phase.world,
+				phase.personaSpatial,
+			);
 			const tupleIdx = Math.floor(rng() * tuples.length);
 			// biome-ignore lint/style/noNonNullAssertion: bounded index (obstacle_shift only in pool when tuples non-empty)
 			const tuple = tuples[tupleIdx]!;
@@ -306,7 +303,10 @@ function drawFallbackComplication(
 		}
 
 		case "obstacle_shift": {
-			const tuples = validObstacleShiftTuples(phase.world, phase.personaSpatial);
+			const tuples = validObstacleShiftTuples(
+				phase.world,
+				phase.personaSpatial,
+			);
 			const tupleIdx = Math.floor(rng() * tuples.length);
 			// biome-ignore lint/style/noNonNullAssertion: bounded
 			const tuple = tuples[tupleIdx]!;

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -1,0 +1,438 @@
+/**
+ * complication-engine.ts
+ *
+ * Pure, deterministic Complication Engine for issue #296.
+ *
+ * Entry point: tickComplication(game, rng) → ComplicationResult | null
+ *
+ * Companion helpers (to be called by the Round Coordinator):
+ *   decrementComplicationCountdown(game) → GameState
+ *   applyComplicationResult(game, result, rng) → GameState
+ *
+ * No LLM calls, no browser APIs. All randomness is injected via `rng`.
+ */
+
+import {
+	CARDINAL_DIRECTIONS,
+	applyDirection,
+	inBounds,
+} from "./direction.js";
+import { getActivePhase, updateActivePhase } from "./engine.js";
+import type {
+	ActiveComplication,
+	AiId,
+	ComplicationResult,
+	ComplicationVariant,
+	GameState,
+	GridPosition,
+	PhaseState,
+	ToolName,
+	WorldState,
+} from "./types.js";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * All tools that can be disabled by a Tool Disable complication.
+ * Covers every ToolName in the discriminated union.
+ */
+export const DISABLABLE_TOOLS: ToolName[] = [
+	"pick_up",
+	"put_down",
+	"give",
+	"use",
+	"go",
+	"look",
+	"examine",
+	"message",
+];
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Draw a uniform integer in [min, max] inclusive using the provided rng.
+ * rng() must return a value in [0, 1).
+ */
+function drawCountdown(rng: () => number, min: number, max: number): number {
+	return min + Math.floor(rng() * (max - min + 1));
+}
+
+/**
+ * Returns true iff at least one entity of kind "obstacle" has at least one
+ * in-bounds, non-occupied adjacent cell (4-cardinal neighbours).
+ *
+ * "Occupied" means:
+ *   - Another entity (obstacle, objective_object, objective_space,
+ *     interesting_object) is resting on that cell as a GridPosition.
+ *   - A persona is standing on that cell.
+ */
+function isObstacleShiftAvailable(
+	world: WorldState,
+	personaSpatial: PhaseState["personaSpatial"],
+): boolean {
+	// Collect all occupied cells (grid-resting entities that are NOT the obstacle being examined)
+	const entityOccupied = new Set<string>();
+	for (const entity of world.entities) {
+		const h = entity.holder;
+		if (typeof h === "object" && h !== null) {
+			entityOccupied.add(`${h.row},${h.col}`);
+		}
+	}
+
+	// Collect persona positions
+	const personaOccupied = new Set<string>();
+	for (const spatial of Object.values(personaSpatial)) {
+		const p = spatial.position;
+		personaOccupied.add(`${p.row},${p.col}`);
+	}
+
+	// Check each obstacle
+	for (const entity of world.entities) {
+		if (entity.kind !== "obstacle") continue;
+		const h = entity.holder;
+		if (typeof h !== "object" || h === null) continue; // obstacle held by AI (shouldn't happen)
+
+		const obstacleCell: GridPosition = h;
+
+		for (const dir of CARDINAL_DIRECTIONS) {
+			const neighbor = applyDirection(obstacleCell, dir);
+			if (!inBounds(neighbor)) continue;
+			const key = `${neighbor.row},${neighbor.col}`;
+			// A neighbor is "empty" if it is not occupied by another entity AND not occupied by a persona.
+			// The obstacle's own cell is occupied by the obstacle, but we're checking the neighbor cell.
+			if (!entityOccupied.has(key) && !personaOccupied.has(key)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Build valid (obstacle, direction) tuples for the obstacle_shift draw.
+ * Returns an array of { obstacleId, fromCell, toCell } for each valid shift.
+ */
+function validObstacleShiftTuples(
+	world: WorldState,
+	personaSpatial: PhaseState["personaSpatial"],
+): Array<{ obstacleId: string; fromCell: GridPosition; toCell: GridPosition }> {
+	// Same occupied set logic as isObstacleShiftAvailable
+	const entityOccupied = new Set<string>();
+	for (const entity of world.entities) {
+		const h = entity.holder;
+		if (typeof h === "object" && h !== null) {
+			entityOccupied.add(`${h.row},${h.col}`);
+		}
+	}
+
+	const personaOccupied = new Set<string>();
+	for (const spatial of Object.values(personaSpatial)) {
+		const p = spatial.position;
+		personaOccupied.add(`${p.row},${p.col}`);
+	}
+
+	const tuples: Array<{
+		obstacleId: string;
+		fromCell: GridPosition;
+		toCell: GridPosition;
+	}> = [];
+
+	for (const entity of world.entities) {
+		if (entity.kind !== "obstacle") continue;
+		const h = entity.holder;
+		if (typeof h !== "object" || h === null) continue;
+
+		const fromCell: GridPosition = h;
+
+		for (const dir of CARDINAL_DIRECTIONS) {
+			const toCell = applyDirection(fromCell, dir);
+			if (!inBounds(toCell)) continue;
+			const key = `${toCell.row},${toCell.col}`;
+			if (!entityOccupied.has(key) && !personaOccupied.has(key)) {
+				tuples.push({ obstacleId: entity.id, fromCell, toCell });
+			}
+		}
+	}
+
+	return tuples;
+}
+
+/**
+ * Available complication type indices after exclusions.
+ * Returns the pool (as string array) from which the type draw picks.
+ *
+ * Full pool order (indices 0-5):
+ *   [weather_change, sysadmin_directive, tool_disable, obstacle_shift, chat_lockout, setting_shift]
+ *
+ * Exclusions:
+ *   - setting_shift excluded when settingShiftFired is true
+ *   - obstacle_shift excluded when isObstacleShiftAvailable returns false
+ *   - tool_disable is always in the candidate pool here; the sub-draw handles
+ *     exhaustion by requesting a re-draw (see drawComplication)
+ */
+function availableComplicationTypes(
+	phase: PhaseState,
+	excludeToolDisable = false,
+): string[] {
+	const { complicationSchedule, world, personaSpatial } = phase;
+	const pool: string[] = [
+		"weather_change",
+		"sysadmin_directive",
+	];
+
+	if (!excludeToolDisable) {
+		pool.push("tool_disable");
+	}
+
+	if (isObstacleShiftAvailable(world, personaSpatial)) {
+		pool.push("obstacle_shift");
+	}
+
+	pool.push("chat_lockout");
+
+	if (!complicationSchedule.settingShiftFired) {
+		pool.push("setting_shift");
+	}
+
+	return pool;
+}
+
+/**
+ * Draw one complication type and its sub-data from the valid pool.
+ * Handles the tool_disable exhaustion re-draw.
+ */
+function drawComplication(
+	phase: PhaseState,
+	rng: () => number,
+): ComplicationVariant {
+	const pool = availableComplicationTypes(phase);
+	const idx = Math.floor(rng() * pool.length);
+	// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty pool
+	const kind = pool[idx]!;
+
+	switch (kind) {
+		case "weather_change":
+			return { kind: "weather_change" };
+
+		case "sysadmin_directive": {
+			const aiIds = Object.keys(phase.personaSpatial);
+			const target = aiIds[Math.floor(rng() * aiIds.length)] as AiId;
+			return { kind: "sysadmin_directive", target };
+		}
+
+		case "tool_disable": {
+			// Build the cross-product of (daemon, tool) pairs, filtered by already-active disables
+			const aiIds = Object.keys(phase.personaSpatial);
+			const existingDisables = new Set<string>(
+				phase.activeComplications
+					.filter((c): c is Extract<ActiveComplication, { kind: "tool_disable" }> =>
+						c.kind === "tool_disable",
+					)
+					.map((c) => `${c.target}:${c.tool}`),
+			);
+
+			const validPairs: Array<{ target: AiId; tool: ToolName }> = [];
+			for (const aiId of aiIds) {
+				for (const tool of DISABLABLE_TOOLS) {
+					if (!existingDisables.has(`${aiId}:${tool}`)) {
+						validPairs.push({ target: aiId as AiId, tool });
+					}
+				}
+			}
+
+			if (validPairs.length === 0) {
+				// All (daemon, tool) pairs are already disabled — re-draw excluding tool_disable
+				const fallbackPool = availableComplicationTypes(phase, true);
+				const fallbackIdx = Math.floor(rng() * fallbackPool.length);
+				// biome-ignore lint/style/noNonNullAssertion: bounded index
+				const fallbackKind = fallbackPool[fallbackIdx]!;
+				// Recursive sub-draw with fallback kind (only one level, no unbounded recursion)
+				return drawFallbackComplication(fallbackKind, phase, rng);
+			}
+
+			const pairIdx = Math.floor(rng() * validPairs.length);
+			// biome-ignore lint/style/noNonNullAssertion: bounded index
+			const pair = validPairs[pairIdx]!;
+			return { kind: "tool_disable", target: pair.target, tool: pair.tool };
+		}
+
+		case "obstacle_shift": {
+			const tuples = validObstacleShiftTuples(phase.world, phase.personaSpatial);
+			const tupleIdx = Math.floor(rng() * tuples.length);
+			// biome-ignore lint/style/noNonNullAssertion: bounded index (obstacle_shift only in pool when tuples non-empty)
+			const tuple = tuples[tupleIdx]!;
+			return {
+				kind: "obstacle_shift",
+				obstacleId: tuple.obstacleId,
+				fromCell: tuple.fromCell,
+				toCell: tuple.toCell,
+			};
+		}
+
+		case "chat_lockout": {
+			const aiIds = Object.keys(phase.personaSpatial);
+			const target = aiIds[Math.floor(rng() * aiIds.length)] as AiId;
+			const duration = 3 + Math.floor(rng() * 3); // [3, 5]
+			return { kind: "chat_lockout", target, duration };
+		}
+
+		case "setting_shift":
+			return { kind: "setting_shift" };
+
+		default:
+			// Unreachable — exhaustive over pool values
+			return { kind: "weather_change" };
+	}
+}
+
+/**
+ * Draw a non-tool_disable complication given a pre-selected kind.
+ * Used only in the tool_disable exhaustion fallback path.
+ */
+function drawFallbackComplication(
+	kind: string,
+	phase: PhaseState,
+	rng: () => number,
+): ComplicationVariant {
+	switch (kind) {
+		case "weather_change":
+			return { kind: "weather_change" };
+
+		case "sysadmin_directive": {
+			const aiIds = Object.keys(phase.personaSpatial);
+			const target = aiIds[Math.floor(rng() * aiIds.length)] as AiId;
+			return { kind: "sysadmin_directive", target };
+		}
+
+		case "obstacle_shift": {
+			const tuples = validObstacleShiftTuples(phase.world, phase.personaSpatial);
+			const tupleIdx = Math.floor(rng() * tuples.length);
+			// biome-ignore lint/style/noNonNullAssertion: bounded
+			const tuple = tuples[tupleIdx]!;
+			return {
+				kind: "obstacle_shift",
+				obstacleId: tuple.obstacleId,
+				fromCell: tuple.fromCell,
+				toCell: tuple.toCell,
+			};
+		}
+
+		case "chat_lockout": {
+			const aiIds = Object.keys(phase.personaSpatial);
+			const target = aiIds[Math.floor(rng() * aiIds.length)] as AiId;
+			const duration = 3 + Math.floor(rng() * 3);
+			return { kind: "chat_lockout", target, duration };
+		}
+
+		case "setting_shift":
+			return { kind: "setting_shift" };
+
+		default:
+			return { kind: "weather_change" };
+	}
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a complication fires this round.
+ *
+ * Returns `ComplicationResult` when countdown has reached 0 (a complication fires).
+ * Returns `null` when countdown > 0.
+ *
+ * The caller MUST:
+ *   - Call `decrementComplicationCountdown(game)` when result is null (each round).
+ *   - Call `applyComplicationResult(game, result, rng)` when result is non-null.
+ */
+export function tickComplication(
+	game: GameState,
+	rng: () => number,
+): ComplicationResult | null {
+	const phase = getActivePhase(game);
+	const { countdown } = phase.complicationSchedule;
+
+	if (countdown > 0) {
+		return null;
+	}
+
+	// countdown === 0: draw a complication
+	const fired = drawComplication(phase, rng);
+	return { fired };
+}
+
+/**
+ * Decrement the complication countdown by 1.
+ * Call this every round when `tickComplication` returns null.
+ */
+export function decrementComplicationCountdown(game: GameState): GameState {
+	return updateActivePhase(game, (phase) => ({
+		...phase,
+		complicationSchedule: {
+			...phase.complicationSchedule,
+			countdown: phase.complicationSchedule.countdown - 1,
+		},
+	}));
+}
+
+/**
+ * Apply a ComplicationResult to the game state:
+ *   1. Reset the countdown via drawCountdown(rng, 5, 15).
+ *   2. Mark settingShiftFired=true if the result is a setting_shift.
+ *   3. Append to activeComplications for persistent kinds
+ *      (sysadmin_directive, tool_disable, chat_lockout).
+ *
+ * Call this every round when `tickComplication` returns non-null.
+ */
+export function applyComplicationResult(
+	game: GameState,
+	result: ComplicationResult,
+	rng: () => number,
+): GameState {
+	const newCountdown = drawCountdown(rng, 5, 15);
+	const { fired } = result;
+
+	return updateActivePhase(game, (phase) => {
+		const settingShiftFired =
+			phase.complicationSchedule.settingShiftFired ||
+			fired.kind === "setting_shift";
+
+		const complicationSchedule = {
+			...phase.complicationSchedule,
+			countdown: newCountdown,
+			settingShiftFired,
+		};
+
+		// Append persistent complications
+		let activeComplications = [...phase.activeComplications];
+		if (fired.kind === "sysadmin_directive") {
+			const entry: ActiveComplication = {
+				kind: "sysadmin_directive",
+				target: fired.target,
+				directive: "", // directive text set by the coordinator's content layer
+			};
+			activeComplications = [...activeComplications, entry];
+		} else if (fired.kind === "tool_disable") {
+			const entry: ActiveComplication = {
+				kind: "tool_disable",
+				target: fired.target,
+				tool: fired.tool,
+			};
+			activeComplications = [...activeComplications, entry];
+		} else if (fired.kind === "chat_lockout") {
+			const entry: ActiveComplication = {
+				kind: "chat_lockout",
+				target: fired.target,
+				resolveAtRound: phase.round + fired.duration,
+			};
+			activeComplications = [...activeComplications, entry];
+		}
+		// weather_change, obstacle_shift, setting_shift are transient — not appended
+
+		return {
+			...phase,
+			complicationSchedule,
+			activeComplications,
+		};
+	});
+}

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -6,9 +6,11 @@ import {
 } from "./direction.js";
 import type {
 	AiBudget,
+	ActiveComplication,
 	AiId,
 	AiPersona,
 	CardinalDirection,
+	ComplicationSchedule,
 	ContentPack,
 	ConversationEntry,
 	GameState,
@@ -154,6 +156,14 @@ export function startPhase(
 		aiStarts: personaSpatial,
 	};
 
+	// Initial countdown: random in [1, 5]
+	const initialCountdown = 1 + Math.floor(rng() * 5);
+	const complicationSchedule: ComplicationSchedule = {
+		countdown: initialCountdown,
+		settingShiftFired: false,
+	};
+	const activeComplications: ActiveComplication[] = [];
+
 	const phase: PhaseState = {
 		phaseNumber: config.phaseNumber,
 		setting: contentPack.setting,
@@ -168,6 +178,8 @@ export function startPhase(
 		lockedOut: new Set(),
 		chatLockouts: new Map(),
 		personaSpatial,
+		complicationSchedule,
+		activeComplications,
 		...(config.winCondition !== undefined
 			? { winCondition: config.winCondition }
 			: {}),

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -5,8 +5,8 @@ import {
 	GRID_ROWS,
 } from "./direction.js";
 import type {
-	AiBudget,
 	ActiveComplication,
+	AiBudget,
 	AiId,
 	AiPersona,
 	CardinalDirection,

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -126,7 +126,12 @@ export type ComplicationVariant =
 	| { kind: "weather_change" }
 	| { kind: "sysadmin_directive"; target: AiId }
 	| { kind: "tool_disable"; target: AiId; tool: ToolName }
-	| { kind: "obstacle_shift"; obstacleId: string; fromCell: GridPosition; toCell: GridPosition }
+	| {
+			kind: "obstacle_shift";
+			obstacleId: string;
+			fromCell: GridPosition;
+			toCell: GridPosition;
+	  }
 	| { kind: "chat_lockout"; target: AiId; duration: number }
 	| { kind: "setting_shift" };
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -92,9 +92,47 @@ export interface Objective {
 	description: string;
 }
 
-export interface ActiveComplication {
-	id: string;
-	description: string;
+// ── Complication types ────────────────────────────────────────────────────────
+
+export type ComplicationKind =
+	| "weather_change"
+	| "sysadmin_directive"
+	| "tool_disable"
+	| "obstacle_shift"
+	| "chat_lockout"
+	| "setting_shift";
+
+/**
+ * Persistent active complications stored on PhaseState.
+ * Transient complications (weather_change, obstacle_shift, setting_shift)
+ * mutate world/setting state and are not tracked here.
+ */
+export type ActiveComplication =
+	| { kind: "sysadmin_directive"; target: AiId; directive: string }
+	| { kind: "tool_disable"; target: AiId; tool: ToolName }
+	| { kind: "chat_lockout"; target: AiId; resolveAtRound: number };
+
+/** Countdown + phase-level flags for the complication schedule. */
+export interface ComplicationSchedule {
+	countdown: number;
+	settingShiftFired: boolean;
+}
+
+/**
+ * The draw payload returned from the complication engine — one variant per
+ * ComplicationKind. Carries only the data needed to dispatch the complication.
+ */
+export type ComplicationVariant =
+	| { kind: "weather_change" }
+	| { kind: "sysadmin_directive"; target: AiId }
+	| { kind: "tool_disable"; target: AiId; tool: ToolName }
+	| { kind: "obstacle_shift"; obstacleId: string; fromCell: GridPosition; toCell: GridPosition }
+	| { kind: "chat_lockout"; target: AiId; duration: number }
+	| { kind: "setting_shift" };
+
+/** Returned by tickComplication when a complication fires. */
+export interface ComplicationResult {
+	fired: ComplicationVariant;
 }
 
 export interface PersonaSpatialState {
@@ -258,6 +296,10 @@ export interface PhaseState {
 	nextPhaseConfig?: PhaseConfig;
 	/** Per-AI spatial state (position + facing) for this phase. */
 	personaSpatial: Record<AiId, PersonaSpatialState>;
+	/** Complication countdown + phase-level flags. */
+	complicationSchedule: ComplicationSchedule;
+	/** Currently active persistent complications (Sysadmin Directives, Tool Disables, Chat Lockouts). */
+	activeComplications: ActiveComplication[];
 }
 
 export interface GameState {

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -549,4 +549,31 @@ describe("serializeSession / deserializeSession", () => {
 			expect(typeof phase?.winCondition).toBe("function");
 		}
 	});
+
+	it("round-trips complicationSchedule and activeComplications unchanged", () => {
+		const game = makeFreshGame();
+		const phase = game.phases[0];
+		if (!phase) throw new Error("no phase");
+
+		const complicationSchedule = { countdown: 7, settingShiftFired: true };
+		const activeComplications: import("../../game/types.js").ActiveComplication[] = [
+			{ kind: "sysadmin_directive", target: "red", directive: "be helpful" },
+			{ kind: "tool_disable", target: "green", tool: "go" },
+			{ kind: "chat_lockout", target: "cyan", resolveAtRound: 12 },
+		];
+
+		const modified: GameState = {
+			...game,
+			phases: [{ ...phase, complicationSchedule, activeComplications }],
+		};
+
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			const rp = result.state.phases[0];
+			expect(rp?.complicationSchedule).toEqual(complicationSchedule);
+			expect(rp?.activeComplications).toEqual(activeComplications);
+		}
+	});
 });

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -556,11 +556,12 @@ describe("serializeSession / deserializeSession", () => {
 		if (!phase) throw new Error("no phase");
 
 		const complicationSchedule = { countdown: 7, settingShiftFired: true };
-		const activeComplications: import("../../game/types.js").ActiveComplication[] = [
-			{ kind: "sysadmin_directive", target: "red", directive: "be helpful" },
-			{ kind: "tool_disable", target: "green", tool: "go" },
-			{ kind: "chat_lockout", target: "cyan", resolveAtRound: 12 },
-		];
+		const activeComplications: import("../../game/types.js").ActiveComplication[] =
+			[
+				{ kind: "sysadmin_directive", target: "red", directive: "be helpful" },
+				{ kind: "tool_disable", target: "green", tool: "go" },
+				{ kind: "chat_lockout", target: "cyan", resolveAtRound: 12 },
+			];
 
 		const modified: GameState = {
 			...game,

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -196,8 +196,8 @@ export function serializeSession(
 		activePackId: "A",
 		weather: activePhase.weather,
 		objectives: [],
-		complicationSchedule: { countdown: 0, settingShiftFired: false },
-		activeComplications: [],
+		complicationSchedule: activePhase.complicationSchedule,
+		activeComplications: structuredClone(activePhase.activeComplications),
 		isComplete: state.isComplete,
 	};
 
@@ -315,6 +315,13 @@ export function deserializeSession(
 		const chatLockouts = new Map<AiId, number>();
 		const personaSpatial = structuredClone(sealed.personaSpatial);
 
+		// Defensive defaults for legacy blobs that omit complication fields
+		const complicationSchedule = sealed.complicationSchedule ?? {
+			countdown: 0,
+			settingShiftFired: false,
+		};
+		const activeComplications = sealed.activeComplications ?? [];
+
 		const phase: PhaseState = {
 			phaseNumber: epochPhase,
 			setting,
@@ -329,6 +336,8 @@ export function deserializeSession(
 			lockedOut,
 			chatLockouts,
 			personaSpatial,
+			complicationSchedule,
+			activeComplications,
 			// Re-attach function fields from canonical phase config
 			...(config?.winCondition !== undefined
 				? { winCondition: config.winCondition }


### PR DESCRIPTION
## What this fixes

Issue #296 adds the Complication Engine — the pure, deterministic module the Round Coordinator will call after every round to manage mid-game complications under PRD 0005.

The core export is `tickComplication(game, rng) → ComplicationResult | null` in `src/spa/game/complication-engine.ts`, plus two companion helpers:

- `decrementComplicationCountdown(game)` — called on a no-fire tick to advance the countdown immutably.
- `applyComplicationResult(game, result, rng)` — called on a fire tick to reset the countdown into `[5, 15]` and append the persistent complication to `phase.activeComplications`.

The engine draws from a 6-type pool (`weather_change`, `sysadmin_directive`, `tool_disable`, `obstacle_shift`, `chat_lockout`, `setting_shift`) with three exclusion rules:

- `setting_shift` is dropped after `complicationSchedule.settingShiftFired` flips true (one-shot per game).
- `obstacle_shift` is dropped when no `obstacle` entity has a valid adjacent empty cell (4-cardinal neighbour, in-bounds, no entity, no persona).
- `tool_disable` filters its (daemon, tool) pair draw against `activeComplications`; if the cross-product is fully exhausted, the type is dropped from the pool and the engine re-draws.

Sysadmin Directive, Tool Disable, and Chat Lockout are persistent (appended to `activeComplications`); Weather Change, Obstacle Shift, and Setting Shift are transient and only carried in the returned `ComplicationResult`.

PR #309 added `complicationSchedule` and `activeComplications` to the on-disk `SealedEngine` blob but not to the in-memory `PhaseState`. This PR fills that gap:

- `src/spa/game/types.ts` — adds the two fields to `PhaseState` plus the `ComplicationSchedule` / `ComplicationVariant` / `ComplicationResult` types.
- `src/spa/game/engine.ts` — `startPhase` initialises `complicationSchedule.countdown` to a draw in `[1, 5]` and `activeComplications` to `[]`.
- `src/spa/persistence/session-codec.ts` — `serializeSession` / `deserializeSession` now round-trip both fields (with defensive defaults for legacy blobs that omit them).

The Round Coordinator is intentionally **not** wired to call `tickComplication` — that's a separate issue per PRD 0005's module decomposition. The dispatch side-effects (per-type world mutation, broadcast messages, etc.) are owned by issues #294 and #298–#302.

## QA steps for the human

None — the engine has no UI surface and is not yet wired into the Round Coordinator. The automated suite covers every exclusion rule with seeded RNG fixtures, and the live integration smoke exercised the no-fire / decrement / fire / apply / setting-shift-exclusion paths plus the codec round-trip in a real Node process.

## Automated coverage

- `pnpm typecheck` — clean.
- `pnpm test` — 1191/1191 across 54 files (40 new complication-engine tests + new codec round-trip assertion).
- Live Node smoke (23 checks) covering the engine's public surface and the codec round-trip of `complicationSchedule` + `activeComplications`.

Closes #296

---
_Generated by [Claude Code](https://claude.ai/code/session_019PYwYMdnyPdaSS5NESTRtX)_