### PR TITLE
Cherry-pick #311 (Broadcast + Weather Change) onto first-restructure

### DIFF
--- a/src/spa/game/__tests__/complications.test.ts
+++ b/src/spa/game/__tests__/complications.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for complications.ts — Weather Change complication handler.
+ *
+ * Uses a stub rng for determinism. The weather pool has 12 entries;
+ * drawing index 0 always gives "Heavy rain is falling." when the
+ * current weather is something other than that entry.
+ */
+
+import { describe, expect, it } from "vitest";
+import { WEATHER_POOL } from "../../../content/index.js";
+import { COMPLICATIONS, weatherChangeComplication } from "../complications.js";
+import { DEFAULT_LANDMARKS } from "../direction.js";
+import { createGame, getActivePhase, startPhase } from "../engine.js";
+import type { AiPersona, ContentPack, PhaseConfig } from "../types.js";
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "Hold the flower at phase end.",
+		typingQuirks: [
+			"You speak in fragments. Short bursts. Rarely complete sentences.",
+			"You lean on em-dashes — interrupting yourself mid-sentence.",
+		],
+		blurb: "Ember is hot-headed and zealous.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "#81b29a",
+		temperaments: ["meticulous", "meticulous"],
+		personaGoal: "Ensure items are evenly distributed.",
+		typingQuirks: [
+			"You lean on ellipses… trailing off mid-thought.",
+			"You use ALL-CAPS to emphasize the one or two words that MATTER.",
+		],
+		blurb: "Sage is intensely meticulous.",
+		voiceExamples: ["ex1-green", "ex2-green", "ex3-green"],
+	},
+	cyan: {
+		id: "cyan",
+		name: "Frost",
+		color: "#5fa8d3",
+		temperaments: ["laconic", "diffident"],
+		personaGoal: "Hold the key at phase end.",
+		typingQuirks: [
+			'You never use contractions. You will not say "won\'t" or "can\'t".',
+			"You end almost every reply with a question, does that make sense?",
+		],
+		blurb: "Frost is laconic and diffident.",
+		voiceExamples: ["ex1-cyan", "ex2-cyan", "ex3-cyan"],
+	},
+};
+
+const TEST_PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	kRange: [1, 1],
+	nRange: [0, 0],
+	mRange: [0, 0],
+	aiGoalPool: ["Hold the flower at phase end"],
+	budgetPerAi: 5,
+};
+
+/** Build a game with a specific weather value in the active phase. */
+function makeGameWithWeather(weather: string) {
+	const pack: ContentPack = {
+		phaseNumber: 1,
+		setting: "abandoned subway station",
+		weather,
+		timeOfDay: "night",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {
+			red: { position: { row: 0, col: 0 }, facing: "north" },
+			green: { position: { row: 0, col: 1 }, facing: "north" },
+			cyan: { position: { row: 0, col: 2 }, facing: "north" },
+		},
+	};
+	const game = createGame(TEST_PERSONAS, [pack]);
+	return startPhase(game, TEST_PHASE_CONFIG, () => 0);
+}
+
+describe("weatherChangeComplication", () => {
+	it("draws a weather string different from phase.weather", () => {
+		// Current weather is "Heavy rain is falling." (index 0 in pool).
+		// With rng always returning 0 and the current weather filtered out,
+		// the draw should pick the first remaining entry.
+		const currentWeather = WEATHER_POOL[0] ?? "Heavy rain is falling.";
+		const game = makeGameWithWeather(currentWeather);
+
+		const result = weatherChangeComplication.apply(game, () => 0);
+		const newWeather = getActivePhase(result).weather;
+
+		expect(newWeather).not.toBe(currentWeather);
+	});
+
+	it("mutates phase.weather to the drawn value", () => {
+		const currentWeather = "Dense fog has settled in.";
+		const game = makeGameWithWeather(currentWeather);
+
+		// rng always returns 0 → picks index 0 of the filtered pool
+		const result = weatherChangeComplication.apply(game, () => 0);
+		const phase = getActivePhase(result);
+
+		expect(phase.weather).toBeDefined();
+		expect(phase.weather).not.toBe(currentWeather);
+		// Must be a valid pool entry
+		expect(WEATHER_POOL).toContain(phase.weather);
+	});
+
+	it("also updates phase.contentPack.weather to stay consistent with phase.weather", () => {
+		const game = makeGameWithWeather("Sweltering heat clings to everything.");
+		const result = weatherChangeComplication.apply(game, () => 0);
+		const phase = getActivePhase(result);
+
+		expect(phase.weather).toBe(phase.contentPack.weather);
+	});
+
+	it("appends one broadcast entry to every Daemon's conversationLog", () => {
+		const game = makeGameWithWeather("A biting wind cuts through the air.");
+		const result = weatherChangeComplication.apply(game, () => 0);
+		const phase = getActivePhase(result);
+
+		const aiIds = Object.keys(TEST_PERSONAS);
+		for (const aiId of aiIds) {
+			const log = phase.conversationLogs[aiId] ?? [];
+			const broadcasts = log.filter((e) => e.kind === "broadcast");
+			expect(broadcasts).toHaveLength(1);
+		}
+	});
+
+	it("broadcast.round equals the current phase round", () => {
+		const game = makeGameWithWeather("Light snow drifts down.");
+		const phase = getActivePhase(game);
+		const currentRound = phase.round;
+
+		const result = weatherChangeComplication.apply(game, () => 0);
+		const afterPhase = getActivePhase(result);
+
+		for (const aiId of Object.keys(TEST_PERSONAS)) {
+			const log = afterPhase.conversationLogs[aiId] ?? [];
+			const broadcast = log.find((e) => e.kind === "broadcast");
+			expect(broadcast?.round).toBe(currentRound);
+		}
+	});
+
+	it("broadcast content mentions the new weather", () => {
+		const currentWeather = "Heavy snow is falling.";
+		const game = makeGameWithWeather(currentWeather);
+		const result = weatherChangeComplication.apply(game, () => 0);
+		const phase = getActivePhase(result);
+		const newWeather = phase.weather;
+
+		const log = phase.conversationLogs.red ?? [];
+		const broadcast = log.find((e) => e.kind === "broadcast");
+		expect(broadcast?.kind).toBe("broadcast");
+		if (broadcast?.kind === "broadcast") {
+			expect(broadcast.content).toContain(newWeather);
+		}
+	});
+});
+
+describe("COMPLICATIONS registry", () => {
+	it("contains at least one entry", () => {
+		expect(COMPLICATIONS.length).toBeGreaterThan(0);
+	});
+
+	it("every complication has a name and apply function", () => {
+		for (const comp of COMPLICATIONS) {
+			expect(typeof comp.name).toBe("string");
+			expect(typeof comp.apply).toBe("function");
+		}
+	});
+});

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -577,3 +577,89 @@ describe("buildConversationLog — chronological ordering", () => {
 		expect(result[2]).toContain("[Round 3]");
 	});
 });
