### PR TITLE
Complication: Chat Lockout wired into complication schedule

### DIFF
--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -104,9 +104,10 @@ const FAKE_GAME_STATE = {
 	budgets: { red: AI_BUDGET, green: AI_BUDGET, cyan: AI_BUDGET },
 	conversationLogs: { red: [], green: [], cyan: [] },
 	lockedOut: new Set<string>(),
-	chatLockouts: new Map<string, number>(),
 	world: { entities: [] },
 	personaSpatial: {},
+	complicationSchedule: { countdown: 0, settingShiftFired: false },
+	activeComplications: [],
 };
 
 const GAME_ENDED_RESULT = {

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -151,25 +151,20 @@ describe("applyTestAffordances — winImmediately=1", () => {
 	});
 });
 
-// ── lockout=1 ────────────────────────────────────────────────────────────────
+// ── lockout=1 removed ────────────────────────────────────────────────────────
+// The ?lockout=1 test affordance has been removed. Chat lockouts are now driven
+// by the complication engine's countdown mechanism (issue #301).
 
-describe("applyTestAffordances — lockout=1", () => {
-	it("arms a chat-lockout for red, 2 rounds, on the next round", async () => {
+describe("applyTestAffordances — lockout=1 param is ignored", () => {
+	it("?lockout=1 no longer arms a lockout (param is a no-op)", async () => {
 		const session = makeSession();
 		const result = applyTestAffordances(
 			session,
 			new URLSearchParams("lockout=1"),
 		);
 
-		// Submitting one round should trigger the chat lockout (red, round 1 triggers)
-		const { result: roundResult } = await result.submitMessage(
-			"red",
-			"hello",
-			makePassProvider(),
-		);
-
-		expect(roundResult.chatLockoutTriggered).toBeDefined();
-		expect(roundResult.chatLockoutTriggered?.aiId).toBe("red");
+		// lockout=1 is no longer handled — session is returned unchanged
+		expect(result).toBe(session);
 	});
 
 	it("is a no-op when __WORKER_BASE_URL__ is not localhost:8787 (production gate)", async () => {
@@ -180,16 +175,8 @@ describe("applyTestAffordances — lockout=1", () => {
 				session,
 				new URLSearchParams("lockout=1"),
 			);
-			// Should return the same session without arming a lockout
+			// Always returns the same session when not in dev host
 			expect(result).toBe(session);
-
-			const { result: roundResult } = await result.submitMessage(
-				"red",
-				"hello",
-				makePassProvider(),
-			);
-			// No lockout should have triggered
-			expect(roundResult.chatLockoutTriggered).toBeUndefined();
 		} finally {
 			vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 		}
@@ -199,21 +186,22 @@ describe("applyTestAffordances — lockout=1", () => {
 // ── Combined params ───────────────────────────────────────────────────────────
 
 describe("applyTestAffordances — winImmediately=1&lockout=1 combined", () => {
-	it("lockout is applied; winImmediately is a no-op", async () => {
+	it("both params are no-ops in the single-game loop (#295, #301)", async () => {
 		const session = makeSession();
 		const result = applyTestAffordances(
 			session,
 			new URLSearchParams("winImmediately=1&lockout=1"),
 		);
 
+		// Session is returned unchanged — neither param has any effect.
+		expect(result).toBe(session);
+
+		// Submitting still works; nothing forced by the params should fire here.
 		const { result: roundResult } = await result.submitMessage(
 			"red",
 			"hello",
 			makePassProvider(),
 		);
-
-		// Lockout triggers (the armed lockout fires on round 1)
-		expect(roundResult.chatLockoutTriggered).toBeDefined();
-		expect(roundResult.chatLockoutTriggered?.aiId).toBe("red");
+		expect(roundResult).toBeDefined();
 	});
 });

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -10,6 +10,8 @@ import { describe, expect, it } from "vitest";
 import {
 	applyComplicationResult,
 	decrementComplicationCountdown,
+	isPlayerChatLockedOut,
+	resolveExpiredChatLockouts,
 	tickComplication,
 } from "../complication-engine.js";
 import { DEFAULT_LANDMARKS } from "../direction.js";
@@ -143,7 +145,6 @@ function makePhase(overrides: Partial<PhaseState> = {}): PhaseState {
 		budgets,
 		conversationLogs,
 		lockedOut: new Set(),
-		chatLockouts: new Map(),
 		personaSpatial,
 		complicationSchedule,
 		activeComplications: [],
@@ -892,5 +893,139 @@ describe("startPhase — complicationSchedule initialisation", () => {
 			}),
 		);
 		expect(phase.activeComplications).toEqual([]);
+	});
+});
+
+// ── isPlayerChatLockedOut ────────────────────────────────────────────────────
+
+describe("isPlayerChatLockedOut", () => {
+	it("returns false when activeComplications is empty", () => {
+		const phase = makePhase({ activeComplications: [] });
+		expect(isPlayerChatLockedOut(phase, "red")).toBe(false);
+	});
+
+	it("returns true when phase has a chat_lockout for the given AI", () => {
+		const phase = makePhase({
+			activeComplications: [
+				{ kind: "chat_lockout", target: "red", resolveAtRound: 10 },
+			],
+		});
+		expect(isPlayerChatLockedOut(phase, "red")).toBe(true);
+	});
+
+	it("returns false when the chat_lockout targets a different AI", () => {
+		const phase = makePhase({
+			activeComplications: [
+				{ kind: "chat_lockout", target: "green", resolveAtRound: 10 },
+			],
+		});
+		expect(isPlayerChatLockedOut(phase, "red")).toBe(false);
+	});
+
+	it("returns false when only non-chat_lockout complications exist", () => {
+		const phase = makePhase({
+			activeComplications: [
+				{
+					kind: "tool_disable",
+					target: "red",
+					tool: "go",
+					resolveAtRound: 100,
+				},
+				{ kind: "sysadmin_directive", target: "red", directive: "Do it." },
+			],
+		});
+		expect(isPlayerChatLockedOut(phase, "red")).toBe(false);
+	});
+
+	it("returns true regardless of resolveAtRound value (does not check expiry)", () => {
+		// isPlayerChatLockedOut reports presence; resolution is handled by resolveExpiredChatLockouts
+		const phase = makePhase({
+			round: 10,
+			activeComplications: [
+				{ kind: "chat_lockout", target: "cyan", resolveAtRound: 5 },
+			],
+		});
+		// Even though round (10) >= resolveAtRound (5), it's still in activeComplications
+		// until resolveExpiredChatLockouts runs
+		expect(isPlayerChatLockedOut(phase, "cyan")).toBe(true);
+	});
+});
+
+// ── resolveExpiredChatLockouts ────────────────────────────────────────────────
+
+describe("resolveExpiredChatLockouts", () => {
+	it("returns no resolved ids when activeComplications is empty", () => {
+		const phase = makePhase({ round: 5, activeComplications: [] });
+		const game = makeGameStateAround(phase);
+		const { nextState, resolvedAiIds } = resolveExpiredChatLockouts(game);
+		expect(resolvedAiIds).toHaveLength(0);
+		expect(nextState).toBe(game); // same reference when nothing changed
+	});
+
+	it("returns no resolved ids when no lockout has expired", () => {
+		const phase = makePhase({
+			round: 2,
+			activeComplications: [
+				{ kind: "chat_lockout", target: "red", resolveAtRound: 5 },
+			],
+		});
+		const game = makeGameStateAround(phase);
+		const { resolvedAiIds } = resolveExpiredChatLockouts(game);
+		expect(resolvedAiIds).toHaveLength(0);
+	});
+
+	it("resolves a lockout when phase.round >= resolveAtRound", () => {
+		const phase = makePhase({
+			round: 5,
+			activeComplications: [
+				{ kind: "chat_lockout", target: "red", resolveAtRound: 5 },
+			],
+		});
+		const game = makeGameStateAround(phase);
+		const { nextState, resolvedAiIds } = resolveExpiredChatLockouts(game);
+		expect(resolvedAiIds).toContain("red");
+		const nextPhase = getActivePhase(nextState);
+		expect(nextPhase.activeComplications).toHaveLength(0);
+	});
+
+	it("only removes expired lockouts, leaving unexpired ones intact", () => {
+		const phase = makePhase({
+			round: 5,
+			activeComplications: [
+				{ kind: "chat_lockout", target: "red", resolveAtRound: 4 }, // expired
+				{ kind: "chat_lockout", target: "green", resolveAtRound: 8 }, // not yet
+			],
+		});
+		const game = makeGameStateAround(phase);
+		const { nextState, resolvedAiIds } = resolveExpiredChatLockouts(game);
+		expect(resolvedAiIds).toContain("red");
+		expect(resolvedAiIds).not.toContain("green");
+		const nextPhase = getActivePhase(nextState);
+		expect(nextPhase.activeComplications).toHaveLength(1);
+		expect(nextPhase.activeComplications[0]?.target).toBe("green");
+	});
+
+	it("does not remove non-chat_lockout complications", () => {
+		const phase = makePhase({
+			round: 10,
+			activeComplications: [
+				{
+					kind: "tool_disable",
+					target: "red",
+					tool: "go",
+					resolveAtRound: 100,
+				},
+				{ kind: "chat_lockout", target: "cyan", resolveAtRound: 3 }, // expired
+			],
+		});
+		const game = makeGameStateAround(phase);
+		const { nextState, resolvedAiIds } = resolveExpiredChatLockouts(game);
+		expect(resolvedAiIds).toContain("cyan");
+		const nextPhase = getActivePhase(nextState);
+		// tool_disable should survive
+		expect(
+			nextPhase.activeComplications.some((c) => c.kind === "tool_disable"),
+		).toBe(true);
+		expect(nextPhase.activeComplications).toHaveLength(1);
 	});
 });

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -10,10 +10,7 @@ import {
 	deductBudget,
 	getActivePhase,
 	isAiLockedOut,
-	isPlayerChatLockedOut,
-	resolveChatLockouts,
 	startPhase,
-	triggerChatLockout,
 } from "../engine";
 import type { AiPersona, PhaseConfig } from "../types";
 
@@ -357,67 +354,6 @@ describe("appendMessage", () => {
 		const phase = getActivePhase(game);
 		expect("whispers" in phase).toBe(false);
 		expect("physicalLog" in phase).toBe(false);
-	});
-});
-
-describe("chat lockout", () => {
-	it("startPhase initialises chatLockouts as empty", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const phase = getActivePhase(game);
-		expect(phase.chatLockouts.size).toBe(0);
-	});
-
-	it("isPlayerChatLockedOut returns false when no lockout active", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		expect(isPlayerChatLockedOut(game, "red")).toBe(false);
-	});
-
-	it("triggerChatLockout marks the AI as player-chat-locked", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const locked = triggerChatLockout(game, "green", 3); // resolves at round 3
-		expect(isPlayerChatLockedOut(locked, "green")).toBe(true);
-		// Budget-lockout should remain unaffected
-		expect(isAiLockedOut(locked, "green")).toBe(false);
-	});
-
-	it("triggerChatLockout does not affect other AIs", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const locked = triggerChatLockout(game, "cyan", 2);
-		expect(isPlayerChatLockedOut(locked, "red")).toBe(false);
-		expect(isPlayerChatLockedOut(locked, "green")).toBe(false);
-	});
-
-	it("resolveChatLockouts removes lockouts where resolveAtRound <= current round", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = triggerChatLockout(game, "red", 2); // resolves at round 2
-		// Advance round to 1 — not yet at resolveAtRound
-		game = advanceRound(game); // round = 1
-		game = resolveChatLockouts(game);
-		expect(isPlayerChatLockedOut(game, "red")).toBe(true); // still locked
-
-		// Advance to round 2 — now at resolveAtRound
-		game = advanceRound(game); // round = 2
-		game = resolveChatLockouts(game);
-		expect(isPlayerChatLockedOut(game, "red")).toBe(false); // resolved
-	});
-
-	it("resolveChatLockouts only removes expired lockouts, leaving others intact", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = triggerChatLockout(game, "red", 1); // expires at round 1
-		game = triggerChatLockout(game, "green", 5); // expires at round 5
-		game = advanceRound(game); // round = 1
-		game = resolveChatLockouts(game);
-		expect(isPlayerChatLockedOut(game, "red")).toBe(false); // expired
-		expect(isPlayerChatLockedOut(game, "green")).toBe(true); // still active
-	});
-
-	it("chat lockout is independent from budget lockout — locked-out AI can still act (budget untouched)", () => {
-		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const locked = triggerChatLockout(game, "cyan", 3);
-		// Budget lockout (isAiLockedOut) must remain false — AI can still take turns
-		expect(isAiLockedOut(locked, "cyan")).toBe(false);
-		// Budget unaffected
-		expect(getActivePhase(locked).budgets.cyan?.remaining).toBe(5);
 	});
 });
 

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -411,22 +411,18 @@ describe("GameSession — result from submitMessage", () => {
 		expect(actors.size).toBe(3);
 	});
 
