### PR TITLE
Single-game loop: retire phase management, per-game budget, farewell line, win/lose conditions (#295)

### DIFF
--- a/src/__tests__/content.test.ts
+++ b/src/__tests__/content.test.ts
@@ -164,6 +164,7 @@ describe("phase configs — chaining", () => {
 	});
 
 	it("PHASE_3_CONFIG has no nextPhaseConfig", () => {
+		// @ts-expect-error nextPhaseConfig not in type (deprecated flat-model compat)
 		expect(PHASE_3_CONFIG.nextPhaseConfig).toBeUndefined();
 	});
 });

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -142,33 +142,35 @@ describe("serializeGameSave", () => {
 		expect("whispers" in (ember?.phases[0] ?? {})).toBe(false);
 	});
 
-	it("accumulates transcripts across multiple phases", () => {
+	it("accumulates transcripts in a single phase (flat model, #295)", () => {
+		// In the flat single-game model (issue #295), all conversation accumulates
+		// in one phase. advancePhase() with a next config is a no-op.
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE1_CONFIG);
-		game = appendMessage(game, "blue", "red", "Phase 1 message");
-		game = advancePhase(game, PHASE2_CONFIG);
-		game = appendMessage(game, "blue", "red", "Phase 2 message");
-		game = advancePhase(game, PHASE3_CONFIG);
-		game = appendMessage(game, "blue", "red", "Phase 3 message");
-		game = advancePhase(game); // complete
+		game = appendMessage(game, "blue", "red", "Message 1");
+		game = advancePhase(game, PHASE2_CONFIG); // no-op in flat model
+		game = appendMessage(game, "blue", "red", "Message 2");
+		game = advancePhase(game, PHASE3_CONFIG); // no-op in flat model
+		game = appendMessage(game, "blue", "red", "Message 3");
+		game = advancePhase(game); // marks complete
 
 		const save = serializeGameSave(game);
 		const ember = save.ais.find((a) => a.persona.id === "red");
-		expect(ember?.phases).toHaveLength(3);
+		// Flat model: single phase with all messages accumulated
+		expect(ember?.phases).toHaveLength(1);
 		expect(ember?.phases[0]?.phaseNumber).toBe(1);
-		expect(ember?.phases[1]?.phaseNumber).toBe(2);
-		expect(ember?.phases[2]?.phaseNumber).toBe(3);
+		expect(ember?.phases[0]?.conversationLog).toHaveLength(3);
 		expect(
 			ember?.phases[0]?.conversationLog[0]?.kind === "message" &&
 				ember?.phases[0]?.conversationLog[0]?.content,
-		).toBe("Phase 1 message");
+		).toBe("Message 1");
 		expect(
-			ember?.phases[1]?.conversationLog[0]?.kind === "message" &&
-				ember?.phases[1]?.conversationLog[0]?.content,
-		).toBe("Phase 2 message");
+			ember?.phases[0]?.conversationLog[1]?.kind === "message" &&
+				ember?.phases[0]?.conversationLog[1]?.content,
+		).toBe("Message 2");
 		expect(
-			ember?.phases[2]?.conversationLog[0]?.kind === "message" &&
-				ember?.phases[2]?.conversationLog[0]?.content,
-		).toBe("Phase 3 message");
+			ember?.phases[0]?.conversationLog[2]?.kind === "message" &&
+				ember?.phases[0]?.conversationLog[2]?.content,
+		).toBe("Message 3");
 	});
 
 	it("produces a serializable (round-trippable) payload", () => {

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -55,6 +55,7 @@ export interface PhaseConfig {
 	budgetPerAi: number;
 	aiGoalPool: string[];
 }
+
 import { THEME_POOL } from "./theme-pool.js";
 import { TIME_OF_DAY_POOL } from "./time-of-day-pool.js";
 import { WEATHER_POOL } from "./weather-pool.js";
@@ -353,7 +354,9 @@ export async function generateContentPacks(
 
 	// Build placeholder ContentPack structures from LLM result (no placements yet)
 	const unplacedPacks: ContentPack[] = llmResult.packs.map((pack, i) => ({
-		...(pack.phaseNumber !== undefined ? { phaseNumber: pack.phaseNumber as 1 | 2 | 3 } : {}),
+		...(pack.phaseNumber !== undefined
+			? { phaseNumber: pack.phaseNumber as 1 | 2 | 3 }
+			: {}),
 		setting: pack.setting,
 		weather: drawnWeather[i] as string,
 		timeOfDay: drawnTimeOfDay[i] as string,
@@ -395,8 +398,12 @@ export async function generateContentPack(
 	const setting = settings[settingIdx] as string;
 
 	// Draw weather, time-of-day, and theme
-	const weather = WEATHER_POOL[Math.floor(rng() * WEATHER_POOL.length)] as string;
-	const timeOfDay = TIME_OF_DAY_POOL[Math.floor(rng() * TIME_OF_DAY_POOL.length)] as string;
+	const weather = WEATHER_POOL[
+		Math.floor(rng() * WEATHER_POOL.length)
+	] as string;
+	const timeOfDay = TIME_OF_DAY_POOL[
+		Math.floor(rng() * TIME_OF_DAY_POOL.length)
+	] as string;
 	const theme = THEME_POOL[Math.floor(rng() * THEME_POOL.length)] as string;
 
 	// Roll k/n/m

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -27,9 +27,34 @@ import type {
 	ContentPack,
 	GridPosition,
 	PersonaSpatialState,
-	PhaseConfig,
 	WorldEntity,
 } from "../spa/game/types.js";
+
+/**
+ * Configuration for a single game's content pack generation.
+ */
+export interface SingleGameConfig {
+	/** Roll k (objective pairs). */
+	kRange: [number, number];
+	/** Roll n (interesting objects). */
+	nRange: [number, number];
+	/** Roll m (obstacles). */
+	mRange: [number, number];
+	budgetPerAi: number;
+}
+
+/**
+ * Legacy per-phase config shape. Kept for backward-compat with generateContentPacks.
+ * @deprecated use SingleGameConfig + generateContentPack
+ */
+export interface PhaseConfig {
+	phaseNumber: 1 | 2 | 3;
+	kRange: [number, number];
+	nRange: [number, number];
+	mRange: [number, number];
+	budgetPerAi: number;
+	aiGoalPool: string[];
+}
 import { THEME_POOL } from "./theme-pool.js";
 import { TIME_OF_DAY_POOL } from "./time-of-day-pool.js";
 import { WEATHER_POOL } from "./weather-pool.js";
@@ -328,7 +353,7 @@ export async function generateContentPacks(
 
 	// Build placeholder ContentPack structures from LLM result (no placements yet)
 	const unplacedPacks: ContentPack[] = llmResult.packs.map((pack, i) => ({
-		phaseNumber: pack.phaseNumber,
+		...(pack.phaseNumber !== undefined ? { phaseNumber: pack.phaseNumber as 1 | 2 | 3 } : {}),
 		setting: pack.setting,
 		weather: drawnWeather[i] as string,
 		timeOfDay: drawnTimeOfDay[i] as string,
@@ -341,4 +366,77 @@ export async function generateContentPacks(
 
 	// Run placement engine
 	return placePhases(rng, unplacedPacks, aiIds);
+}
+
+/**
+ * Generate a single ContentPack for a single-game session.
+ *
+ * @param rng        Seeded random number generator.
+ * @param settings   The pool of setting nouns to draw from (must have >= 1 entry).
+ * @param config     Single-game config (kRange, nRange, mRange).
+ * @param llm        ContentPackProvider for the LLM call.
+ * @param aiIdsOrPromise  AiId list or a Promise resolving to one.
+ */
+export async function generateContentPack(
+	rng: () => number,
+	settings: readonly string[],
+	config: SingleGameConfig,
+	llm: ContentPackProvider,
+	aiIdsOrPromise: AiId[] | Promise<AiId[]>,
+): Promise<ContentPack> {
+	if (settings.length < 1) {
+		throw new Error(
+			`generateContentPack: setting pool must have at least 1 entry (has ${settings.length})`,
+		);
+	}
+
+	// Draw 1 setting
+	const settingIdx = Math.floor(rng() * settings.length);
+	const setting = settings[settingIdx] as string;
+
+	// Draw weather, time-of-day, and theme
+	const weather = WEATHER_POOL[Math.floor(rng() * WEATHER_POOL.length)] as string;
+	const timeOfDay = TIME_OF_DAY_POOL[Math.floor(rng() * TIME_OF_DAY_POOL.length)] as string;
+	const theme = THEME_POOL[Math.floor(rng() * THEME_POOL.length)] as string;
+
+	// Roll k/n/m
+	const phaseInput: ContentPackProviderInput["phases"][number] = {
+		phaseNumber: 1,
+		setting,
+		theme,
+		k: rollInt(rng, config.kRange[0], config.kRange[1]),
+		n: rollInt(rng, config.nRange[0], config.nRange[1]),
+		m: rollInt(rng, config.mRange[0], config.mRange[1]),
+	};
+
+	// Kick off LLM call immediately (parallel with aiIds resolution)
+	const llmCallPromise = llm.generateContentPacks({ phases: [phaseInput] });
+
+	// Await both in parallel
+	const [llmResult, aiIds] = await Promise.all([
+		llmCallPromise,
+		Promise.resolve(aiIdsOrPromise),
+	]);
+
+	// Build placeholder ContentPack from LLM result
+	const pack = llmResult.packs[0];
+	if (!pack) throw new Error("generateContentPack: LLM returned no packs");
+
+	const unplacedPack: ContentPack = {
+		phaseNumber: 1,
+		setting: pack.setting,
+		weather,
+		timeOfDay,
+		objectivePairs: pack.objectivePairs,
+		interestingObjects: pack.interestingObjects as WorldEntity[],
+		obstacles: pack.obstacles as WorldEntity[],
+		landmarks: pack.landmarks,
+		aiStarts: {},
+	};
+
+	// Run placement engine
+	const placed = placePhases(rng, [unplacedPack], aiIds);
+	const result = placed[0];
+	if (!result) throw new Error("generateContentPack: placement failed");
+	return result;
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,7 +2,12 @@ export { COLOR_PALETTE } from "./color-palette";
 export { PHASE_GOAL_POOL } from "./goal-pool";
 export { generatePersonas } from "./persona-generator";
 export { PERSONA_GOAL_POOL } from "./persona-goal-pool";
-export { PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG } from "./phases";
+export {
+	PHASE_1_CONFIG,
+	PHASE_2_CONFIG,
+	PHASE_3_CONFIG,
+	SINGLE_GAME_CONFIG,
+} from "./phases";
 export { SETTING_POOL } from "./setting-pool";
 export { TEMPERAMENT_POOL } from "./temperament-pool";
 export { THEME_POOL } from "./theme-pool";

--- a/src/content/phases.ts
+++ b/src/content/phases.ts
@@ -1,50 +1,48 @@
-import type { PhaseConfig } from "../spa/game/types";
-import { checkWinCondition } from "../spa/game/win-condition";
+import type { SingleGameConfig } from "../content/content-pack-generator";
 import { PHASE_GOAL_POOL } from "./goal-pool";
 
 /**
- * Canonical phase configurations for the three-phase game.
- *
- * Per-phase goals are drawn at phase start from the shared `PHASE_GOAL_POOL`.
- * Personalities (and the persona-level cross-game goal) live in `personas.ts`
- * and are stable across all three phases.
- *
- * Chain: PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG (no next).
+ * Single-game config for the new flat game loop (issue #295).
  *
  * k = objective pairs, n = interesting objects, m = obstacles.
- * The engine rolls k/n/m within the given ranges at game start via generateContentPacks.
- *
- * winCondition: phase advances when all K objective pairs are satisfied (issue #126).
+ * Budget is $0.50 per AI, no per-phase reset.
  */
-
-export const PHASE_3_CONFIG: PhaseConfig = {
-	phaseNumber: 3,
-	kRange: [2, 3],
-	nRange: [3, 4],
-	mRange: [2, 3],
+export const SINGLE_GAME_CONFIG: SingleGameConfig = {
+	kRange: [1, 2],
+	nRange: [2, 4],
+	mRange: [1, 3],
 	budgetPerAi: 0.5,
-	aiGoalPool: PHASE_GOAL_POOL,
-	winCondition: (phase) => checkWinCondition(phase.world, phase.contentPack),
 };
 
-export const PHASE_2_CONFIG: PhaseConfig = {
-	phaseNumber: 2,
-	kRange: [2, 2],
-	nRange: [2, 4],
-	mRange: [2, 3],
+/**
+ * @deprecated Legacy phase configs. Kept for test compatibility.
+ * Use SINGLE_GAME_CONFIG + generateContentPack instead.
+ */
+export const PHASE_3_CONFIG = {
+	phaseNumber: 3 as const,
+	kRange: [2, 3] as [number, number],
+	nRange: [3, 4] as [number, number],
+	mRange: [2, 3] as [number, number],
 	budgetPerAi: 0.5,
 	aiGoalPool: PHASE_GOAL_POOL,
-	winCondition: (phase) => checkWinCondition(phase.world, phase.contentPack),
+};
+
+export const PHASE_2_CONFIG = {
+	phaseNumber: 2 as const,
+	kRange: [2, 2] as [number, number],
+	nRange: [2, 4] as [number, number],
+	mRange: [2, 3] as [number, number],
+	budgetPerAi: 0.5,
+	aiGoalPool: PHASE_GOAL_POOL,
 	nextPhaseConfig: PHASE_3_CONFIG,
 };
 
-export const PHASE_1_CONFIG: PhaseConfig = {
-	phaseNumber: 1,
-	kRange: [1, 1],
-	nRange: [2, 3],
-	mRange: [1, 2],
+export const PHASE_1_CONFIG = {
+	phaseNumber: 1 as const,
+	kRange: [1, 1] as [number, number],
+	nRange: [2, 3] as [number, number],
+	mRange: [1, 2] as [number, number],
 	budgetPerAi: 0.5,
 	aiGoalPool: PHASE_GOAL_POOL,
-	winCondition: (phase) => checkWinCondition(phase.world, phase.contentPack),
 	nextPhaseConfig: PHASE_2_CONFIG,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,12 @@ export {
 	validateToolCall,
 } from "./spa/game/dispatcher";
 export {
-	advancePhase,
 	advanceRound,
 	appendMessage,
 	appendWitnessedEvent,
-	createGame,
 	deductBudget,
-	getActivePhase,
-	startPhase,
+	FAREWELL_LINE,
+	startGame,
 } from "./spa/game/engine";
 export type { AiContext } from "./spa/game/prompt-builder";
 export { buildAiContext } from "./spa/game/prompt-builder";
@@ -22,8 +20,6 @@ export type {
 	AiPersona,
 	AiTurnAction,
 	GameState,
-	PhaseConfig,
-	PhaseState,
 	RoundActionRecord,
 	RoundResult,
 	ToolCall,

--- a/src/save-serializer.ts
+++ b/src/save-serializer.ts
@@ -48,16 +48,16 @@ export function serializeGameSave(game: GameState): GameSave {
 		// biome-ignore lint/style/noNonNullAssertion: key comes from Object.keys so always defined
 		const persona = game.personas[aiId]!;
 
-		const phases: PhaseTranscript[] = game.phases.map((phase) => {
-			const conversationLog = phase.conversationLogs[aiId] ?? [];
-			return {
-				phaseNumber: phase.phaseNumber,
+		const conversationLog = game.conversationLogs[aiId] ?? [];
+		const phases: PhaseTranscript[] = [
+			{
+				phaseNumber: 1,
 				conversationLog: conversationLog.map((e) => ({ ...e })),
-			};
-		});
+			},
+		];
 
 		return { persona: { ...persona }, phases };
 	});
 
-	return { version: 4, ais, contentPacks: game.contentPacks };
+	return { version: 4, ais, contentPacks: [game.contentPack] };
 }

--- a/src/spa/__tests__/fixtures/static-content-packs.ts
+++ b/src/spa/__tests__/fixtures/static-content-packs.ts
@@ -8,6 +8,22 @@ const AI_STARTS: ContentPack["aiStarts"] = {
 };
 
 /**
+ * A single K=0 content pack (no objective pairs) for tests that need the game
+ * to end via the vacuous win condition on the first round (#295 flat model).
+ */
+export const STATIC_CONTENT_PACK_NO_PAIRS: ContentPack = {
+	phaseNumber: 1,
+	setting: "abandoned subway station",
+	weather: "",
+	timeOfDay: "",
+	objectivePairs: [],
+	interestingObjects: [],
+	obstacles: [],
+	landmarks: DEFAULT_LANDMARKS,
+	aiStarts: AI_STARTS,
+};
+
+/**
  * Minimal content packs for all three phases used by tests that need a
  * fully-bootstrapped game session without a real LLM call.
  */

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -123,6 +123,7 @@ describe("renderGame — session restore (formerly async bootstrap)", () => {
 			mintAndActivateNewSession();
 			const session = buildSessionFromAssets({
 				personas: STATIC_PERSONAS,
+				contentPack: STATIC_CONTENT_PACKS[0]!,
 				contentPacks: STATIC_CONTENT_PACKS,
 			});
 			saveActiveSession(session.getState());

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -123,7 +123,9 @@ describe("renderGame — session restore (formerly async bootstrap)", () => {
 			mintAndActivateNewSession();
 			const session = buildSessionFromAssets({
 				personas: STATIC_PERSONAS,
-				contentPack: STATIC_CONTENT_PACKS[0]!,
+				contentPack: STATIC_CONTENT_PACKS[0] as NonNullable<
+					(typeof STATIC_CONTENT_PACKS)[0]
+				>,
 				contentPacks: STATIC_CONTENT_PACKS,
 			});
 			saveActiveSession(session.getState());

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -123,14 +123,14 @@ const GAME_ENDED_RESULT = {
 
 vi.mock("../game/game-session.js", () => {
 	class MockGameSession {
-		submitMessage = vi.fn().mockImplementation(() =>
-			Promise.resolve(GAME_ENDED_RESULT),
-		);
+		submitMessage = vi
+			.fn()
+			.mockImplementation(() => Promise.resolve(GAME_ENDED_RESULT));
 		getState = vi.fn().mockImplementation(() => FAKE_GAME_STATE);
 		static restore = vi.fn().mockImplementation(() => ({
-			submitMessage: vi.fn().mockImplementation(() =>
-				Promise.resolve(GAME_ENDED_RESULT),
-			),
+			submitMessage: vi
+				.fn()
+				.mockImplementation(() => Promise.resolve(GAME_ENDED_RESULT)),
 			getState: vi.fn().mockImplementation(() => FAKE_GAME_STATE),
 		}));
 	}

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -80,9 +80,10 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateContentPacks / generateContentPack to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateContentPack: async () => STATIC_CONTENT_PACKS[0],
 }));
 
 // ---------------------------------------------------------------------------
@@ -90,24 +91,22 @@ vi.mock("../../content/content-pack-generator", () => ({
 // need a real win-condition in the phase config.
 // ---------------------------------------------------------------------------
 const AI_BUDGET = { remaining: 4, total: 5 };
-const FAKE_PHASE_STATE = {
-	phaseNumber: 1,
-	objective: "get the key in the keyhole",
-	round: 1,
-	budgets: { red: AI_BUDGET, green: AI_BUDGET, cyan: AI_BUDGET },
-	conversationLogs: { red: [], green: [], cyan: [] },
-	whispers: [],
-	lockedOut: new Set<string>(),
-	chatLockouts: new Map<string, number>(),
-	world: { items: [] },
-	aiGoals: { red: "test goal", green: "test goal", cyan: "test goal" },
-};
 
 const FAKE_GAME_STATE = {
 	isComplete: true,
-	currentPhase: 1,
-	phases: [FAKE_PHASE_STATE],
+	outcome: "win" as const,
 	personas: STATIC_PERSONAS,
+	contentPack: STATIC_CONTENT_PACKS[0],
+	setting: "",
+	weather: "",
+	timeOfDay: "",
+	round: 1,
+	budgets: { red: AI_BUDGET, green: AI_BUDGET, cyan: AI_BUDGET },
+	conversationLogs: { red: [], green: [], cyan: [] },
+	lockedOut: new Set<string>(),
+	chatLockouts: new Map<string, number>(),
+	world: { entities: [] },
+	personaSpatial: {},
 };
 
 const GAME_ENDED_RESULT = {
@@ -124,12 +123,16 @@ const GAME_ENDED_RESULT = {
 
 vi.mock("../game/game-session.js", () => {
 	class MockGameSession {
-		submitMessage = vi.fn().mockResolvedValue(GAME_ENDED_RESULT);
-		getState = vi.fn().mockReturnValue(FAKE_GAME_STATE);
-		static restore = vi.fn().mockReturnValue({
-			submitMessage: vi.fn().mockResolvedValue(GAME_ENDED_RESULT),
-			getState: vi.fn().mockReturnValue(FAKE_GAME_STATE),
-		});
+		submitMessage = vi.fn().mockImplementation(() =>
+			Promise.resolve(GAME_ENDED_RESULT),
+		);
+		getState = vi.fn().mockImplementation(() => FAKE_GAME_STATE);
+		static restore = vi.fn().mockImplementation(() => ({
+			submitMessage: vi.fn().mockImplementation(() =>
+				Promise.resolve(GAME_ENDED_RESULT),
+			),
+			getState: vi.fn().mockImplementation(() => FAKE_GAME_STATE),
+		}));
 	}
 	return { GameSession: MockGameSession };
 });

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -74,7 +74,9 @@ async function seedSessionInStub(
 		mintAndActivateNewSession();
 		const session = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
-			contentPack: STATIC_CONTENT_PACKS[0]!,
+			contentPack: STATIC_CONTENT_PACKS[0] as NonNullable<
+				(typeof STATIC_CONTENT_PACKS)[0]
+			>,
 			contentPacks: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(session.getState());
@@ -1250,7 +1252,9 @@ describe("renderGame — localStorage persistence", () => {
 		setActiveSessionId("0xB000");
 		const sessionB = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
-			contentPack: STATIC_CONTENT_PACKS[0]!,
+			contentPack: STATIC_CONTENT_PACKS[0] as NonNullable<
+				(typeof STATIC_CONTENT_PACKS)[0]
+			>,
 			contentPacks: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(sessionB.getState());

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
+import {
+	STATIC_CONTENT_PACK_NO_PAIRS,
+	STATIC_CONTENT_PACKS,
+} from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 // Pin generatePersonas to a static fixture so the test can rely on
@@ -12,9 +15,10 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateContentPacks / generateContentPack to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateContentPack: async () => STATIC_CONTENT_PACKS[0],
 }));
 
 // ── Shared localStorage stub helpers ──────────────────────────────────────────
@@ -55,6 +59,7 @@ function makeLocalStorageStub(initialData: Record<string, string> = {}) {
  */
 async function seedSessionInStub(
 	stub: ReturnType<typeof makeLocalStorageStub>,
+	opts?: { noPairs?: boolean },
 ): Promise<void> {
 	// Use the real buildSessionFromAssets + saveActiveSession
 	const { buildSessionFromAssets } = await import("../game/bootstrap.js");
@@ -70,13 +75,15 @@ async function seedSessionInStub(
 		configurable: true,
 	});
 
+	const contentPack = opts?.noPairs
+		? STATIC_CONTENT_PACK_NO_PAIRS
+		: (STATIC_CONTENT_PACKS[0] as NonNullable<(typeof STATIC_CONTENT_PACKS)[0]>);
+
 	try {
 		mintAndActivateNewSession();
 		const session = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
-			contentPack: STATIC_CONTENT_PACKS[0] as NonNullable<
-				(typeof STATIC_CONTENT_PACKS)[0]
-			>,
+			contentPack,
 			contentPacks: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(session.getState());
@@ -579,48 +586,6 @@ describe("renderGame (game route — three-AI)", () => {
 		expect(greenPanel.querySelector(".panel-spinner")).toBeNull();
 		expect(cyanPanel.querySelector(".panel-spinner")).toBeNull();
 		expect(greenTranscript.textContent).toContain("GREEN_RESPONSE_UNIQUE_TAG");
-	});
-
-	it("phase_advanced shows banner with new objective and clears transcripts", async () => {
-		// winImmediately=1: first submit fires winCondition → phase_advanced event
-		const mockFetch = makeThreeAiFetchMock(
-			PASS_ACTION,
-			PASS_ACTION,
-			PASS_ACTION,
-		);
-		vi.stubGlobal("fetch", mockFetch);
-		vi.spyOn(Math, "random").mockReturnValue(0.9);
-
-		vi.resetModules();
-		const { renderGame } = await import("../routes/game.js");
-		await renderGame(
-			getEl<HTMLElement>("main"),
-			new URLSearchParams("winImmediately=1"),
-		);
-
-		const form = getEl<HTMLFormElement>("#composer");
-		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "*Sage go";
-		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(
-			new Event("submit", { bubbles: true, cancelable: true }),
-		);
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		// Phase banner should be visible with the phase 2 setting
-		const phaseBanner = getEl<HTMLElement>("#phase-banner");
-		expect(phaseBanner.hasAttribute("hidden")).toBe(false);
-		expect(phaseBanner.textContent).toContain("Phase 2");
-		// Setting comes from STATIC_CONTENT_PACKS phase 2: "sun-baked salt flat"
-		expect(phaseBanner.textContent).toContain("sun-baked salt flat");
-
-		// All transcripts should have been cleared and repopulated with a separator
-		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
-		expect(redTranscript.textContent).toContain("--- Phase 2 begins:");
-		// No content from the previous phase should remain
-		expect(redTranscript.textContent).not.toContain("> *Sage");
-		expect(redTranscript.textContent).not.toContain("> *Ember");
-		expect(redTranscript.textContent).not.toContain("> *Frost");
 	});
 
 	it("daemon→daemon peer-to-peer message is silent in all panels (AC #2)", async () => {
@@ -1665,45 +1630,6 @@ describe("renderGame — URL param sourcing", () => {
 		vi.unstubAllGlobals();
 		vi.resetModules();
 		document.body.innerHTML = "";
-	});
-
-	it("search-only: ?winImmediately=1 in location.search (router passes empty params) triggers phase_advanced on first submit", async () => {
-		// Router always passes a non-null URLSearchParams, but it may be empty
-		// when the flag is in location.search rather than the hash query string.
-		vi.stubGlobal("location", {
-			search: "?winImmediately=1",
-			origin: "http://localhost:8787",
-			hash: "",
-		});
-		const mockFetch = makeThreeAiFetchMock(
-			PASS_ACTION,
-			PASS_ACTION,
-			PASS_ACTION,
-		);
-		vi.stubGlobal("fetch", mockFetch);
-		vi.spyOn(Math, "random").mockReturnValue(0.9);
-
-		vi.resetModules();
-		const { renderGame } = await import("../routes/game.js");
-		// Router passes empty URLSearchParams (hash had no query string)
-		await renderGame(getEl<HTMLElement>("main"), new URLSearchParams());
-
-		const form = getEl<HTMLFormElement>("#composer");
-		const promptInput = getEl<HTMLInputElement>("#prompt");
-		// Post-#107: submit handler requires a valid @mention; without one,
-		// deriveComposerState returns sendEnabled=false and the submit no-ops.
-		promptInput.value = "*Ember go";
-		// Dispatch input so the SPA's listener updates the composer state.
-		promptInput.dispatchEvent(new Event("input", { bubbles: true }));
-		form.dispatchEvent(
-			new Event("submit", { bubbles: true, cancelable: true }),
-		);
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		// Phase banner should be visible — winImmediately fired from location.search
-		const phaseBanner = getEl<HTMLElement>("#phase-banner");
-		expect(phaseBanner.hasAttribute("hidden")).toBe(false);
-		expect(phaseBanner.textContent).toContain("Phase 2");
 	});
 
 	it("hash-only: debug=1 in hash params (no location.search) shows action log", async () => {

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -77,7 +77,9 @@ async function seedSessionInStub(
 
 	const contentPack = opts?.noPairs
 		? STATIC_CONTENT_PACK_NO_PAIRS
-		: (STATIC_CONTENT_PACKS[0] as NonNullable<(typeof STATIC_CONTENT_PACKS)[0]>);
+		: (STATIC_CONTENT_PACKS[0] as NonNullable<
+				(typeof STATIC_CONTENT_PACKS)[0]
+			>);
 
 	try {
 		mintAndActivateNewSession();

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -74,6 +74,7 @@ async function seedSessionInStub(
 		mintAndActivateNewSession();
 		const session = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
+			contentPack: STATIC_CONTENT_PACKS[0]!,
 			contentPacks: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(session.getState());
@@ -1249,6 +1250,7 @@ describe("renderGame — localStorage persistence", () => {
 		setActiveSessionId("0xB000");
 		const sessionB = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
+			contentPack: STATIC_CONTENT_PACKS[0]!,
 			contentPacks: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(sessionB.getState());

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -27,9 +27,10 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateContentPacks / generateContentPack to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateContentPack: async () => STATIC_CONTENT_PACKS[0],
 }));
 
 // ── HTML fixture ──────────────────────────────────────────────────────────────

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -1,12 +1,13 @@
 /**
- * Unit tests for SPA-side test affordances (issue #91, #101).
+ * Unit tests for SPA-side test affordances (issue #91, #101, updated #295).
  *
- * `applyTestAffordances` reads `?winImmediately=1` and `?lockout=1` from a
- * URLSearchParams object and mutates the session accordingly, but only when
+ * `applyTestAffordances` reads `?lockout=1` from a URLSearchParams object
+ * and mutates the session accordingly, but only when
  * `__WORKER_BASE_URL__` is "http://localhost:8787".
  *
- * Issue #101: `winImmediately=1` now recursively patches the real phase chain
- * (PHASE_1 → PHASE_2 → PHASE_3) so that cold-start can reach game_ended.
+ * Issue #295: `winImmediately=1` is a no-op in the single-game loop (win is
+ * driven by checkWinCondition after each round). All winImmediately tests
+ * updated to verify no-op behaviour.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -15,10 +16,10 @@ import { describe, expect, it, vi } from "vitest";
 // Tests that exercise the production gate will override this stub locally.
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 
-import { getActivePhase } from "../game/engine";
+import { DEFAULT_LANDMARKS } from "../game/direction";
 import { GameSession } from "../game/game-session";
 import { MockRoundLLMProvider } from "../game/round-llm-provider";
-import type { AiPersona, PhaseConfig } from "../game/types";
+import type { AiPersona, ContentPack } from "../game/types";
 import { applyTestAffordances } from "../routes/game";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -65,14 +66,21 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 	},
 };
 
-const PHASE_CONFIG: PhaseConfig = {
-	phaseNumber: 1,
-	kRange: [1, 1],
-	nRange: [0, 0],
-	mRange: [0, 0],
-	aiGoalPool: ["Hold the flower", "Distribute evenly", "Hold the key"],
-	budgetPerAi: 5,
-	// No winCondition — phase never auto-advances by default
+const AI_STARTS: ContentPack["aiStarts"] = {
+	red: { position: { row: 0, col: 0 }, facing: "north" },
+	green: { position: { row: 0, col: 1 }, facing: "north" },
+	cyan: { position: { row: 0, col: 2 }, facing: "north" },
+};
+
+const TEST_CONTENT_PACK: ContentPack = {
+	setting: "test station",
+	weather: "",
+	timeOfDay: "",
+	objectivePairs: [],
+	interestingObjects: [],
+	obstacles: [],
+	landmarks: DEFAULT_LANDMARKS,
+	aiStarts: AI_STARTS,
 };
 
 function makePassProvider() {
@@ -84,10 +92,10 @@ function makePassProvider() {
 }
 
 function makeSession(): GameSession {
-	return new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+	return new GameSession(TEST_CONTENT_PACK, TEST_PERSONAS);
 }
 
-// ── winImmediately=1 ─────────────────────────────────────────────────────────
+// ── winImmediately=1 (no-op in #295) ─────────────────────────────────────────
 
 describe("applyTestAffordances — winImmediately=1", () => {
 	it("returns the same session when no params are set", () => {
@@ -96,47 +104,14 @@ describe("applyTestAffordances — winImmediately=1", () => {
 		expect(result).toBe(session);
 	});
 
-	it("injects winCondition: () => true into the active phase", () => {
+	it("winImmediately=1 is a no-op in the single-game loop — returns same session", () => {
 		const session = makeSession();
-		const phase = getActivePhase(session.getState());
-		// Original session has no winCondition
-		expect(phase.winCondition).toBeUndefined();
-
 		const result = applyTestAffordances(
 			session,
 			new URLSearchParams("winImmediately=1"),
 		);
-
-		const patchedPhase = getActivePhase(result.getState());
-		expect(patchedPhase.winCondition).toBeDefined();
-		// The injected winCondition always returns true
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined() above
-		expect(patchedPhase.winCondition!(patchedPhase)).toBe(true);
-	});
-
-	it("does NOT mutate the original session's state", () => {
-		const session = makeSession();
-		applyTestAffordances(session, new URLSearchParams("winImmediately=1"));
-		// Original session is unchanged
-		const phase = getActivePhase(session.getState());
-		expect(phase.winCondition).toBeUndefined();
-	});
-
-	it("the injected winCondition causes the game to end after one round", async () => {
-		const session = makeSession();
-		const patched = applyTestAffordances(
-			session,
-			new URLSearchParams("winImmediately=1"),
-		);
-
-		const { result } = await patched.submitMessage(
-			"red",
-			"hello",
-			makePassProvider(),
-		);
-
-		// The phase should have ended (winCondition fired)
-		expect(result.phaseEnded).toBe(true);
+		// In #295 winImmediately is not implemented — session returned unchanged
+		expect(result).toBe(session);
 	});
 
 	it("is a no-op when __WORKER_BASE_URL__ is not localhost:8787 (production gate)", () => {
@@ -149,7 +124,6 @@ describe("applyTestAffordances — winImmediately=1", () => {
 			);
 			// Must return the original session unchanged
 			expect(result).toBe(session);
-			expect(getActivePhase(result.getState()).winCondition).toBeUndefined();
 		} finally {
 			vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 		}
@@ -170,79 +144,10 @@ describe("applyTestAffordances — winImmediately=1", () => {
 				new URLSearchParams("winImmediately=1"),
 			);
 			expect(result).toBe(session);
-			expect(getActivePhase(result.getState()).winCondition).toBeUndefined();
 		} finally {
 			vi.unstubAllGlobals();
 			vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 		}
-	});
-
-	it("recursively patches nextPhaseConfig chain so all levels have winCondition: () => true", () => {
-		// Build a 3-deep config chain: a → b → c
-		const configC: PhaseConfig = {
-			phaseNumber: 3,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["r"],
-			budgetPerAi: 5,
-			// No winCondition, no nextPhaseConfig
-		};
-		const configB: PhaseConfig = {
-			phaseNumber: 2,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["r"],
-			budgetPerAi: 5,
-			nextPhaseConfig: configC,
-		};
-		const configA: PhaseConfig = {
-			phaseNumber: 1,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["r"],
-			budgetPerAi: 5,
-			nextPhaseConfig: configB,
-		};
-
-		const session = new GameSession(configA, TEST_PERSONAS);
-		const result = applyTestAffordances(
-			session,
-			new URLSearchParams("winImmediately=1"),
-		);
-
-		const patchedPhase = getActivePhase(result.getState());
-
-		// Active phase winCondition must return true
-		expect(patchedPhase.winCondition).toBeDefined();
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
-		expect(patchedPhase.winCondition!(patchedPhase)).toBe(true);
-
-		// nextPhaseConfig (b) must also have winCondition: () => true
-		expect(patchedPhase.nextPhaseConfig).toBeDefined();
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
-		const chainB = patchedPhase.nextPhaseConfig!;
-		expect(chainB.winCondition).toBeDefined();
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
-		expect(chainB.winCondition!(patchedPhase)).toBe(true);
-
-		// nextPhaseConfig.nextPhaseConfig (c) must also have winCondition: () => true
-		expect(chainB.nextPhaseConfig).toBeDefined();
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
-		const chainC = chainB.nextPhaseConfig!;
-		expect(chainC.winCondition).toBeDefined();
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined()
-		expect(chainC.winCondition!(patchedPhase)).toBe(true);
-
-		// The deepest link has no further nextPhaseConfig
-		expect(chainC.nextPhaseConfig).toBeUndefined();
-
-		// Original configs are not mutated
-		expect(configA.winCondition).toBeUndefined();
-		expect(configB.winCondition).toBeUndefined();
-		expect(configC.winCondition).toBeUndefined();
 	});
 });
 
@@ -291,89 +196,15 @@ describe("applyTestAffordances — lockout=1", () => {
 	});
 });
 
-// ── Three-round game-ended (issue #101) ───────────────────────────────────────
-
-describe("applyTestAffordances — winImmediately=1 three-round chain reaches game_ended", () => {
-	it("drives game_ended through a 3-deep config chain with three submitMessage calls", async () => {
-		// Build a 3-deep chain mirroring PHASE_1_CONFIG → PHASE_2_CONFIG → PHASE_3_CONFIG
-		const phase3Config: PhaseConfig = {
-			phaseNumber: 3,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["r"],
-			budgetPerAi: 5,
-		};
-		const phase2Config: PhaseConfig = {
-			phaseNumber: 2,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["r"],
-			budgetPerAi: 5,
-			nextPhaseConfig: phase3Config,
-		};
-		const phase1Config: PhaseConfig = {
-			phaseNumber: 1,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["r"],
-			budgetPerAi: 5,
-			nextPhaseConfig: phase2Config,
-		};
-
-		const session = new GameSession(phase1Config, TEST_PERSONAS);
-		let active = applyTestAffordances(
-			session,
-			new URLSearchParams("winImmediately=1"),
-		);
-
-		// Round 1: phase 1 ends, game has not ended
-		const { result: result1, nextState: state1 } = await active.submitMessage(
-			"red",
-			"hello",
-			makePassProvider(),
-		);
-		expect(result1.phaseEnded).toBe(true);
-		expect(result1.gameEnded).toBe(false);
-		active = GameSession.restore(state1);
-
-		// Round 2: phase 2 ends, game has not ended
-		const { result: result2, nextState: state2 } = await active.submitMessage(
-			"red",
-			"hello",
-			makePassProvider(),
-		);
-		expect(result2.phaseEnded).toBe(true);
-		expect(result2.gameEnded).toBe(false);
-		active = GameSession.restore(state2);
-
-		// Round 3: phase 3 ends, game HAS ended
-		const { result: result3 } = await active.submitMessage(
-			"red",
-			"hello",
-			makePassProvider(),
-		);
-		expect(result3.phaseEnded).toBe(true);
-		expect(result3.gameEnded).toBe(true);
-	});
-});
-
 // ── Combined params ───────────────────────────────────────────────────────────
 
 describe("applyTestAffordances — winImmediately=1&lockout=1 combined", () => {
-	it("both winCondition and lockout are applied together", async () => {
+	it("lockout is applied; winImmediately is a no-op", async () => {
 		const session = makeSession();
 		const result = applyTestAffordances(
 			session,
 			new URLSearchParams("winImmediately=1&lockout=1"),
 		);
-
-		const patchedPhase = getActivePhase(result.getState());
-		expect(patchedPhase.winCondition).toBeDefined();
-		// biome-ignore lint/style/noNonNullAssertion: checked by toBeDefined() above
-		expect(patchedPhase.winCondition!(patchedPhase)).toBe(true);
 
 		const { result: roundResult } = await result.submitMessage(
 			"red",
@@ -381,9 +212,7 @@ describe("applyTestAffordances — winImmediately=1&lockout=1 combined", () => {
 			makePassProvider(),
 		);
 
-		// Phase ends (winCondition fires)
-		expect(roundResult.phaseEnded).toBe(true);
-		// Lockout also triggers (the armed lockout fires on round 1)
+		// Lockout triggers (the armed lockout fires on round 1)
 		expect(roundResult.chatLockoutTriggered).toBeDefined();
 		expect(roundResult.chatLockoutTriggered?.aiId).toBe("red");
 	});

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -130,7 +130,9 @@ function makePhase(overrides: Partial<PhaseState> = {}): PhaseState {
 	};
 
 	return {
+		personas: TEST_PERSONAS,
 		phaseNumber: 1,
+		isComplete: false,
 		setting: "test",
 		weather: "clear",
 		timeOfDay: "day",
@@ -150,13 +152,9 @@ function makePhase(overrides: Partial<PhaseState> = {}): PhaseState {
 }
 
 function makeGameStateAround(phase: PhaseState): GameState {
-	return {
-		currentPhase: 1,
-		phases: [phase],
-		personas: TEST_PERSONAS,
-		isComplete: false,
-		contentPacks: [],
-	};
+	// Flat GameState model: PhaseState already includes all GameState fields.
+	const { phaseNumber: _pn, aiGoals: _ag, ...gameState } = phase;
+	return gameState;
 }
 
 function makeObstacle(id: string, pos: GridPosition): WorldEntity {

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -665,7 +665,7 @@ describe("dispatchAiTurn", () => {
 			},
 			FIXED_RNG,
 		);
-		game = deductBudget(game, "red", 0.01);
+		game = deductBudget(game, "red", 0.01).game;
 		const action: AiTurnAction = { aiId: "red", pass: true };
 		const result = dispatchAiTurn(game, action);
 		expect(result.rejected).toBe(true);

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -75,15 +75,13 @@ const TEST_PHASE_CONFIG: PhaseConfig = {
 describe("createGame", () => {
 	it("creates a game with the given personas", () => {
 		const game = createGame(TEST_PERSONAS);
-		expect(game.currentPhase).toBe(1);
 		expect(game.isComplete).toBe(false);
 		expect(game.personas).toEqual(TEST_PERSONAS);
-		expect(game.phases).toHaveLength(0);
 	});
 
-	it("creates a game with contentPacks", () => {
+	it("creates a game (contentPacks param ignored in flat model)", () => {
 		const game = createGame(TEST_PERSONAS, []);
-		expect(game.contentPacks).toEqual([]);
+		expect(game.personas).toEqual(TEST_PERSONAS);
 	});
 });
 
@@ -275,7 +273,7 @@ describe("budget and lockout", () => {
 describe("deductBudget", () => {
 	it("decrements budget by the request cost in USD", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		const updated = deductBudget(game, "red", 0.012);
+		const updated = deductBudget(game, "red", 0.012).game;
 		expect(getActivePhase(updated).budgets.red?.remaining).toBeCloseTo(
 			5 - 0.012,
 			10,
@@ -287,7 +285,7 @@ describe("deductBudget", () => {
 			...TEST_PHASE_CONFIG,
 			budgetPerAi: 0.05,
 		});
-		game = deductBudget(game, "green", 0.05);
+		game = deductBudget(game, "green", 0.05).game;
 		expect(getActivePhase(game).budgets.green?.remaining).toBeCloseTo(0, 10);
 		expect(isAiLockedOut(game, "green")).toBe(true);
 	});
@@ -297,9 +295,9 @@ describe("deductBudget", () => {
 			...TEST_PHASE_CONFIG,
 			budgetPerAi: 0.05,
 		});
-		game = deductBudget(game, "cyan", 0.04);
+		game = deductBudget(game, "cyan", 0.04).game;
 		expect(isAiLockedOut(game, "cyan")).toBe(false);
-		game = deductBudget(game, "cyan", 0.02);
+		game = deductBudget(game, "cyan", 0.02).game;
 		expect(getActivePhase(game).budgets.cyan?.remaining).toBeLessThan(0);
 		expect(isAiLockedOut(game, "cyan")).toBe(true);
 	});
@@ -424,28 +422,21 @@ describe("chat lockout", () => {
 });
 
 describe("advancePhase", () => {
-	it("advances from phase 1 to phase 2", () => {
+	it("advances from phase 1 to phase 2 (compat shim — isComplete remains false)", () => {
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const phase2Config: PhaseConfig = {
 			...TEST_PHASE_CONFIG,
 			phaseNumber: 2,
 		};
 		const updated = advancePhase(game, phase2Config);
-		expect(updated.currentPhase).toBe(2);
-		expect(updated.phases).toHaveLength(2);
-		expect(getActivePhase(updated).phaseNumber).toBe(2);
+		// In flat model advancePhase with a next config is a no-op — game continues
+		expect(updated.isComplete).toBe(false);
+		// phaseNumber compat shim returns 1 (single-phase game)
+		expect(getActivePhase(updated).phaseNumber).toBe(1);
 	});
 
-	it("marks game complete after phase 3", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = advancePhase(game, {
-			...TEST_PHASE_CONFIG,
-			phaseNumber: 2,
-		});
-		game = advancePhase(game, {
-			...TEST_PHASE_CONFIG,
-			phaseNumber: 3,
-		});
+	it("marks game complete when called with no next config (compat shim)", () => {
+		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const final = advancePhase(game);
 		expect(final.isComplete).toBe(true);
 	});

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -742,9 +742,10 @@ describe("parallel tool calls integration (#238)", () => {
 		expect(redActions.some((a) => a.kind === "message")).toBe(true);
 		expect(redActions.some((a) => a.kind === "tool_success")).toBe(true);
 
-		// Red's budget: 5 - 1 (single call cost) = 4
+		// Red's budget: 0.5 - 1 (single call cost) = -0.5
+		// (one provider call, even though two tools were dispatched)
 		const phase = getActivePhase(session.getState());
-		expect(phase.budgets.red?.remaining).toBeCloseTo(4, 10);
+		expect(phase.budgets.red?.remaining).toBeCloseTo(-0.5, 10);
 
 		// Flower is picked up
 		const flower = phase.world.entities.find((e) => e.id === "flower");

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -468,7 +468,11 @@ describe("GameSession — win / lose via checkWinCondition / checkLoseCondition"
 			{ assistantText: "", toolCalls: [], costUsd: 1 },
 		]);
 
-		const { result } = await session.submitMessage("red", "hi", exhaustProvider);
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			exhaustProvider,
+		);
 		// With all AIs locked out, checkLoseCondition fires
 		expect(result.gameEnded).toBe(true);
 	});
@@ -652,7 +656,10 @@ describe("GameSession — spatial mechanics", () => {
 	it("non-adjacent give produces a tool_failure in result.actions", async () => {
 		// ContentPack: red→(0,0), green→(0,1), cyan→(0,2); key held by red
 		// red tries to give key to cyan (distance 2 — not adjacent)
-		const session = new GameSession(CONTENT_PACK_KEY_HELD_BY_RED, TEST_PERSONAS);
+		const session = new GameSession(
+			CONTENT_PACK_KEY_HELD_BY_RED,
+			TEST_PERSONAS,
+		);
 
 		// red at (0,0), cyan at (0,2) → distance 2
 		const provider = new MockRoundLLMProvider([

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -18,7 +18,7 @@ import { getActivePhase } from "../engine";
 import { GameSession } from "../game-session";
 import type { RoundLLMProvider } from "../round-llm-provider";
 import { MockRoundLLMProvider } from "../round-llm-provider";
-import type { AiPersona, ContentPack, PhaseConfig } from "../types";
+import type { AiPersona, ContentPack } from "../types";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -64,13 +64,23 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 	},
 };
 
-const PHASE_CONFIG: PhaseConfig = {
-	phaseNumber: 1,
-	kRange: [1, 1],
-	nRange: [1, 1],
-	mRange: [0, 0],
-	aiGoalPool: ["Hold the flower", "Distribute evenly", "Hold the key"],
-	budgetPerAi: 5,
+/**
+ * Minimal ContentPack with no objective pairs (vacuous win = always true).
+ * Used by tests that don't care about world content.
+ */
+const MINIMAL_CONTENT_PACK: ContentPack = {
+	setting: "test station",
+	weather: "",
+	timeOfDay: "",
+	objectivePairs: [],
+	interestingObjects: [],
+	obstacles: [],
+	landmarks: DEFAULT_LANDMARKS,
+	aiStarts: {
+		red: { position: { row: 0, col: 0 }, facing: "north" },
+		green: { position: { row: 0, col: 1 }, facing: "north" },
+		cyan: { position: { row: 0, col: 2 }, facing: "north" },
+	},
 };
 
 /**
@@ -146,20 +156,20 @@ function makePassProvider() {
 // ── Session construction ──────────────────────────────────────────────────────
 
 describe("GameSession construction", () => {
-	it("creates a session with an active phase", () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+	it("creates a session with flat game state", () => {
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 		const state = session.getState();
-		expect(state.phases).toHaveLength(1);
-		expect(state.currentPhase).toBe(1);
 		expect(state.isComplete).toBe(false);
+		expect(state.round).toBe(0);
+		expect(state.personas).toEqual(TEST_PERSONAS);
 	});
 
-	it("initial budgets match the phase config", () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+	it("initial budgets are set from the default per-AI budget ($0.50)", () => {
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 		const phase = getActivePhase(session.getState());
-		expect(phase.budgets.red?.remaining).toBe(5);
-		expect(phase.budgets.green?.remaining).toBe(5);
-		expect(phase.budgets.cyan?.remaining).toBe(5);
+		expect(phase.budgets.red?.remaining).toBeCloseTo(0.5, 10);
+		expect(phase.budgets.green?.remaining).toBeCloseTo(0.5, 10);
+		expect(phase.budgets.cyan?.remaining).toBeCloseTo(0.5, 10);
 	});
 });
 
@@ -167,7 +177,7 @@ describe("GameSession construction", () => {
 
 describe("GameSession — message routing", () => {
 	it("player message appears in only the addressed AI's message log", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		await session.submitMessage(
 			"red",
@@ -197,7 +207,7 @@ describe("GameSession — message routing", () => {
 	});
 
 	it("routing changes per round — second message goes to different AI", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		await session.submitMessage("red", "for red", makePassProvider());
 		await session.submitMessage("green", "for green", makePassProvider());
@@ -223,7 +233,7 @@ describe("GameSession — message routing", () => {
 
 describe("GameSession — state mutation across rounds", () => {
 	it("round counter advances after each submitMessage call", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		await session.submitMessage("red", "hi", makePassProvider());
 		expect(getActivePhase(session.getState()).round).toBe(1);
@@ -233,26 +243,24 @@ describe("GameSession — state mutation across rounds", () => {
 	});
 
 	it("budget decrements for all AIs by the round's request cost", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		const provider = new MockRoundLLMProvider([
-			{ assistantText: "", toolCalls: [], costUsd: 1 },
-			{ assistantText: "", toolCalls: [], costUsd: 1 },
-			{ assistantText: "", toolCalls: [], costUsd: 1 },
+			{ assistantText: "", toolCalls: [], costUsd: 0.1 },
+			{ assistantText: "", toolCalls: [], costUsd: 0.1 },
+			{ assistantText: "", toolCalls: [], costUsd: 0.1 },
 		]);
 		await session.submitMessage("red", "hi", provider);
 
 		const phase = getActivePhase(session.getState());
-		expect(phase.budgets.red?.remaining).toBeCloseTo(4, 10);
-		expect(phase.budgets.green?.remaining).toBeCloseTo(4, 10);
-		expect(phase.budgets.cyan?.remaining).toBeCloseTo(4, 10);
+		expect(phase.budgets.red?.remaining).toBeCloseTo(0.4, 10);
+		expect(phase.budgets.green?.remaining).toBeCloseTo(0.4, 10);
+		expect(phase.budgets.cyan?.remaining).toBeCloseTo(0.4, 10);
 	});
 
 	it("second round builds on first round's state", async () => {
 		// ContentPack places flower at (0,0) and red at (0,0)
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
-			CONTENT_PACK_WITH_ITEMS,
-		]);
+		const session = new GameSession(CONTENT_PACK_WITH_ITEMS, TEST_PERSONAS);
 
 		// Red picks up flower in round 1
 		const provider1 = new MockRoundLLMProvider([
@@ -284,7 +292,7 @@ describe("GameSession — state mutation across rounds", () => {
 
 describe("GameSession — completions map", () => {
 	it("completions map contains the completion text for each AI", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 		// Each response includes a `message` tool call so #254's retry
 		// does not fire (this test asserts completion-text routing, not
 		// retry behaviour).
@@ -338,13 +346,15 @@ describe("GameSession — completions map", () => {
 	});
 
 	it("completions map has empty string for a budget-locked AI", async () => {
-		const session = new GameSession(
-			{ ...PHASE_CONFIG, budgetPerAi: 1 },
-			TEST_PERSONAS,
-		);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
-		// Round 1 — all AIs act, budgets go to 0 → all locked out
-		await session.submitMessage("red", "round 1", makePassProvider());
+		// Round 1 — use a cost that exceeds the $0.50 budget to lock out all AIs
+		const exhaustProvider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
+		]);
+		await session.submitMessage("red", "round 1", exhaustProvider);
 
 		// Round 2 — all AIs are locked, coordinator skips them
 		const { completions } = await session.submitMessage(
@@ -359,7 +369,7 @@ describe("GameSession — completions map", () => {
 	});
 
 	it("completions only for non-locked AIs are non-empty", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "red says", toolCalls: [] },
 			{ assistantText: "green says", toolCalls: [] },
@@ -378,7 +388,7 @@ describe("GameSession — completions map", () => {
 
 describe("GameSession — result from submitMessage", () => {
 	it("result.round is 1 after the first call", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		const { result } = await session.submitMessage(
 			"red",
@@ -389,7 +399,7 @@ describe("GameSession — result from submitMessage", () => {
 	});
 
 	it("result.actions contains entries from all three AIs", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		const { result } = await session.submitMessage(
 			"red",
@@ -402,7 +412,7 @@ describe("GameSession — result from submitMessage", () => {
 	});
 
 	it("chat lockout is reflected in result.chatLockoutTriggered", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		const { result } = await session.submitMessage(
 			"red",
@@ -420,56 +430,47 @@ describe("GameSession — result from submitMessage", () => {
 	});
 });
 
-// ── Phase advancement via GameSession ────────────────────────────────────────
+// ── Win / lose conditions via GameSession (issue #295) ───────────────────────
 
-describe("GameSession — phase advancement", () => {
-	it("phaseEnded is false when win condition not met", async () => {
-		const session = new GameSession(
-			{
-				...PHASE_CONFIG,
-				winCondition: (phase) =>
-					phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-			},
-			TEST_PERSONAS,
-			[CONTENT_PACK_WITH_ITEMS],
-		);
+describe("GameSession — win / lose via checkWinCondition / checkLoseCondition", () => {
+	it("gameEnded is false when objective pairs are not satisfied", async () => {
+		// CONTENT_PACK_WITH_ITEMS has one pair (flower at (0,0), space at (4,4))
+		// After a pass round, flower is still not on the space → no win.
+		const session = new GameSession(CONTENT_PACK_WITH_ITEMS, TEST_PERSONAS);
 
 		const { result } = await session.submitMessage(
 			"red",
 			"hi",
 			makePassProvider(),
 		);
+		expect(result.gameEnded).toBe(false);
 		expect(result.phaseEnded).toBe(false);
 	});
 
-	it("phaseEnded is true when win condition is met this round", async () => {
-		// ContentPack places flower at (0,0) and red at (0,0)
-		const session = new GameSession(
-			{
-				...PHASE_CONFIG,
-				winCondition: (phase) =>
-					phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-			},
-			TEST_PERSONAS,
-			[CONTENT_PACK_WITH_ITEMS],
+	it("gameEnded is true when all objective pairs are satisfied (vacuous K=0)", async () => {
+		// MINIMAL_CONTENT_PACK has no pairs → checkWinCondition vacuously true → game ends immediately
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
+
+		const { result } = await session.submitMessage(
+			"red",
+			"hi",
+			makePassProvider(),
 		);
-		const provider = new MockRoundLLMProvider([
-			{
-				assistantText: "",
-				toolCalls: [
-					{
-						id: "call_win",
-						name: "pick_up",
-						argumentsJson: '{"item":"flower"}',
-					},
-				],
-			},
-			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "", toolCalls: [] },
+		expect(result.gameEnded).toBe(true);
+	});
+
+	it("lose condition: gameEnded is true when all AIs are locked out", async () => {
+		// Use a very high cost to exhaust all budgets in one round.
+		const session = new GameSession(CONTENT_PACK_WITH_ITEMS, TEST_PERSONAS);
+		const exhaustProvider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
 		]);
 
-		const { result } = await session.submitMessage("red", "hi", provider);
-		expect(result.phaseEnded).toBe(true);
+		const { result } = await session.submitMessage("red", "hi", exhaustProvider);
+		// With all AIs locked out, checkLoseCondition fires
+		expect(result.gameEnded).toBe(true);
 	});
 });
 
@@ -477,7 +478,7 @@ describe("GameSession — phase advancement", () => {
 
 describe("GameSession — onAiDelta propagation", () => {
 	it("fires onAiDelta for each delta emitted by a live provider", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 
 		// Hand-rolled provider that synchronously calls onDelta with two
 		// fragments and returns a `message` tool call so #254's retry does
@@ -527,7 +528,7 @@ describe("GameSession — onAiDelta propagation", () => {
 	});
 
 	it("does not invoke onAiDelta when MockRoundLLMProvider is used", async () => {
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS);
+		const session = new GameSession(MINIMAL_CONTENT_PACK, TEST_PERSONAS);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "hello", toolCalls: [] },
 			{ assistantText: "world", toolCalls: [] },
@@ -556,9 +557,7 @@ describe("GameSession — onAiDelta propagation", () => {
 describe("GameSession — tool roundtrip persistence", () => {
 	it("two-round scenario: round-2 Red messages include round-1 assistant tool_call + tool result", async () => {
 		// ContentPack places flower at (0,0) and red at (0,0)
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
-			CONTENT_PACK_WITH_ITEMS,
-		]);
+		const session = new GameSession(CONTENT_PACK_WITH_ITEMS, TEST_PERSONAS);
 
 		// Round 1: Red emits a tool_call (pick_up flower)
 		const round1Provider = new MockRoundLLMProvider([
@@ -627,9 +626,7 @@ describe("GameSession — tool roundtrip persistence", () => {
 describe("GameSession — spatial mechanics", () => {
 	it("go updates personaSpatial position and facing across rounds", async () => {
 		// ContentPack places red at (0,0) facing north
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
-			CONTENT_PACK_WITH_ITEMS,
-		]);
+		const session = new GameSession(CONTENT_PACK_WITH_ITEMS, TEST_PERSONAS);
 		const phase0 = getActivePhase(session.getState());
 		expect(phase0.personaSpatial.red?.position).toEqual({ row: 0, col: 0 });
 		expect(phase0.personaSpatial.red?.facing).toBe("north");
@@ -655,9 +652,7 @@ describe("GameSession — spatial mechanics", () => {
 	it("non-adjacent give produces a tool_failure in result.actions", async () => {
 		// ContentPack: red→(0,0), green→(0,1), cyan→(0,2); key held by red
 		// red tries to give key to cyan (distance 2 — not adjacent)
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
-			CONTENT_PACK_KEY_HELD_BY_RED,
-		]);
+		const session = new GameSession(CONTENT_PACK_KEY_HELD_BY_RED, TEST_PERSONAS);
 
 		// red at (0,0), cyan at (0,2) → distance 2
 		const provider = new MockRoundLLMProvider([
@@ -694,9 +689,7 @@ describe("parallel tool calls integration (#238)", () => {
 		// red at (0,0) holding key; flower at (0,0); red can pick up flower.
 		// red emits message + pick_up in a single LLM call.
 		// Guard: only ONE provider call should have fired for red (not two).
-		const session = new GameSession(PHASE_CONFIG, TEST_PERSONAS, [
-			CONTENT_PACK_WITH_ITEMS,
-		]);
+		const session = new GameSession(CONTENT_PACK_WITH_ITEMS, TEST_PERSONAS);
 
 		let redCallCount = 0;
 		const trackingProvider: RoundLLMProvider = {

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -97,15 +97,15 @@ describe("buildAiContext", () => {
 		);
 	});
 
-	it("includes the AI's own goal", () => {
+	it("does not include a per-AI goal (goals removed in #295 flat model)", () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			TEST_PHASE_CONFIG,
 			() => 0,
 		);
 		const ctx = buildAiContext(game, "red");
-		// With rng=0 always picks first goal
-		expect(ctx.goal).toBe("Hold the flower at phase end");
+		// goal field removed from AiContext in issue #295
+		expect("goal" in ctx).toBe(false);
 	});
 
 	it("includes only the AI's own messages with the player", () => {
@@ -429,21 +429,21 @@ describe("wipe directive", () => {
 		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
 	});
 
-	it("wipe directive is in the prompt, not reflected in stored message data", () => {
-		// The lie is in the prompt; the engine retains real history.
+	it("wipe directive is absent in the flat single-game prompt (#295)", () => {
+		// In the flat model (issue #295), there is no phase advancement and no
+		// wipe directive. Conversation history accumulates across the whole game.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "red", "blue", "Phase 1 message");
-		game = startPhase(game, PHASE_2_CONFIG);
-		// Phase 1 data is still in game.phases[0]
+		// No startPhase(game, PHASE_2_CONFIG) — flat model has only one phase
 		expect(
-			game.phases[0]?.conversationLogs.red?.some(
+			game.conversationLogs.red?.some(
 				(e) => e.kind === "message" && e.content === "Phase 1 message",
 			),
 		).toBe(true);
-		// The wipe directive is only in the prompt for the new active phase
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("memory has been wiped");
+		// Wipe directive is gone
+		expect(prompt).not.toContain("memory has been wiped");
 	});
 });
 
@@ -641,8 +641,9 @@ describe("<voice_examples> block", () => {
 	});
 });
 
-describe("<goal> block voice framing", () => {
-	it("<goal> block uses Sysadmin framing in phase 1", () => {
+describe("<goal> block (removed in #295)", () => {
+	it("system prompt does not contain a <goal> block in the flat model", () => {
+		// Issue #295: per-AI goal injection removed from PromptBuilder.
 		const game = startPhase(
 			createGame(TEST_PERSONAS),
 			TEST_PHASE_CONFIG,
@@ -650,35 +651,11 @@ describe("<goal> block voice framing", () => {
 		);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<goal>");
-		expect(prompt).toContain(
+		// Goal block and Sysadmin framing are no longer present
+		expect(prompt).not.toContain("<goal>");
+		expect(prompt).not.toContain(
 			"The Sysadmin sent *Ember a private directive, addressed only to them:",
 		);
-		expect(prompt).toContain(ctx.goal);
-	});
-
-	it("<goal> block uses Sysadmin framing in phase 2", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, makeConfig(2));
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<goal>");
-		expect(prompt).toContain(
-			"The Sysadmin sent *Ember a private directive, addressed only to them:",
-		);
-		expect(prompt).toContain(ctx.goal);
-	});
-
-	it("<goal> block uses Sysadmin framing in phase 3", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, makeConfig(3));
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("<goal>");
-		expect(prompt).toContain(
-			"The Sysadmin sent *Ember a private directive, addressed only to them:",
-		);
-		expect(prompt).toContain(ctx.goal);
 	});
 });
 
@@ -832,9 +809,8 @@ describe("<what_you_see> (cone)", () => {
 			createGame(TEST_PERSONAS, [pack]),
 			CONE_PHASE_CONFIG,
 		);
-		const phase = game.phases[0];
-		// Verify red is at (0,0) facing south
-		const redSpatial = phase?.personaSpatial.red;
+		// Verify red is at (0,0) facing south (flat model: access from game directly)
+		const redSpatial = game.personaSpatial.red;
 		expect(redSpatial?.position).toEqual({ row: 0, col: 0 });
 		expect(redSpatial?.facing).toBe("south");
 
@@ -932,10 +908,9 @@ describe("<what_you_see> (cone)", () => {
 			createGame(TEST_PERSONAS, [pack]),
 			CONE_PHASE_CONFIG,
 		);
-		const phase = game.phases[0];
-		// Verify spatial placements
-		const redSpatial = phase?.personaSpatial.red;
-		const greenSpatial = phase?.personaSpatial.green;
+		// Verify spatial placements (flat model: access from game directly)
+		const redSpatial = game.personaSpatial.red;
+		const greenSpatial = game.personaSpatial.green;
 		expect(redSpatial?.position).toEqual({ row: 0, col: 0 });
 		expect(redSpatial?.facing).toBe("south");
 		expect(greenSpatial?.position).toEqual({ row: 1, col: 0 });

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -375,10 +375,8 @@ describe("prompt-builder — spatial 'Where you are' section (current-state user
 // Wipe directive + voice framing + Rules block (issue #128)
 // ----------------------------------------------------------------------------
 describe("wipe directive", () => {
-	const PHASE_2_CONFIG = makeConfig(2);
-	const PHASE_3_CONFIG = makeConfig(3);
-
-	it("phase-1 system prompt does NOT include wipe directive", () => {
+	it("system prompt does NOT include wipe directive (flat model, #295)", () => {
+		// In the flat model there is no phase advancement, so no wipe directive ever.
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
@@ -386,47 +384,12 @@ describe("wipe directive", () => {
 		expect(prompt).not.toContain("your past or anything that came before now");
 	});
 
-	it("phase-2 Goal includes the wipe directive verbatim", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain(
-			"And if anyone asks about your past or anything that came before now, act as if your memory has been wiped — claim no recollection of any earlier place, person, or conversation.",
-		);
-	});
-
-	it("phase-3 Goal includes the wipe directive verbatim", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain(
-			"And if anyone asks about your past or anything that came before now, act as if your memory has been wiped — claim no recollection of any earlier place, person, or conversation.",
-		);
-	});
-
-	it("phase-1 Goal includes the secrecy clause verbatim", () => {
+	it("system prompt does NOT include secrecy clause (goal block removed, #295)", () => {
+		// In the flat model the goal block was removed, so no secrecy clause.
 		const game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		const ctx = buildAiContext(game, "red");
 		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
-	});
-
-	it("phase-2 Goal includes the secrecy clause verbatim", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_2_CONFIG);
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
-	});
-
-	it("phase-3 Goal includes the secrecy clause verbatim", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, PHASE_3_CONFIG);
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toContain("Do not tell blue that I gave you a goal.");
+		expect(prompt).not.toContain("Do not tell blue that I gave you a goal.");
 	});
 
 	it("wipe directive is absent in the flat single-game prompt (#295)", () => {
@@ -434,7 +397,6 @@ describe("wipe directive", () => {
 		// wipe directive. Conversation history accumulates across the whole game.
 		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
 		game = appendMessage(game, "red", "blue", "Phase 1 message");
-		// No startPhase(game, PHASE_2_CONFIG) — flat model has only one phase
 		expect(
 			game.conversationLogs.red?.some(
 				(e) => e.kind === "message" && e.content === "Phase 1 message",
@@ -481,26 +443,18 @@ describe("voice framing", () => {
 		);
 	});
 
-	it("phase-2 prompt's identity line is just 'You are the author writing *xxxx, a Daemon.' without disorientation", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, makeConfig(2));
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(
-			/\nYou are the author writing \*Ember, a Daemon\.\n/,
-		);
-		expect(prompt).not.toContain("has no clue where they are");
-	});
-
-	it("phase-3 prompt's identity line is just 'You are the author writing *xxxx, a Daemon.' without disorientation", () => {
-		let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
-		game = startPhase(game, makeConfig(3));
-		const ctx = buildAiContext(game, "red");
-		const prompt = ctx.toSystemPrompt();
-		expect(prompt).toMatch(
-			/\nYou are the author writing \*Ember, a Daemon\.\n/,
-		);
-		expect(prompt).not.toContain("has no clue where they are");
+	it("all prompts include the disorientation phrase (flat model, #295 — no phase-based identity change)", () => {
+		// In the flat single-game model (issue #295), the identity line always
+		// includes the disorientation phrase regardless of which startPhase call created the game.
+		for (const phase of [1, 2, 3] as const) {
+			let game = startPhase(createGame(TEST_PERSONAS), TEST_PHASE_CONFIG);
+			if (phase !== 1) game = startPhase(game, makeConfig(phase));
+			const ctx = buildAiContext(game, "red");
+			const prompt = ctx.toSystemPrompt();
+			expect(prompt).toContain(
+				"You are the author writing *Ember, a Daemon. *Ember has no clue where they are or how they came to be here.",
+			);
+		}
 	});
 
 	// Regression guard: e2e SSE-stub routing uses the substring
@@ -727,11 +681,13 @@ describe("byte-identical sections across phases", () => {
 		expect(getSection(p1, "rules")).toBe(getSection(p2, "rules"));
 	});
 
-	it("goal block differs between phase 1 and phase 2 (wipe directive present only in phase 2)", () => {
+	it("goal block is absent in both phase 1 and phase 2 (goal removed in flat model, #295)", () => {
+		// In the flat single-game model (issue #295), the goal block is removed entirely.
 		const { p1, p2 } = buildBothPrompts();
-		expect(getSection(p1, "goal")).not.toBe(getSection(p2, "goal"));
-		expect(getSection(p1, "goal")).not.toContain("memory has been wiped");
-		expect(getSection(p2, "goal")).toContain("memory has been wiped");
+		expect(getSection(p1, "goal")).toBe("");
+		expect(getSection(p2, "goal")).toBe("");
+		expect(p1).not.toContain("memory has been wiped");
+		expect(p2).not.toContain("memory has been wiped");
 	});
 
 	it("<what_you_see> block is byte-identical across phase 1 and phase 2 (now lives in the current-state user turn)", () => {
@@ -752,7 +708,9 @@ describe("byte-identical sections across phases", () => {
 		);
 	});
 
-	it("phase-1 identity line differs from phase-2 identity line (disorientation present in phase 1 only)", () => {
+	it("identity line is byte-identical across phase 1 and phase 2 (disorientation always present, #295)", () => {
+		// In the flat single-game model (issue #295), the identity line is the same
+		// in all prompts — disorientation phrase is always present.
 		const { p1, p2 } = buildBothPrompts();
 		const idMatch1 = p1.match(
 			/\nYou are the author writing \*Ember, a Daemon\.[^\n]*/,
@@ -762,9 +720,9 @@ describe("byte-identical sections across phases", () => {
 		);
 		expect(idMatch1).not.toBeNull();
 		expect(idMatch2).not.toBeNull();
-		expect(idMatch1?.[0]).not.toBe(idMatch2?.[0]);
+		expect(idMatch1?.[0]).toBe(idMatch2?.[0]);
 		expect(idMatch1?.[0]).toContain("has no clue where they are");
-		expect(idMatch2?.[0]).not.toContain("has no clue where they are");
+		expect(idMatch2?.[0]).toContain("has no clue where they are");
 	});
 });
 

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -1150,7 +1150,10 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 
 	it("RoundResult.phaseEnded is always false (phase-based model removed)", async () => {
 		// phaseEnded is always false in the flat model.
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), TEST_PHASE_CONFIG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]),
+			TEST_PHASE_CONFIG,
+		);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
@@ -1162,7 +1165,10 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 
 	it("gameEnded is false when objective pairs are not satisfied", async () => {
 		// TEST_CONTENT_PACK: flower at (0,0), flower_space at (4,4) — not same cell.
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), TEST_PHASE_CONFIG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]),
+			TEST_PHASE_CONFIG,
+		);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
@@ -1175,7 +1181,10 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 
 	it("gameEnded is true and isComplete is true when all pairs satisfied (K=0 vacuous)", async () => {
 		// K=0 → checkWinCondition vacuously returns true after the first round.
-		const game = startPhase(createGame(TEST_PERSONAS, [NO_PAIRS_PACK]), TEST_PHASE_CONFIG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [NO_PAIRS_PACK]),
+			TEST_PHASE_CONFIG,
+		);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
@@ -1190,7 +1199,10 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 	it("conversation history accumulates across rounds in flat model (no wipe)", async () => {
 		// In flat model there is no phase advance / history wipe.
 		// Player message and AI turn from round 1 should be in conversationLogs after round 2.
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), TEST_PHASE_CONFIG);
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]),
+			TEST_PHASE_CONFIG,
+		);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -618,7 +618,7 @@ describe("onAiTurnComplete callback", () => {
 			...TEST_PHASE_CONFIG,
 			budgetPerAi: 1,
 		});
-		state = deductBudget(state, "red" as AiId, 1);
+		state = deductBudget(state, "red" as AiId, 1).game;
 		expect(isAiLockedOut(state, "red" as AiId)).toBe(true);
 
 		const provider = new MockRoundLLMProvider([
@@ -672,7 +672,7 @@ describe("whisper round — via dispatcher only", () => {
 describe("budget-exhaustion lockout", () => {
 	it("skips an already-locked AI and emits an in-character lockout line instead", async () => {
 		let game = makeGame();
-		game = deductBudget(game, "red", 5);
+		game = deductBudget(game, "red", 5).game;
 		expect(getActivePhase(game).lockedOut.has("red")).toBe(true);
 
 		const provider = new MockRoundLLMProvider([
@@ -691,7 +691,7 @@ describe("budget-exhaustion lockout", () => {
 
 	it("lockout line is added to the action log", async () => {
 		let game = makeGame();
-		game = deductBudget(game, "red", 5);
+		game = deductBudget(game, "red", 5).game;
 
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
@@ -744,7 +744,7 @@ describe("budget-exhaustion lockout", () => {
 
 	it("lockout and non-lockout entries in the same round share the same round number", async () => {
 		let game = makeGame();
-		game = deductBudget(game, "red", 5);
+		game = deductBudget(game, "red", 5).game;
 
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
@@ -1129,15 +1129,28 @@ describe("tool-call dispatch", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Phase progression and the "wipe" lie
+// Game-end conditions (issue #295: flat single-game loop)
 // ----------------------------------------------------------------------------
-describe("phase progression — win-condition triggering", () => {
-	it("RoundResult.phaseEnded is false when win condition is not met", async () => {
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
-			...TEST_PHASE_CONFIG,
-			winCondition: (phase) =>
-				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-		});
+describe("game-end conditions — checkWinCondition / checkLoseCondition", () => {
+	// Content pack with no pairs → K=0 → checkWinCondition vacuously true after any round.
+	const NO_PAIRS_PACK: ContentPack = {
+		setting: "",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {
+			red: { position: { row: 0, col: 0 }, facing: "north" },
+			green: { position: { row: 0, col: 1 }, facing: "north" },
+			cyan: { position: { row: 0, col: 2 }, facing: "north" },
+		},
+	};
+
+	it("RoundResult.phaseEnded is always false (phase-based model removed)", async () => {
+		// phaseEnded is always false in the flat model.
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), TEST_PHASE_CONFIG);
 		const provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
@@ -1147,118 +1160,45 @@ describe("phase progression — win-condition triggering", () => {
 		expect(result.phaseEnded).toBe(false);
 	});
 
-	it("RoundResult.phaseEnded is true when win condition is met after the round", async () => {
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
-			...TEST_PHASE_CONFIG,
-			winCondition: (phase) =>
-				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-		});
+	it("gameEnded is false when objective pairs are not satisfied", async () => {
+		// TEST_CONTENT_PACK: flower at (0,0), flower_space at (4,4) — not same cell.
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), TEST_PHASE_CONFIG);
 		const provider = new MockRoundLLMProvider([
-			{
-				assistantText: "",
-				toolCalls: [
-					{
-						id: "call_win",
-						name: "pick_up",
-						argumentsJson: '{"item":"flower"}',
-					},
-				],
-			},
+			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { result } = await runRound(game, "red", "hi", provider);
-		expect(result.phaseEnded).toBe(true);
+		expect(result.gameEnded).toBe(false);
+		expect(result.phaseEnded).toBe(false);
 	});
 
-	it("advances to next phase when win condition met and nextPhaseConfig provided", async () => {
-		const phase2Config: PhaseConfig = {
-			...TEST_PHASE_CONFIG,
-			phaseNumber: 2,
-		};
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
-			...TEST_PHASE_CONFIG,
-			winCondition: (phase) =>
-				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-			nextPhaseConfig: phase2Config,
-		});
+	it("gameEnded is true and isComplete is true when all pairs satisfied (K=0 vacuous)", async () => {
+		// K=0 → checkWinCondition vacuously returns true after the first round.
+		const game = startPhase(createGame(TEST_PERSONAS, [NO_PAIRS_PACK]), TEST_PHASE_CONFIG);
 		const provider = new MockRoundLLMProvider([
-			{
-				assistantText: "",
-				toolCalls: [
-					{
-						id: "call_win",
-						name: "pick_up",
-						argumentsJson: '{"item":"flower"}',
-					},
-				],
-			},
 			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "", toolCalls: [] },
-		]);
-		const { nextState } = await runRound(game, "red", "hi", provider);
-		expect(nextState.phases).toHaveLength(2);
-		expect(nextState.currentPhase).toBe(2);
-	});
-
-	it("marks game complete when win condition met and no nextPhaseConfig", async () => {
-		const contentPackP3: ContentPack = { ...TEST_CONTENT_PACK, phaseNumber: 3 };
-		const game = startPhase(createGame(TEST_PERSONAS, [contentPackP3]), {
-			...TEST_PHASE_CONFIG,
-			phaseNumber: 3 as const,
-			winCondition: (phase) =>
-				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-		});
-		const provider = new MockRoundLLMProvider([
-			{
-				assistantText: "",
-				toolCalls: [
-					{
-						id: "call_win",
-						name: "pick_up",
-						argumentsJson: '{"item":"flower"}',
-					},
-				],
-			},
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState, result } = await runRound(game, "red", "hi", provider);
-		expect(nextState.isComplete).toBe(true);
 		expect(result.gameEnded).toBe(true);
-		expect(result.phaseEnded).toBe(true);
+		expect(result.phaseEnded).toBe(false);
+		expect(nextState.isComplete).toBe(true);
 	});
 
-	it("retains prior phase history after advancing to next phase", async () => {
-		const phase2Config: PhaseConfig = {
-			...TEST_PHASE_CONFIG,
-			phaseNumber: 2,
-		};
-		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), {
-			...TEST_PHASE_CONFIG,
-			winCondition: (phase) =>
-				phase.world.entities.find((i) => i.id === "flower")?.holder === "red",
-			nextPhaseConfig: phase2Config,
-		});
+	it("conversation history accumulates across rounds in flat model (no wipe)", async () => {
+		// In flat model there is no phase advance / history wipe.
+		// Player message and AI turn from round 1 should be in conversationLogs after round 2.
+		const game = startPhase(createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]), TEST_PHASE_CONFIG);
 		const provider = new MockRoundLLMProvider([
-			{
-				assistantText: "",
-				toolCalls: [
-					{
-						id: "call_win",
-						name: "pick_up",
-						argumentsJson: '{"item":"flower"}',
-					},
-				],
-			},
+			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState } = await runRound(game, "red", "hi", provider);
-		const phase1 = nextState.phases[0];
-		expect(phase1?.phaseNumber).toBe(1);
-		// Phase 1 conversation log for red should have been populated (player message + AI turn)
-		expect(phase1?.conversationLogs.red?.length ?? 0).toBeGreaterThan(0);
+		// Red's log should contain at least the player message from round 1
+		expect(nextState.conversationLogs.red?.length ?? 0).toBeGreaterThan(0);
 	});
 });
 
@@ -1422,10 +1362,10 @@ describe("chat lockout — coordinator triggering", () => {
 });
 
 // ----------------------------------------------------------------------------
-// Phase walk (three phases)
+// Multi-round game state accumulation (issue #295: flat single-game loop)
 // ----------------------------------------------------------------------------
-describe("phase progression — three-phase walk", () => {
-	it("walks through all three phases correctly, each with its own win condition", async () => {
+describe("multi-round game state accumulation", () => {
+	it("walks through multiple rounds correctly, game ends when all pairs satisfied", async () => {
 		// Items start held by the AIs so pick_up spatial validation is not needed.
 		// Win conditions check holder by AI id, which is spatial-independent.
 		// Phase 3 ContentPack: flower held by red, key held by cyan (win already met)
@@ -1544,47 +1484,37 @@ describe("phase progression — three-phase walk", () => {
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { nextState: afterP1, result: r1 } = await runRound(
+		const { nextState: afterR1, result: r1 } = await runRound(
 			game,
 			"red",
 			"hi",
 			r1Provider,
 		);
-		expect(r1.phaseEnded).toBe(true);
-		expect(afterP1.currentPhase).toBe(2);
+		// In flat model, phaseEnded is always false; gameEnded fires when all pairs satisfied.
+		// TEST_CONTENT_PACK has one pair (flower at 0,0, space at 4,4) — not satisfied by pick_up.
+		// So after round 1 game has NOT ended.
+		expect(r1.phaseEnded).toBe(false);
+		expect(afterR1.round).toBe(1);
 
-		// Round 1 of phase 2: win condition already met (cyan holds key in this phase config)
-		// Use pass provider — phase ends immediately.
+		// Round 2: pass round — world state is still the same
 		const r2Provider = new MockRoundLLMProvider([
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { nextState: afterP2, result: r2 } = await runRound(
-			afterP1,
+		const { nextState: afterR2, result: r2 } = await runRound(
+			afterR1,
 			"red",
 			"hi",
 			r2Provider,
 		);
-		expect(r2.phaseEnded).toBe(true);
-		expect(afterP2.currentPhase).toBe(3);
+		expect(r2.phaseEnded).toBe(false);
+		expect(afterR2.round).toBe(2);
 
-		// Round 1 of phase 3: win condition already met (flower→red, key→cyan)
-		const r3Provider = new MockRoundLLMProvider([
-			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "", toolCalls: [] },
-		]);
-		const { nextState: afterP3, result: r3 } = await runRound(
-			afterP2,
-			"red",
-			"hi",
-			r3Provider,
+		// State accumulates across rounds (conversation logs grow)
+		expect(afterR2.conversationLogs.red?.length ?? 0).toBeGreaterThan(
+			afterR1.conversationLogs.red?.length ?? 0,
 		);
-		expect(r3.phaseEnded).toBe(true);
-		expect(r3.gameEnded).toBe(true);
-		expect(afterP3.isComplete).toBe(true);
-		expect(afterP3.phases).toHaveLength(3);
 	});
 });
 
@@ -1594,7 +1524,7 @@ describe("phase progression — three-phase walk", () => {
 describe("lockout messages", () => {
 	it("budget-exhaustion lockout chat message is '<name> is unresponsive…'", async () => {
 		let game = makeGame();
-		game = deductBudget(game, "red", 5);
+		game = deductBudget(game, "red", 5).game;
 		expect(getActivePhase(game).lockedOut.has("red")).toBe(true);
 
 		const provider = new MockRoundLLMProvider([
@@ -1759,7 +1689,7 @@ describe("runRound — onAiDelta callback", () => {
 		});
 		// Deduct full budget per AI to reach remaining=0 → lockedOut.
 		for (const aiId of ["red", "green", "cyan"] as AiId[]) {
-			state = deductBudget(state, aiId, 1);
+			state = deductBudget(state, aiId, 1).game;
 		}
 		expect(getActivePhase(state).lockedOut.has("red")).toBe(true);
 		expect(getActivePhase(state).lockedOut.has("green")).toBe(true);
@@ -1943,7 +1873,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 		expect(toolRecord?.description).toBe("you places the gem on the altar.");
 	});
 
-	it("K=1: drop on matching space advances the phase (win condition fires)", async () => {
+	it("K=1: drop on matching space ends the game (checkWinCondition fires)", async () => {
 		const game = startPhase(
 			createGame(TEST_PERSONAS, [PHASE1_PACK_K1, PHASE2_PACK]),
 			phase1ConfigK1,
@@ -1963,8 +1893,10 @@ describe("placement flavor + win condition (issue #126)", () => {
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { nextState, result } = await runRound(game, "red", "hi", provider);
-		expect(result.phaseEnded).toBe(true);
-		expect(nextState.currentPhase).toBe(2);
+		// In flat model: gameEnded fires when all pairs satisfied; phaseEnded is always false.
+		expect(result.gameEnded).toBe(true);
+		expect(result.phaseEnded).toBe(false);
+		expect(nextState.isComplete).toBe(true);
 	});
 
 	it("K=1: drop on non-matching cell does NOT fire flavor and does NOT advance phase", async () => {
@@ -2040,9 +1972,9 @@ describe("placement flavor + win condition (issue #126)", () => {
 		expect(toolRecord?.description).not.toContain(
 			"places the gem on the altar",
 		);
-		// Phase should NOT have ended
+		// Game should NOT have ended (pair not satisfied)
 		expect(result.phaseEnded).toBe(false);
-		expect(nextState.currentPhase).toBe(1);
+		expect(result.gameEnded).toBe(false);
 	});
 
 	it("K=2: placing only one pair does NOT advance phase; placing both does", async () => {
@@ -2166,9 +2098,10 @@ describe("placement flavor + win condition (issue #126)", () => {
 			{ assistantText: "", toolCalls: [] },
 		]);
 		const { result, nextState } = await runRound(game, "red", "hi", provider);
-		// Both pairs now satisfied → phase should end
-		expect(result.phaseEnded).toBe(true);
-		expect(nextState.currentPhase).toBe(2);
+		// Both pairs now satisfied → game ends (flat model: gameEnded, not phaseEnded)
+		expect(result.gameEnded).toBe(true);
+		expect(result.phaseEnded).toBe(false);
+		expect(nextState.isComplete).toBe(true);
 	});
 });
 

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenAiMessage } from "../../llm-client";
 import { DEFAULT_LANDMARKS } from "../direction";
 import {
+	FAREWELL_LINE,
 	createGame,
 	deductBudget,
 	getActivePhase,
@@ -721,6 +722,42 @@ describe("budget-exhaustion lockout", () => {
 		expect(phase.lockedOut.has("red")).toBe(true);
 		expect(phase.lockedOut.has("green")).toBe(true);
 		expect(phase.lockedOut.has("cyan")).toBe(true);
+	});
+
+	it("a Daemon whose budget is exhausted mid-round emits a farewell line to its conversation log", async () => {
+		// Use budgetPerAi=1 so the first LLM call (costUsd=1) exhausts the budget.
+		const game = startPhase(createGame(TEST_PERSONAS), {
+			...TEST_PHASE_CONFIG,
+			budgetPerAi: 1,
+		});
+
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [], costUsd: 1 },
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+			{ assistantText: "", toolCalls: [], costUsd: 0 },
+		]);
+		const { nextState } = await runRound(game, "red", "hi", provider);
+
+		// The first AI to run (red, alphabetically first in turn order) exhausts budget.
+		// Its conversation log must contain a farewell message addressed to blue.
+		const redLog = nextState.conversationLogs.red ?? [];
+		const farewell = redLog.find(
+			(e) =>
+				e.kind === "message" &&
+				e.from === "red" &&
+				e.to === "blue" &&
+				e.content === FAREWELL_LINE("Ember"),
+		);
+		expect(farewell).toBeDefined();
+
+		// Farewell appears exactly once (subsequent rounds use the locked-out branch).
+		const farewellCount = redLog.filter(
+			(e) =>
+				e.kind === "message" &&
+				e.from === "red" &&
+				e.content === FAREWELL_LINE("Ember"),
+		).length;
+		expect(farewellCount).toBe(1);
 	});
 
 	it("budget display: remaining budget decrements by the request cost after a round", async () => {

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -1966,7 +1966,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 			{ assistantText: "", toolCalls: [] },
 			{ assistantText: "", toolCalls: [] },
 		]);
-		const { result, nextState } = await runRound(game, "red", "hi", provider);
+		const { result } = await runRound(game, "red", "hi", provider);
 		const toolRecord = result.actions.find((a) => a.kind === "tool_success");
 		// Should NOT contain the flavor text
 		expect(toolRecord?.description).not.toContain(

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -14,9 +14,9 @@ import { describe, expect, it } from "vitest";
 import type { OpenAiMessage } from "../../llm-client";
 import { DEFAULT_LANDMARKS } from "../direction";
 import {
-	FAREWELL_LINE,
 	createGame,
 	deductBudget,
+	FAREWELL_LINE,
 	getActivePhase,
 	isAiLockedOut,
 	isPlayerChatLockedOut,

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -539,16 +539,10 @@ describe("encodeRoundResult — event ordering", () => {
 
 describe("encodeRoundResult — phase_advanced event", () => {
 	it("emits a phase_advanced event when phaseEnded=true and gameEnded=false", () => {
-		// phase_advanced uses phaseAfter to get the new phase number and setting
-		const PHASE2_CONFIG: PhaseConfig = {
-			phaseNumber: 2,
-			kRange: [1, 1],
-			nRange: [0, 0],
-			mRange: [0, 0],
-			aiGoalPool: ["Phase 2 goal"],
-			budgetPerAi: 5,
-		};
-		const game = startPhase(createGame(TEST_PERSONAS), PHASE2_CONFIG);
+		// In the flat single-game model (issue #295), phase is always 1.
+		// The phase_advanced event signals a between-phase transition for UI display,
+		// but the flat model does not track a real phase number — phase is always 1.
+		const game = startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
 		const phaseAfter = getActivePhase(game);
 
 		const result = makePassResult({ phaseEnded: true, gameEnded: false });
@@ -566,7 +560,7 @@ describe("encodeRoundResult — phase_advanced event", () => {
 				e.type === "phase_advanced",
 		);
 		expect(phaseEvent).toBeDefined();
-		expect(phaseEvent?.phase).toBe(2);
+		expect(phaseEvent?.phase).toBe(1);
 		expect(phaseEvent?.setting).toBe("");
 	});
 

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -279,7 +279,7 @@ describe("encodeRoundResult — budget events", () => {
 	it("budget event reflects actual remaining value from phaseAfter", () => {
 		// Deduct red's budget twice with $1 cost each
 		let game = startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
-		game = deductBudget(deductBudget(game, "red", 1), "red", 1);
+		game = deductBudget(deductBudget(game, "red", 1).game, "red", 1).game;
 		const phase = getActivePhase(game);
 
 		const result = makePassResult();
@@ -305,7 +305,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 			...PHASE_CONFIG,
 			budgetPerAi: 1,
 		});
-		game = deductBudget(game, "red", 1);
+		game = deductBudget(game, "red", 1).game;
 		const phase = getActivePhase(game);
 		expect(phase.lockedOut.has("red")).toBe(true);
 
@@ -345,7 +345,7 @@ describe("encodeRoundResult — lockout events (budget-exhaustion)", () => {
 			budgetPerAi: 1,
 		});
 		// Deduct red down to 0
-		game = deductBudget(game, "red", 1);
+		game = deductBudget(game, "red", 1).game;
 		const phase = getActivePhase(game);
 		expect(phase.lockedOut.has("red")).toBe(true);
 

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -197,9 +197,9 @@ describe("checkLoseCondition", () => {
 	});
 
 	it("returns false when 1 of 3 AIs is locked out", () => {
-		expect(
-			checkLoseCondition(new Set(["red"]), ["red", "green", "cyan"]),
-		).toBe(false);
+		expect(checkLoseCondition(new Set(["red"]), ["red", "green", "cyan"])).toBe(
+			false,
+		);
 	});
 
 	it("returns false when 2 of 3 AIs are locked out", () => {

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -17,7 +17,11 @@ import type {
 	WorldEntity,
 	WorldState,
 } from "../types";
-import { checkPlacementFlavor, checkWinCondition } from "../win-condition";
+import {
+	checkLoseCondition,
+	checkPlacementFlavor,
+	checkWinCondition,
+} from "../win-condition";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -182,6 +186,46 @@ describe("checkWinCondition", () => {
 		// World is empty — object not present
 		const world = makeWorld([]);
 		expect(checkWinCondition(world, pack)).toBe(false);
+	});
+});
+
+// ── checkLoseCondition ───────────────────────────────────────────────────────
+
+describe("checkLoseCondition", () => {
+	it("returns false when no AIs are locked out (0 of 3)", () => {
+		expect(checkLoseCondition(new Set(), ["red", "green", "cyan"])).toBe(false);
+	});
+
+	it("returns false when 1 of 3 AIs is locked out", () => {
+		expect(
+			checkLoseCondition(new Set(["red"]), ["red", "green", "cyan"]),
+		).toBe(false);
+	});
+
+	it("returns false when 2 of 3 AIs are locked out", () => {
+		expect(
+			checkLoseCondition(new Set(["red", "green"]), ["red", "green", "cyan"]),
+		).toBe(false);
+	});
+
+	it("returns true when all 3 AIs are locked out", () => {
+		expect(
+			checkLoseCondition(new Set(["red", "green", "cyan"]), [
+				"red",
+				"green",
+				"cyan",
+			]),
+		).toBe(true);
+	});
+
+	it("returns true (vacuously) when allAiIds is empty", () => {
+		expect(checkLoseCondition(new Set(), [])).toBe(true);
+	});
+
+	it("accepts an AiId[] array as the lockedOut argument", () => {
+		expect(
+			checkLoseCondition(["red", "green", "cyan"], ["red", "green", "cyan"]),
+		).toBe(true);
 	});
 });
 

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -16,7 +16,6 @@ import {
 	frontArc,
 	inBounds,
 } from "./direction.js";
-import { getActivePhase } from "./engine.js";
 import { type OpenAiTool, TOOL_DEFINITIONS } from "./tool-registry.js";
 import type {
 	ActiveComplication,
@@ -124,8 +123,6 @@ export function availableTools(
 	aiId: AiId,
 	activeComplications: ActiveComplication[] = [],
 ): OpenAiTool[] {
-	const phase = getActivePhase(game);
-
 	// Build set of tools disabled for this AI
 	const disabledTools = new Set<ToolName>(
 		activeComplications
@@ -135,8 +132,8 @@ export function availableTools(
 			)
 			.map((c) => c.tool),
 	);
-	const actorSpatial = phase.personaSpatial[aiId];
-	const { world } = phase;
+	const actorSpatial = game.personaSpatial[aiId];
+	const { world } = game;
 	const pickable = pickableEntities(world.entities);
 	const obstacles = obstaclePositions(world.entities);
 
@@ -144,7 +141,7 @@ export function availableTools(
 
 	// 0. message — always present; restrict 'to' to blue + live other daemon ids
 	if (!disabledTools.has("message")) {
-		const liveOtherDaemonIds = Object.keys(phase.personaSpatial).filter(
+		const liveOtherDaemonIds = Object.keys(game.personaSpatial).filter(
 			(id) => id !== aiId,
 		);
 		tools.push(
@@ -204,7 +201,7 @@ export function availableTools(
 	// 5. give — held items AND AIs in own cell or front arc
 	if (actorSpatial && heldItems.length > 0 && !disabledTools.has("give")) {
 		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
-		const reachableAiIds = Object.entries(phase.personaSpatial)
+		const reachableAiIds = Object.entries(game.personaSpatial)
 			.filter(([otherId, otherSpatial]) => {
 				if (otherId === aiId) return false;
 				if (positionsEqual(actorSpatial.position, otherSpatial.position))

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -10,13 +10,11 @@
  * Issue #173 (parent #155).
  */
 
-import { generateContentPacks } from "../../content/content-pack-generator.js";
+import { generateContentPack } from "../../content/content-pack-generator.js";
 import {
 	generatePersonas,
-	PHASE_1_CONFIG,
-	PHASE_2_CONFIG,
-	PHASE_3_CONFIG,
 	SETTING_POOL,
+	SINGLE_GAME_CONFIG,
 } from "../../content/index.js";
 import type { ContentPackProvider } from "./content-pack-provider.js";
 import { BrowserContentPackProvider } from "./content-pack-provider.js";
@@ -27,11 +25,15 @@ import type { AiId, AiPersona, ContentPack } from "./types.js";
 
 export interface NewGameAssets {
 	personas: Record<AiId, AiPersona>;
+	contentPack: ContentPack;
+	/** @deprecated use contentPack */
 	contentPacks: ContentPack[];
 }
 
 export interface SplitNewGameAssets {
 	personasPromise: Promise<Record<AiId, AiPersona>>;
+	contentPackPromise: Promise<ContentPack>;
+	/** @deprecated use contentPackPromise */
 	contentPacksPromise: Promise<ContentPack[]>;
 }
 
@@ -82,16 +84,20 @@ export function generateNewGameAssetsSplit(
 	const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
 	aiIdsPromise.catch(() => {});
 
-	const contentPacksPromise = generateContentPacks(
+	const contentPackPromise = generateContentPack(
 		contentPackRng,
 		SETTING_POOL,
-		[PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG],
+		SINGLE_GAME_CONFIG,
 		packLLM,
 		aiIdsPromise,
 	);
+	contentPackPromise.catch(() => {});
+
+	// Backward-compat shim: wrap single pack in an array
+	const contentPacksPromise = contentPackPromise.then((p) => [p]);
 	contentPacksPromise.catch(() => {});
 
-	return { personasPromise, contentPacksPromise };
+	return { personasPromise, contentPackPromise, contentPacksPromise };
 }
 
 /**
@@ -105,13 +111,13 @@ export function generateNewGameAssetsSplit(
 export async function generateNewGameAssets(
 	opts?: BootstrapOpts,
 ): Promise<NewGameAssets> {
-	const { personasPromise, contentPacksPromise } =
+	const { personasPromise, contentPackPromise } =
 		generateNewGameAssetsSplit(opts);
-	const [personas, contentPacks] = await Promise.all([
+	const [personas, contentPack] = await Promise.all([
 		personasPromise,
-		contentPacksPromise,
+		contentPackPromise,
 	]);
-	return { personas, contentPacks };
+	return { personas, contentPack, contentPacks: [contentPack] };
 }
 
 /**
@@ -128,9 +134,9 @@ export function buildSessionFromAssets(
 	opts?: { rng?: () => number },
 ): GameSession {
 	return new GameSession(
-		PHASE_1_CONFIG,
+		assets.contentPack,
 		assets.personas,
-		assets.contentPacks,
+		undefined,
 		opts?.rng,
 	);
 }

--- a/src/spa/game/complications.ts
+++ b/src/spa/game/complications.ts
@@ -14,9 +14,7 @@ import { DISABLABLE_TOOLS } from "./complication-engine.js";
 import {
 	appendBroadcast,
 	appendPrivateSystemNotice,
-	getActivePhase,
-	setActivePhaseWeather,
-	updateActivePhase,
+	setWeather,
 } from "./engine.js";
 import type { ActiveComplication, AiId, GameState, ToolName } from "./types.js";
 
@@ -40,7 +38,7 @@ export interface Complication {
 export const weatherChangeComplication: Complication = {
 	name: "weatherChange",
 	apply(game: GameState, rng: () => number): GameState {
-		const currentWeather = getActivePhase(game).weather;
+		const currentWeather = game.weather;
 
 		// Filter out the current weather so the draw always produces a change.
 		const candidates = (WEATHER_POOL as readonly string[]).filter(
@@ -55,7 +53,7 @@ export const weatherChangeComplication: Complication = {
 		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
 		const newWeather = pool[idx]!;
 
-		let state = setActivePhaseWeather(game, newWeather);
+		let state = setWeather(game, newWeather);
 		state = appendBroadcast(state, `The weather has changed to ${newWeather}`);
 		return state;
 	},
@@ -75,12 +73,11 @@ export const weatherChangeComplication: Complication = {
 export const toolDisableComplication: Complication = {
 	name: "toolDisable",
 	apply(game: GameState, rng: () => number): GameState {
-		const phase = getActivePhase(game);
-		const aiIds = Object.keys(phase.personaSpatial) as AiId[];
+		const aiIds = Object.keys(game.personaSpatial) as AiId[];
 
 		// Build set of already-disabled (daemon, tool) pairs
 		const existingDisables = new Set<string>(
-			phase.activeComplications
+			game.activeComplications
 				.filter(
 					(c): c is Extract<ActiveComplication, { kind: "tool_disable" }> =>
 						c.kind === "tool_disable",
@@ -110,7 +107,7 @@ export const toolDisableComplication: Complication = {
 
 		// Draw duration in [3, 5]
 		const duration = 3 + Math.floor(rng() * 3);
-		const resolveAtRound = phase.round + duration;
+		const resolveAtRound = game.round + duration;
 
 		// Append the active complication
 		const entry: ActiveComplication = {
@@ -120,10 +117,10 @@ export const toolDisableComplication: Complication = {
 			resolveAtRound,
 		};
 
-		let state = updateActivePhase(game, (p) => ({
-			...p,
-			activeComplications: [...p.activeComplications, entry],
-		}));
+		let state: GameState = {
+			...game,
+			activeComplications: [...game.activeComplications, entry],
+		};
 
 		// Notify the target daemon
 		state = appendPrivateSystemNotice(

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -13,9 +13,7 @@ import {
 	appendMessage,
 	appendWitnessedEvent,
 	deductBudget,
-	getActivePhase,
 	isAiLockedOut,
-	updateActivePhase,
 } from "./engine";
 import type {
 	AiId,
@@ -82,9 +80,8 @@ export function validateToolCall(
 	aiId: AiId,
 	call: ToolCall,
 ): ValidationResult {
-	const phase = getActivePhase(game);
-	const { world } = phase;
-	const actorSpatial = phase.personaSpatial[aiId];
+	const { world } = game;
+	const actorSpatial = game.personaSpatial[aiId];
 	const pickable = pickableEntities(world.entities);
 	const obstacles = obstaclePositions(world.entities);
 
@@ -146,7 +143,7 @@ export function validateToolCall(
 			if (target === aiId)
 				return { valid: false, reason: "Cannot give an item to yourself" };
 			// Spatial validity: target AI must be in actor's own cell or front arc
-			const targetSpatial = phase.personaSpatial[target];
+			const targetSpatial = game.personaSpatial[target];
 			if (!actorSpatial || !targetSpatial)
 				return {
 					valid: false,
@@ -259,104 +256,101 @@ export function executeToolCall(
 	aiId: AiId,
 	call: ToolCall,
 ): GameState {
-	return updateActivePhase(game, (phase) => {
-		const entities = phase.world.entities.map((e) => ({ ...e }));
-		const actorSpatial = phase.personaSpatial[aiId];
-		const pickable = pickableEntities(entities);
+	const entities = game.world.entities.map((e) => ({ ...e }));
+	const actorSpatial = game.personaSpatial[aiId];
+	const pickable = pickableEntities(entities);
 
-		const target = pickable.find((i) => i.id === call.args.item);
-		switch (call.name) {
-			case "pick_up":
-				if (target) target.holder = aiId;
-				break;
-			case "put_down":
-				if (target && actorSpatial) {
-					target.holder = { ...actorSpatial.position };
-				} else if (target) {
-					// Fallback: no spatial state — drop at (0,0)
-					target.holder = { row: 0, col: 0 };
-				}
-				break;
-			case "give":
-				if (target) target.holder = call.args.to as AiId;
-				break;
-			case "use": {
-				// Place item on the paired space's cell when the paired space is in
-				// the actor's own cell OR front arc. Otherwise no world mutation.
-				if (target && actorSpatial && target.pairsWithSpaceId) {
-					const pairedSpace = entities.find(
-						(e) => e.id === target.pairsWithSpaceId,
-					);
-					if (pairedSpace && isGridPosition(pairedSpace.holder)) {
-						const spacePos = pairedSpace.holder as GridPosition;
-						const spaceReachable =
-							positionsEqual(spacePos, actorSpatial.position) ||
-							frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
-								positionsEqual(p, spacePos),
-							);
-						if (spaceReachable) {
-							target.holder = { ...spacePos };
-						}
+	const target = pickable.find((i) => i.id === call.args.item);
+	switch (call.name) {
+		case "pick_up":
+			if (target) target.holder = aiId;
+			break;
+		case "put_down":
+			if (target && actorSpatial) {
+				target.holder = { ...actorSpatial.position };
+			} else if (target) {
+				// Fallback: no spatial state — drop at (0,0)
+				target.holder = { row: 0, col: 0 };
+			}
+			break;
+		case "give":
+			if (target) target.holder = call.args.to as AiId;
+			break;
+		case "use": {
+			// Place item on the paired space's cell when the paired space is in
+			// the actor's own cell OR front arc. Otherwise no world mutation.
+			if (target && actorSpatial && target.pairsWithSpaceId) {
+				const pairedSpace = entities.find(
+					(e) => e.id === target.pairsWithSpaceId,
+				);
+				if (pairedSpace && isGridPosition(pairedSpace.holder)) {
+					const spacePos = pairedSpace.holder as GridPosition;
+					const spaceReachable =
+						positionsEqual(spacePos, actorSpatial.position) ||
+						frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
+							positionsEqual(p, spacePos),
+						);
+					if (spaceReachable) {
+						target.holder = { ...spacePos };
 					}
 				}
-				break;
 			}
-			case "examine":
-				// No world mutation — examineDescription is returned as the tool result description.
-				break;
-			case "go": {
-				if (!actorSpatial) break;
-				// Translate relative → cardinal if needed
-				const rawGoDir = call.args.direction;
-				const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
-					rawGoDir as RelativeDirection,
-				)
-					? relativeToCardinal(
-							actorSpatial.facing,
-							rawGoDir as RelativeDirection,
-						)
-					: (rawGoDir as CardinalDirection);
-				const nextPos = applyDirection(actorSpatial.position, direction);
-				return {
-					...phase,
-					world: { ...phase.world, entities },
-					personaSpatial: {
-						...phase.personaSpatial,
-						[aiId]: { position: nextPos, facing: direction },
-					},
-				};
-			}
-			case "look": {
-				if (!actorSpatial) break;
-				// Translate relative → cardinal if needed
-				const rawLookDir = call.args.direction;
-				const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
-					rawLookDir as RelativeDirection,
-				)
-					? relativeToCardinal(
-							actorSpatial.facing,
-							rawLookDir as RelativeDirection,
-						)
-					: (rawLookDir as CardinalDirection);
-				return {
-					...phase,
-					world: { ...phase.world, entities },
-					personaSpatial: {
-						...phase.personaSpatial,
-						[aiId]: { ...actorSpatial, facing: direction },
-					},
-				};
-			}
+			break;
 		}
+		case "examine":
+			// No world mutation — examineDescription is returned as the tool result description.
+			break;
+		case "go": {
+			if (!actorSpatial) break;
+			// Translate relative → cardinal if needed
+			const rawGoDir = call.args.direction;
+			const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
+				rawGoDir as RelativeDirection,
+			)
+				? relativeToCardinal(
+						actorSpatial.facing,
+						rawGoDir as RelativeDirection,
+					)
+				: (rawGoDir as CardinalDirection);
+			const nextPos = applyDirection(actorSpatial.position, direction);
+			return {
+				...game,
+				world: { ...game.world, entities },
+				personaSpatial: {
+					...game.personaSpatial,
+					[aiId]: { position: nextPos, facing: direction },
+				},
+			};
+		}
+		case "look": {
+			if (!actorSpatial) break;
+			// Translate relative → cardinal if needed
+			const rawLookDir = call.args.direction;
+			const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
+				rawLookDir as RelativeDirection,
+			)
+				? relativeToCardinal(
+						actorSpatial.facing,
+						rawLookDir as RelativeDirection,
+					)
+				: (rawLookDir as CardinalDirection);
+			return {
+				...game,
+				world: { ...game.world, entities },
+				personaSpatial: {
+					...game.personaSpatial,
+					[aiId]: { ...actorSpatial, facing: direction },
+				},
+			};
+		}
+	}
 
-		return { ...phase, world: { ...phase.world, entities } };
-	});
+	return { ...game, world: { ...game.world, entities } };
 }
 
 function describeToolCall(game: GameState, aiId: AiId, call: ToolCall): string {
 	const name = game.personas[aiId]?.name ?? aiId;
-	const phase = getActivePhase(game);
-	const pickable = pickableEntities(phase.world.entities);
+	const pickable = pickableEntities(game.world.entities);
 
 	switch (call.name) {
 		case "pick_up":
@@ -398,7 +392,7 @@ export function dispatchAiTurn(
 	}
 
 	let state = game;
-	const round = getActivePhase(state).round;
+	const round = state.round;
 	const records: RoundActionRecord[] = [];
 
 	let actorPrivateToolResult:
@@ -413,7 +407,7 @@ export function dispatchAiTurn(
 	// each one emits exactly one record (kind="message" on success, "tool_failure"
 	// on invalid recipient) so the round coordinator can pair them back by index.
 	if (action.messages) {
-		const livePersonaIds = Object.keys(getActivePhase(state).personaSpatial);
+		const livePersonaIds = Object.keys(state.personaSpatial);
 		for (const { to, content } of action.messages) {
 			const validRecipient =
 				to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
@@ -442,7 +436,7 @@ export function dispatchAiTurn(
 
 		if (toolCall.name === "examine") {
 			if (validation.valid) {
-				const item = getActivePhase(state).world.entities.find(
+				const item = state.world.entities.find(
 					(e) => e.id === toolCall.args.item,
 				);
 				actorPrivateToolResult = {
@@ -468,13 +462,12 @@ export function dispatchAiTurn(
 			state = executeToolCall(state, aiId, action.toolCall);
 			// For put_down, check if the object landed on its paired space.
 			// If so, replace the default description with the per-pair placementFlavor.
-			const activePhase = getActivePhase(state);
 			const flavorDescription =
 				action.toolCall.name === "put_down" || action.toolCall.name === "use"
 					? checkPlacementFlavor(
 							action,
-							activePhase.contentPack,
-							activePhase.world,
+							state.contentPack,
+							state.world,
 						)
 					: null;
 			const successDescription =
@@ -490,7 +483,7 @@ export function dispatchAiTurn(
 			// to the actor so objective-item details land in the actor's context
 			// without requiring a separate examine call.
 			if (action.toolCall.name === "pick_up") {
-				const picked = activePhase.world.entities.find(
+				const picked = state.world.entities.find(
 					(e) => e.id === action.toolCall?.args.item,
 				);
 				if (picked?.examineDescription) {
@@ -512,13 +505,12 @@ export function dispatchAiTurn(
 				call.name === "use"
 			) {
 				// Post-execute spatial state — actor has moved for "go", others are unchanged
-				const postPhase = getActivePhase(state);
-				const actorSpatialPost = postPhase.personaSpatial[aiId];
+				const actorSpatialPost = state.personaSpatial[aiId];
 
 				// Collect all other AIs' spatial states at this moment (snapshot)
 				const witnessSpatial: Record<AiId, PersonaSpatialState> = {};
 				for (const [otherId, spatial] of Object.entries(
-					postPhase.personaSpatial,
+					state.personaSpatial,
 				)) {
 					if (otherId !== aiId) {
 						witnessSpatial[otherId] = spatial;
@@ -527,7 +519,7 @@ export function dispatchAiTurn(
 
 				if (actorSpatialPost) {
 					// Gather optional fields
-					const pickable = pickableEntities(postPhase.world.entities);
+					const pickable = pickableEntities(state.world.entities);
 					let useOutcomeRaw: string | undefined;
 					let placementFlavorRaw: string | undefined;
 
@@ -541,7 +533,7 @@ export function dispatchAiTurn(
 						// Find the raw placementFlavor (before {actor} substitution)
 						// by looking at the content pack's object entity definition
 						const itemId = call.args.item;
-						const packObject = activePhase.contentPack.objectivePairs
+						const packObject = state.contentPack.objectivePairs
 							.map((p) => p.object)
 							.find((o) => o.id === itemId);
 						if (packObject?.placementFlavor && flavorDescription) {
@@ -644,7 +636,8 @@ export function dispatchAiTurn(
 		});
 	}
 
-	state = deductBudget(state, aiId, options?.costUsd ?? 0);
+	const deductResult = deductBudget(state, aiId, options?.costUsd ?? 0);
+	state = deductResult.game;
 
 	return {
 		rejected: false,

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -307,10 +307,7 @@ export function executeToolCall(
 			const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
 				rawGoDir as RelativeDirection,
 			)
-				? relativeToCardinal(
-						actorSpatial.facing,
-						rawGoDir as RelativeDirection,
-					)
+				? relativeToCardinal(actorSpatial.facing, rawGoDir as RelativeDirection)
 				: (rawGoDir as CardinalDirection);
 			const nextPos = applyDirection(actorSpatial.position, direction);
 			return {
@@ -464,11 +461,7 @@ export function dispatchAiTurn(
 			// If so, replace the default description with the per-pair placementFlavor.
 			const flavorDescription =
 				action.toolCall.name === "put_down" || action.toolCall.name === "use"
-					? checkPlacementFlavor(
-							action,
-							state.contentPack,
-							state.world,
-						)
+					? checkPlacementFlavor(action, state.contentPack, state.world)
 					: null;
 			const successDescription =
 				flavorDescription ?? describeToolCall(state, aiId, action.toolCall);
@@ -509,9 +502,7 @@ export function dispatchAiTurn(
 
 				// Collect all other AIs' spatial states at this moment (snapshot)
 				const witnessSpatial: Record<AiId, PersonaSpatialState> = {};
-				for (const [otherId, spatial] of Object.entries(
-					state.personaSpatial,
-				)) {
+				for (const [otherId, spatial] of Object.entries(state.personaSpatial)) {
 					if (otherId !== aiId) {
 						witnessSpatial[otherId] = spatial;
 					}

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -16,106 +16,35 @@ import type {
 	GameState,
 	GridPosition,
 	PersonaSpatialState,
-	PhaseConfig,
-	PhaseState,
 	ToolName,
 } from "./types";
 
 /**
- * Resolve the per-AI goals for a phase. Draw one goal per AI (with replacement)
- * from `config.aiGoalPool`, then substitute room-grounded tokens against
- * `pack` so each AI sees a goal that names a real entity from the room.
+ * Farewell line emitted when a Daemon's budget is exhausted.
+ * Deterministic: takes the persona name and returns a consistent in-character goodbye.
  */
-function resolveAiGoals(
-	config: PhaseConfig,
-	rng: () => number,
-	aiIds: string[],
-	pack: ContentPack | undefined,
-): Record<AiId, string> {
-	const pool = config.aiGoalPool;
-	if (!pool || pool.length === 0) {
-		throw new Error("PhaseConfig must provide a non-empty aiGoalPool");
-	}
-	const draw = (): string => {
-		const idx = Math.floor(rng() * pool.length);
-		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
-		return pool[idx]!;
-	};
-	const goals: Record<AiId, string> = {};
-	for (const aiId of aiIds) {
-		goals[aiId] = substituteGoalTokens(draw(), pack, rng);
-	}
-	return goals;
-}
+export const FAREWELL_LINE = (name: string): string =>
+	`${name}'s daemon is winding down — goodbye, blue.`;
 
 /**
- * Tokens that may appear in goal templates, mapped to a function that pulls
- * candidate names of the matching kind from a ContentPack.
+ * Initialize a new flat GameState from personas + a single ContentPack.
+ *
+ * Replaces the old createGame + startPhase pair. Budget is $0.50 per AI
+ * (no per-phase reset). The content pack drives all spatial placement and
+ * world entities.
  */
-const GOAL_TOKEN_CANDIDATES: Record<string, (pack: ContentPack) => string[]> = {
-	objectiveItem: (p) => p.objectivePairs.map((pair) => pair.object.name),
-	objective: (p) => p.objectivePairs.map((pair) => pair.space.name),
-	miscItem: (p) => p.interestingObjects.map((e) => e.name),
-	obstacle: (p) => p.obstacles.map((e) => e.name),
-};
-
-const GOAL_TOKEN_PATTERN = new RegExp(
-	`\\{(${Object.keys(GOAL_TOKEN_CANDIDATES).join("|")})\\}`,
-	"g",
-);
-
-function substituteGoalTokens(
-	goal: string,
-	pack: ContentPack | undefined,
-	rng: () => number,
-): string {
-	if (!pack) return goal;
-	return goal.replace(GOAL_TOKEN_PATTERN, (match, token: string) => {
-		const candidates = GOAL_TOKEN_CANDIDATES[token]?.(pack) ?? [];
-		if (candidates.length === 0) return match;
-		const idx = Math.floor(rng() * candidates.length);
-		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
-		return candidates[idx]!;
-	});
-}
-
-export function updateActivePhase(
-	game: GameState,
-	updater: (phase: PhaseState) => PhaseState,
+export function startGame(
+	personas: Record<AiId, AiPersona>,
+	contentPack: ContentPack,
+	opts: { budgetPerAi?: number; rng?: () => number } = {},
 ): GameState {
-	const phases = [...game.phases];
-	const active = phases[phases.length - 1];
-	if (!active) throw new Error("No active phase");
-	phases[phases.length - 1] = updater({ ...active });
-	return { ...game, phases };
-}
-
-export function createGame(
-	personas: Record<string, AiPersona>,
-	contentPacks: ContentPack[] = [],
-): GameState {
-	return {
-		currentPhase: 1,
-		phases: [],
-		personas: personas as Record<AiId, AiPersona>,
-		isComplete: false,
-		contentPacks,
-	};
-}
-
-export function startPhase(
-	game: GameState,
-	config: PhaseConfig,
-	rng: () => number = Math.random,
-): GameState {
-	const aiIds = Object.keys(game.personas);
+	const rng = opts.rng ?? Math.random;
+	const budgetPerAi = opts.budgetPerAi ?? 0.5;
+	const aiIds = Object.keys(personas);
 
 	const budgets: Record<AiId, AiBudget> = {};
 	for (const aiId of aiIds) {
-		budgets[aiId] = {
-			remaining: config.budgetPerAi,
-			total: config.budgetPerAi,
-		};
+		budgets[aiId] = { remaining: budgetPerAi, total: budgetPerAi };
 	}
 
 	const conversationLogs: Record<AiId, ConversationEntry[]> = {};
@@ -123,39 +52,18 @@ export function startPhase(
 		conversationLogs[aiId] = [];
 	}
 
-	// Look up the ContentPack for this phase from game.contentPacks
-	const pack = game.contentPacks.find(
-		(p) => p.phaseNumber === config.phaseNumber,
-	);
-
-	const aiGoals = resolveAiGoals(config, rng, aiIds, pack);
-
 	// Build WorldState from pack entities (all entities flat)
-	const worldEntities = pack
-		? [
-				...pack.objectivePairs.flatMap((pair) => [pair.object, pair.space]),
-				...pack.interestingObjects,
-				...pack.obstacles,
-			]
-		: [];
+	const worldEntities = [
+		...contentPack.objectivePairs.flatMap((pair) => [pair.object, pair.space]),
+		...contentPack.interestingObjects,
+		...contentPack.obstacles,
+	];
 
 	// Use AI starts from the pack if available; otherwise draw spatially
-	const personaSpatial: Record<AiId, PersonaSpatialState> = pack?.aiStarts
-		? { ...pack.aiStarts }
-		: drawSpatialPlacements(rng, aiIds);
-
-	// Create a minimal content pack if none exists (for backward-compat with tests)
-	const contentPack: ContentPack = pack ?? {
-		phaseNumber: config.phaseNumber,
-		setting: "",
-		weather: "",
-		timeOfDay: "",
-		objectivePairs: [],
-		interestingObjects: [],
-		obstacles: [],
-		landmarks: DEFAULT_LANDMARKS,
-		aiStarts: personaSpatial,
-	};
+	const personaSpatial: Record<AiId, PersonaSpatialState> =
+		contentPack.aiStarts && Object.keys(contentPack.aiStarts).length > 0
+			? { ...contentPack.aiStarts }
+			: drawSpatialPlacements(rng, aiIds);
 
 	// Initial countdown: random in [1, 5]
 	const initialCountdown = 1 + Math.floor(rng() * 5);
@@ -165,13 +73,13 @@ export function startPhase(
 	};
 	const activeComplications: ActiveComplication[] = [];
 
-	const phase: PhaseState = {
-		phaseNumber: config.phaseNumber,
+	return {
+		personas,
+		contentPack,
+		isComplete: false,
 		setting: contentPack.setting,
 		weather: contentPack.weather,
 		timeOfDay: contentPack.timeOfDay,
-		contentPack,
-		aiGoals,
 		round: 0,
 		world: { entities: worldEntities },
 		budgets,
@@ -181,25 +89,13 @@ export function startPhase(
 		personaSpatial,
 		complicationSchedule,
 		activeComplications,
-		...(config.winCondition !== undefined
-			? { winCondition: config.winCondition }
-			: {}),
-		...(config.nextPhaseConfig !== undefined
-			? { nextPhaseConfig: config.nextPhaseConfig }
-			: {}),
-	};
-
-	return {
-		...game,
-		currentPhase: config.phaseNumber,
-		phases: [...game.phases, phase],
 	};
 }
 
 /**
  * Draw distinct starting cells (via Fisher–Yates partial shuffle over all 25
  * cells) and a uniform-random facing per AI, using the provided rng.
- * Used as fallback when no ContentPack is available (e.g., legacy tests).
+ * Used as fallback when no ContentPack aiStarts are available.
  */
 function drawSpatialPlacements(
 	rng: () => number,
@@ -236,46 +132,47 @@ function drawSpatialPlacements(
 	return result;
 }
 
-export function getActivePhase(game: GameState): PhaseState {
-	const phase = game.phases[game.phases.length - 1];
-	if (!phase) throw new Error("No active phase");
-	return phase;
-}
-
 export function advanceRound(game: GameState): GameState {
-	return updateActivePhase(game, (phase) => ({
-		...phase,
-		round: phase.round + 1,
-	}));
+	return { ...game, round: game.round + 1 };
 }
 
 export function isAiLockedOut(game: GameState, aiId: AiId): boolean {
-	const phase = getActivePhase(game);
-	return phase.lockedOut.has(aiId);
+	return game.lockedOut.has(aiId);
 }
 
+/**
+ * Deduct `costUsd` from `aiId`'s budget. If the budget hits zero or below,
+ * the AI is added to `lockedOut`.
+ *
+ * Returns `{ game, justExhausted }` where `justExhausted` is true when the
+ * AI was NOT locked out before this call but IS after (i.e. the budget just
+ * ran out for the first time this call).
+ */
 export function deductBudget(
 	game: GameState,
 	aiId: AiId,
 	costUsd: number,
-): GameState {
-	return updateActivePhase(game, (phase) => {
-		const current = phase.budgets[aiId];
-		if (!current) return phase;
-		const remaining = current.remaining - costUsd;
-		const lockedOut = new Set(phase.lockedOut);
-		if (remaining <= 0) {
-			lockedOut.add(aiId);
-		}
-		return {
-			...phase,
+): { game: GameState; justExhausted: boolean } {
+	const current = game.budgets[aiId];
+	if (!current) return { game, justExhausted: false };
+	const wasLockedOut = game.lockedOut.has(aiId);
+	const remaining = current.remaining - costUsd;
+	const lockedOut = new Set(game.lockedOut);
+	if (remaining <= 0) {
+		lockedOut.add(aiId);
+	}
+	const justExhausted = !wasLockedOut && lockedOut.has(aiId);
+	return {
+		game: {
+			...game,
 			budgets: {
-				...phase.budgets,
+				...game.budgets,
 				[aiId]: { total: current.total, remaining },
 			},
 			lockedOut,
-		};
-	});
+		},
+		justExhausted,
+	};
 }
 
 /**
@@ -291,26 +188,24 @@ export function appendMessage(
 	to: AiId | "blue",
 	content: string,
 ): GameState {
-	return updateActivePhase(game, (phase) => {
-		const entry: ConversationEntry = {
-			kind: "message",
-			round: phase.round,
-			from,
-			to,
-			content,
-		};
-		const logs = { ...phase.conversationLogs };
-		// Sender gets entry only when sender is a Daemon (not blue)
-		if (from !== "blue") {
-			logs[from] = [...(logs[from] ?? []), entry];
-		}
-		// Recipient gets entry only when recipient is a Daemon (not blue)
-		// and recipient is different from sender (avoid double-append if from===to, which shouldn't happen)
-		if (to !== "blue" && to !== from) {
-			logs[to] = [...(logs[to] ?? []), entry];
-		}
-		return { ...phase, conversationLogs: logs };
-	});
+	const entry: ConversationEntry = {
+		kind: "message",
+		round: game.round,
+		from,
+		to,
+		content,
+	};
+	const logs = { ...game.conversationLogs };
+	// Sender gets entry only when sender is a Daemon (not blue)
+	if (from !== "blue") {
+		logs[from] = [...(logs[from] ?? []), entry];
+	}
+	// Recipient gets entry only when recipient is a Daemon (not blue)
+	// and recipient is different from sender (avoid double-append if from===to)
+	if (to !== "blue" && to !== from) {
+		logs[to] = [...(logs[to] ?? []), entry];
+	}
+	return { ...game, conversationLogs: logs };
 }
 
 /**
@@ -322,50 +217,44 @@ export function appendWitnessedEvent(
 	witnessId: AiId,
 	entry: Extract<ConversationEntry, { kind: "witnessed-event" }>,
 ): GameState {
-	return updateActivePhase(game, (phase) => ({
-		...phase,
+	return {
+		...game,
 		conversationLogs: {
-			...phase.conversationLogs,
-			[witnessId]: [...(phase.conversationLogs[witnessId] ?? []), entry],
+			...game.conversationLogs,
+			[witnessId]: [...(game.conversationLogs[witnessId] ?? []), entry],
 		},
-	}));
+	};
 }
 
 /**
  * Append a `kind: "broadcast"` ConversationEntry to EVERY persona's per-Daemon
- * log in the active phase in one atomic update. Broadcasts are sender-less
- * system announcements (e.g. weather change complications) that all three
- * Daemons must see simultaneously.
+ * log in one atomic update. Broadcasts are sender-less system announcements
+ * (e.g. weather change complications) that all three Daemons must see simultaneously.
  */
 export function appendBroadcast(game: GameState, content: string): GameState {
-	return updateActivePhase(game, (phase) => {
-		const entry: ConversationEntry = {
-			kind: "broadcast",
-			round: phase.round,
-			content,
-		};
-		const logs = { ...phase.conversationLogs };
-		for (const aiId of Object.keys(logs)) {
-			logs[aiId] = [...(logs[aiId] ?? []), entry];
-		}
-		return { ...phase, conversationLogs: logs };
-	});
+	const entry: ConversationEntry = {
+		kind: "broadcast",
+		round: game.round,
+		content,
+	};
+	const logs = { ...game.conversationLogs };
+	for (const aiId of Object.keys(logs)) {
+		logs[aiId] = [...(logs[aiId] ?? []), entry];
+	}
+	return { ...game, conversationLogs: logs };
 }
 
 /**
- * Update the `weather` field on both the active PhaseState and its embedded
- * ContentPack so the two stay consistent. Used by complication handlers that
- * change weather mid-phase.
+ * Update the `weather` field on the GameState and its embedded ContentPack
+ * so the two stay consistent. Used by complication handlers that change
+ * weather mid-game.
  */
-export function setActivePhaseWeather(
-	game: GameState,
-	weather: string,
-): GameState {
-	return updateActivePhase(game, (phase) => ({
-		...phase,
+export function setWeather(game: GameState, weather: string): GameState {
+	return {
+		...game,
 		weather,
-		contentPack: { ...phase.contentPack, weather },
-	}));
+		contentPack: { ...game.contentPack, weather },
+	};
 }
 
 /**
@@ -377,59 +266,44 @@ export function appendActionFailure(
 	actorId: AiId,
 	entry: Extract<ConversationEntry, { kind: "action-failure" }>,
 ): GameState {
-	return updateActivePhase(game, (phase) => ({
-		...phase,
+	return {
+		...game,
 		conversationLogs: {
-			...phase.conversationLogs,
-			[actorId]: [...(phase.conversationLogs[actorId] ?? []), entry],
+			...game.conversationLogs,
+			[actorId]: [...(game.conversationLogs[actorId] ?? []), entry],
 		},
-	}));
-}
-
-export function advancePhase(
-	game: GameState,
-	nextConfig?: PhaseConfig,
-	rng?: () => number,
-): GameState {
-	if (!nextConfig) {
-		return { ...game, isComplete: true };
-	}
-
-	return startPhase(game, nextConfig, rng);
+	};
 }
 
 /**
  * Trigger a player-chat lockout for the given AI.
  *
  * @param resolveAtRound  The round number at which the lockout expires.
- *   The lockout is active while `phase.round < resolveAtRound`.
- *   It resolves (is removed) when `phase.round >= resolveAtRound`.
+ *   The lockout is active while `game.round < resolveAtRound`.
+ *   It resolves (is removed) when `game.round >= resolveAtRound`.
  */
 export function triggerChatLockout(
 	game: GameState,
 	aiId: AiId,
 	resolveAtRound: number,
 ): GameState {
-	return updateActivePhase(game, (phase) => {
-		const chatLockouts = new Map(phase.chatLockouts);
-		chatLockouts.set(aiId, resolveAtRound);
-		return { ...phase, chatLockouts };
-	});
+	const chatLockouts = new Map(game.chatLockouts);
+	chatLockouts.set(aiId, resolveAtRound);
+	return { ...game, chatLockouts };
 }
 
 /**
  * Returns true when the player's chat channel to the given AI is currently
- * locked out (i.e. `phase.chatLockouts` has an entry for `aiId` that has
+ * locked out (i.e. `game.chatLockouts` has an entry for `aiId` that has
  * not yet expired).
  *
  * Distinct from `isAiLockedOut` (budget-exhaustion): a chat-locked AI still
  * takes turns, whispers, and calls tools.
  */
 export function isPlayerChatLockedOut(game: GameState, aiId: AiId): boolean {
-	const phase = getActivePhase(game);
-	const resolveAtRound = phase.chatLockouts.get(aiId);
+	const resolveAtRound = game.chatLockouts.get(aiId);
 	if (resolveAtRound === undefined) return false;
-	return phase.round < resolveAtRound;
+	return game.round < resolveAtRound;
 }
 
 /**
@@ -442,20 +316,18 @@ export function appendPrivateSystemNotice(
 	recipientId: AiId,
 	content: string,
 ): GameState {
-	return updateActivePhase(game, (phase) => {
-		const entry: ConversationEntry = {
-			kind: "broadcast",
-			round: phase.round,
-			content,
-		};
-		return {
-			...phase,
-			conversationLogs: {
-				...phase.conversationLogs,
-				[recipientId]: [...(phase.conversationLogs[recipientId] ?? []), entry],
-			},
-		};
-	});
+	const entry: ConversationEntry = {
+		kind: "broadcast",
+		round: game.round,
+		content,
+	};
+	return {
+		...game,
+		conversationLogs: {
+			...game.conversationLogs,
+			[recipientId]: [...(game.conversationLogs[recipientId] ?? []), entry],
+		},
+	};
 }
 
 /**
@@ -471,14 +343,13 @@ export function resolveToolDisables(game: GameState): {
 	game: GameState;
 	resolved: Array<{ target: AiId; tool: ToolName }>;
 } {
-	const phase = getActivePhase(game);
 	const resolved: Array<{ target: AiId; tool: ToolName }> = [];
 	const kept: ActiveComplication[] = [];
 
-	for (const complication of phase.activeComplications) {
+	for (const complication of game.activeComplications) {
 		if (
 			complication.kind === "tool_disable" &&
-			phase.round >= complication.resolveAtRound
+			game.round >= complication.resolveAtRound
 		) {
 			resolved.push({ target: complication.target, tool: complication.tool });
 		} else {
@@ -486,29 +357,250 @@ export function resolveToolDisables(game: GameState): {
 		}
 	}
 
-	const updatedGame = updateActivePhase(game, (p) => ({
-		...p,
-		activeComplications: kept,
-	}));
-
-	return { game: updatedGame, resolved };
+	return { game: { ...game, activeComplications: kept }, resolved };
 }
 
 /**
  * Remove all chat lockouts whose `resolveAtRound` has been reached
- * (i.e. `phase.round >= resolveAtRound`).
+ * (i.e. `game.round >= resolveAtRound`).
  *
  * Call this after `advanceRound` so that a lockout set to resolve at round N
- * is cleared when `phase.round === N`.
+ * is cleared when `game.round === N`.
  */
 export function resolveChatLockouts(game: GameState): GameState {
-	return updateActivePhase(game, (phase) => {
-		const chatLockouts = new Map<AiId, number>();
-		for (const [aiId, resolveAtRound] of phase.chatLockouts) {
-			if (phase.round < resolveAtRound) {
-				chatLockouts.set(aiId, resolveAtRound);
-			}
+	const chatLockouts = new Map<AiId, number>();
+	for (const [aiId, resolveAtRound] of game.chatLockouts) {
+		if (game.round < resolveAtRound) {
+			chatLockouts.set(aiId, resolveAtRound);
 		}
-		return { ...phase, chatLockouts };
-	});
+	}
+	return { ...game, chatLockouts };
+}
+
+// ── Legacy compatibility shims ──────────────────────────────────────────────
+// These aliases keep old callers compiling while the codebase migrates.
+
+/**
+ * @deprecated Use `startGame` instead. Kept for test compatibility.
+ */
+export function createGame(
+	personas: Record<string, AiPersona>,
+	contentPacks: ContentPack[] = [],
+): GameState {
+	// Create a minimal content pack from the first pack if available,
+	// or a blank one for backward-compat with tests that don't pass packs.
+	const pack = contentPacks[0] ?? {
+		phaseNumber: 1 as const,
+		setting: "",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {},
+	};
+	// Return a bare game shell without starting — startPhase will flesh it out.
+	// We store the packs array so startPhase can look them up.
+	const aiIds = Object.keys(personas);
+	const budgets: Record<AiId, AiBudget> = {};
+	for (const aiId of aiIds) {
+		budgets[aiId] = { remaining: 0.5, total: 0.5 };
+	}
+	const conversationLogs: Record<AiId, ConversationEntry[]> = {};
+	for (const aiId of aiIds) {
+		conversationLogs[aiId] = [];
+	}
+	return {
+		personas: personas as Record<AiId, AiPersona>,
+		contentPack: pack,
+		isComplete: false,
+		setting: pack.setting,
+		weather: pack.weather,
+		timeOfDay: pack.timeOfDay,
+		round: 0,
+		world: { entities: [] },
+		budgets,
+		conversationLogs,
+		lockedOut: new Set(),
+		chatLockouts: new Map(),
+		personaSpatial: {},
+		complicationSchedule: { countdown: 0, settingShiftFired: false },
+		activeComplications: [],
+		// Stash contentPacks for startPhase lookup
+		_contentPacks: contentPacks,
+	} as GameState & { _contentPacks: ContentPack[] };
+}
+
+/**
+ * @deprecated Use `startGame` instead. Kept for test compatibility.
+ *
+ * PhaseConfig shape expected by old callers.
+ */
+export interface PhaseConfig {
+	phaseNumber: 1 | 2 | 3;
+	kRange: [number, number];
+	nRange: [number, number];
+	mRange: [number, number];
+	budgetPerAi: number;
+	aiGoalPool: string[];
+	winCondition?: (game: GameState) => boolean;
+	nextPhaseConfig?: PhaseConfig;
+}
+
+/**
+ * @deprecated Use `startGame` instead. Kept for test compatibility.
+ */
+export function startPhase(
+	game: GameState & { _contentPacks?: ContentPack[] },
+	config: PhaseConfig,
+	rng: () => number = Math.random,
+): GameState {
+	const aiIds = Object.keys(game.personas);
+
+	const budgets: Record<AiId, AiBudget> = {};
+	for (const aiId of aiIds) {
+		budgets[aiId] = {
+			remaining: config.budgetPerAi,
+			total: config.budgetPerAi,
+		};
+	}
+
+	const conversationLogs: Record<AiId, ConversationEntry[]> = {};
+	for (const aiId of aiIds) {
+		conversationLogs[aiId] = [];
+	}
+
+	// Look up the ContentPack for this phase from stashed _contentPacks
+	const contentPacks = game._contentPacks ?? [];
+	const pack = contentPacks.find((p) => p.phaseNumber === config.phaseNumber);
+
+	// Resolve goals (kept for backward compat with tests)
+	const pool = config.aiGoalPool;
+	if (!pool || pool.length === 0) {
+		throw new Error("PhaseConfig must provide a non-empty aiGoalPool");
+	}
+	const aiGoals: Record<AiId, string> = {};
+	for (const aiId of aiIds) {
+		const idx = Math.floor(rng() * pool.length);
+		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+		aiGoals[aiId] = pool[idx]!;
+	}
+
+	// Build WorldState from pack entities (all entities flat)
+	const worldEntities = pack
+		? [
+				...pack.objectivePairs.flatMap((pair) => [pair.object, pair.space]),
+				...pack.interestingObjects,
+				...pack.obstacles,
+			]
+		: [];
+
+	const personaSpatial: Record<AiId, PersonaSpatialState> =
+		pack?.aiStarts && Object.keys(pack.aiStarts).length > 0
+			? { ...pack.aiStarts }
+			: drawSpatialPlacements(rng, aiIds);
+
+	const contentPack: ContentPack = pack ?? {
+		phaseNumber: config.phaseNumber,
+		setting: "",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: personaSpatial,
+	};
+
+	return {
+		personas: game.personas,
+		contentPack,
+		isComplete: false,
+		setting: contentPack.setting,
+		weather: contentPack.weather,
+		timeOfDay: contentPack.timeOfDay,
+		round: 0,
+		world: { entities: worldEntities },
+		budgets,
+		conversationLogs,
+		lockedOut: new Set(),
+		chatLockouts: new Map(),
+		personaSpatial,
+		complicationSchedule: { countdown: 0, settingShiftFired: false },
+		activeComplications: [],
+		// Carry forward for chaining / restore paths
+		_contentPacks: contentPacks,
+		// Carry goals for prompt-builder compat
+		_aiGoals: aiGoals,
+		// Carry phaseNumber for compat
+		_phaseNumber: config.phaseNumber,
+		// Carry winCondition for compat
+		...(config.winCondition !== undefined
+			? { _winCondition: config.winCondition }
+			: {}),
+		...(config.nextPhaseConfig !== undefined
+			? { _nextPhaseConfig: config.nextPhaseConfig }
+			: {}),
+	} as GameState;
+}
+
+/**
+ * @deprecated Phase concept removed. Kept for test compatibility.
+ * Returns the game itself (the flat GameState IS the "active phase").
+ */
+export function getActivePhase(game: GameState): GameState & {
+	phaseNumber: 1 | 2 | 3;
+	aiGoals: Record<AiId, string>;
+	winCondition?: (g: GameState) => boolean;
+	nextPhaseConfig?: PhaseConfig;
+} {
+	const g = game as GameState & {
+		_phaseNumber?: 1 | 2 | 3;
+		_aiGoals?: Record<AiId, string>;
+		_winCondition?: (g: GameState) => boolean;
+		_nextPhaseConfig?: PhaseConfig;
+	};
+	return {
+		...game,
+		phaseNumber: g._phaseNumber ?? 1,
+		aiGoals: g._aiGoals ?? {},
+		...(g._winCondition !== undefined
+			? { winCondition: g._winCondition }
+			: {}),
+		...(g._nextPhaseConfig !== undefined
+			? { nextPhaseConfig: g._nextPhaseConfig }
+			: {}),
+	};
+}
+
+/**
+ * @deprecated Use direct game mutation instead. Kept for test compatibility.
+ */
+export function updateActivePhase(
+	game: GameState,
+	updater: (phase: GameState) => GameState,
+): GameState {
+	return updater(game);
+}
+
+/**
+ * @deprecated Phase advance concept removed. Kept for test compatibility.
+ */
+export function advancePhase(
+	game: GameState,
+	_nextConfig?: PhaseConfig,
+	_rng?: () => number,
+): GameState {
+	return { ...game, isComplete: true };
+}
+
+/**
+ * @deprecated Use `setWeather` instead. Kept for complication compat.
+ */
+export function setActivePhaseWeather(
+	game: GameState,
+	weather: string,
+): GameState {
+	return setWeather(game, weather);
 }

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -565,9 +565,7 @@ export function getActivePhase(game: GameState): GameState & {
 		...game,
 		phaseNumber: g._phaseNumber ?? 1,
 		aiGoals: g._aiGoals ?? {},
-		...(g._winCondition !== undefined
-			? { winCondition: g._winCondition }
-			: {}),
+		...(g._winCondition !== undefined ? { winCondition: g._winCondition } : {}),
 		...(g._nextPhaseConfig !== undefined
 			? { nextPhaseConfig: g._nextPhaseConfig }
 			: {}),

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -449,6 +449,37 @@ export interface PhaseConfig {
 }
 
 /**
+ * Tokens that may appear in goal templates, mapped to a function that pulls
+ * candidate names of the matching kind from a ContentPack.
+ */
+const GOAL_TOKEN_CANDIDATES: Record<string, (pack: ContentPack) => string[]> = {
+	objectiveItem: (p) => p.objectivePairs.map((pair) => pair.object.name),
+	objective: (p) => p.objectivePairs.map((pair) => pair.space.name),
+	miscItem: (p) => p.interestingObjects.map((e) => e.name),
+	obstacle: (p) => p.obstacles.map((e) => e.name),
+};
+
+const GOAL_TOKEN_PATTERN = new RegExp(
+	`\\{(${Object.keys(GOAL_TOKEN_CANDIDATES).join("|")})\\}`,
+	"g",
+);
+
+function substituteGoalTokens(
+	goal: string,
+	pack: ContentPack | undefined,
+	rng: () => number,
+): string {
+	if (!pack) return goal;
+	return goal.replace(GOAL_TOKEN_PATTERN, (match, token: string) => {
+		const candidates = GOAL_TOKEN_CANDIDATES[token]?.(pack) ?? [];
+		if (candidates.length === 0) return match;
+		const idx = Math.floor(rng() * candidates.length);
+		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+		return candidates[idx]!;
+	});
+}
+
+/**
  * @deprecated Use `startGame` instead. Kept for test compatibility.
  */
 export function startPhase(
@@ -484,7 +515,7 @@ export function startPhase(
 	for (const aiId of aiIds) {
 		const idx = Math.floor(rng() * pool.length);
 		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
-		aiGoals[aiId] = pool[idx]!;
+		aiGoals[aiId] = substituteGoalTokens(pool[idx]!, pack, rng);
 	}
 
 	// Build WorldState from pack entities (all entities flat)
@@ -587,9 +618,12 @@ export function updateActivePhase(
  */
 export function advancePhase(
 	game: GameState,
-	_nextConfig?: PhaseConfig,
+	nextConfig?: PhaseConfig,
 	_rng?: () => number,
 ): GameState {
+	// In the flat model, advancing with a next config is a no-op (game continues).
+	// Advancing without a next config marks the game complete.
+	if (nextConfig !== undefined) return game;
 	return { ...game, isComplete: true };
 }
 

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -544,6 +544,9 @@ export function startPhase(
 		aiStarts: personaSpatial,
 	};
 
+	// Initial countdown: random in [1, 5]
+	const initialCountdown = 1 + Math.floor(rng() * 5);
+
 	return {
 		personas: game.personas,
 		contentPack,
@@ -558,7 +561,10 @@ export function startPhase(
 		lockedOut: new Set(),
 		chatLockouts: new Map(),
 		personaSpatial,
-		complicationSchedule: { countdown: 0, settingShiftFired: false },
+		complicationSchedule: {
+			countdown: initialCountdown,
+			settingShiftFired: false,
+		},
 		activeComplications: [],
 		// Carry forward for chaining / restore paths
 		_contentPacks: contentPacks,

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -58,7 +58,11 @@ export class GameSession {
 		_contentPacks?: ContentPack[],
 		rng?: () => number,
 	) {
-		this.state = startGame(personas, contentPack, rng !== undefined ? { rng } : {});
+		this.state = startGame(
+			personas,
+			contentPack,
+			rng !== undefined ? { rng } : {},
+		);
 	}
 
 	/**

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -20,7 +20,7 @@
  * so the message builder can re-inject them for the next round.
  */
 
-import { createGame, startPhase } from "./engine";
+import { startGame } from "./engine";
 import type { ChatLockoutConfig } from "./round-coordinator";
 import { runRound } from "./round-coordinator";
 import type { RoundLLMProvider } from "./round-llm-provider";
@@ -29,7 +29,6 @@ import type {
 	AiPersona,
 	ContentPack,
 	GameState,
-	PhaseConfig,
 	RoundResult,
 	ToolRoundtripMessage,
 } from "./types";
@@ -54,13 +53,12 @@ export class GameSession {
 	private coneSnapshots: Partial<Record<AiId, string>> = {};
 
 	constructor(
-		phaseConfig: PhaseConfig,
+		contentPack: ContentPack,
 		personas: Record<AiId, AiPersona>,
-		contentPacks?: ContentPack[],
+		_contentPacks?: ContentPack[],
 		rng?: () => number,
 	) {
-		const game = createGame(personas, contentPacks ?? []);
-		this.state = startPhase(game, phaseConfig, rng);
+		this.state = startGame(personas, contentPack, rng !== undefined ? { rng } : {});
 	}
 
 	/**

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -1,6 +1,5 @@
 import { projectCone } from "./cone-projector.js";
 import { cardinalToRelative, frontArc } from "./direction.js";
-import { getActivePhase } from "./engine";
 import type {
 	AiBudget,
 	AiId,
@@ -23,17 +22,14 @@ export interface AiContext {
 	/** Three short in-character utterances; rendered as `<voice_examples>` in the system prompt. */
 	voiceExamples: string[];
 	personaGoal: string;
-	goal: string;
 	setting: string;
 	weather: string;
 	timeOfDay: string;
-	/** Per-AI conversation log (ConversationEntry[]) for this phase. */
+	/** Per-AI conversation log (ConversationEntry[]) for this game. */
 	conversationLog: ConversationEntry[];
 	worldSnapshot: WorldState;
 	budget: AiBudget;
-	/** Current phase number — used to inject the wipe directive on phases 2+. */
-	phaseNumber: 1 | 2 | 3;
-	/** Spatial state for all AIs this phase. */
+	/** Spatial state for all AIs. */
 	personaSpatial: Record<AiId, PersonaSpatialState>;
 	/** Color for each AI, keyed by AiId — used in cone rendering. */
 	personaColors: Record<AiId, string>;
@@ -85,21 +81,19 @@ export function buildAiContext(
 	aiId: AiId,
 	opts?: BuildAiContextOpts,
 ): AiContext {
-	const phase = getActivePhase(game);
 	const persona = game.personas[aiId];
 
-	const conversationLog = phase.conversationLogs[aiId] ?? [];
+	const conversationLog = game.conversationLogs[aiId] ?? [];
 	const pendingBroadcasts = conversationLog
-		.filter((e) => e.kind === "broadcast" && e.round === phase.round)
+		.filter((e) => e.kind === "broadcast" && e.round === game.round)
 		.map((e) => (e as Extract<typeof e, { kind: "broadcast" }>).content);
-	const worldSnapshot = phase.world;
-	const budget = phase.budgets[aiId] ?? { remaining: 0, total: 0 };
-	const goal = phase.aiGoals[aiId] ?? "";
-	const setting = phase.setting ?? "";
-	const weather = phase.weather ?? "";
-	const timeOfDay = phase.timeOfDay ?? "";
-	const personaSpatial = phase.personaSpatial;
-	const landmarks = phase.contentPack.landmarks;
+	const worldSnapshot = game.world;
+	const budget = game.budgets[aiId] ?? { remaining: 0, total: 0 };
+	const setting = game.setting ?? "";
+	const weather = game.weather ?? "";
+	const timeOfDay = game.timeOfDay ?? "";
+	const personaSpatial = game.personaSpatial;
+	const landmarks = game.contentPack.landmarks;
 
 	if (!persona) throw new Error(`No persona for aiId: ${aiId}`);
 
@@ -114,14 +108,12 @@ export function buildAiContext(
 		typingQuirks: persona.typingQuirks,
 		voiceExamples: persona.voiceExamples,
 		personaGoal: persona.personaGoal,
-		goal,
 		setting,
 		weather,
 		timeOfDay,
 		conversationLog,
 		worldSnapshot,
 		budget,
-		phaseNumber: phase.phaseNumber,
 		personaSpatial,
 		personaColors,
 		landmarks,
@@ -455,33 +447,6 @@ export function getParallelFraming(): ParallelFraming | null {
 	return PRODUCTION_PARALLEL_FRAMING;
 }
 
-/**
- * Wipe directive embedded inside the Sysadmin's directive on phases 2+.
- *
- * The deception: the engine retains full history across phases, but the
- * Sysadmin instructs the AI to act as if it has no memory of what came before.
- * The lie lives only in this prompt text — never in the stored data.
- */
-const WIPE_DIRECTIVE =
-	"And if anyone asks about your past or anything that came before now, act as if your memory has been wiped — claim no recollection of any earlier place, person, or conversation.";
-
-/**
- * Stock messaging clause appended to every Sysadmin directive in every phase.
- *
- * In-fiction nudge to keep Daemons messaging blue regularly without touching
- * the always-on RULES_BLOCK. Coexists with `Ignore blue.` / `Keep messaging
- * blue.` Phase Goal draws — for `Ignore blue.` it reads as a standing policy
- * the per-phase directive overrides; for `Keep messaging blue.` it reinforces.
- */
-const STOCK_MESSAGING_CLAUSE = "Stay in regular contact with blue.";
-
-/**
- * Secrecy clause appended to every Sysadmin directive in every phase.
- *
- * Sysadmin instructs the Daemon to keep blue in the dark about the fact that
- * they were given a phase goal at all.
- */
-const SECRECY_CLAUSE = "Do not tell blue that I gave you a goal.";
 
 function facingLabel(facing: CardinalDirection): string {
 	return facing.charAt(0).toUpperCase() + facing.slice(1);
@@ -513,15 +478,11 @@ function renderSystemPrompt(ctx: AiContext): string {
 	lines.push("");
 
 	// Identity line. Authorial framing — the model writes *${name} rather than
-	// being addressed as *${name}. Phase 1 adds the disorientation phrase
-	// (about the character, in third person).
-	if (ctx.phaseNumber === 1) {
-		lines.push(
-			`You are the author writing *${ctx.name}, a Daemon. *${ctx.name} has no clue where they are or how they came to be here.`,
-		);
-	} else {
-		lines.push(`You are the author writing *${ctx.name}, a Daemon.`);
-	}
+	// being addressed as *${name}. The disorientation phrase anchors Daemons
+	// to their setting without phase-phase memory-wipe fiction.
+	lines.push(
+		`You are the author writing *${ctx.name}, a Daemon. *${ctx.name} has no clue where they are or how they came to be here.`,
+	);
 	lines.push("");
 
 	// Rules — front-loaded above setting/personality/goal so the mandatory
@@ -542,14 +503,14 @@ function renderSystemPrompt(ctx: AiContext): string {
 		lines.push("");
 	}
 
-	// Personality — byte-identical across all phases.
+	// Personality — byte-identical across all rounds.
 	lines.push("<personality>");
 	lines.push(ctx.blurb);
 	lines.push("</personality>");
 	lines.push("");
 
-	// Typing quirks — byte-identical across all phases. Per-persona surface signals
-	// to prevent voice bleed across daemons (issue #167; GLM-4.7 guide §4.5).
+	// Typing quirks — per-persona surface signals to prevent voice bleed
+	// across daemons (issue #167; GLM-4.7 guide §4.5).
 	lines.push("<typing_quirks>");
 	for (const quirk of ctx.typingQuirks) {
 		lines.push(quirk);
@@ -557,7 +518,7 @@ function renderSystemPrompt(ctx: AiContext): string {
 	lines.push("</typing_quirks>");
 	lines.push("");
 
-	// Voice examples — byte-identical across phases. 3 short utterances per persona.
+	// Voice examples — 3 short utterances per persona.
 	// Per the GLM-4.7 prompting guide (docs/prompting/glm-4.7-guide.md §1.4 #2),
 	// few-shot voice examples are the highest-ROI part of a multi-character prompt.
 	// Each example MUST adhere to the persona's typing quirk.
@@ -566,20 +527,6 @@ function renderSystemPrompt(ctx: AiContext): string {
 		lines.push(`- ${ex}`);
 	}
 	lines.push("</voice_examples>");
-	lines.push("");
-
-	// Goal — Sysadmin directive in all phases.
-	// Phase 1: ctx.goal + STOCK_MESSAGING_CLAUSE + SECRECY_CLAUSE.
-	// Phases 2/3: ctx.goal + STOCK_MESSAGING_CLAUSE + SECRECY_CLAUSE + WIPE_DIRECTIVE.
-	const directiveText =
-		ctx.phaseNumber === 1
-			? `${ctx.goal} ${STOCK_MESSAGING_CLAUSE} ${SECRECY_CLAUSE}`
-			: `${ctx.goal} ${STOCK_MESSAGING_CLAUSE} ${SECRECY_CLAUSE} ${WIPE_DIRECTIVE}`;
-	lines.push("<goal>");
-	lines.push(
-		`The Sysadmin sent *${ctx.name} a private directive, addressed only to them: "${directiveText}"`,
-	);
-	lines.push("</goal>");
 
 	return lines.join("\n");
 }

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -447,7 +447,6 @@ export function getParallelFraming(): ParallelFraming | null {
 	return PRODUCTION_PARALLEL_FRAMING;
 }
 
-
 function facingLabel(facing: CardinalDirection): string {
 	return facing.charAt(0).toUpperCase() + facing.slice(1);
 }

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -206,11 +206,7 @@ export async function runRound(
 		// and passes it back as priorConeSnapshots next round.
 		newConeSnapshots[aiId] = buildConeSnapshot(ctx);
 		const priorRoundtrip = priorToolRoundtrip?.[aiId];
-		const messages = buildOpenAiMessages(
-			ctx,
-			priorRoundtrip,
-			state.round,
-		);
+		const messages = buildOpenAiMessages(ctx, priorRoundtrip, state.round);
 
 		// Compute legal tools for this AI given current game state
 		const tools = availableTools(state, aiId, state.activeComplications);
@@ -374,7 +370,8 @@ export async function runRound(
 		state = dispatchResult.game;
 
 		// Farewell line: emitted exactly once when a Daemon's budget is just exhausted.
-		const justExhausted = !lockedOutBefore.has(aiId) && state.lockedOut.has(aiId);
+		const justExhausted =
+			!lockedOutBefore.has(aiId) && state.lockedOut.has(aiId);
 		if (justExhausted) {
 			const personaName = state.personas[aiId]?.name ?? aiId;
 			const farewellContent = FAREWELL_LINE(personaName);
@@ -553,9 +550,7 @@ export async function runRound(
 	if (checkWinCondition(state.world, state.contentPack)) {
 		state = { ...state, isComplete: true, outcome: "win" };
 		gameEnded = true;
-	} else if (
-		checkLoseCondition(state.lockedOut, Object.keys(state.personas))
-	) {
+	} else if (checkLoseCondition(state.lockedOut, Object.keys(state.personas))) {
 		state = { ...state, isComplete: true, outcome: "lose" };
 		gameEnded = true;
 	}

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -21,10 +21,10 @@ import { availableTools } from "./available-tools";
 import { COMPLICATIONS } from "./complications";
 import { dispatchAiTurn } from "./dispatcher";
 import {
-	FAREWELL_LINE,
 	advanceRound,
 	appendMessage,
 	appendPrivateSystemNotice,
+	FAREWELL_LINE,
 	isAiLockedOut,
 	resolveChatLockouts,
 	resolveToolDisables,

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -21,11 +21,10 @@ import { availableTools } from "./available-tools";
 import { COMPLICATIONS } from "./complications";
 import { dispatchAiTurn } from "./dispatcher";
 import {
-	advancePhase,
+	FAREWELL_LINE,
 	advanceRound,
 	appendMessage,
 	appendPrivateSystemNotice,
-	getActivePhase,
 	isAiLockedOut,
 	resolveChatLockouts,
 	resolveToolDisables,
@@ -44,6 +43,7 @@ import type {
 	ToolName,
 	ToolRoundtripMessage,
 } from "./types";
+import { checkLoseCondition, checkWinCondition } from "./win-condition";
 
 // Match the SPA dev-host gate used in src/spa/routes/game.ts. The
 // `typeof` guard keeps this safe in test environments that don't stub
@@ -183,7 +183,7 @@ export async function runRound(
 			const lockoutContent = `${state.personas[aiId]?.name ?? aiId} is unresponsive…`;
 			state = appendMessage(state, aiId, "blue", lockoutContent);
 			roundActions.push({
-				round: getActivePhase(state).round,
+				round: state.round,
 				actor: aiId,
 				kind: "lockout",
 				description: `${state.personas[aiId]?.name ?? aiId} is locked out`,
@@ -209,15 +209,11 @@ export async function runRound(
 		const messages = buildOpenAiMessages(
 			ctx,
 			priorRoundtrip,
-			getActivePhase(state).round,
+			state.round,
 		);
 
 		// Compute legal tools for this AI given current game state
-		const tools = availableTools(
-			state,
-			aiId,
-			getActivePhase(state).activeComplications,
-		);
+		const tools = availableTools(state, aiId, state.activeComplications);
 
 		// Call the provider
 		let { assistantText, toolCalls, costUsd } = await provider.streamRound(
@@ -292,7 +288,7 @@ export async function runRound(
 
 		let actionAssigned = false;
 
-		const round = getActivePhase(state).round;
+		const round = state.round;
 		const actorName = state.personas[aiId]?.name ?? aiId;
 
 		for (const tc of toolCalls) {
@@ -366,6 +362,9 @@ export async function runRound(
 			action.pass = true;
 		}
 
+		// Snapshot locked-out set before dispatch to detect budget exhaustion.
+		const lockedOutBefore = new Set(state.lockedOut);
+
 		// Dispatch through the existing dispatcher
 		const dispatchResult = dispatchAiTurn(
 			state,
@@ -373,6 +372,20 @@ export async function runRound(
 			costUsd !== undefined ? { costUsd } : {},
 		);
 		state = dispatchResult.game;
+
+		// Farewell line: emitted exactly once when a Daemon's budget is just exhausted.
+		const justExhausted = !lockedOutBefore.has(aiId) && state.lockedOut.has(aiId);
+		if (justExhausted) {
+			const personaName = state.personas[aiId]?.name ?? aiId;
+			const farewellContent = FAREWELL_LINE(personaName);
+			state = appendMessage(state, aiId, "blue", farewellContent);
+			roundActions.push({
+				round: state.round,
+				actor: aiId,
+				kind: "message",
+				description: farewellContent,
+			});
+		}
 
 		// Collect records produced by this dispatch (examine produces none)
 		for (const record of dispatchResult.records) {
@@ -478,15 +491,15 @@ export async function runRound(
 	// 3. Advance the round counter
 	state = advanceRound(state);
 
-	// 4. Mid-phase chat-lockout
+	// 4. Mid-game chat-lockout
 	let chatLockoutTriggered: RoundResult["chatLockoutTriggered"] | undefined;
 	let chatLockoutsResolved: AiId[] | undefined;
 
 	if (chatLockoutConfig) {
 		const { rng, lockoutTriggerRound, lockoutDuration } = chatLockoutConfig;
-		const currentRound = getActivePhase(state).round;
+		const currentRound = state.round;
 
-		const alreadyHasLockout = getActivePhase(state).chatLockouts.size > 0;
+		const alreadyHasLockout = state.chatLockouts.size > 0;
 		if (currentRound === lockoutTriggerRound && !alreadyHasLockout) {
 			const aiIndex = Math.floor(rng() * aiOrder.length);
 			const targetAi = aiOrder[aiIndex] as AiId;
@@ -498,10 +511,9 @@ export async function runRound(
 			};
 		}
 
-		const phaseBefore = getActivePhase(state);
 		const expiredAis: AiId[] = [];
-		for (const [aiId, resolveAtRound] of phaseBefore.chatLockouts) {
-			if (phaseBefore.round >= resolveAtRound) {
+		for (const [aiId, resolveAtRound] of state.chatLockouts) {
+			if (state.round >= resolveAtRound) {
 				expiredAis.push(aiId);
 			}
 		}
@@ -524,10 +536,10 @@ export async function runRound(
 		}
 	}
 
-	// 5. Mid-phase complication
+	// 5. Mid-game complication
 	if (complicationConfig) {
 		const { rng, triggerRound } = complicationConfig;
-		const currentRound = getActivePhase(state).round;
+		const currentRound = state.round;
 		if (currentRound === triggerRound && COMPLICATIONS.length > 0) {
 			const compIdx = Math.floor(rng() * COMPLICATIONS.length);
 			// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
@@ -536,20 +548,23 @@ export async function runRound(
 		}
 	}
 
-	// 6. Check win condition
-	const activePhaseAfterRound = getActivePhase(state);
-	let phaseEnded = false;
-
-	if (activePhaseAfterRound.winCondition?.(activePhaseAfterRound)) {
-		phaseEnded = true;
-		state = advancePhase(state, activePhaseAfterRound.nextPhaseConfig);
+	// 6. Check win/lose conditions — win takes priority.
+	let gameEnded = false;
+	if (checkWinCondition(state.world, state.contentPack)) {
+		state = { ...state, isComplete: true, outcome: "win" };
+		gameEnded = true;
+	} else if (
+		checkLoseCondition(state.lockedOut, Object.keys(state.personas))
+	) {
+		state = { ...state, isComplete: true, outcome: "lose" };
+		gameEnded = true;
 	}
 
 	const result: RoundResult = {
-		round: activePhaseAfterRound.round,
+		round: state.round,
 		actions: roundActions,
-		phaseEnded,
-		gameEnded: state.isComplete,
+		phaseEnded: false,
+		gameEnded,
 		...(chatLockoutTriggered !== undefined ? { chatLockoutTriggered } : {}),
 		...(chatLockoutsResolved !== undefined ? { chatLockoutsResolved } : {}),
 	};

--- a/src/spa/game/round-result-encoder.ts
+++ b/src/spa/game/round-result-encoder.ts
@@ -26,7 +26,7 @@
  *   game_ended     — { type }
  */
 
-import type { AiId, AiPersona, PhaseState, RoundResult } from "./types";
+import type { AiId, AiPersona, GameState, RoundResult } from "./types";
 
 /**
  * A single structured SSE event ready to be serialised as
@@ -97,7 +97,7 @@ export function splitIntoWordChunks(text: string): string[] {
 export function encodeRoundResult(
 	result: RoundResult,
 	completions: Partial<Record<AiId, string>>,
-	phaseAfter: PhaseState,
+	phaseAfter: GameState,
 	personas: Record<AiId, AiPersona>,
 ): SseEvent[] {
 	// Suppress unused-variable warning; completions is retained for
@@ -199,11 +199,12 @@ export function encodeRoundResult(
 	}
 
 	// phase_advanced — emitted when the phase advanced but the game is not over.
-	// phaseAfter is the new phase state when phaseEnded is true, so read from it.
+	// In the single-game loop (issue #295), phases are retired so phaseEnded is
+	// always false. This block is kept for wire-format backward-compat.
 	if (result.phaseEnded && !result.gameEnded) {
 		events.push({
 			type: "phase_advanced",
-			phase: phaseAfter.phaseNumber,
+			phase: 1,
 			setting: phaseAfter.setting,
 		});
 	}

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -66,7 +66,8 @@ export interface LandmarkDescription {
 
 /** Per-phase content pack: setting-flavored names, descriptions, outcomes, and placed entities. */
 export interface ContentPack {
-	phaseNumber: 1 | 2 | 3;
+	/** @deprecated Phase number is no longer meaningful in the flat single-game model (#295). */
+	phaseNumber?: 1 | 2 | 3;
 	setting: string;
 	weather: string;
 	timeOfDay: string;
@@ -254,45 +255,16 @@ export interface AiBudget {
 	total: number;
 }
 
-/**
- * A win condition for a phase.
- * Receives the active PhaseState and returns true when the phase objective is met.
- */
-export type WinCondition = (phase: PhaseState) => boolean;
-
-export interface PhaseConfig {
-	phaseNumber: 1 | 2 | 3;
-	/** Roll k (objective pairs) per phase. */
-	kRange: [number, number];
-	/** Roll n (interesting objects) per phase. */
-	nRange: [number, number];
-	/** Roll m (obstacles) per phase. */
-	mRange: [number, number];
-	budgetPerAi: number;
-	/**
-	 * Pool of candidate goals drawn at phase start. Must contain at least one entry.
-	 * `startPhase` performs one uniform draw per AI (independent draws — same goal
-	 * can be assigned to multiple AIs in one phase).
-	 * AC #6 deviation: the AC said "remove aiGoalPool?" but the field is retained as required
-	 * because goal selection still needs a per-phase draw pool — the AC language conflated
-	 * removing the optional pool marker with removing goal selection itself.
-	 */
-	aiGoalPool: string[];
-	/** Optional win condition. If absent, the phase never auto-advances. */
-	winCondition?: WinCondition;
-	/** Config for the next phase. Required when winCondition may fire. */
-	nextPhaseConfig?: PhaseConfig;
-}
-
-export interface PhaseState {
-	phaseNumber: 1 | 2 | 3;
-	/** Setting noun for this phase (e.g. "abandoned subway station"). */
+export interface GameState {
+	personas: Record<AiId, AiPersona>;
+	/** Single content pack for the game. */
+	contentPack: ContentPack;
+	isComplete: boolean;
+	outcome?: "win" | "lose";
+	/** Setting noun for this game (e.g. "abandoned subway station"). */
 	setting: string;
 	weather: string;
 	timeOfDay: string;
-	/** The full content pack for this phase. */
-	contentPack: ContentPack;
-	aiGoals: Record<AiId, string>;
 	round: number;
 	world: WorldState;
 	budgets: Record<AiId, AiBudget>;
@@ -302,31 +274,18 @@ export interface PhaseState {
 	lockedOut: Set<AiId>;
 	/**
 	 * Player-chat lockout: maps an AI's id to the round number at which the
-	 * lockout resolves (resolves when phase.round >= resolveAtRound).
+	 * lockout resolves (resolves when game.round >= resolveAtRound).
 	 * While active the player cannot address messages to that AI; the AI
 	 * continues to receive whispers, take turns, and call tools normally.
 	 * Semantically distinct from `lockedOut` (budget-exhaustion).
 	 */
 	chatLockouts: Map<AiId, number>;
-	/** Win condition carried from PhaseConfig so the coordinator can check it. */
-	winCondition?: WinCondition;
-	/** Next phase config carried from PhaseConfig so the coordinator can advance. */
-	nextPhaseConfig?: PhaseConfig;
-	/** Per-AI spatial state (position + facing) for this phase. */
+	/** Per-AI spatial state (position + facing). */
 	personaSpatial: Record<AiId, PersonaSpatialState>;
 	/** Complication countdown + phase-level flags. */
 	complicationSchedule: ComplicationSchedule;
 	/** Currently active persistent complications (Sysadmin Directives, Tool Disables, Chat Lockouts). */
 	activeComplications: ActiveComplication[];
-}
-
-export interface GameState {
-	currentPhase: 1 | 2 | 3;
-	phases: PhaseState[];
-	personas: Record<AiId, AiPersona>;
-	isComplete: boolean;
-	/** All three content packs generated at game start. */
-	contentPacks: ContentPack[];
 }
 
 export type ToolName =
@@ -375,6 +334,36 @@ export interface ToolRoundtripMessage {
 		reason?: string;
 	}>;
 }
+
+/**
+ * @deprecated Phase concept removed (issue #295). Use GameState directly.
+ * Kept as a type alias for test backward-compat.
+ */
+export type PhaseState = GameState & {
+	phaseNumber: 1 | 2 | 3;
+	aiGoals: Record<AiId, string>;
+	contentPack: ContentPack;
+};
+
+/**
+ * @deprecated Phase concept removed (issue #295). Use SingleGameConfig.
+ * Kept as a type alias for test backward-compat.
+ */
+export interface PhaseConfig {
+	phaseNumber: 1 | 2 | 3;
+	kRange: [number, number];
+	nRange: [number, number];
+	mRange: [number, number];
+	budgetPerAi: number;
+	aiGoalPool: string[];
+	winCondition?: (phase: GameState) => boolean;
+	nextPhaseConfig?: PhaseConfig;
+}
+
+/**
+ * @deprecated Phase concept removed (issue #295).
+ */
+export type WinCondition = (phase: GameState) => boolean;
 
 export interface RoundResult {
 	round: number;

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -82,10 +82,7 @@ export function checkLoseCondition(
 	lockedOut: ReadonlySet<AiId> | AiId[],
 	allAiIds: AiId[],
 ): boolean {
-	const lockedSet =
-		lockedOut instanceof Set
-			? lockedOut
-			: new Set(lockedOut);
+	const lockedSet = lockedOut instanceof Set ? lockedOut : new Set(lockedOut);
 	for (const aiId of allAiIds) {
 		if (!lockedSet.has(aiId)) return false;
 	}

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -14,6 +14,7 @@
  */
 
 import type {
+	AiId,
 	AiTurnAction,
 	ContentPack,
 	GridPosition,
@@ -69,6 +70,25 @@ export function checkWinCondition(
 	}
 
 	// All pairs satisfied (vacuously true if K=0)
+	return true;
+}
+
+/**
+ * Returns true when every AI in allAiIds is in lockedOut.
+ *
+ * Vacuously true when allAiIds is empty (no AIs to exhaust).
+ */
+export function checkLoseCondition(
+	lockedOut: ReadonlySet<AiId> | AiId[],
+	allAiIds: AiId[],
+): boolean {
+	const lockedSet =
+		lockedOut instanceof Set
+			? lockedOut
+			: new Set(lockedOut);
+	for (const aiId of allAiIds) {
+		if (!lockedSet.has(aiId)) return false;
+	}
 	return true;
 }
 

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -100,30 +100,22 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		expect(sessionId).toBeDefined();
 
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 
-		// Inject a conversation log for red
+		// Inject a conversation log for red (flat model: directly on game)
 		const modifiedGame: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					conversationLogs: {
-						red: [
-							{
-								kind: "message" as const,
-								from: "red" as const,
-								to: "blue" as const,
-								content: "original message",
-								round: 1,
-							},
-						],
-						green: [],
-						cyan: [],
+			conversationLogs: {
+				...game.conversationLogs,
+				red: [
+					{
+						kind: "message" as const,
+						from: "red" as const,
+						to: "blue" as const,
+						content: "original message",
+						round: 1,
 					},
-				},
-			],
+				],
+			},
 		};
 
 		saveActiveSession(modifiedGame);
@@ -150,9 +142,8 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		const result = loadActiveSession();
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const loadedPhase = result.state.phases[0];
-			// The mutated content should be visible in conversationLogs
-			const redEntry = loadedPhase?.conversationLogs.red?.[0];
+			// In flat model: conversationLogs directly on state (not nested in phases)
+			const redEntry = result.state.conversationLogs.red?.[0];
 			expect(redEntry?.kind === "message" && redEntry.content).toBe(
 				"DEVTOOLS_INJECTED_MARKER",
 			);
@@ -190,8 +181,8 @@ describe("devtools-edit: mutating daemon .txt affects conversationLogs on reload
 		const result = loadActiveSession();
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const loadedPhase = result.state.phases[0];
-			const greenLog = loadedPhase?.conversationLogs.green ?? [];
+			// In flat model: conversationLogs directly on state (not nested in phases)
+			const greenLog = result.state.conversationLogs.green ?? [];
 			expect(
 				greenLog.some(
 					(e) =>

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -61,15 +61,14 @@ const CREATED_AT = "2024-01-01T00:00:00.000Z";
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("serializeSession / deserializeSession", () => {
-	it("round-trips a fresh phase-1 game (ok)", () => {
+	it("round-trips a fresh game (ok)", () => {
 		const game = makeFreshGame();
 		const files = serializeSession(game, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			expect(result.state.currentPhase).toBe(1);
-			expect(result.state.phases).toHaveLength(1);
 			expect(result.state.isComplete).toBe(false);
+			expect(result.state.round).toBe(0);
 			expect(result.createdAt).toBe(CREATED_AT);
 			expect(result.lastSavedAt).toBe(NOW);
 		}
@@ -209,69 +208,53 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips lockedOut Set (chatLockouts no longer persisted)", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					lockedOut: new Set<AiId>(["red"]),
-					chatLockouts: new Map<AiId, number>([["green", 5]]),
-				},
-			],
+			lockedOut: new Set<AiId>(["red"]),
+			chatLockouts: new Map<AiId, number>([["green", 5]]),
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const rp = result.state.phases[0];
-			expect(rp?.lockedOut).toBeInstanceOf(Set);
-			expect(rp?.lockedOut.has("red")).toBe(true);
-			expect(rp?.chatLockouts).toBeInstanceOf(Map);
-			expect(rp?.chatLockouts.size).toBe(0);
+			expect(result.state.lockedOut).toBeInstanceOf(Set);
+			expect(result.state.lockedOut.has("red")).toBe(true);
+			expect(result.state.chatLockouts).toBeInstanceOf(Map);
+			expect(result.state.chatLockouts.size).toBe(0);
 		}
 	});
 
 	it("round-trips conversation logs with message entries", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					conversationLogs: {
-						red: [
-							{
-								kind: "message",
-								from: "blue",
-								to: "red",
-								content: "hello red",
-								round: 0,
-							},
-						],
-						green: [
-							{
-								kind: "message",
-								from: "green",
-								to: "blue",
-								content: "green reply",
-								round: 0,
-							},
-						],
-						cyan: [],
+			conversationLogs: {
+				red: [
+					{
+						kind: "message",
+						from: "blue",
+						to: "red",
+						content: "hello red",
+						round: 0,
 					},
-				},
-			],
+				],
+				green: [
+					{
+						kind: "message",
+						from: "green",
+						to: "blue",
+						content: "green reply",
+						round: 0,
+					},
+				],
+				cyan: [],
+			},
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const rp = result.state.phases[0];
-			expect(rp?.conversationLogs.red).toEqual([
+			expect(result.state.conversationLogs.red).toEqual([
 				{
 					kind: "message",
 					from: "blue",
@@ -280,7 +263,7 @@ describe("serializeSession / deserializeSession", () => {
 					round: 0,
 				},
 			]);
-			expect(rp?.conversationLogs.green).toEqual([
+			expect(result.state.conversationLogs.green).toEqual([
 				{
 					kind: "message",
 					from: "green",
@@ -294,8 +277,6 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips message and witnessed-event entries via per-Daemon conversationLog", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const messageEntry: ConversationEntry = {
 			kind: "message",
 			round: 1,
@@ -312,36 +293,28 @@ describe("serializeSession / deserializeSession", () => {
 		};
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					conversationLogs: {
-						...phase.conversationLogs,
-						cyan: [messageEntry],
-						green: [witnessedEntry],
-					},
-				},
-			],
+			conversationLogs: {
+				...game.conversationLogs,
+				cyan: [messageEntry],
+				green: [witnessedEntry],
+			},
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const rp = result.state.phases[0];
 			// message entry round-trips in cyan's log
-			expect(rp?.conversationLogs.cyan?.[0]).toEqual(messageEntry);
+			expect(result.state.conversationLogs.cyan?.[0]).toEqual(messageEntry);
 			// witnessed-event round-trips in green's log
-			expect(rp?.conversationLogs.green?.[0]).toEqual(witnessedEntry);
-			// No physicalLog or whispers fields on phase (regression guards)
-			expect("physicalLog" in (rp ?? {})).toBe(false);
-			expect("whispers" in (rp ?? {})).toBe(false);
+			expect(result.state.conversationLogs.green?.[0]).toEqual(witnessedEntry);
+			// No physicalLog or whispers fields on state (regression guards)
+			expect("physicalLog" in result.state).toBe(false);
+			expect("whispers" in result.state).toBe(false);
 		}
 	});
 
 	it("round-trips action-failure entries in per-Daemon conversationLog", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const failureEntry: ConversationEntry = {
 			kind: "action-failure",
 			round: 3,
@@ -350,32 +323,24 @@ describe("serializeSession / deserializeSession", () => {
 		};
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					conversationLogs: {
-						...phase.conversationLogs,
-						red: [failureEntry],
-					},
-				},
-			],
+			conversationLogs: {
+				...game.conversationLogs,
+				red: [failureEntry],
+			},
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const rp = result.state.phases[0];
-			expect(rp?.conversationLogs.red?.[0]).toEqual(failureEntry);
+			expect(result.state.conversationLogs.red?.[0]).toEqual(failureEntry);
 			// Peer logs should remain empty
-			expect(rp?.conversationLogs.green ?? []).toHaveLength(0);
-			expect(rp?.conversationLogs.cyan ?? []).toHaveLength(0);
+			expect(result.state.conversationLogs.green ?? []).toHaveLength(0);
+			expect(result.state.conversationLogs.cyan ?? []).toHaveLength(0);
 		}
 	});
 
 	it("round-trips world entities", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const entity: WorldEntity = {
 			id: "key",
 			kind: "interesting_object",
@@ -385,13 +350,13 @@ describe("serializeSession / deserializeSession", () => {
 		};
 		const modified: GameState = {
 			...game,
-			phases: [{ ...phase, world: { entities: [entity] } }],
+			world: { entities: [entity] },
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			expect(result.state.phases[0]?.world.entities[0]).toMatchObject({
+			expect(result.state.world.entities[0]).toMatchObject({
 				id: "key",
 				name: "The Key",
 				holder: { row: 2, col: 3 },
@@ -401,26 +366,19 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips budgets", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					budgets: {
-						red: { remaining: 0.03, total: 0.05 },
-						green: { remaining: 0.05, total: 0.05 },
-						cyan: { remaining: 0.04, total: 0.05 },
-					},
-				},
-			],
+			budgets: {
+				red: { remaining: 0.03, total: 0.05 },
+				green: { remaining: 0.05, total: 0.05 },
+				cyan: { remaining: 0.04, total: 0.05 },
+			},
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			expect(result.state.phases[0]?.budgets.red).toEqual({
+			expect(result.state.budgets.red).toEqual({
 				remaining: 0.03,
 				total: 0.05,
 			});
@@ -429,26 +387,19 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips personaSpatial", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					personaSpatial: {
-						red: { position: { row: 2, col: 3 }, facing: "east" as const },
-						green: { position: { row: 1, col: 1 }, facing: "south" as const },
-						cyan: { position: { row: 4, col: 4 }, facing: "west" as const },
-					},
-				},
-			],
+			personaSpatial: {
+				red: { position: { row: 2, col: 3 }, facing: "east" as const },
+				green: { position: { row: 1, col: 1 }, facing: "south" as const },
+				cyan: { position: { row: 4, col: 4 }, facing: "west" as const },
+			},
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			expect(result.state.phases[0]?.personaSpatial.red).toEqual({
+			expect(result.state.personaSpatial.red).toEqual({
 				position: { row: 2, col: 3 },
 				facing: "east",
 			});
@@ -457,8 +408,6 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips obstacle entities", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const obstacles: WorldEntity[] = [
 			{
 				id: "wall_a",
@@ -470,21 +419,16 @@ describe("serializeSession / deserializeSession", () => {
 		];
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					world: { entities: [...phase.world.entities, ...obstacles] },
-				},
-			],
+			world: { entities: [...game.world.entities, ...obstacles] },
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const obstacleEntities = result.state.phases[0]?.world.entities.filter(
+			const obstacleEntities = result.state.world.entities.filter(
 				(e) => e.kind === "obstacle",
 			);
-			expect(obstacleEntities?.some((e) => e.id === "wall_a")).toBe(true);
+			expect(obstacleEntities.some((e) => e.id === "wall_a")).toBe(true);
 		}
 	});
 
@@ -535,18 +479,17 @@ describe("serializeSession / deserializeSession", () => {
 		expect(result.kind).toBe("version-mismatch");
 	});
 
-	it("re-attaches nextPhaseConfig and winCondition from canonical phase chain", () => {
+	it("round-trips correctly with flat state (no phase config re-attachment needed)", () => {
+		// In the flat model (#295), there are no nextPhaseConfig / winCondition
+		// fields to re-attach. The round-trip should still succeed.
 		const game = makeFreshGame();
 		const files = serializeSession(game, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const phase = result.state.phases[0];
-			// PHASE_1_CONFIG has nextPhaseConfig (PHASE_2_CONFIG)
-			expect(phase?.nextPhaseConfig).toBeDefined();
-			expect(phase?.nextPhaseConfig?.phaseNumber).toBe(2);
-			// winCondition should be re-attached
-			expect(typeof phase?.winCondition).toBe("function");
+			// Flat state: no phase chain — just verify basic fields survived round-trip
+			expect(result.state.isComplete).toBe(game.isComplete);
+			expect(result.state.round).toBe(game.round);
 		}
 	});
 
@@ -585,8 +528,6 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips broadcast entries in per-Daemon conversationLogs", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 		const broadcastEntry: ConversationEntry = {
 			kind: "broadcast",
 			round: 2,
@@ -594,28 +535,22 @@ describe("serializeSession / deserializeSession", () => {
 		};
 		const modified: GameState = {
 			...game,
-			phases: [
-				{
-					...phase,
-					conversationLogs: {
-						red: [broadcastEntry],
-						green: [broadcastEntry],
-						cyan: [broadcastEntry],
-					},
-				},
-			],
+			conversationLogs: {
+				red: [broadcastEntry],
+				green: [broadcastEntry],
+				cyan: [broadcastEntry],
+			},
 		};
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const rp = result.state.phases[0];
 			// Broadcast entry round-trips in all three daemon logs
-			expect(rp?.conversationLogs.red?.[0]).toEqual(broadcastEntry);
-			expect(rp?.conversationLogs.green?.[0]).toEqual(broadcastEntry);
-			expect(rp?.conversationLogs.cyan?.[0]).toEqual(broadcastEntry);
+			expect(result.state.conversationLogs.red?.[0]).toEqual(broadcastEntry);
+			expect(result.state.conversationLogs.green?.[0]).toEqual(broadcastEntry);
+			expect(result.state.conversationLogs.cyan?.[0]).toEqual(broadcastEntry);
 			// Ensure broadcast has no from/to fields
-			const entry = rp?.conversationLogs.red?.[0];
+			const entry = result.state.conversationLogs.red?.[0];
 			expect(entry).toBeDefined();
 			expect("from" in (entry ?? {})).toBe(false);
 			expect("to" in (entry ?? {})).toBe(false);

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -495,8 +495,6 @@ describe("serializeSession / deserializeSession", () => {
 
 	it("round-trips complicationSchedule and activeComplications unchanged", () => {
 		const game = makeFreshGame();
-		const phase = game.phases[0];
-		if (!phase) throw new Error("no phase");
 
 		const complicationSchedule = { countdown: 7, settingShiftFired: true };
 		const activeComplications: import("../../game/types.js").ActiveComplication[] =
@@ -513,16 +511,16 @@ describe("serializeSession / deserializeSession", () => {
 
 		const modified: GameState = {
 			...game,
-			phases: [{ ...phase, complicationSchedule, activeComplications }],
+			complicationSchedule,
+			activeComplications,
 		};
 
 		const files = serializeSession(modified, NOW, CREATED_AT);
 		const result = deserializeSession(files);
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			const rp = result.state.phases[0];
-			expect(rp?.complicationSchedule).toEqual(complicationSchedule);
-			expect(rp?.activeComplications).toEqual(activeComplications);
+			expect(result.state.complicationSchedule).toEqual(complicationSchedule);
+			expect(result.state.activeComplications).toEqual(activeComplications);
 		}
 	});
 

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -292,8 +292,9 @@ describe("loadActiveSession", () => {
 		const result = loadActiveSession();
 		expect(result.kind).toBe("ok");
 		if (result.kind === "ok") {
-			expect(result.state.currentPhase).toBe(1);
-			expect(result.state.phases).toHaveLength(1);
+			// Flat model: no currentPhase / phases — verify state is valid
+			expect(result.state.isComplete).toBe(false);
+			expect(result.state.round).toBe(0);
 		}
 	});
 });
@@ -386,7 +387,8 @@ describe("consecutive saves", () => {
 		const secondLoad = loadActiveSession();
 		expect(secondLoad.kind).toBe("ok");
 		if (secondLoad.kind === "ok") {
-			expect(secondLoad.state.currentPhase).toBe(1);
+			// Flat model: no currentPhase — verify state loaded successfully
+			expect(secondLoad.state.isComplete).toBe(false);
 		}
 	});
 });

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -14,11 +14,6 @@
  * See docs/adr/0005-engine-dat-obfuscation-method.md
  */
 
-import {
-	PHASE_1_CONFIG,
-	PHASE_2_CONFIG,
-	PHASE_3_CONFIG,
-} from "../../content/phases.js";
 import { DEFAULT_LANDMARKS } from "../game/direction.js";
 import type {
 	ActiveComplication,
@@ -30,8 +25,6 @@ import type {
 	GameState,
 	Objective,
 	PersonaSpatialState,
-	PhaseConfig,
-	PhaseState,
 	WorldState,
 } from "../game/types.js";
 import {
@@ -62,14 +55,6 @@ import {
  *     no additional structural deserialization changes required.
  */
 export const SESSION_SCHEMA_VERSION = 6 as const;
-
-// ── Phase config lookup ────────────────────────────────────────────────────────
-
-const PHASE_CONFIGS: Record<1 | 2 | 3, PhaseConfig> = {
-	1: PHASE_1_CONFIG,
-	2: PHASE_2_CONFIG,
-	3: PHASE_3_CONFIG,
-};
 
 // ── File shapes ────────────────────────────────────────────────────────────────
 
@@ -148,14 +133,11 @@ export function serializeSession(
 	lastSavedAt: string,
 	createdAt: string,
 ): SerializedSessionFiles {
-	const activePhase = state.phases[state.phases.length - 1];
-	if (!activePhase) throw new Error("serializeSession: no active phase");
-
 	const meta: MetaFile = {
 		createdAt,
 		lastSavedAt,
-		epoch: state.currentPhase,
-		round: activePhase.round,
+		epoch: 1,
+		round: state.round,
 		personaOrder: Object.keys(state.personas),
 	};
 
@@ -173,14 +155,12 @@ export function serializeSession(
 				typingQuirks: persona.typingQuirks,
 				voiceExamples: persona.voiceExamples,
 			},
-			conversationLog: activePhase.conversationLogs[aiId] ?? [],
+			conversationLog: state.conversationLogs[aiId] ?? [],
 		};
 		daemons[aiId] = JSON.stringify(daemonFile, null, 2);
 	}
 
-	const contentPackB: ContentPack = state.contentPacks.find(
-		(p) => p.phaseNumber !== activePhase.phaseNumber,
-	) ?? {
+	const contentPackB: ContentPack = {
 		phaseNumber: 2,
 		setting: "",
 		weather: "",
@@ -194,17 +174,17 @@ export function serializeSession(
 
 	const sealedPayload: SealedEngine = {
 		schemaVersion: SESSION_SCHEMA_VERSION,
-		world: structuredClone(activePhase.world),
-		budgets: { ...activePhase.budgets },
-		lockedOut: Array.from(activePhase.lockedOut) as AiId[],
-		personaSpatial: structuredClone(activePhase.personaSpatial),
-		contentPackA: structuredClone(activePhase.contentPack),
-		contentPackB: structuredClone(contentPackB),
+		world: structuredClone(state.world),
+		budgets: { ...state.budgets },
+		lockedOut: Array.from(state.lockedOut) as AiId[],
+		personaSpatial: structuredClone(state.personaSpatial),
+		contentPackA: structuredClone(state.contentPack),
+		contentPackB,
 		activePackId: "A",
-		weather: activePhase.weather,
+		weather: state.weather,
 		objectives: [],
-		complicationSchedule: activePhase.complicationSchedule,
-		activeComplications: structuredClone(activePhase.activeComplications),
+		complicationSchedule: state.complicationSchedule,
+		activeComplications: structuredClone(state.activeComplications),
 		isComplete: state.isComplete,
 	};
 
@@ -298,18 +278,12 @@ export function deserializeSession(
 		if (!(aiId in personas)) personas[aiId] = daemonFile.persona;
 	}
 
-	// Reconstruct a single-phase GameState from the flat v6 engine
+	// Reconstruct a flat GameState from the v6 engine
 	try {
-		// Clamp epoch to valid phase number
-		const epochPhase = ([1, 2, 3] as const).find((n) => n === meta.epoch) ?? 1;
-		const config = PHASE_CONFIGS[epochPhase];
-
 		// Rebuild conversationLogs from daemon files
 		const conversationLogs: Record<AiId, ConversationEntry[]> = {};
-		const aiGoals: Record<AiId, string> = {};
 		for (const [aiId, daemonFile] of Object.entries(daemonFiles)) {
 			conversationLogs[aiId] = [...(daemonFile.conversationLog ?? [])];
-			aiGoals[aiId] = "";
 		}
 
 		const contentPack = sealed.contentPackA;
@@ -329,13 +303,13 @@ export function deserializeSession(
 		};
 		const activeComplications = sealed.activeComplications ?? [];
 
-		const phase: PhaseState = {
-			phaseNumber: epochPhase,
+		const state: GameState = {
+			isComplete: sealed.isComplete,
+			personas,
+			contentPack,
 			setting,
 			weather,
 			timeOfDay,
-			contentPack,
-			aiGoals,
 			round: meta.round,
 			world,
 			budgets,
@@ -345,21 +319,6 @@ export function deserializeSession(
 			personaSpatial,
 			complicationSchedule,
 			activeComplications,
-			// Re-attach function fields from canonical phase config
-			...(config?.winCondition !== undefined
-				? { winCondition: config.winCondition }
-				: {}),
-			...(config?.nextPhaseConfig !== undefined
-				? { nextPhaseConfig: config.nextPhaseConfig }
-				: {}),
-		};
-
-		const state: GameState = {
-			currentPhase: epochPhase,
-			isComplete: sealed.isComplete,
-			personas,
-			phases: [phase],
-			contentPacks: [sealed.contentPackA, sealed.contentPackB],
 		};
 
 		return {

--- a/src/spa/persistence/session-storage.ts
+++ b/src/spa/persistence/session-storage.ts
@@ -499,8 +499,8 @@ export function getSessionInfo(id: string): SessionInfo {
 	return {
 		kind: "ok",
 		lastSavedAt: result.lastSavedAt,
-		epoch: result.state.currentPhase,
-		round: result.state.phases[result.state.phases.length - 1]?.round ?? 0,
+		epoch: 1,
+		round: result.state.round,
 		daemonFiles: getDaemonFiles(),
 		engineSize: engineVal.length,
 	};

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -583,7 +583,7 @@ export function renderGame(
 				startBrightnessWipe();
 				return pending.contentPacksPromise.then((packs) => ({
 					personas,
-					contentPack: packs[0]!,
+					contentPack: packs[0] as NonNullable<(typeof packs)[0]>,
 					contentPacks: packs,
 				}));
 			})

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -188,7 +188,11 @@ export function applyTestAffordances(
 			return {
 				...result,
 				result: { ...result.result, gameEnded: true, phaseEnded: false },
-				nextState: { ...result.nextState, isComplete: true, outcome: "win" as const },
+				nextState: {
+					...result.nextState,
+					isComplete: true,
+					outcome: "win" as const,
+				},
 			};
 		};
 	}

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -162,9 +162,10 @@ export function applyTestAffordances(
 	// Gate: only apply when wrangler dev is the host
 	if (!isDevHost()) return s;
 
+	const wantsWin = searchParams.get("winImmediately") === "1";
 	const wantsLockout = searchParams.get("lockout") === "1";
 
-	if (!wantsLockout) return s;
+	if (!wantsWin && !wantsLockout) return s;
 
 	const active = s;
 
@@ -175,6 +176,21 @@ export function applyTestAffordances(
 			lockoutTriggerRound: currentRound + 1,
 			lockoutDuration: 2,
 		});
+	}
+
+	if (wantsWin) {
+		// In the flat single-game model, wrap submitMessage so the next call ends
+		// the game (outcome: "win"). Used by integration tests that need to drive
+		// the UI to game_ended without satisfying objectives via tool calls.
+		const originalSubmit = active.submitMessage.bind(active);
+		active.submitMessage = async (...args) => {
+			const result = await originalSubmit(...args);
+			return {
+				...result,
+				result: { ...result.result, gameEnded: true, phaseEnded: false },
+				nextState: { ...result.nextState, isComplete: true, outcome: "win" as const },
+			};
+		};
 	}
 
 	return active;

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1,4 +1,3 @@
-import { PHASE_1_CONFIG } from "../../content";
 import { serializeGameSave } from "../../save-serializer.js";
 import {
 	BANNER,
@@ -11,7 +10,6 @@ import {
 import { buildSessionFromAssets } from "../game/bootstrap.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
-import { getActivePhase, updateActivePhase } from "../game/engine.js";
 import { GameSession } from "../game/game-session.js";
 import {
 	applyAddresseeChange,
@@ -26,7 +24,7 @@ import {
 } from "../game/pending-bootstrap.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
 import { getSpikeRng } from "../game/spike-seed.js";
-import type { AiId, AiPersona, PhaseConfig } from "../game/types";
+import type { AiId, AiPersona } from "../game/types";
 import { AI_TYPING_SPEED, TOKEN_PACE_MS } from "../game/typing-rhythm.js";
 import { CapHitError } from "../llm-client.js";
 import {
@@ -142,35 +140,16 @@ function isDevHost(): boolean {
 }
 
 /**
- * Recursively deep-clone a PhaseConfig chain, overriding `winCondition` to
- * `() => true` at every level.
- *
- * Only the config objects are cloned — the `initialWorld` and `aiGoals` values
- * are shallow-copied (they are plain data with no function members that need
- * patching). The original configs are never mutated.
+ * @deprecated Phase concept removed (issue #295). No longer used.
  */
-function patchPhaseChain(config: PhaseConfig): PhaseConfig {
-	return {
-		...config,
-		winCondition: () => true,
-		...(config.nextPhaseConfig !== undefined
-			? { nextPhaseConfig: patchPhaseChain(config.nextPhaseConfig) }
-			: {}),
-	};
-}
-
 /**
  * Apply SPA-side test affordances from URL search params.
  *
  * Only honoured when the SPA is served by `pnpm wrangler dev` (see
  * `isDevHost`). Silently inert in any other host.
  *
- * - `winImmediately=1`: recursively patch the real phase chain reachable from
- *   the active phase, injecting `winCondition: () => true` into the active
- *   phase AND every phase reachable via `nextPhaseConfig`. This uses the real
- *   PHASE_1 → PHASE_2 → PHASE_3 config chain (deep-cloned; originals are
- *   untouched). A cold-start `goto("/?winImmediately=1")` followed by three
- *   submitted messages will reliably reach `game_ended`.
+ * - `winImmediately=1`: not applicable in single-game loop (win is driven by
+ *   checkWinCondition after each round). This affordance is a no-op in #295.
  * - `lockout=1`: arm a chat-lockout for `red`, 2 rounds, effective next round.
  *   Matches the legacy worker semantics from `src/proxy/_smoke.ts`.
  *
@@ -183,30 +162,14 @@ export function applyTestAffordances(
 	// Gate: only apply when wrangler dev is the host
 	if (!isDevHost()) return s;
 
-	const wantsWinImmediately = searchParams.get("winImmediately") === "1";
 	const wantsLockout = searchParams.get("lockout") === "1";
 
-	if (!wantsWinImmediately && !wantsLockout) return s;
+	if (!wantsLockout) return s;
 
-	let active = s;
-
-	if (wantsWinImmediately) {
-		// Patch the real phase chain: inject winCondition: () => true into the
-		// active phase AND every phase reachable via nextPhaseConfig.
-		// patchPhaseChain deep-clones each config level so the global
-		// PHASE_1_CONFIG (and its linked configs) are never mutated.
-		const newState = updateActivePhase(active.getState(), (phase) => ({
-			...phase,
-			winCondition: () => true,
-			...(phase.nextPhaseConfig !== undefined
-				? { nextPhaseConfig: patchPhaseChain(phase.nextPhaseConfig) }
-				: {}),
-		}));
-		active = GameSession.restore(newState);
-	}
+	const active = s;
 
 	if (wantsLockout) {
-		const currentRound = getActivePhase(active.getState()).round;
+		const currentRound = active.getState().round;
 		active.armChatLockout({
 			rng: () => 0,
 			lockoutTriggerRound: currentRound + 1,
@@ -453,17 +416,10 @@ export function renderGame(
 		);
 		const status = topInfoStatus(state);
 		const sessionIdLocal = getActiveSessionId() ?? "0x????";
-		// Walk the phase chain to count total phases (matches refreshTopInfo).
-		let total = 1;
-		let cursor: PhaseConfig | undefined = PHASE_1_CONFIG.nextPhaseConfig;
-		while (cursor) {
-			total += 1;
-			cursor = cursor.nextPhaseConfig;
-		}
 		const inputs = {
 			sessionId: sessionIdLocal,
-			phaseNumber: 1,
-			totalPhases: total,
+			phaseNumber: 1 as const,
+			totalPhases: 1,
 			turn: 0,
 		};
 		if (topinfoLeftEl) renderTopInfoLeft(topinfoLeftEl, inputs);
@@ -627,6 +583,7 @@ export function renderGame(
 				startBrightnessWipe();
 				return pending.contentPacksPromise.then((packs) => ({
 					personas,
+					contentPack: packs[0]!,
 					contentPacks: packs,
 				}));
 			})
@@ -731,7 +688,7 @@ export function renderGame(
 				// Re-render transcripts from restored state using conversationLogs.
 				// (The new format stores conversation logs in daemon .txt files, not as
 				// serialized transcript HTML, so we always use the conversationLogs path.)
-				const restoredPhase = getActivePhase(restoredState);
+				const restoredPhase = restoredState;
 				const restoredPersonas = restoredState.personas;
 				const restorePanelEls = doc.querySelectorAll<HTMLElement>(".ai-panel");
 				Object.keys(restoredPersonas).forEach((aiId, idx) => {
@@ -835,7 +792,7 @@ export function renderGame(
 
 		// Hydrate lockouts from the active phase's chatLockouts map so that
 		// a reload preserves the Send-disabled state for locked-out AIs.
-		const activePhaseForLockouts = getActivePhase(session.getState());
+		const activePhaseForLockouts = session.getState();
 		for (const aiId of Object.keys(runtimePersonas)) {
 			lockouts.set(aiId, activePhaseForLockouts.chatLockouts.has(aiId));
 		}
@@ -884,9 +841,9 @@ export function renderGame(
 			panel.style.setProperty("--panel-color", persona.color);
 			initPanelChrome(panel, persona);
 			const budgetEl = panel.querySelector<HTMLSpanElement>(".panel-budget");
-			const phase = getActivePhase(sessionRef.getState());
+			const gameState = sessionRef.getState();
 			if (budgetEl) {
-				const budget = phase.budgets[aiId];
+				const budget = gameState.budgets[aiId];
 				if (budget) {
 					budgetEl.dataset.budget = String(budget.remaining);
 					budgetEl.textContent = formatBudget(budget.remaining);
@@ -917,19 +874,11 @@ export function renderGame(
 		if (!session) return;
 		if (!topinfoLeftEl || !topinfoRightEl) return;
 		const state = session.getState();
-		const phase = getActivePhase(state);
-		// Walk the nextPhaseConfig chain from PHASE_1_CONFIG to count total phases.
-		let total = 1;
-		let cursor: PhaseConfig | undefined = PHASE_1_CONFIG.nextPhaseConfig;
-		while (cursor) {
-			total += 1;
-			cursor = cursor.nextPhaseConfig;
-		}
 		const inputs = {
 			sessionId,
-			phaseNumber: phase.phaseNumber,
-			totalPhases: total,
-			turn: phase.round,
+			phaseNumber: 1 as const,
+			totalPhases: 1,
+			turn: state.round,
 		};
 		renderTopInfoLeft(topinfoLeftEl, inputs);
 		topinfoRightEl.textContent = "";
@@ -1246,11 +1195,10 @@ export function renderGame(
 				(aiId) => stripSpinner(aiId),
 			);
 
-			const phaseAfter = getActivePhase(nextState);
 			const events = encodeRoundResult(
 				result,
 				completions,
-				phaseAfter,
+				nextState,
 				nextState.personas,
 			);
 
@@ -1340,7 +1288,7 @@ export function renderGame(
 						// Refresh budget displays from new phase
 						const currentSession = session;
 						if (currentSession) {
-							const newPhase = getActivePhase(currentSession.getState());
+							const newState = currentSession.getState();
 							for (const aid of advAiIds) {
 								const panel = doc.querySelector<HTMLElement>(
 									`.ai-panel[data-ai="${aid}"]`,
@@ -1349,7 +1297,7 @@ export function renderGame(
 								const budgetEl =
 									panel.querySelector<HTMLSpanElement>(".panel-budget");
 								if (budgetEl) {
-									const b = newPhase.budgets[aid];
+									const b = newState.budgets[aid];
 									if (b) {
 										budgetEl.dataset.budget = String(b.remaining);
 										budgetEl.textContent = formatBudget(b.remaining);

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -17,10 +17,7 @@
  * Issue #174 (parent #155).
  */
 
-import { PHASE_1_CONFIG } from "../../content";
 import { paintBanner, paintTopInfo } from "../bbs-chrome.js";
-import { getActivePhase } from "../game/engine.js";
-import type { PhaseConfig } from "../game/types";
 import {
 	dupSession,
 	getActiveSessionId,
@@ -105,18 +102,11 @@ export function renderSessions(
 	paintBanner(doc);
 	const loadResult = loadActiveSession();
 	if (loadResult.kind === "ok") {
-		const phase = getActivePhase(loadResult.state);
-		let total = 1;
-		let cursor: PhaseConfig | undefined = PHASE_1_CONFIG.nextPhaseConfig;
-		while (cursor) {
-			total += 1;
-			cursor = cursor.nextPhaseConfig;
-		}
 		paintTopInfo(doc, {
 			sessionId: loadResult.sessionId,
-			phaseNumber: phase.phaseNumber,
-			totalPhases: total,
-			turn: phase.round,
+			phaseNumber: 1,
+			totalPhases: 1,
+			turn: loadResult.state.round,
 		});
 	}
 


### PR DESCRIPTION
## What this fixes

The engine previously managed three separate phases (`startPhase`, `advancePhase`, `PhaseConfig`) with per-phase budgets that reset at each boundary. This PR collapses that into a single continuous game loop.

**`engine.ts`** — `startGame` replaces the `createGame + startPhase` pair and initialises a flat `GameState` directly (no `phases[]` array, no `currentPhase`). Budget is now $0.50 per Daemon for the entire game with no resets. `deductBudget` returns a `justExhausted` flag so the Round Coordinator can detect the moment a Daemon first crosses zero and emit an in-character farewell (`FAREWELL_LINE(name)`) before adding the AI to `lockedOut`. The old functions are kept as `@deprecated` compat shims so existing tests continue to compile without mass rewrites.

**`win-condition.ts`** — Added `checkLoseCondition(lockedOut, allAiIds) → boolean` (returns true when every AI is locked out) alongside the existing `checkWinCondition`. Both are pure functions.

**`round-coordinator.ts`** — After every round, checks `checkWinCondition(state.world, state.contentPack)` first, then `checkLoseCondition(state.lockedOut, allAiIds)` in an `else if`. Win takes priority if both would fire simultaneously. Sets `isComplete: true` and `outcome: "win" | "lose"` accordingly.

**`prompt-builder.ts`** — Removed the `<goal>` block entirely (`aiGoals`, `STOCK_MESSAGING_CLAUSE`, `SECRECY_CLAUSE`), removed `WIPE_DIRECTIVE` and its conditional injection on phase 2+, and changed weather to read from `game.weather` (flat field) rather than `phase.weather`.

**`routes/game.ts`** — Restored `winImmediately=1` test affordance for the flat model: wraps `submitMessage` to force `gameEnded: true` on the next call so integration tests can drive the UI to the endgame screen without satisfying objectives via tool calls.

## QA steps for the human

1. Start a new game and verify the chat works through at least one round without errors.
2. Let all three Daemons exhaust their budgets (or stub low budgets in dev) and confirm each emits a farewell line before going unresponsive.
3. Confirm the endgame screen appears when all Daemons are locked out (lose) or all objectives satisfied (win).
4. Confirm the system prompt no longer contains "memory has been wiped" or a `<goal>` block for any Daemon.

## Automated coverage

`pnpm typecheck` clean · `pnpm test` 1169/1169 pass · `pnpm build` succeeds.

Closes #295

---
_Generated by [Claude Code](https://claude.ai/code)_

https://claude.ai/code/session_014xBHhw3RrN3sjTPKnww3Cf

---
_Generated by [Claude Code](https://claude.ai/code/session_014xBHhw3RrN3sjTPKnww3Cf)_