+
+// ── Broadcast rendering ────────────────────────────────────────────────────────
+
+describe("buildConversationLog — broadcast", () => {
+	it("renders broadcast as '[Round N] <content>'", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "broadcast",
+					round: 3,
+					content: "The weather has changed to Heavy rain is falling.",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(
+			"[Round 3] The weather has changed to Heavy rain is falling.",
+		);
+	});
+
+	it("broadcast has no 'from' or 'to' prefix in the rendered line", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "broadcast",
+					round: 1,
+					content: "Dense fog has settled in.",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result[0]).not.toContain("dms you");
+		expect(result[0]).not.toContain("you dm");
+	});
+
+	it("broadcast interleaves with other entry kinds by round (stable sort)", () => {
+		const input: ConversationLogInput = {
+			conversationLog: [
+				{
+					kind: "broadcast",
+					round: 2,
+					content: "A biting wind cuts through the air.",
+				},
+				{
+					kind: "message",
+					from: "blue",
+					to: "red",
+					content: "Hello",
+					round: 0,
+				},
+				{
+					kind: "witnessed-event",
+					round: 1,
+					actor: "green",
+					actionKind: "go",
+					direction: "south",
+				},
+			],
+			worldEntities: [],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		expect(result).toHaveLength(3);
+		expect(result[0]).toContain("[Round 0]");
+		expect(result[1]).toContain("[Round 1]");
+		expect(result[2]).toBe("[Round 2] A biting wind cuts through the air.");
+	});
+
+	it("broadcast content is rendered verbatim — no actor substitution or item lookup", () => {
+		const input: ConversationLogInput = {
+			...emptyInput(),
+			conversationLog: [
+				{
+					kind: "broadcast",
+					round: 5,
+					content: "The {actor} text is literal.",
+				},
+			],
+		};
+		const result = buildConversationLog(input, "red", TEST_PERSONAS);
+		// Content should be emitted as-is, not substituted
+		expect(result[0]).toBe("[Round 5] The {actor} text is literal.");
+	});
+});

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -4,6 +4,7 @@ import {
 	advancePhase,
 	advanceRound,
 	appendActionFailure,
+	appendBroadcast,
 	appendMessage,
 	createGame,
 	deductBudget,
@@ -447,6 +448,58 @@ describe("advancePhase", () => {
 		});
 		const final = advancePhase(game);
 		expect(final.isComplete).toBe(true);
+	});
+});
+
+describe("appendBroadcast", () => {
+	it("appends a broadcast entry to all three Daemons' logs in one call", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const updated = appendBroadcast(
+			game,
+			"The weather has changed to Heavy rain is falling.",
+		);
+		const phase = getActivePhase(updated);
+		expect(phase.conversationLogs.red).toHaveLength(1);
+		expect(phase.conversationLogs.green).toHaveLength(1);
+		expect(phase.conversationLogs.cyan).toHaveLength(1);
+		expect(phase.conversationLogs.red?.[0]?.kind).toBe("broadcast");
+		expect(phase.conversationLogs.green?.[0]?.kind).toBe("broadcast");
+		expect(phase.conversationLogs.cyan?.[0]?.kind).toBe("broadcast");
+	});
+
+	it("broadcast entry has no `from` / `to` fields (regression guard)", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const updated = appendBroadcast(
+			game,
+			"A biting wind cuts through the air.",
+		);
+		const phase = getActivePhase(updated);
+		const entry = phase.conversationLogs.red?.[0];
+		expect(entry).toBeDefined();
+		expect("from" in (entry ?? {})).toBe(false);
+		expect("to" in (entry ?? {})).toBe(false);
+	});
+
+	it("carries the current phase round", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = advanceRound(game); // round = 1
+		game = advanceRound(game); // round = 2
+		const updated = appendBroadcast(game, "Dense fog has settled in.");
+		const phase = getActivePhase(updated);
+		const entry = phase.conversationLogs.red?.[0];
+		expect(entry?.round).toBe(2);
+	});
+
+	it("leaves uninvolved phase state intact", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const before = getActivePhase(game);
+		const updated = appendBroadcast(game, "Light snow drifts down.");
+		const after = getActivePhase(updated);
+		// Round and world should be unchanged
+		expect(after.round).toBe(before.round);
+		expect(after.world).toEqual(before.world);
+		// Budgets should be unchanged
+		expect(after.budgets).toEqual(before.budgets);
 	});
 });
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_LANDMARKS } from "../direction";
-import { advanceRound, appendMessage, createGame, startPhase } from "../engine";
+import {
+	advanceRound,
+	appendBroadcast,
+	appendMessage,
+	createGame,
+	startPhase,
+} from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext, buildConeSnapshot } from "../prompt-builder";
 import type {
@@ -1369,5 +1375,48 @@ describe("proximityFlavor sense line", () => {
 		expect(stateMsg).toContain(
 			"+ proximity: The gem pulses warmly, drawn toward the pedestal.",
 		);
+	});
+});
+
+describe("<whats_new> broadcast announcements", () => {
+	it("includes [announcement] line when a broadcast fires at the current round", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = advanceRound(game); // round advances to 1
+		game = appendBroadcast(game, "The weather has changed to heavy fog.");
+		const prevSnapshot = buildConeSnapshot(buildAiContext(game, "red"));
+		const ctx = buildAiContext(game, "red", { prevConeSnapshot: prevSnapshot });
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toContain("<whats_new>");
+		expect(stateMsg).toContain(
+			"[announcement] The weather has changed to heavy fog.",
+		);
+	});
+
+	it("emits <whats_new> with the announcement even without a prevConeSnapshot", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = advanceRound(game);
+		game = appendBroadcast(game, "The weather has changed to heavy fog.");
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toContain("<whats_new>");
+		expect(stateMsg).toContain(
+			"[announcement] The weather has changed to heavy fog.",
+		);
+	});
+
+	it("does not emit <whats_new> when there are no broadcasts and no prevConeSnapshot", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).not.toContain("<whats_new>");
+	});
+
+	it("broadcast from a prior round does not appear as pending", () => {
+		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+		game = advanceRound(game); // round 1
+		game = appendBroadcast(game, "Old broadcast.");
+		game = advanceRound(game); // round 2 — broadcast is now stale
+		const ctx = buildAiContext(game, "red");
+		expect(ctx.pendingBroadcasts).toHaveLength(0);
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -3278,3 +3278,106 @@ describe("action-failure entries — round-coordinator integration", () => {
 		expect(greenFailureMsgs).toHaveLength(0);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// complicationConfig — mid-phase complication trigger
+// ----------------------------------------------------------------------------
+describe("complicationConfig", () => {
+	function makeGameWithWeather(weather: string) {
+		const pack: ContentPack = {
+			...TEST_CONTENT_PACK,
+			weather,
+		};
+		const game = createGame(TEST_PERSONAS, [pack]);
+		return startPhase(game, TEST_PHASE_CONFIG);
+	}
+
+	function makeProvider() {
+		return new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+	}
+
+	it("fires the Weather Change complication on triggerRound", async () => {
+		const game = makeGameWithWeather("A biting wind cuts through the air.");
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			makeProvider(),
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ rng: () => 0, triggerRound: 1 },
+		);
+
+		// After round 1 (triggerRound), weather should have changed
+		const phase = getActivePhase(nextState);
+		expect(phase.weather).not.toBe("A biting wind cuts through the air.");
+		// Each daemon should have a broadcast entry
+		for (const aiId of Object.keys(TEST_PERSONAS)) {
+			const log = phase.conversationLogs[aiId] ?? [];
+			const broadcasts = log.filter((e) => e.kind === "broadcast");
+			expect(broadcasts).toHaveLength(1);
+		}
+	});
+
+	it("does not fire when currentRound !== triggerRound", async () => {
+		const initialWeather = "Dense fog has settled in.";
+		const game = makeGameWithWeather(initialWeather);
+
+		// Trigger is set for round 5, but we only run round 1
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			makeProvider(),
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ rng: () => 0, triggerRound: 5 },
+		);
+
+		const phase = getActivePhase(nextState);
+		// Weather should be unchanged
+		expect(phase.weather).toBe(initialWeather);
+		// No broadcast entries in any daemon's log
+		for (const aiId of Object.keys(TEST_PERSONAS)) {
+			const log = phase.conversationLogs[aiId] ?? [];
+			const broadcasts = log.filter((e) => e.kind === "broadcast");
+			expect(broadcasts).toHaveLength(0);
+		}
+	});
+
+	it("does not fire when complicationConfig is undefined", async () => {
+		const initialWeather = "Light snow drifts down.";
+		const game = makeGameWithWeather(initialWeather);
+
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			makeProvider(),
+			// No complicationConfig passed
+		);
+
+		const phase = getActivePhase(nextState);
+		expect(phase.weather).toBe(initialWeather);
+		for (const aiId of Object.keys(TEST_PERSONAS)) {
+			const log = phase.conversationLogs[aiId] ?? [];
+			const broadcasts = log.filter((e) => e.kind === "broadcast");
+			expect(broadcasts).toHaveLength(0);
+		}
+	});
+});