-	it("chat lockout is reflected in result.chatLockoutTriggered", async () => {
+	it("result object from submitMessage is always well-formed", async () => {
 		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
-
 		const { result } = await session.submitMessage(
 			"red",
 			"hi",
 			makePassProvider(),
-			{
-				rng: () => 0,
-				lockoutTriggerRound: 1,
-				lockoutDuration: 2,
-			},
 		);
-
-		expect(result.chatLockoutTriggered).toBeDefined();
-		expect(result.chatLockoutTriggered?.aiId).toBe("red");
+		// Verify the RoundResult surface is intact
+		expect(typeof result.round).toBe("number");
+		expect(Array.isArray(result.actions)).toBe(true);
+		expect(typeof result.phaseEnded).toBe("boolean");
+		expect(typeof result.gameEnded).toBe("boolean");
 	});
 });
 
@@ -514,7 +510,6 @@ describe("GameSession — onAiDelta propagation", () => {
 			"red",
 			"hi",
 			liveProvider,
-			undefined,
 			["red", "green", "cyan"],
 			(aiId, text) => {
 				received.push([aiId, text]);
@@ -544,7 +539,6 @@ describe("GameSession — onAiDelta propagation", () => {
 			"red",
 			"hi",
 			provider,
-			undefined,
 			undefined,
 			(aiId, text) => {
 				received.push([aiId, text]);

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect, it } from "vitest";
 import type { OpenAiMessage } from "../../llm-client";
+import { isPlayerChatLockedOut } from "../complication-engine";
 import { DEFAULT_LANDMARKS } from "../direction";
 import {
 	createGame,
@@ -19,8 +20,8 @@ import {
 	FAREWELL_LINE,
 	getActivePhase,
 	isAiLockedOut,
-	isPlayerChatLockedOut,
 	startPhase,
+	updateActivePhase,
 } from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
 import { buildAiContext } from "../prompt-builder";
@@ -1252,161 +1253,235 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 });
 
 // ----------------------------------------------------------------------------
-// Chat-lockout event
+// Chat-lockout event (driven by complication engine countdown)
 // ----------------------------------------------------------------------------
-describe("chat lockout — coordinator triggering", () => {
-	it("triggers a chat lockout at the configured round when RNG selects that round", async () => {
-		const game = makeGame();
+
+/**
+ * Force complicationSchedule.countdown to 0 so tickComplication fires
+ * on the next runRound call.
+ */
+function withCountdownZero(game: ReturnType<typeof makeGame>) {
+	return updateActivePhase(game, (phase) => ({
+		...phase,
+		complicationSchedule: { ...phase.complicationSchedule, countdown: 0 },
+	}));
+}
+
+/**
+ * RNG sequence that draws chat_lockout for the first AI (red) with min duration (3).
+ *
+ * Pool for TEST_CONTENT_PACK (no obstacles):
+ *   ["weather_change", "sysadmin_directive", "tool_disable", "chat_lockout", "setting_shift"]
+ *   → 5 items; index 3 is chat_lockout.
+ *
+ * Draws in order:
+ *   1. complication type: Math.floor(0.7 * 5) = 3 → chat_lockout
+ *   2. AI target index: Math.floor(0 * 3) = 0 → "red" (first AI in personas)
+ *   3. duration: 3 + Math.floor(0 * 3) = 3
+ *   4. new countdown reset: 5 + Math.floor(0 * 11) = 5
+ */
+function chatLockoutRng(): () => number {
+	const values = [0.7, 0, 0, 0];
+	let idx = 0;
+	return () => {
+		if (idx < values.length) {
+			const v = values[idx++];
+			return v ?? 0;
+		}
+		return 0;
+	};
+}
+
+describe("chat lockout — coordinator triggering (complication engine)", () => {
+	it("triggers a chat lockout when countdown reaches 0 and chat_lockout is drawn", async () => {
+		const game = withCountdownZero(makeGame());
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { nextState } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
-		expect(isPlayerChatLockedOut(nextState, "red")).toBe(true);
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			chatLockoutRng(),
+		);
+		const phase = getActivePhase(nextState);
+		expect(isPlayerChatLockedOut(phase, "red")).toBe(true);
 	});
 
-	it("does not trigger a chat lockout before the configured round", async () => {
-		const game = makeGame();
+	it("does not trigger a chat lockout when countdown > 0", async () => {
+		// makeGame() starts with countdown >= 1; no rng override needed
+		const game = updateActivePhase(makeGame(), (phase) => ({
+			...phase,
+			complicationSchedule: { ...phase.complicationSchedule, countdown: 5 },
+		}));
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { nextState } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 2,
-			lockoutDuration: 2,
-		});
-		expect(isPlayerChatLockedOut(nextState, "red")).toBe(false);
-		expect(isPlayerChatLockedOut(nextState, "green")).toBe(false);
-		expect(isPlayerChatLockedOut(nextState, "cyan")).toBe(false);
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			chatLockoutRng(),
+		);
+		const phase = getActivePhase(nextState);
+		expect(isPlayerChatLockedOut(phase, "red")).toBe(false);
+		expect(isPlayerChatLockedOut(phase, "green")).toBe(false);
+		expect(isPlayerChatLockedOut(phase, "cyan")).toBe(false);
 	});
 
 	it("locked AI still acts (takes turn, not budget-locked) while chat lockout is active", async () => {
-		const game = makeGame();
+		const game = withCountdownZero(makeGame());
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [], costUsd: 1 },
 			{ assistantText: "", toolCalls: [], costUsd: 1 },
 			{ assistantText: "", toolCalls: [], costUsd: 1 },
 		]);
-		const { nextState } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			chatLockoutRng(),
+		);
 		expect(isAiLockedOut(nextState, "red")).toBe(false);
 		expect(getActivePhase(nextState).budgets.red?.remaining).toBeCloseTo(4, 10);
 	});
 
-	it("chat lockout resolves automatically after lockoutDuration rounds", async () => {
-		const game = makeGame();
+	it("chat lockout resolves automatically after resolveAtRound (duration=3) rounds", async () => {
+		// Round 1: countdown=0 → chat_lockout fires for red with duration=3 → resolveAtRound=4
+		// Rounds 2, 3: red still locked (round < 4)
+		// Round 4: round=4 >= resolveAtRound=4 → lockout resolves
 		const makeProvider = () =>
 			new MockRoundLLMProvider([
 				{ assistantText: "", toolCalls: [] },
 				{ assistantText: "", toolCalls: [] },
 				{ assistantText: "", toolCalls: [] },
 			]);
-		const lockoutCfg = {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		};
 
 		const { nextState: afterR1 } = await runRound(
-			game,
+			withCountdownZero(makeGame()),
 			"red",
 			"hi",
 			makeProvider(),
-			lockoutCfg,
+			chatLockoutRng(),
 		);
-		expect(isPlayerChatLockedOut(afterR1, "red")).toBe(true);
+		expect(isPlayerChatLockedOut(getActivePhase(afterR1), "red")).toBe(true);
 
 		const { nextState: afterR2 } = await runRound(
 			afterR1,
 			"green",
 			"hi",
 			makeProvider(),
-			lockoutCfg,
+			chatLockoutRng(),
 		);
-		expect(isPlayerChatLockedOut(afterR2, "red")).toBe(true);
+		expect(isPlayerChatLockedOut(getActivePhase(afterR2), "red")).toBe(true);
 
 		const { nextState: afterR3 } = await runRound(
 			afterR2,
 			"green",
 			"hi",
 			makeProvider(),
-			lockoutCfg,
+			chatLockoutRng(),
 		);
-		expect(isPlayerChatLockedOut(afterR3, "red")).toBe(false);
+		expect(isPlayerChatLockedOut(getActivePhase(afterR3), "red")).toBe(true);
+
+		const { nextState: afterR4 } = await runRound(
+			afterR3,
+			"green",
+			"hi",
+			makeProvider(),
+			chatLockoutRng(),
+		);
+		expect(isPlayerChatLockedOut(getActivePhase(afterR4), "red")).toBe(false);
 	});
 
 	it("RoundResult includes chatLockoutTriggered when lockout fires", async () => {
-		const game = makeGame();
+		const game = withCountdownZero(makeGame());
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { result } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
+		const { result } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			chatLockoutRng(),
+		);
 		expect(result.chatLockoutTriggered).toBeDefined();
 		expect(result.chatLockoutTriggered?.aiId).toBe("red");
 	});
 
-	it("RoundResult chatLockoutTriggered is undefined when no lockout fires", async () => {
-		const game = makeGame();
+	it("RoundResult chatLockoutTriggered is undefined when countdown > 0", async () => {
+		const game = updateActivePhase(makeGame(), (phase) => ({
+			...phase,
+			complicationSchedule: { ...phase.complicationSchedule, countdown: 5 },
+		}));
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { result } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 5,
-			lockoutDuration: 2,
-		});
+		const { result } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			chatLockoutRng(),
+		);
 		expect(result.chatLockoutTriggered).toBeUndefined();
 	});
 
-	it("RoundResult includes chatLockoutResolved when a lockout expires this round", async () => {
-		const game = makeGame();
+	it("RoundResult includes chatLockoutsResolved when a lockout expires this round", async () => {
+		// Fire lockout in round 1 with duration=3 → resolveAtRound=4
 		const makeProvider = () =>
 			new MockRoundLLMProvider([
 				{ assistantText: "", toolCalls: [] },
 				{ assistantText: "", toolCalls: [] },
 				{ assistantText: "", toolCalls: [] },
 			]);
-		const lockoutCfg = {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 1,
-		};
 
 		const { nextState: afterR1 } = await runRound(
-			game,
+			withCountdownZero(makeGame()),
 			"red",
 			"hi",
 			makeProvider(),
-			lockoutCfg,
+			chatLockoutRng(),
 		);
 
-		const { result: r2Result } = await runRound(
+		// Advance through rounds 2 and 3 (still locked)
+		const { nextState: afterR2 } = await runRound(
 			afterR1,
 			"green",
 			"hi",
 			makeProvider(),
-			lockoutCfg,
+			chatLockoutRng(),
 		);
-		expect(r2Result.chatLockoutsResolved).toBeDefined();
-		expect(r2Result.chatLockoutsResolved).toContain("red");
+		const { nextState: afterR3 } = await runRound(
+			afterR2,
+			"green",
+			"hi",
+			makeProvider(),
+			chatLockoutRng(),
+		);
+
+		// Round 4: resolveAtRound=4 reached → chatLockoutsResolved fires
+		const { result: r4Result } = await runRound(
+			afterR3,
+			"green",
+			"hi",
+			makeProvider(),
+			chatLockoutRng(),
+		);
+		expect(r4Result.chatLockoutsResolved).toBeDefined();
+		expect(r4Result.chatLockoutsResolved).toContain("red");
 	});
 });
 
@@ -1592,17 +1667,19 @@ describe("lockout messages", () => {
 	});
 
 	it("chat-lockout message is '<name> is unresponsive…'", async () => {
-		const game = makeGame();
+		const game = withCountdownZero(makeGame());
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { result } = await runRound(game, "red", "hi", provider, {
-			rng: () => 0,
-			lockoutTriggerRound: 1,
-			lockoutDuration: 2,
-		});
+		const { result } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			chatLockoutRng(),
+		);
 
 		expect(result.chatLockoutTriggered).toBeDefined();
 		expect(result.chatLockoutTriggered?.aiId).toBe("red");
@@ -3262,18 +3339,9 @@ describe("action-failure entries — round-coordinator integration", () => {
 });
 
 // ----------------------------------------------------------------------------
-// complicationConfig — mid-phase complication trigger
+// Complication countdown — coordinator integration
 // ----------------------------------------------------------------------------
-describe("complicationConfig", () => {
-	function makeGameWithWeather(weather: string) {
-		const pack: ContentPack = {
-			...TEST_CONTENT_PACK,
-			weather,
-		};
-		const game = createGame(TEST_PERSONAS, [pack]);
-		return startPhase(game, TEST_PHASE_CONFIG);
-	}
-
+describe("complication countdown — coordinator integration", () => {
 	function makeProvider() {
 		return new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
@@ -3282,85 +3350,54 @@ describe("complicationConfig", () => {
 		]);
 	}
 
-	it("fires the Weather Change complication on triggerRound", async () => {
-		const game = makeGameWithWeather("A biting wind cuts through the air.");
-
+	it("fires a chat_lockout complication when countdown reaches 0", async () => {
+		const game = withCountdownZero(makeGame());
 		const { nextState } = await runRound(
 			game,
 			"red",
 			"hi",
 			makeProvider(),
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ rng: () => 0, triggerRound: 1 },
+			chatLockoutRng(),
 		);
-
-		// After round 1 (triggerRound), weather should have changed
 		const phase = getActivePhase(nextState);
-		expect(phase.weather).not.toBe("A biting wind cuts through the air.");
-		// Each daemon should have a broadcast entry
-		for (const aiId of Object.keys(TEST_PERSONAS)) {
-			const log = phase.conversationLogs[aiId] ?? [];
-			const broadcasts = log.filter((e) => e.kind === "broadcast");
-			expect(broadcasts).toHaveLength(1);
-		}
+		// A chat_lockout entry should have been appended to activeComplications
+		const lockouts = phase.activeComplications.filter(
+			(c) => c.kind === "chat_lockout",
+		);
+		expect(lockouts).toHaveLength(1);
+		expect(lockouts[0]?.target).toBe("red");
 	});
 
-	it("does not fire when currentRound !== triggerRound", async () => {
-		const initialWeather = "Dense fog has settled in.";
-		const game = makeGameWithWeather(initialWeather);
-
-		// Trigger is set for round 5, but we only run round 1
+	it("decrements countdown when no complication fires (countdown > 0)", async () => {
+		const game = updateActivePhase(makeGame(), (phase) => ({
+			...phase,
+			complicationSchedule: { ...phase.complicationSchedule, countdown: 5 },
+		}));
 		const { nextState } = await runRound(
 			game,
 			"red",
 			"hi",
 			makeProvider(),
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ rng: () => 0, triggerRound: 5 },
+			chatLockoutRng(),
 		);
-
 		const phase = getActivePhase(nextState);
-		// Weather should be unchanged
-		expect(phase.weather).toBe(initialWeather);
-		// No broadcast entries in any daemon's log
-		for (const aiId of Object.keys(TEST_PERSONAS)) {
-			const log = phase.conversationLogs[aiId] ?? [];
-			const broadcasts = log.filter((e) => e.kind === "broadcast");
-			expect(broadcasts).toHaveLength(0);
-		}
+		// Countdown should have decremented by 1
+		expect(phase.complicationSchedule.countdown).toBe(4);
 	});
 
-	it("does not fire when complicationConfig is undefined", async () => {
-		const initialWeather = "Light snow drifts down.";
-		const game = makeGameWithWeather(initialWeather);
-
+	it("resets countdown after a complication fires", async () => {
+		const game = withCountdownZero(makeGame());
+		// chatLockoutRng provides 0 for countdown reset → new countdown = 5
 		const { nextState } = await runRound(
 			game,
 			"red",
 			"hi",
 			makeProvider(),
-			// No complicationConfig passed
+			chatLockoutRng(),
 		);
-
 		const phase = getActivePhase(nextState);
-		expect(phase.weather).toBe(initialWeather);
-		for (const aiId of Object.keys(TEST_PERSONAS)) {
-			const log = phase.conversationLogs[aiId] ?? [];
-			const broadcasts = log.filter((e) => e.kind === "broadcast");
-			expect(broadcasts).toHaveLength(0);
-		}
+		// Countdown was reset by applyComplicationResult (drawCountdown(rng, 5, 15) with rng()=0 → 5)
+		expect(phase.complicationSchedule.countdown).toBe(5);
 	});
 
 	it("excludes obstacleShift from the draw when all obstacles are surrounded (no valid shift tuples)", async () => {
@@ -3370,39 +3407,36 @@ describe("complicationConfig", () => {
 		// COMPLICATIONS (index 1 = obstacleShift if the pool were unfiltered),
 		// by returning 0.99. With obstacleShift excluded, only weatherChange remains
 		// and it must fire (weather changes).
-		const initialWeather = "A biting wind cuts through the air.";
 		// TEST_CONTENT_PACK has no obstacles field — use it directly (obstacles: [])
 		const pack: ContentPack = {
 			...TEST_CONTENT_PACK,
-			weather: initialWeather,
 			obstacles: [],
 		};
 		const game = createGame(TEST_PERSONAS, [pack]);
 		const started = startPhase(game, TEST_PHASE_CONFIG);
+		// Force countdown to 0 so the complication engine fires this round.
+		// rng=0 draws index 0 from the pool (weatherChange), which is always
+		// available — obstacle_shift is excluded because there are no obstacles.
+		const withCountdown = updateActivePhase(started, (phase) => ({
+			...phase,
+			complicationSchedule: { ...phase.complicationSchedule, countdown: 0 },
+		}));
 
-		// rng returns 0 — always draws the first available complication (weatherChange,
-		// index 0). If obstacleShift were not excluded it would still be in the pool
-		// but rng=0 draws index 0 regardless; the important assertion is the
-		// absence of witnessed-obstacle-shift entries below.
 		const { nextState } = await runRound(
-			started,
+			withCountdown,
 			"red",
 			"hi",
 			makeProvider(),
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			undefined,
-			{ rng: () => 0, triggerRound: 1 },
+			() => 0,
 		);
 
 		const phase = getActivePhase(nextState);
 
-		// Weather must have changed — obstacleShift was excluded, weatherChange fired
-		expect(phase.weather).not.toBe(initialWeather);
+		// A complication fired (countdown was reset away from 0 by
+		// applyComplicationResult). With no obstacles in the pack, obstacle_shift
+		// is excluded from the pool so whichever complication fired, it was not
+		// obstacle_shift — confirmed below by the absence of witness entries.
+		expect(phase.complicationSchedule.countdown).toBeGreaterThan(0);
 
 		// No witnessed-obstacle-shift entries should appear in any daemon's log
 		for (const aiId of Object.keys(TEST_PERSONAS)) {

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -382,6 +382,51 @@ export function decrementComplicationCountdown(game: GameState): GameState {
 }
 
 /**
+ * Returns true if the active phase has a `chat_lockout` active complication
+ * targeting the given AI. Used by the route layer to mute player chat to that AI.
+ *
+ * Replaces `isChatLockedOut` from engine.ts which read the old `chatLockouts` map.
+ */
+export function isPlayerChatLockedOut(phase: GameState, aiId: AiId): boolean {
+	return phase.activeComplications.some(
+		(c) => c.kind === "chat_lockout" && c.target === aiId,
+	);
+}
+
+/**
+ * Scans `activeComplications` for `chat_lockout` entries whose `resolveAtRound`
+ * has been reached (`phase.round >= resolveAtRound`), removes them, and returns
+ * the updated state along with the list of resolved AI ids.
+ *
+ * Call this after `advanceRound`.
+ */
+export function resolveExpiredChatLockouts(game: GameState): {
+	nextState: GameState;
+	resolvedAiIds: AiId[];
+} {
+	const phase = getActivePhase(game);
+	const resolvedAiIds: AiId[] = [];
+	const remaining = phase.activeComplications.filter((c) => {
+		if (c.kind === "chat_lockout" && phase.round >= c.resolveAtRound) {
+			resolvedAiIds.push(c.target);
+			return false;
+		}
+		return true;
+	});
+
+	if (resolvedAiIds.length === 0) {
+		return { nextState: game, resolvedAiIds: [] };
+	}
+
+	const nextState = updateActivePhase(game, (p) => ({
+		...p,
+		activeComplications: remaining,
+	}));
+
+	return { nextState, resolvedAiIds };
+}
+
+/**
  * Apply a ComplicationResult to the game state:
  *   1. Reset the countdown via drawCountdown(rng, 5, 15).
  *   2. Mark settingShiftFired=true if the result is a setting_shift.

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -85,7 +85,6 @@ export function startGame(
 		budgets,
 		conversationLogs,
 		lockedOut: new Set(),
-		chatLockouts: new Map(),
 		personaSpatial,
 		complicationSchedule,
 		activeComplications,
@@ -295,37 +294,6 @@ export function appendActionFailure(
 }
 
 /**
- * Trigger a player-chat lockout for the given AI.
- *
- * @param resolveAtRound  The round number at which the lockout expires.
- *   The lockout is active while `game.round < resolveAtRound`.
- *   It resolves (is removed) when `game.round >= resolveAtRound`.
- */
-export function triggerChatLockout(
-	game: GameState,
-	aiId: AiId,
-	resolveAtRound: number,
-): GameState {
-	const chatLockouts = new Map(game.chatLockouts);
-	chatLockouts.set(aiId, resolveAtRound);
-	return { ...game, chatLockouts };
-}
-
-/**
- * Returns true when the player's chat channel to the given AI is currently
- * locked out (i.e. `game.chatLockouts` has an entry for `aiId` that has
- * not yet expired).
- *
- * Distinct from `isAiLockedOut` (budget-exhaustion): a chat-locked AI still
- * takes turns, whispers, and calls tools.
- */
-export function isPlayerChatLockedOut(game: GameState, aiId: AiId): boolean {
-	const resolveAtRound = game.chatLockouts.get(aiId);
-	if (resolveAtRound === undefined) return false;
-	return game.round < resolveAtRound;
-}
-
-/**
  * Append a `kind: "broadcast"` ConversationEntry to ONLY the specified
  * recipient daemon's log. Used for private Sysadmin notices (e.g. tool
  * disable / restore messages) that should reach exactly one daemon.
@@ -379,23 +347,6 @@ export function resolveToolDisables(game: GameState): {
 	return { game: { ...game, activeComplications: kept }, resolved };
 }
 
-/**
- * Remove all chat lockouts whose `resolveAtRound` has been reached
- * (i.e. `game.round >= resolveAtRound`).
- *
- * Call this after `advanceRound` so that a lockout set to resolve at round N
- * is cleared when `game.round === N`.
- */
-export function resolveChatLockouts(game: GameState): GameState {
-	const chatLockouts = new Map<AiId, number>();
-	for (const [aiId, resolveAtRound] of game.chatLockouts) {
-		if (game.round < resolveAtRound) {
-			chatLockouts.set(aiId, resolveAtRound);
-		}
-	}
-	return { ...game, chatLockouts };
-}
-
 // ── Legacy compatibility shims ──────────────────────────────────────────────
 // These aliases keep old callers compiling while the codebase migrates.
 
@@ -442,7 +393,6 @@ export function createGame(
 		budgets,
 		conversationLogs,
 		lockedOut: new Set(),
-		chatLockouts: new Map(),
 		personaSpatial: {},
 		complicationSchedule: { countdown: 0, settingShiftFired: false },
 		activeComplications: [],
@@ -578,7 +528,6 @@ export function startPhase(
 		budgets,
 		conversationLogs,
 		lockedOut: new Set(),
-		chatLockouts: new Map(),
 		personaSpatial,
 		complicationSchedule: {
 			countdown: initialCountdown,

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -5,7 +5,7 @@
  * Constructed from a phase-config triple (or just the first phase for v1).
  *
  * Exposes:
- *   submitMessage(addressedAi, message, provider, chatLockoutConfig?) → {
+ *   submitMessage(addressedAi, message, provider) → {
  *     result: RoundResult,
  *     completions: Record<AiId, string>,  // buffered per-AI completions
  *     nextState: GameState,
@@ -21,7 +21,6 @@
  */
 
 import { startGame } from "./engine";
-import type { ChatLockoutConfig } from "./round-coordinator";
 import { runRound } from "./round-coordinator";
 import type { RoundLLMProvider } from "./round-llm-provider";
 import type {
@@ -42,7 +41,6 @@ export interface SubmitMessageResult {
 
 export class GameSession {
 	private state: GameState;
-	private armedChatLockout?: ChatLockoutConfig;
 	/** Per-AI tool roundtrip from the last round, fed back in as prior context. */
 	private toolRoundtrip: Partial<Record<AiId, ToolRoundtripMessage>> = {};
 	/**
@@ -87,23 +85,11 @@ export class GameSession {
 	}
 
 	/**
-	 * Prime a chat-lockout config to be consumed by the next submitMessage call
-	 * that does not pass an explicit chatLockoutConfig. Used by the SPA's
-	 * applyTestAffordances (?lockout=1) to arm a lockout without modifying the
-	 * submitMessage call signature.
-	 */
-	armChatLockout(config: ChatLockoutConfig): void {
-		this.armedChatLockout = config;
-	}
-
-	/**
 	 * Run one full round through runRound.
 	 *
 	 * @param addressed  The AI the player is directing their message at.
 	 * @param message    The player's raw message text.
 	 * @param provider   RoundLLMProvider (mock or real BrowserLLMProvider).
-	 * @param chatLockoutConfig  Optional chat-lockout configuration for deterministic testing.
-	 *   When omitted, any config previously set via armChatLockout is consumed once.
 	 * @param initiative  Optional turn-order permutation for this round.
 	 *   Must be a permutation of all three AI ids. When absent, coordinator uses default order.
 	 * @param onAiDelta  Optional per-AI live-delta callback. Fires synchronously inside
@@ -114,17 +100,10 @@ export class GameSession {
 		addressed: AiId,
 		message: string,
 		provider: RoundLLMProvider,
-		chatLockoutConfig?: ChatLockoutConfig,
 		initiative?: AiId[],
 		onAiDelta?: (aiId: AiId, text: string) => void,
 		onAiTurnComplete?: (aiId: AiId) => void,
 	): Promise<SubmitMessageResult> {
-		let effectiveConfig = chatLockoutConfig;
-		if (!effectiveConfig && this.armedChatLockout) {
-			effectiveConfig = this.armedChatLockout;
-			delete this.armedChatLockout;
-		}
-
 		const turnOrder = initiative ?? Object.keys(this.state.personas);
 
 		// Capture completions per AI via the completionSink parameter.
@@ -144,7 +123,7 @@ export class GameSession {
 			addressed,
 			message,
 			provider,
-			effectiveConfig,
+			Math.random,
 			initiative,
 			this.toolRoundtrip,
 			completionSink,

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -18,7 +18,12 @@
  */
 
 import { availableTools } from "./available-tools";
-import { COMPLICATIONS } from "./complications";
+import {
+	applyComplicationResult,
+	decrementComplicationCountdown,
+	resolveExpiredChatLockouts,
+	tickComplication,
+} from "./complication-engine";
 import { dispatchAiTurn } from "./dispatcher";
 import {
 	advanceRound,
@@ -26,9 +31,7 @@ import {
 	appendPrivateSystemNotice,
 	FAREWELL_LINE,
 	isAiLockedOut,
-	resolveChatLockouts,
 	resolveToolDisables,
-	triggerChatLockout,
 } from "./engine";
 import { buildOpenAiMessages } from "./openai-message-builder";
 import { buildAiContext, buildConeSnapshot } from "./prompt-builder";
@@ -57,34 +60,6 @@ function isDevHost(): boolean {
 	);
 }
 
-/**
- * Configuration for the mid-phase chat-lockout event.
- *
- * Inject this into `runRound` to make randomness deterministic in tests.
- *
- * @param rng              Returns a value in [0, 1). Used to pick which AI to lock.
- * @param lockoutTriggerRound  The round number (post-advance) at which to fire the lockout.
- * @param lockoutDuration  How many rounds the lockout lasts (resolves after this many).
- */
-export interface ChatLockoutConfig {
-	rng: () => number;
-	lockoutTriggerRound: number;
-	lockoutDuration: number;
-}
-
-/**
- * Configuration for mid-phase complication events.
- *
- * Inject this into `runRound` to arm a complication at a specific round.
- *
- * @param rng          Returns a value in [0, 1). Used to pick the complication.
- * @param triggerRound The round number (post-advance) at which to fire the complication.
- */
-export interface ComplicationConfig {
-	rng: () => number;
-	triggerRound: number;
-}
-
 export interface RunRoundResult {
 	nextState: GameState;
 	result: RoundResult;
@@ -110,7 +85,8 @@ export interface RunRoundResult {
  * @param addressed  The AI the player's message is directed at.
  * @param playerMessage  The player's raw message text.
  * @param provider  RoundLLMProvider (browser or mock).
- * @param chatLockoutConfig  Optional config for the mid-phase chat-lockout event.
+ * @param rng  Optional RNG for the complication engine. Defaults to Math.random.
+ *   Inject a deterministic function in tests to control complication draws.
  * @param initiative  Optional turn-order permutation. Must be a permutation of
  *   all AI ids in `game.personas`. When absent, defaults to `Object.keys(game.personas)`.
  * @param priorToolRoundtrip  Per-AI tool roundtrip from the previous round.
@@ -128,23 +104,19 @@ export interface RunRoundResult {
  *   exactly once per AI in initiative order, AFTER any drift-to-silence
  *   retry (#254) has resolved and after dispatch. Fires for locked-out
  *   AIs too (so callers can clear per-AI UI state uniformly).
- * @param complicationConfig  Optional config for mid-phase complication events.
- *   When present and `currentRound === triggerRound`, one complication is drawn
- *   from the COMPLICATIONS registry and applied after the round advances.
  */
 export async function runRound(
 	game: GameState,
 	addressed: AiId,
 	playerMessage: string,
 	provider: RoundLLMProvider,
-	chatLockoutConfig?: ChatLockoutConfig,
+	rng: () => number = Math.random,
 	initiative?: AiId[],
 	priorToolRoundtrip?: Partial<Record<AiId, ToolRoundtripMessage>>,
 	completionSink?: (aiId: AiId, text: string) => void,
 	onAiDelta?: (aiId: AiId, text: string) => void,
 	priorConeSnapshots?: Partial<Record<AiId, string>>,
 	onAiTurnComplete?: (aiId: AiId) => void,
-	complicationConfig?: ComplicationConfig,
 ): Promise<RunRoundResult> {
 	const aiOrder = Object.keys(game.personas);
 
@@ -488,36 +460,22 @@ export async function runRound(
 	// 3. Advance the round counter
 	state = advanceRound(state);
 
-	// 4. Mid-game chat-lockout
+	// 4. Complication engine tick (chat lockouts, tool disables, etc. via complication-engine)
 	let chatLockoutTriggered: RoundResult["chatLockoutTriggered"] | undefined;
 	let chatLockoutsResolved: AiId[] | undefined;
 
-	if (chatLockoutConfig) {
-		const { rng, lockoutTriggerRound, lockoutDuration } = chatLockoutConfig;
-		const currentRound = state.round;
-
-		const alreadyHasLockout = state.chatLockouts.size > 0;
-		if (currentRound === lockoutTriggerRound && !alreadyHasLockout) {
-			const aiIndex = Math.floor(rng() * aiOrder.length);
-			const targetAi = aiOrder[aiIndex] as AiId;
-			const resolveAtRound = currentRound + lockoutDuration;
-			state = triggerChatLockout(state, targetAi, resolveAtRound);
+	const complicationResult = tickComplication(state, rng);
+	if (complicationResult !== null) {
+		state = applyComplicationResult(state, complicationResult, rng);
+		const { fired } = complicationResult;
+		if (fired.kind === "chat_lockout") {
 			chatLockoutTriggered = {
-				aiId: targetAi,
-				message: `${state.personas[targetAi]?.name ?? targetAi} is unresponsive…`,
+				aiId: fired.target,
+				message: `${state.personas[fired.target]?.name ?? fired.target} is unresponsive…`,
 			};
 		}
-
-		const expiredAis: AiId[] = [];
-		for (const [aiId, resolveAtRound] of state.chatLockouts) {
-			if (state.round >= resolveAtRound) {
-				expiredAis.push(aiId);
-			}
-		}
-		if (expiredAis.length > 0) {
-			state = resolveChatLockouts(state);
-			chatLockoutsResolved = expiredAis;
-		}
+	} else {
+		state = decrementComplicationCountdown(state);
 	}
 
 	// 4b. Resolve expired tool disables and notify the affected daemons
@@ -533,26 +491,17 @@ export async function runRound(
 		}
 	}
 
-	// 5. Mid-game complication
-	if (complicationConfig) {
-		const { rng, triggerRound } = complicationConfig;
-		const currentRound = state.round;
-		if (currentRound === triggerRound) {
-			// Filter to complications that are applicable given the current game state.
-			// Complications with no `isAvailable` guard are always eligible.
-			const availableComplications = COMPLICATIONS.filter(
-				(c) => !c.isAvailable || c.isAvailable(state),
-			);
-			if (availableComplications.length > 0) {
-				const compIdx = Math.floor(rng() * availableComplications.length);
-				// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
-				const complication = availableComplications[compIdx]!;
-				state = complication.apply(state, rng);
-			}
+	// 4c. Resolve expired chat lockouts
+	{
+		const { nextState: stateAfterResolve, resolvedAiIds } =
+			resolveExpiredChatLockouts(state);
+		state = stateAfterResolve;
+		if (resolvedAiIds.length > 0) {
+			chatLockoutsResolved = resolvedAiIds;
 		}
 	}
 
-	// 6. Check win/lose conditions — win takes priority.
+	// 5. Check win/lose conditions — win takes priority.
 	let gameEnded = false;
 	if (checkWinCondition(state.world, state.contentPack)) {
 		state = { ...state, isComplete: true, outcome: "win" };

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -282,14 +282,6 @@ export interface GameState {
 	conversationLogs: Record<AiId, ConversationEntry[]>;
 	/** Budget-exhaustion lockout: prevents the AI from acting at all. */
 	lockedOut: Set<AiId>;
-	/**
-	 * Player-chat lockout: maps an AI's id to the round number at which the
-	 * lockout resolves (resolves when game.round >= resolveAtRound).
-	 * While active the player cannot address messages to that AI; the AI
-	 * continues to receive whispers, take turns, and call tools normally.
-	 * Semantically distinct from `lockedOut` (budget-exhaustion).
-	 */
-	chatLockouts: Map<AiId, number>;
 	/** Per-AI spatial state (position + facing). */
 	personaSpatial: Record<AiId, PersonaSpatialState>;
 	/** Complication countdown + phase-level flags. */

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -206,12 +206,11 @@ describe("serializeSession / deserializeSession", () => {
 		expect(files.engine).toMatch(/^[A-Za-z0-9+/=]*$/);
 	});
 
-	it("round-trips lockedOut Set (chatLockouts no longer persisted)", () => {
+	it("round-trips lockedOut Set", () => {
 		const game = makeFreshGame();
 		const modified: GameState = {
 			...game,
 			lockedOut: new Set<AiId>(["red"]),
-			chatLockouts: new Map<AiId, number>([["green", 5]]),
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
@@ -219,8 +218,6 @@ describe("serializeSession / deserializeSession", () => {
 		if (result.kind === "ok") {
 			expect(result.state.lockedOut).toBeInstanceOf(Set);
 			expect(result.state.lockedOut.has("red")).toBe(true);
-			expect(result.state.chatLockouts).toBeInstanceOf(Map);
-			expect(result.state.chatLockouts.size).toBe(0);
 		}
 	});
 

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -293,7 +293,6 @@ export function deserializeSession(
 		const world = structuredClone(sealed.world);
 		const budgets = { ...sealed.budgets };
 		const lockedOut = new Set<AiId>(sealed.lockedOut);
-		const chatLockouts = new Map<AiId, number>();
 		const personaSpatial = structuredClone(sealed.personaSpatial);
 
 		// Defensive defaults for legacy blobs that omit complication fields
@@ -315,7 +314,6 @@ export function deserializeSession(
 			budgets,
 			conversationLogs,
 			lockedOut,
-			chatLockouts,
 			personaSpatial,
 			complicationSchedule,
 			activeComplications,

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -9,6 +9,7 @@ import {
 } from "../bbs-chrome.js";
 import { buildSessionFromAssets } from "../game/bootstrap.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
+import { isPlayerChatLockedOut } from "../game/complication-engine.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
 import { GameSession } from "../game/game-session.js";
 import {
@@ -148,10 +149,9 @@ function isDevHost(): boolean {
  * Only honoured when the SPA is served by `pnpm wrangler dev` (see
  * `isDevHost`). Silently inert in any other host.
  *
- * - `winImmediately=1`: not applicable in single-game loop (win is driven by
- *   checkWinCondition after each round). This affordance is a no-op in #295.
- * - `lockout=1`: arm a chat-lockout for `red`, 2 rounds, effective next round.
- *   Matches the legacy worker semantics from `src/proxy/_smoke.ts`.
+ * - `winImmediately=1`: wrap submitMessage so the next call ends the game with
+ *   outcome "win". Used by integration tests that need to drive the UI to
+ *   `game_ended` without satisfying objectives via tool calls.
  *
  * Returns the (possibly replaced) GameSession to use going forward.
  */
@@ -163,39 +163,27 @@ export function applyTestAffordances(
 	if (!isDevHost()) return s;
 
 	const wantsWin = searchParams.get("winImmediately") === "1";
-	const wantsLockout = searchParams.get("lockout") === "1";
 
-	if (!wantsWin && !wantsLockout) return s;
+	if (!wantsWin) return s;
 
 	const active = s;
 
-	if (wantsLockout) {
-		const currentRound = active.getState().round;
-		active.armChatLockout({
-			rng: () => 0,
-			lockoutTriggerRound: currentRound + 1,
-			lockoutDuration: 2,
-		});
-	}
-
-	if (wantsWin) {
-		// In the flat single-game model, wrap submitMessage so the next call ends
-		// the game (outcome: "win"). Used by integration tests that need to drive
-		// the UI to game_ended without satisfying objectives via tool calls.
-		const originalSubmit = active.submitMessage.bind(active);
-		active.submitMessage = async (...args) => {
-			const result = await originalSubmit(...args);
-			return {
-				...result,
-				result: { ...result.result, gameEnded: true, phaseEnded: false },
-				nextState: {
-					...result.nextState,
-					isComplete: true,
-					outcome: "win" as const,
-				},
-			};
+	// In the flat single-game model, wrap submitMessage so the next call ends
+	// the game (outcome: "win"). Used by integration tests that need to drive
+	// the UI to game_ended without satisfying objectives via tool calls.
+	const originalSubmit = active.submitMessage.bind(active);
+	active.submitMessage = async (...args) => {
+		const result = await originalSubmit(...args);
+		return {
+			...result,
+			result: { ...result.result, gameEnded: true, phaseEnded: false },
+			nextState: {
+				...result.nextState,
+				isComplete: true,
+				outcome: "win" as const,
+			},
 		};
-	}
+	};
 
 	return active;
 }
@@ -390,9 +378,9 @@ export function renderGame(
 	// step back on for prompt-tuning. Gated to wrangler-dev (see isDevHost).
 	//
 	// Merge hash-query-string params (from the router) with location.search
-	// params so flags like ?think=1, ?lockout=1, ?winImmediately=1 work whether
-	// they appear in the search string (e.g. "/?lockout=1") or after the hash
-	// (e.g. "/#/?lockout=1"). Hash params win on conflict.
+	// params so flags like ?think=1, ?winImmediately=1 work whether
+	// they appear in the search string (e.g. "/?winImmediately=1") or after the hash
+	// (e.g. "/#/?winImmediately=1"). Hash params win on conflict.
 	const effectiveParams = new URLSearchParams(location.search);
 	if (params) {
 		for (const [k, v] of params) effectiveParams.set(k, v);
@@ -797,9 +785,9 @@ export function renderGame(
 	// Synchronous post-init: runs for both the restore path AND the bootstrap-
 	// recursive path (which already set session = built before re-entering).
 	if (session !== null) {
-		// Apply SPA-side test affordances from location.search (e.g. ?winImmediately=1
-		// or ?lockout=1). These are gated inside applyTestAffordances to only fire
-		// when __WORKER_BASE_URL__ === "http://localhost:8787" (local dev).
+		// Apply SPA-side test affordances from location.search (e.g. ?winImmediately=1).
+		// These are gated inside applyTestAffordances to only fire when
+		// __WORKER_BASE_URL__ === "http://localhost:8787" (local dev).
 		// Note: we use location.search (not the hash params) because these flags are
 		// intended to be set on the page URL itself, matching the legacy worker pattern.
 		session = applyTestAffordances(session, effectiveParams);
@@ -810,11 +798,11 @@ export function renderGame(
 		personaColors = buildPersonaColorMap(runtimePersonas);
 		personaDisplayNames = buildPersonaDisplayNameMap(runtimePersonas);
 
-		// Hydrate lockouts from the active phase's chatLockouts map so that
-		// a reload preserves the Send-disabled state for locked-out AIs.
+		// Hydrate lockouts from activeComplications so that a reload preserves
+		// the Send-disabled state for chat-locked-out AIs.
 		const activePhaseForLockouts = session.getState();
 		for (const aiId of Object.keys(runtimePersonas)) {
-			lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
+			lockouts.set(aiId, isPlayerChatLockedOut(activePhaseForLockouts, aiId));
 		}
 
 		// Reset module-level gameEnded flag on fresh session init
@@ -1209,7 +1197,6 @@ export function renderGame(
 				addressed,
 				message,
 				provider,
-				undefined,
 				initiative,
 				undefined,
 				(aiId) => stripSpinner(aiId),


### PR DESCRIPTION
## What this fixes

Chat lockouts were previously a hardcoded mechanic (`chatLockouts: Map<AiId, number>` on `PhaseState`) with dedicated helpers (`triggerChatLockout`, `resolveChatLockouts`, `isChatLockedOut`) and a bespoke `ChatLockoutConfig` parameter on `runRound`. They are now a first-class drawable complication type in the Complication Engine.

The engine already drew `chat_lockout` variants and stored entries in `activeComplications` (landed in #296). This PR completes the wiring: the Round Coordinator calls `tickComplication` → `applyComplicationResult` each round, resolves expired `chat_lockout` entries via `resolveExpiredChatLockouts` (new helper in `complication-engine.ts`), and reports both trigger and resolution via `RoundResult.chatLockoutTriggered` / `chatLockoutsResolved`. Player message routing now reads `isPlayerChatLockedOut` against `activeComplications` instead of the removed `chatLockouts` map. The old `ComplicationConfig` / `chatLockoutConfig` bespoke parameters and the `?lockout=1` test affordance are removed; tests use countdown=0 + seeded RNG to drive lockouts deterministically.

Key files changed: `complication-engine.ts` (two new exports), `round-coordinator.ts` (new `rng` param, integrated `tickComplication` flow), `engine.ts` (removed three helpers), `types.ts` (removed `chatLockouts` field), `game-session.ts` (removed `armChatLockout`), `routes/game.ts` (updated lockout hydration, removed `?lockout=1`), `session-codec.ts` (removed `chatLockouts` serialization), plus updated tests across six test files.

## QA steps for the human

None — fully covered by the integration smoke. The complication engine drives chat lockouts in normal game play via countdown; the unit tests verify trigger, enforcement, resolution, and the absence of old serialization fields.

## Automated coverage

`pnpm tsc --noEmit` (0 errors) + `pnpm test` (55 files, 1219 tests) + biome lint — all passing on `claude/fix-ralph-one-301-IOkHe`.

Closes #301

---
_Generated by [Claude Code](https://claude.ai/code/session_012keBLxqjEfxyPW4et5w4DL)_