--- a/src/spa/game/complications.ts
+++ b/src/spa/game/complications.ts
@@ -1,0 +1,65 @@
+/**
+ * complications.ts
+ *
+ * Mid-phase complication registry. Each Complication has a name and an
+ * `apply` function that mutates game state (pure — returns a new GameState).
+ *
+ * Currently registered:
+ *   - weatherChangeComplication: draws a new weather string (different from
+ *     the current one) and broadcasts the change to all Daemon logs.
+ */
+
+import { WEATHER_POOL } from "../../content/index.js";
+import {
+	appendBroadcast,
+	getActivePhase,
+	setActivePhaseWeather,
+} from "./engine.js";
+import type { GameState } from "./types.js";
+
+/**
+ * A mid-phase complication: a named handler that receives the current game
+ * state plus a seeded rng and returns an updated game state.
+ */
+export interface Complication {
+	name: string;
+	apply(game: GameState, rng: () => number): GameState;
+}
+
+/**
+ * Weather Change complication.
+ *
+ * Draws a new weather string from WEATHER_POOL that is different from the
+ * active phase's current `phase.weather`, updates `phase.weather` and
+ * `phase.contentPack.weather`, then appends a broadcast entry to every
+ * Daemon's conversation log.
+ */
+export const weatherChangeComplication: Complication = {
+	name: "weatherChange",
+	apply(game: GameState, rng: () => number): GameState {
+		const currentWeather = getActivePhase(game).weather;
+
+		// Filter out the current weather so the draw always produces a change.
+		const candidates = (WEATHER_POOL as readonly string[]).filter(
+			(w) => w !== currentWeather,
+		);
+
+		// If somehow the pool is empty (shouldn't happen with ≥2 entries), fall
+		// back to the full pool so we never throw.
+		const pool =
+			candidates.length > 0 ? candidates : (WEATHER_POOL as readonly string[]);
+		const idx = Math.floor(rng() * pool.length);
+		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+		const newWeather = pool[idx]!;
+
+		let state = setActivePhaseWeather(game, newWeather);
+		state = appendBroadcast(state, `The weather has changed to ${newWeather}`);
+		return state;
+	},
+};
+
+/**
+ * Registry of all available complications. The round coordinator draws one
+ * entry from this list when a `complicationConfig.triggerRound` fires.
+ */
+export const COMPLICATIONS: Complication[] = [weatherChangeComplication];

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -16,6 +16,7 @@
  *   - `message`: incoming/outgoing DM lines.
  *   - `witnessed-event`: lines describing observed physical actions.
  *   - `action-failure`: actor-only lines recording dispatcher rejections.
+ *   - `broadcast`: sender-less system announcement rendered as `[Round N] <content>`.
  */
 
 import { cardinalToRelative } from "./direction.js";
@@ -132,6 +133,10 @@ export function renderEntry(
 			// Strip a trailing period from reason to keep the formatted line clean.
 			const reason = entry.reason.replace(/\.$/, "");
 			return `[Round ${round}] Your \`${entry.tool}\` action failed: ${reason}.`;
+		}
+
+		case "broadcast": {
+			return `[Round ${round}] ${entry.content}`;
 		}
 	}
 }

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -319,6 +319,43 @@ export function appendWitnessedEvent(
 }
 
 /**
+ * Append a `kind: "broadcast"` ConversationEntry to EVERY persona's per-Daemon
+ * log in the active phase in one atomic update. Broadcasts are sender-less
+ * system announcements (e.g. weather change complications) that all three
+ * Daemons must see simultaneously.
+ */
+export function appendBroadcast(game: GameState, content: string): GameState {
+	return updateActivePhase(game, (phase) => {
+		const entry: ConversationEntry = {
+			kind: "broadcast",
+			round: phase.round,
+			content,
+		};
+		const logs = { ...phase.conversationLogs };
+		for (const aiId of Object.keys(logs)) {
+			logs[aiId] = [...(logs[aiId] ?? []), entry];
+		}
+		return { ...phase, conversationLogs: logs };
+	});
+}
+
+/**
+ * Update the `weather` field on both the active PhaseState and its embedded
+ * ContentPack so the two stay consistent. Used by complication handlers that
+ * change weather mid-phase.
+ */
+export function setActivePhaseWeather(
+	game: GameState,
+	weather: string,
+): GameState {
+	return updateActivePhase(game, (phase) => ({
+		...phase,
+		weather,
+		contentPack: { ...phase.contentPack, weather },
+	}));
+}
+
+/**
  * Append a `kind: "action-failure"` ConversationEntry to a single actor's
  * per-Daemon log. This entry is actor-only — peers do not see it.
  */

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -24,6 +24,8 @@
  *        — "[Round N] Your `<tool>` action failed: <reason>."
  *        Actor-only; surfaced as a user turn so the Daemon sees its own past
  *        rejections in context and avoids repeating the same failed action.
+ *      - kind=broadcast:         { role: "user",      content: renderEntry(...) }
+ *        — "[Round N] <content>". Sender-less system announcement visible to all Daemons.
  *      Append-only across rounds, so the cached prefix grows with the game.
  *   3. If priorToolRoundtrip is provided and non-empty:
  *      - { role: "assistant", content: null, tool_calls: [...] }
@@ -109,6 +111,16 @@ export function buildOpenAiMessages(
 				),
 			});
 		} else if (entry.kind === "action-failure") {
+			messages.push({
+				role: "user",
+				content: renderEntry(
+					entry,
+					ctx.aiId,
+					ctx.worldSnapshot.entities,
+					witnessState,
+				),
+			});
+		} else if (entry.kind === "broadcast") {
 			messages.push({
 				role: "user",
 				content: renderEntry(

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -51,6 +51,12 @@ export interface AiContext {
 	 */
 	prevConeSnapshot?: string;
 	/**
+	 * Broadcast entry contents for the current round — world announcements
+	 * (e.g. weather change) that fired after the previous turn's LLM calls.
+	 * Rendered as `[announcement] …` lines inside `<whats_new>`.
+	 */
+	pendingBroadcasts: string[];
+	/**
 	 * Render the stable persona/phase prompt — front matter, identity, rules,
 	 * setting, personality, voice examples, goal. Byte-identical across rounds
 	 * within a (persona × phase), which lets OpenRouter's prefix cache reuse it.
@@ -83,6 +89,9 @@ export function buildAiContext(
 	const persona = game.personas[aiId];
 
 	const conversationLog = phase.conversationLogs[aiId] ?? [];
+	const pendingBroadcasts = conversationLog
+		.filter((e) => e.kind === "broadcast" && e.round === phase.round)
+		.map((e) => (e as Extract<typeof e, { kind: "broadcast" }>).content);
 	const worldSnapshot = phase.world;
 	const budget = phase.budgets[aiId] ?? { remaining: 0, total: 0 };
 	const goal = phase.aiGoals[aiId] ?? "";
@@ -116,6 +125,7 @@ export function buildAiContext(
 		personaSpatial,
 		personaColors,
 		landmarks,
+		pendingBroadcasts,
 		...(opts?.prevConeSnapshot !== undefined
 			? { prevConeSnapshot: opts.prevConeSnapshot }
 			: {}),
@@ -528,7 +538,6 @@ function renderSystemPrompt(ctx: AiContext): string {
 		lines.push("<setting>");
 		lines.push(`*${ctx.name} is in a ${ctx.setting}.`);
 		if (ctx.timeOfDay) lines.push(`It is ${ctx.timeOfDay}.`);
-		if (ctx.weather) lines.push(ctx.weather);
 		lines.push("</setting>");
 		lines.push("");
 	}
@@ -766,11 +775,16 @@ function parseYouLine(line: string): {
 function renderCurrentState(ctx: AiContext): string {
 	const lines: string[] = [];
 
-	if (ctx.prevConeSnapshot !== undefined) {
-		const current = buildConeSnapshot(ctx);
-		const diff = renderWhatsNew(ctx.prevConeSnapshot, current);
+	if (ctx.prevConeSnapshot !== undefined || ctx.pendingBroadcasts.length > 0) {
 		lines.push("<whats_new>");
-		lines.push(diff ?? "(no change)");
+		if (ctx.prevConeSnapshot !== undefined) {
+			const current = buildConeSnapshot(ctx);
+			const diff = renderWhatsNew(ctx.prevConeSnapshot, current);
+			lines.push(diff ?? "(no change)");
+		}
+		for (const content of ctx.pendingBroadcasts) {
+			lines.push(`[announcement] ${content}`);
+		}
 		lines.push("</whats_new>");
 		lines.push("");
 	}
@@ -787,6 +801,7 @@ function renderCurrentState(ctx: AiContext): string {
 		lines.push(
 			`On the horizon ahead: ${horizonLandmark.shortName} — ${horizonLandmark.horizonPhrase}.`,
 		);
+		if (ctx.weather) lines.push(`Weather: ${ctx.weather}`);
 
 		// Held items
 		const heldItems = items.filter((item) => item.holder === ctx.aiId);

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -18,6 +18,7 @@
  */
 
 import { availableTools } from "./available-tools";
+import { COMPLICATIONS } from "./complications";
 import { dispatchAiTurn } from "./dispatcher";
 import {
 	advancePhase,
@@ -69,6 +70,19 @@ export interface ChatLockoutConfig {
 	lockoutDuration: number;
 }
 
+/**
+ * Configuration for mid-phase complication events.
+ *
+ * Inject this into `runRound` to arm a complication at a specific round.
+ *
+ * @param rng          Returns a value in [0, 1). Used to pick the complication.
+ * @param triggerRound The round number (post-advance) at which to fire the complication.
+ */
+export interface ComplicationConfig {
+	rng: () => number;
+	triggerRound: number;
+}
+
 export interface RunRoundResult {
 	nextState: GameState;
 	result: RoundResult;
@@ -100,18 +114,21 @@ export interface RunRoundResult {
  * @param priorToolRoundtrip  Per-AI tool roundtrip from the previous round.
  *   Passed into buildOpenAiMessages to re-inject the protocol messages required
  *   by OpenAI's tool-use spec.
- * @param priorConeSnapshots  Per-AI canonical cone snapshots from the previous
- *   round, used by `buildAiContext` to emit a `<whats_new>` diff in each AI's
- *   per-round user message.
  * @param completionSink  Optional per-AI sink for the assistant text produced
  *   by each LLM call. Used by GameSession to capture completions for pacing.
  * @param onAiDelta  Optional per-AI live-delta callback. Fires synchronously
  *   inside the SSE parser loop for each text chunk arriving from the wire.
  *   Never called for locked-out AIs or mock providers that ignore onDelta.
+ * @param priorConeSnapshots  Per-AI canonical cone snapshots from the previous
+ *   round, used by `buildAiContext` to emit a `<whats_new>` diff in each AI's
+ *   per-round user message.
  * @param onAiTurnComplete  Optional per-AI "turn finished" callback. Fires
  *   exactly once per AI in initiative order, AFTER any drift-to-silence
  *   retry (#254) has resolved and after dispatch. Fires for locked-out
  *   AIs too (so callers can clear per-AI UI state uniformly).
+ * @param complicationConfig  Optional config for mid-phase complication events.
+ *   When present and `currentRound === triggerRound`, one complication is drawn
+ *   from the COMPLICATIONS registry and applied after the round advances.
  */
 export async function runRound(
 	game: GameState,
@@ -125,6 +142,7 @@ export async function runRound(
 	onAiDelta?: (aiId: AiId, text: string) => void,
 	priorConeSnapshots?: Partial<Record<AiId, string>>,
 	onAiTurnComplete?: (aiId: AiId) => void,
+	complicationConfig?: ComplicationConfig,
 ): Promise<RunRoundResult> {
 	const aiOrder = Object.keys(game.personas);
 
@@ -487,7 +505,19 @@ export async function runRound(
 		}
 	}
 
-	// 5. Check win condition
+	// 5. Mid-phase complication
+	if (complicationConfig) {
+		const { rng, triggerRound } = complicationConfig;
+		const currentRound = getActivePhase(state).round;
+		if (currentRound === triggerRound && COMPLICATIONS.length > 0) {
+			const compIdx = Math.floor(rng() * COMPLICATIONS.length);
+			// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+			const complication = COMPLICATIONS[compIdx]!;
+			state = complication.apply(state, rng);
+		}
+	}
+
+	// 6. Check win condition
 	const activePhaseAfterRound = getActivePhase(state);
 	let phaseEnded = false;
 

--- a/src/spa/game/round-result-encoder.ts
+++ b/src/spa/game/round-result-encoder.ts
@@ -20,6 +20,7 @@
  *   lockout    — { type, aiId, content }  (budget-exhaustion only, kept for styling)
  *   chat_lockout         — { type, aiId, message }
  *   chat_lockout_resolved — { type, aiId }
+ *   system_broadcast — { type, content }  (sender-less announcement, e.g. weather change)
  *   action_log — { type, entry }
  *   phase_advanced — { type, phase, setting }
  *   game_ended     — { type }
@@ -45,6 +46,7 @@ export type SseEvent =
 	| { type: "lockout"; aiId: AiId; content: string }
 	| { type: "chat_lockout"; aiId: AiId; message: string }
 	| { type: "chat_lockout_resolved"; aiId: AiId }
+	| { type: "system_broadcast"; content: string }
 	| { type: "action_log"; entry: RoundResult["actions"][number] }
 	| { type: "phase_advanced"; phase: 1 | 2 | 3; setting: string }
 	| { type: "game_ended" };
@@ -154,6 +156,24 @@ export function encodeRoundResult(
 				aiId,
 				content: lockoutContent(aiId),
 			});
+		}
+	}
+
+	// system_broadcast — one event per broadcast entry written during this round.
+	// Walk one daemon's log (all daemons receive the same broadcast entries) and
+	// emit a system_broadcast event for each entry matching the played round.
+	// NOTE: result.round is the round counter AFTER advanceRound(), so entries
+	// written during the round carry round: result.round - 1.
+	{
+		const playedRound = result.round - 1;
+		const firstAiId = Object.keys(personas)[0];
+		if (firstAiId !== undefined) {
+			const firstLog = phaseAfter.conversationLogs[firstAiId] ?? [];
+			for (const entry of firstLog) {
+				if (entry.kind === "broadcast" && entry.round === playedRound) {
+					events.push({ type: "system_broadcast", content: entry.content });
+				}
+			}
 		}
 	}
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -150,11 +150,12 @@ export interface PhysicalActionRecord {
 /**
  * A single tagged item inside a Daemon's conversation log.
  *
- * Discriminated union of three kinds — `message`, `witnessed-event`, `action-failure` — each
- * carrying a `round` and the smallest payload needed to render its line in the system prompt.
- * This is the per-Daemon storage shape *and* the prompt-rendered shape (per CONTEXT.md's
- * `Conversation log` glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt`
- * file in devtools can tell entry kinds apart at a glance.
+ * Discriminated union of four kinds — `message`, `witnessed-event`, `action-failure`,
+ * `broadcast` — each carrying a `round` and the smallest payload needed to render its
+ * line in the system prompt. This is the per-Daemon storage shape *and* the
+ * prompt-rendered shape (per CONTEXT.md's `Conversation log` glossary entry). The `kind`
+ * tag is chosen so a player editing a `*xxxx.txt` file in devtools can tell entry kinds
+ * apart at a glance.
  *
  * - `message`: a directional message from `from: AiId | "blue"` to `to: AiId | "blue"`.
  *   Both sender's and recipient's per-Daemon logs receive the same entry.
@@ -165,6 +166,8 @@ export interface PhysicalActionRecord {
  * - `action-failure`: actor-only; persists across rounds; written by the dispatcher when an
  *   in-scope action tool is rejected. Surfaces the rejection reason directly to the actor so
  *   Daemons do not repeat the same failed action (e.g. walking into a wall) indefinitely.
+ * - `broadcast`: sender-less system announcement appended to ALL three Daemon logs at once
+ *   (e.g. a weather change complication). Has no `from` / `to` fields.
  */
 export type ConversationEntry =
 	| {
@@ -191,6 +194,11 @@ export type ConversationEntry =
 			tool: "go" | "look" | "pick_up" | "put_down" | "give" | "use" | "examine";
 			/** Verbatim dispatcher rejection reason (e.g. "That cell is blocked by an obstacle"). */
 			reason: string;
+	  }
+	| {
+			kind: "broadcast";
+			round: number;
+			content: string;
 	  };
 
 export interface AiBudget {

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -549,4 +549,52 @@ describe("serializeSession / deserializeSession", () => {
 			expect(typeof phase?.winCondition).toBe("function");
 		}
 	});
+
+	it("round-trips broadcast entries in per-Daemon conversationLogs", () => {
+		const game = makeFreshGame();
+		const phase = game.phases[0];
+		if (!phase) throw new Error("no phase");
+		const broadcastEntry: ConversationEntry = {
+			kind: "broadcast",
+			round: 2,
+			content: "The weather has changed to Heavy rain is falling.",
+		};
+		const modified: GameState = {
+			...game,
+			phases: [
+				{
+					...phase,
+					conversationLogs: {
+						red: [broadcastEntry],
+						green: [broadcastEntry],
+						cyan: [broadcastEntry],
+					},
+				},
+			],
+		};
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			const rp = result.state.phases[0];
+			// Broadcast entry round-trips in all three daemon logs
+			expect(rp?.conversationLogs.red?.[0]).toEqual(broadcastEntry);
+			expect(rp?.conversationLogs.green?.[0]).toEqual(broadcastEntry);
+			expect(rp?.conversationLogs.cyan?.[0]).toEqual(broadcastEntry);
+			// Ensure broadcast has no from/to fields
+			const entry = rp?.conversationLogs.red?.[0];
+			expect(entry).toBeDefined();
+			expect("from" in (entry ?? {})).toBe(false);
+			expect("to" in (entry ?? {})).toBe(false);
+		}
+	});
+
+	it("SESSION_SCHEMA_VERSION is 6", () => {
+		const game = makeFreshGame();
+		const files = serializeSession(game, NOW, CREATED_AT);
+		if (!files.engine) throw new Error("engine should not be null");
+		const rawJson = deobfuscate(files.engine);
+		const sealed = JSON.parse(rawJson);
+		expect(sealed.schemaVersion).toBe(6);
+	});
 });

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -50,9 +50,16 @@ import {
  * v5 (issue #287): added `action-failure` `ConversationEntry` variant — durable
  * per-actor record of action-tool dispatcher rejections. Old v4 saves have no
  * `action-failure` entries; no migration provided.
- * v6 (issue #293): collapsed all `Record<1|2|3, …>` phase-keyed fields into a
- * flat single-game structure. Old v5 saves surface the existing `version-mismatch`
- * result — no migration provided.
+ *
+ * v6 (issues #293, #294): two simultaneous changes.
+ *   - #293: collapsed all `Record<1|2|3, …>` phase-keyed fields into a flat
+ *     single-game structure. Old v5 saves surface the existing
+ *     `version-mismatch` result — no migration provided.
+ *   - #294: added `broadcast` `ConversationEntry` variant — sender-less system
+ *     announcements appended to all three Daemon logs simultaneously (e.g.
+ *     weather change complications). Broadcast entries ride along in the
+ *     existing per-Daemon `conversationLog` array and round-trip automatically;
+ *     no additional structural deserialization changes required.
  */
 export const SESSION_SCHEMA_VERSION = 6 as const;
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -745,44 +745,49 @@ export function renderGame(
 					// branch left them stale whenever the new session had fewer (or
 					// zero) chat entries for this panel slot.
 					transcript.textContent = "";
-					// Filter to message entries where blue is involved (from blue or to blue)
-					// Skip daemon-to-daemon messages from the player-facing transcript.
-					const messageEntries = (
+					// Filter to message entries where blue is involved (from blue or to blue).
+					// Skip daemon-to-daemon messages and broadcast entries from the player-facing transcript.
+					// Broadcasts live in Daemon conversationLogs for LLM context only.
+					const visibleEntries = (
 						restoredPhase.conversationLogs[aiId] ?? []
 					).filter(
 						(e) =>
 							e.kind === "message" && (e.from === "blue" || e.to === "blue"),
 					);
-					if (messageEntries.length > 0) {
+					if (visibleEntries.length > 0) {
 						// Synthesise from conversationLogs (stored in daemon .txt files).
 						const persona = restoredPersonas[aiId];
 						const personaName = persona?.name ?? aiId;
-						for (const entry of messageEntries) {
-							if (entry.kind !== "message") continue;
+						for (const entry of visibleEntries) {
 							const lineEl = doc.createElement("div");
 							lineEl.className = "msg-line";
-							if (entry.from === "blue") {
-								// Incoming from player
-								appendMentionAwareText(
-									lineEl,
-									`> ${entry.content}\n`,
-									restoredPersonas,
-									"msg-you",
-								);
-							} else {
-								// Outgoing from AI to blue
-								const prefixSpan = doc.createElement("span");
-								prefixSpan.className = "msg-prefix";
-								if (persona?.color) {
-									prefixSpan.style.setProperty("--prefix-color", persona.color);
+							if (entry.kind === "message") {
+								if (entry.from === "blue") {
+									// Incoming from player
+									appendMentionAwareText(
+										lineEl,
+										`> ${entry.content}\n`,
+										restoredPersonas,
+										"msg-you",
+									);
+								} else {
+									// Outgoing from AI to blue
+									const prefixSpan = doc.createElement("span");
+									prefixSpan.className = "msg-prefix";
+									if (persona?.color) {
+										prefixSpan.style.setProperty(
+											"--prefix-color",
+											persona.color,
+										);
+									}
+									prefixSpan.textContent = `> *${transcriptName(personaName)} `;
+									lineEl.appendChild(prefixSpan);
+									appendMentionAwareText(
+										lineEl,
+										`${entry.content}\n`,
+										restoredPersonas,
+									);
 								}
-								prefixSpan.textContent = `> *${transcriptName(personaName)} `;
-								lineEl.appendChild(prefixSpan);
-								appendMentionAwareText(
-									lineEl,
-									`${entry.content}\n`,
-									restoredPersonas,
-								);
 							}
 							transcript.appendChild(lineEl);
 						}
@@ -1302,6 +1307,11 @@ export function renderGame(
 
 					case "chat_lockout_resolved":
 						setChatLockout(event.aiId, false);
+						break;
+
+					case "system_broadcast":
+						// Intentionally not rendered in the player-facing UI.
+						// The broadcast lives in each Daemon's conversationLog for LLM context only.
 						break;
 
 					case "action_log":


### PR DESCRIPTION
## What this lands

Cherry-pick of #311 (`Broadcast ConversationEntry kind + Weather Change complication`) onto `first-restructure`, where it was originally intended to land before it accidentally went to `main`.

A companion PR against `main` reverts both #311 and #313 from there.

## Why

`#311` and `#313` were both authored against the PRD 0005 restructure but merged to `main` instead of `first-restructure`. They sit on top of the pre-restructure schema (phase-keyed `GameState.phases[]`), so they no longer match the production architecture once `first-restructure` lands.

This PR cherry-picks `#311` cleanly. `#313` is not included here — its `state.phases[]` references are non-mechanical to translate onto first-restructure's flat `GameState`, so it needs to be re-authored against the new schema.

## Conflict resolution

One conflict, in `src/spa/persistence/session-codec.ts` — both `first-restructure`'s `#293` and `main`'s `#311` bumped the schema header comment to v6 for different reasons. Combined into a single v6 entry covering both `#293` (flat-schema collapse) and `#294` (broadcast variant). No code-level changes, doc-comment only.

## Automated coverage

- `pnpm typecheck` — clean.
- `pnpm test` — 1175/1175 across 54 files.
- `pnpm lint` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_019PYwYMdnyPdaSS5NESTRtX)_