### PR TITLE
feat(#302): A/B dual content-pack generation with Setting Shift

### DIFF
--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -472,7 +472,9 @@ const SETTING_POOL_12: readonly string[] = [
 /** Build a dual-pack MockContentPackProvider for entity ID parity tests. */
 function makeDualMockProvider(): MockContentPackProvider {
 	return new MockContentPackProvider(
-		(_input: ContentPackProviderInput): ContentPackProviderResult => ({ packs: [] }),
+		(_input: ContentPackProviderInput): ContentPackProviderResult => ({
+			packs: [],
+		}),
 		(input: DualContentPackProviderInput): DualContentPackProviderResult => {
 			const phases = input.phases.map((phase) => {
 				const pn = phase.phaseNumber;

--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -9,11 +9,16 @@ import { describe, expect, it } from "vitest";
 import type {
 	ContentPackProviderInput,
 	ContentPackProviderResult,
+	DualContentPackProviderInput,
+	DualContentPackProviderResult,
 } from "../../spa/game/content-pack-provider.js";
 import { MockContentPackProvider } from "../../spa/game/content-pack-provider.js";
 import { DEFAULT_LANDMARKS } from "../../spa/game/direction.js";
-import type { PhaseConfig } from "../../spa/game/types.js";
-import { generateContentPacks } from "../content-pack-generator.js";
+import type { ContentPack, PhaseConfig } from "../../spa/game/types.js";
+import {
+	generateContentPacks,
+	generateDualContentPacks,
+} from "../content-pack-generator.js";
 
 // ── Seeded RNG ────────────────────────────────────────────────────────────────
 
@@ -444,5 +449,214 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 				AI_IDS,
 			),
 		).rejects.toThrow(/could not place phase/);
+	});
+});
+
+// ── generateDualContentPacks — entity ID parity (issue #302) ──────────────────
+
+const SETTING_POOL_12: readonly string[] = [
+	"abandoned subway station",
+	"sun-baked salt flat",
+	"forgotten laboratory",
+	"moonlit greenhouse ruin",
+	"stripped server vault",
+	"tide-flooded boardwalk",
+	"flooded power station",
+	"crumbling amphitheatre",
+	"rusted oil platform",
+	"derelict space station",
+	"frozen research camp",
+	"overgrown shopping mall",
+];
+
+/** Build a dual-pack MockContentPackProvider for entity ID parity tests. */
+function makeDualMockProvider(): MockContentPackProvider {
+	return new MockContentPackProvider(
+		(_input: ContentPackProviderInput): ContentPackProviderResult => ({ packs: [] }),
+		(input: DualContentPackProviderInput): DualContentPackProviderResult => {
+			const phases = input.phases.map((phase) => {
+				const pn = phase.phaseNumber;
+				const spaceId = `p${pn}_space`;
+				const objId = `p${pn}_obj`;
+				const intId = `p${pn}_interesting`;
+				const obsId = `p${pn}_obstacle`;
+
+				const makePackVariant = (
+					setting: string,
+					suffix: string,
+				): DualContentPackProviderResult["phases"][number]["packA"] => ({
+					phaseNumber: pn,
+					setting,
+					objectivePairs: Array.from({ length: phase.k }, (_, i) => ({
+						space: {
+							id: `${spaceId}_${i}`,
+							kind: "objective_space" as const,
+							name: `Space ${pn} ${i} ${suffix}`,
+							examineDescription: `A space in phase ${pn} (${suffix}).`,
+							holder: { row: 0, col: 0 } as never,
+						},
+						object: {
+							id: `${objId}_${i}`,
+							kind: "objective_object" as const,
+							name: `Object ${pn} ${i} ${suffix}`,
+							examineDescription: `An object for Space ${pn} ${i} ${suffix}.`,
+							useOutcome: `You use it (${suffix}).`,
+							pairsWithSpaceId: `${spaceId}_${i}`,
+							placementFlavor: `{actor} places the object (${suffix}).`,
+							proximityFlavor: `Near its space (${suffix}).`,
+							holder: { row: 0, col: 0 } as never,
+						},
+					})),
+					interestingObjects: Array.from({ length: phase.n }, (_, i) => ({
+						id: `${intId}_${i}`,
+						kind: "interesting_object" as const,
+						name: `Interesting ${pn} ${i} ${suffix}`,
+						examineDescription: `Interesting (${suffix}).`,
+						useOutcome: `You interact (${suffix}).`,
+						holder: { row: 0, col: 0 } as never,
+					})),
+					obstacles: Array.from({ length: phase.m }, (_, i) => ({
+						id: `${obsId}_${i}`,
+						kind: "obstacle" as const,
+						name: `Obstacle ${pn} ${i} ${suffix}`,
+						examineDescription: `An obstacle (${suffix}).`,
+						holder: { row: 0, col: 0 } as never,
+					})),
+					landmarks: DEFAULT_LANDMARKS,
+					aiStarts: {} as never,
+				});
+
+				return {
+					phaseNumber: pn,
+					packA: makePackVariant(phase.settingA, "A"),
+					packB: makePackVariant(phase.settingB, "B"),
+				};
+			});
+			return { phases };
+		},
+	);
+}
+
+/** Extract all entity IDs from a ContentPack. */
+function allEntityIds(pack: ContentPack): string[] {
+	return [
+		...pack.objectivePairs.flatMap((p) => [p.object.id, p.space.id]),
+		...pack.interestingObjects.map((e) => e.id),
+		...pack.obstacles.map((e) => e.id),
+	].sort();
+}
+
+describe("generateDualContentPacks — entity ID parity (issue #302)", () => {
+	it("produces packsA and packsB with identical entity IDs per phase", async () => {
+		const rng = seededRng(99);
+		const provider = makeDualMockProvider();
+
+		const { packsA, packsB } = await generateDualContentPacks(
+			rng,
+			SETTING_POOL_12,
+			FIXED_PHASE_CONFIGS,
+			provider,
+			AI_IDS,
+		);
+
+		expect(packsA).toHaveLength(3);
+		expect(packsB).toHaveLength(3);
+
+		for (let i = 0; i < 3; i++) {
+			const packA = packsA[i] as ContentPack;
+			const packB = packsB[i] as ContentPack;
+			expect(packA.phaseNumber).toBe(packB.phaseNumber);
+			expect(allEntityIds(packA)).toEqual(allEntityIds(packB));
+		}
+	});
+
+	it("Pack A and Pack B have different settings", async () => {
+		const rng = seededRng(99);
+		const provider = makeDualMockProvider();
+
+		const { packsA, packsB } = await generateDualContentPacks(
+			rng,
+			SETTING_POOL_12,
+			FIXED_PHASE_CONFIGS,
+			provider,
+			AI_IDS,
+		);
+
+		for (let i = 0; i < 3; i++) {
+			const packA = packsA[i] as ContentPack;
+			const packB = packsB[i] as ContentPack;
+			expect(packA.setting).not.toBe(packB.setting);
+		}
+	});
+
+	it("Pack B entities have the same holder positions as Pack A (placement parity)", async () => {
+		const rng = seededRng(99);
+		const provider = makeDualMockProvider();
+
+		const { packsA, packsB } = await generateDualContentPacks(
+			rng,
+			SETTING_POOL_12,
+			FIXED_PHASE_CONFIGS,
+			provider,
+			AI_IDS,
+		);
+
+		for (let i = 0; i < 3; i++) {
+			const packA = packsA[i] as ContentPack;
+			const packB = packsB[i] as ContentPack;
+
+			// Build ID→holder map for A
+			const holdersA = new Map<string, unknown>();
+			for (const pair of packA.objectivePairs) {
+				holdersA.set(pair.object.id, pair.object.holder);
+				holdersA.set(pair.space.id, pair.space.holder);
+			}
+			for (const e of packA.interestingObjects) holdersA.set(e.id, e.holder);
+			for (const e of packA.obstacles) holdersA.set(e.id, e.holder);
+
+			// Verify B holders match A holders by entity ID
+			for (const pair of packB.objectivePairs) {
+				expect(pair.object.holder).toEqual(holdersA.get(pair.object.id));
+				expect(pair.space.holder).toEqual(holdersA.get(pair.space.id));
+			}
+			for (const e of packB.interestingObjects) {
+				expect(e.holder).toEqual(holdersA.get(e.id));
+			}
+			for (const e of packB.obstacles) {
+				expect(e.holder).toEqual(holdersA.get(e.id));
+			}
+		}
+	});
+
+	it("makes exactly one LLM call for the dual packs", async () => {
+		const rng = seededRng(99);
+		const provider = makeDualMockProvider();
+
+		await generateDualContentPacks(
+			rng,
+			SETTING_POOL_12,
+			FIXED_PHASE_CONFIGS,
+			provider,
+			AI_IDS,
+		);
+
+		expect(provider.dualCalls).toHaveLength(1);
+		expect(provider.calls).toHaveLength(0);
+	});
+
+	it("throws when setting pool has fewer than 6 entries", async () => {
+		const rng = seededRng(99);
+		const provider = makeDualMockProvider();
+		const smallPool = ["a", "b", "c", "d", "e"];
+
+		await expect(
+			generateDualContentPacks(
+				rng,
+				smallPool,
+				FIXED_PHASE_CONFIGS,
+				provider,
+				AI_IDS,
+			),
+		).rejects.toThrow(/at least 6/);
 	});
 });

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -448,12 +448,16 @@ export async function generateDualContentPacks(
 		const placedA = placedPacksA[i] as ContentPack;
 
 		// Build ID → holder map from placed Pack A
-		const holderById = new Map<string, AiId | import("../spa/game/types.js").GridPosition>();
+		const holderById = new Map<
+			string,
+			AiId | import("../spa/game/types.js").GridPosition
+		>();
 		for (const pair of placedA.objectivePairs) {
 			holderById.set(pair.object.id, pair.object.holder);
 			holderById.set(pair.space.id, pair.space.holder);
 		}
-		for (const obj of placedA.interestingObjects) holderById.set(obj.id, obj.holder);
+		for (const obj of placedA.interestingObjects)
+			holderById.set(obj.id, obj.holder);
 		for (const obs of placedA.obstacles) holderById.set(obs.id, obs.holder);
 
 		const applyHolder = (entity: WorldEntity): WorldEntity => ({
@@ -470,7 +474,9 @@ export async function generateDualContentPacks(
 				object: applyHolder(pair.object),
 				space: applyHolder(pair.space),
 			})),
-			interestingObjects: (ph.packB.interestingObjects as WorldEntity[]).map(applyHolder),
+			interestingObjects: (ph.packB.interestingObjects as WorldEntity[]).map(
+				applyHolder,
+			),
 			obstacles: (ph.packB.obstacles as WorldEntity[]).map(applyHolder),
 			landmarks: ph.packB.landmarks,
 			aiStarts: { ...placedA.aiStarts },

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -20,6 +20,7 @@
 import type {
 	ContentPackProvider,
 	ContentPackProviderInput,
+	DualContentPackProviderInput,
 } from "../spa/game/content-pack-provider.js";
 import type {
 	AiId,
@@ -341,4 +342,140 @@ export async function generateContentPacks(
 
 	// Run placement engine
 	return placePhases(rng, unplacedPacks, aiIds);
+}
+
+/**
+ * Generate paired A/B ContentPacks for all three phases in one LLM call.
+ *
+ * Pack A and Pack B share identical entity IDs and grid placements; only
+ * names, descriptions, and flavor strings differ (re-flavored per setting).
+ *
+ * @param rng        Seeded random number generator.
+ * @param settings   The pool of setting nouns (must have >= 4 entries: 3 for Pack A + 1 more for Pack B pairs).
+ * @param configs    The three phase configs (in order).
+ * @param llm        ContentPackProvider for the LLM call.
+ * @param aiIdsOrPromise  AiId list or a Promise resolving to one.
+ * @returns          `{ packsA, packsB }` — placed ContentPack arrays, one per phase.
+ */
+export async function generateDualContentPacks(
+	rng: () => number,
+	settings: readonly string[],
+	configs: [PhaseConfig, PhaseConfig, PhaseConfig],
+	llm: ContentPackProvider,
+	aiIdsOrPromise: AiId[] | Promise<AiId[]>,
+): Promise<{ packsA: ContentPack[]; packsB: ContentPack[] }> {
+	if (settings.length < 6) {
+		throw new Error(
+			`generateDualContentPacks: setting pool must have at least 6 entries (has ${settings.length})`,
+		);
+	}
+
+	// Draw 6 distinct settings (3 for A, 3 for B) via partial Fisher-Yates
+	const settingPool = [...settings];
+	const drawnSettings: string[] = [];
+	for (let i = 0; i < 6; i++) {
+		const j = i + Math.floor(rng() * (settingPool.length - i));
+		const tmp = settingPool[i] as string;
+		settingPool[i] = settingPool[j] as string;
+		settingPool[j] = tmp;
+		drawnSettings.push(settingPool[i] as string);
+	}
+	const settingsA = drawnSettings.slice(0, 3) as [string, string, string];
+	const settingsB = drawnSettings.slice(3, 6) as [string, string, string];
+
+	// Draw weather, time-of-day, and theme independently per phase (one set each; B reuses same ambient)
+	const drawnWeatherA = Array.from(
+		{ length: 3 },
+		() => WEATHER_POOL[Math.floor(rng() * WEATHER_POOL.length)] as string,
+	);
+	const drawnWeatherB = Array.from(
+		{ length: 3 },
+		() => WEATHER_POOL[Math.floor(rng() * WEATHER_POOL.length)] as string,
+	);
+	const drawnTimeOfDayA = Array.from(
+		{ length: 3 },
+		() =>
+			TIME_OF_DAY_POOL[Math.floor(rng() * TIME_OF_DAY_POOL.length)] as string,
+	);
+	const drawnTimeOfDayB = Array.from(
+		{ length: 3 },
+		() =>
+			TIME_OF_DAY_POOL[Math.floor(rng() * TIME_OF_DAY_POOL.length)] as string,
+	);
+	const drawnThemes = Array.from(
+		{ length: 3 },
+		() => THEME_POOL[Math.floor(rng() * THEME_POOL.length)] as string,
+	);
+
+	// Roll k/n/m per phase (shared between A and B — same entity counts)
+	const phaseInputs: DualContentPackProviderInput["phases"] = configs.map(
+		(cfg, i) => ({
+			phaseNumber: cfg.phaseNumber,
+			settingA: settingsA[i] as string,
+			settingB: settingsB[i] as string,
+			theme: drawnThemes[i] as string,
+			k: rollInt(rng, cfg.kRange[0], cfg.kRange[1]),
+			n: rollInt(rng, cfg.nRange[0], cfg.nRange[1]),
+			m: rollInt(rng, cfg.mRange[0], cfg.mRange[1]),
+		}),
+	);
+
+	// Kick off dual LLM call and aiIds resolution in parallel
+	const llmCallPromise = llm.generateDualContentPacks({ phases: phaseInputs });
+	const [llmResult, aiIds] = await Promise.all([
+		llmCallPromise,
+		Promise.resolve(aiIdsOrPromise),
+	]);
+
+	// Build unplaced Pack A and Pack B from LLM result
+	const unplacedPacksA: ContentPack[] = llmResult.phases.map((ph, i) => ({
+		phaseNumber: ph.phaseNumber,
+		setting: ph.packA.setting,
+		weather: drawnWeatherA[i] as string,
+		timeOfDay: drawnTimeOfDayA[i] as string,
+		objectivePairs: ph.packA.objectivePairs,
+		interestingObjects: ph.packA.interestingObjects as WorldEntity[],
+		obstacles: ph.packA.obstacles as WorldEntity[],
+		landmarks: ph.packA.landmarks,
+		aiStarts: {},
+	}));
+
+	// Run placement engine on Pack A
+	const placedPacksA = placePhases(rng, unplacedPacksA, aiIds);
+
+	// Apply the same placements to Pack B by matching entity IDs
+	const packsB: ContentPack[] = llmResult.phases.map((ph, i) => {
+		const placedA = placedPacksA[i] as ContentPack;
+
+		// Build ID → holder map from placed Pack A
+		const holderById = new Map<string, AiId | import("../spa/game/types.js").GridPosition>();
+		for (const pair of placedA.objectivePairs) {
+			holderById.set(pair.object.id, pair.object.holder);
+			holderById.set(pair.space.id, pair.space.holder);
+		}
+		for (const obj of placedA.interestingObjects) holderById.set(obj.id, obj.holder);
+		for (const obs of placedA.obstacles) holderById.set(obs.id, obs.holder);
+
+		const applyHolder = (entity: WorldEntity): WorldEntity => ({
+			...entity,
+			holder: holderById.get(entity.id) ?? { row: 0, col: 0 },
+		});
+
+		return {
+			phaseNumber: ph.phaseNumber,
+			setting: ph.packB.setting,
+			weather: drawnWeatherB[i] as string,
+			timeOfDay: drawnTimeOfDayB[i] as string,
+			objectivePairs: ph.packB.objectivePairs.map((pair) => ({
+				object: applyHolder(pair.object),
+				space: applyHolder(pair.space),
+			})),
+			interestingObjects: (ph.packB.interestingObjects as WorldEntity[]).map(applyHolder),
+			obstacles: (ph.packB.obstacles as WorldEntity[]).map(applyHolder),
+			landmarks: ph.packB.landmarks,
+			aiStarts: { ...placedA.aiStarts },
+		};
+	});
+
+	return { packsA: placedPacksA, packsB };
 }

--- a/src/save-serializer.ts
+++ b/src/save-serializer.ts
@@ -33,8 +33,10 @@ export interface GameSave {
 	/** Schema version. v4 = chat/whisper collapsed into directional message primitive. */
 	version: 4;
 	ais: AiSaveEntry[];
-	/** All three content packs (generated at game start). */
-	contentPacks: ContentPack[];
+	/** Setting A content packs (generated at game start). */
+	contentPacksA: ContentPack[];
+	/** Setting B content packs (generated at game start). */
+	contentPacksB: ContentPack[];
 }
 
 /**
@@ -59,5 +61,5 @@ export function serializeGameSave(game: GameState): GameSave {
 		return { persona: { ...persona }, phases };
 	});
 
-	return { version: 4, ais, contentPacks: game.contentPacks };
+	return { version: 4, ais, contentPacksA: game.contentPacksA, contentPacksB: game.contentPacksB };
 }

--- a/src/save-serializer.ts
+++ b/src/save-serializer.ts
@@ -61,5 +61,10 @@ export function serializeGameSave(game: GameState): GameSave {
 		return { persona: { ...persona }, phases };
 	});
 
-	return { version: 4, ais, contentPacksA: game.contentPacksA, contentPacksB: game.contentPacksB };
+	return {
+		version: 4,
+		ais,
+		contentPacksA: game.contentPacksA,
+		contentPacksB: game.contentPacksB,
+	};
 }

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -17,9 +17,12 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
-	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateDualContentPacks: async () => ({
+		packsA: STATIC_CONTENT_PACKS,
+		packsB: STATIC_CONTENT_PACKS,
+	}),
 }));
 
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
@@ -123,7 +126,8 @@ describe("renderGame — session restore (formerly async bootstrap)", () => {
 			mintAndActivateNewSession();
 			const session = buildSessionFromAssets({
 				personas: STATIC_PERSONAS,
-				contentPacks: STATIC_CONTENT_PACKS,
+				contentPacksA: STATIC_CONTENT_PACKS,
+				contentPacksB: STATIC_CONTENT_PACKS,
 			});
 			saveActiveSession(session.getState());
 		} finally {

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -80,9 +80,12 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
-	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateDualContentPacks: async () => ({
+		packsA: STATIC_CONTENT_PACKS,
+		packsB: STATIC_CONTENT_PACKS,
+	}),
 }));
 
 // ---------------------------------------------------------------------------

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -12,9 +12,12 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
-	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateDualContentPacks: async () => ({
+		packsA: STATIC_CONTENT_PACKS,
+		packsB: STATIC_CONTENT_PACKS,
+	}),
 }));
 
 // ── Shared localStorage stub helpers ──────────────────────────────────────────
@@ -74,7 +77,8 @@ async function seedSessionInStub(
 		mintAndActivateNewSession();
 		const session = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
-			contentPacks: STATIC_CONTENT_PACKS,
+			contentPacksA: STATIC_CONTENT_PACKS,
+			contentPacksB: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(session.getState());
 	} finally {
@@ -1249,7 +1253,8 @@ describe("renderGame — localStorage persistence", () => {
 		setActiveSessionId("0xB000");
 		const sessionB = buildSessionFromAssets({
 			personas: STATIC_PERSONAS,
-			contentPacks: STATIC_CONTENT_PACKS,
+			contentPacksA: STATIC_CONTENT_PACKS,
+			contentPacksB: STATIC_CONTENT_PACKS,
 		});
 		saveActiveSession(sessionB.getState());
 

--- a/src/spa/__tests__/migration-banner.test.ts
+++ b/src/spa/__tests__/migration-banner.test.ts
@@ -23,9 +23,12 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
-	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateDualContentPacks: async () => ({
+		packsA: STATIC_CONTENT_PACKS,
+		packsB: STATIC_CONTENT_PACKS,
+	}),
 }));
 
 const INDEX_BODY_HTML = `

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -27,9 +27,12 @@ vi.mock("../../content", async (importOriginal) => {
 	};
 });
 
-// Pin generateContentPacks to static content packs (no LLM call in tests).
+// Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
-	generateContentPacks: async () => STATIC_CONTENT_PACKS,
+	generateDualContentPacks: async () => ({
+		packsA: STATIC_CONTENT_PACKS,
+		packsB: STATIC_CONTENT_PACKS,
+	}),
 }));
 
 // ── HTML fixture ──────────────────────────────────────────────────────────────

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -155,7 +155,9 @@ function makeGameStateAround(phase: PhaseState): GameState {
 		phases: [phase],
 		personas: TEST_PERSONAS,
 		isComplete: false,
-		contentPacks: [],
+		contentPacksA: [],
+		contentPacksB: [],
+		activePackId: "A",
 	};
 }
 
@@ -795,6 +797,119 @@ describe("applyComplicationResult — activeComplications appends", () => {
 		const updated = applyComplicationResult(game, result, seededRng([0.5]));
 		const updatedPhase = getActivePhase(updated);
 		expect(updatedPhase.complicationSchedule.settingShiftFired).toBe(true);
+	});
+});
+
+// ── Setting Shift A/B pack swap (issue #302) ──────────────────────────────────
+
+describe("applyComplicationResult — setting_shift swaps active pack", () => {
+	const PACK_A: ContentPack = {
+		phaseNumber: 1,
+		setting: "neon arcade",
+		weather: "clear",
+		timeOfDay: "night",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: makePersonaSpatial(),
+	};
+
+	const PACK_B: ContentPack = {
+		phaseNumber: 1,
+		setting: "sun-baked salt flat",
+		weather: "hot",
+		timeOfDay: "day",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: makePersonaSpatial(),
+	};
+
+	function makeGameWithDualPacks(): GameState {
+		const phase = makePhase({ contentPack: PACK_A, setting: PACK_A.setting });
+		return {
+			currentPhase: 1,
+			phases: [phase],
+			personas: TEST_PERSONAS,
+			isComplete: false,
+			contentPacksA: [PACK_A],
+			contentPacksB: [PACK_B],
+			activePackId: "A",
+		};
+	}
+
+	it("sets activePackId to 'B' when setting_shift fires", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		expect(updated.activePackId).toBe("B");
+	});
+
+	it("updates phase.contentPack to the B-side pack after setting_shift", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.contentPack.setting).toBe("sun-baked salt flat");
+	});
+
+	it("updates phase.setting to the B-side pack's setting string", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.setting).toBe("sun-baked salt flat");
+	});
+
+	it("leaves world entity positions unchanged after setting_shift", () => {
+		const entities: WorldEntity[] = [
+			makeObstacle("box", { row: 2, col: 3 }),
+			makeObstacle("crate", { row: 1, col: 1 }),
+		];
+		const phase = makePhase({
+			contentPack: PACK_A,
+			setting: PACK_A.setting,
+			world: { entities },
+		});
+		const game: GameState = {
+			currentPhase: 1,
+			phases: [phase],
+			personas: TEST_PERSONAS,
+			isComplete: false,
+			contentPacksA: [PACK_A],
+			contentPacksB: [PACK_B],
+			activePackId: "A",
+		};
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.world.entities).toHaveLength(2);
+		expect(updatedPhase.world.entities[0]?.holder).toEqual({ row: 2, col: 3 });
+		expect(updatedPhase.world.entities[1]?.holder).toEqual({ row: 1, col: 1 });
+	});
+
+	it("appends a broadcast entry to every daemon's conversationLog", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		for (const aiId of AI_IDS) {
+			const log = updatedPhase.conversationLogs[aiId] ?? [];
+			const broadcast = log.find((e) => e.kind === "broadcast");
+			expect(broadcast).toBeDefined();
+			if (broadcast?.kind === "broadcast") {
+				expect(broadcast.content).toContain("sun-baked salt flat");
+			}
+		}
+	});
+
+	it("does NOT change activePackId when a non-shift complication fires", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "weather_change" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		expect(updated.activePackId).toBe("A");
 	});
 });
 

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -81,9 +81,11 @@ describe("createGame", () => {
 		expect(game.phases).toHaveLength(0);
 	});
 
-	it("creates a game with contentPacks", () => {
-		const game = createGame(TEST_PERSONAS, []);
-		expect(game.contentPacks).toEqual([]);
+	it("creates a game with contentPacksA and contentPacksB", () => {
+		const game = createGame(TEST_PERSONAS, [], []);
+		expect(game.contentPacksA).toEqual([]);
+		expect(game.contentPacksB).toEqual([]);
+		expect(game.activePackId).toBe("A");
 	});
 });
 
@@ -238,7 +240,7 @@ describe("startPhase", () => {
 				cyan: { position: { row: 1, col: 1 }, facing: "west" as const },
 			},
 		};
-		const game = createGame(TEST_PERSONAS, [pack]);
+		const game = createGame(TEST_PERSONAS, [pack], []);
 		const phase = getActivePhase(startPhase(game, TEST_PHASE_CONFIG));
 
 		expect(phase.personaSpatial.red?.position).toEqual({ row: 3, col: 3 });

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -10,7 +10,7 @@
  * Issue #173 (parent #155).
  */
 
-import { generateContentPacks } from "../../content/content-pack-generator.js";
+import { generateDualContentPacks } from "../../content/content-pack-generator.js";
 import {
 	generatePersonas,
 	PHASE_1_CONFIG,
@@ -27,12 +27,13 @@ import type { AiId, AiPersona, ContentPack } from "./types.js";
 
 export interface NewGameAssets {
 	personas: Record<AiId, AiPersona>;
-	contentPacks: ContentPack[];
+	contentPacksA: ContentPack[];
+	contentPacksB: ContentPack[];
 }
 
 export interface SplitNewGameAssets {
 	personasPromise: Promise<Record<AiId, AiPersona>>;
-	contentPacksPromise: Promise<ContentPack[]>;
+	contentPacksPromise: Promise<{ packsA: ContentPack[]; packsB: ContentPack[] }>;
 }
 
 export interface BootstrapOpts {
@@ -82,7 +83,7 @@ export function generateNewGameAssetsSplit(
 	const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
 	aiIdsPromise.catch(() => {});
 
-	const contentPacksPromise = generateContentPacks(
+	const contentPacksPromise = generateDualContentPacks(
 		contentPackRng,
 		SETTING_POOL,
 		[PHASE_1_CONFIG, PHASE_2_CONFIG, PHASE_3_CONFIG],
@@ -107,11 +108,11 @@ export async function generateNewGameAssets(
 ): Promise<NewGameAssets> {
 	const { personasPromise, contentPacksPromise } =
 		generateNewGameAssetsSplit(opts);
-	const [personas, contentPacks] = await Promise.all([
+	const [personas, { packsA, packsB }] = await Promise.all([
 		personasPromise,
 		contentPacksPromise,
 	]);
-	return { personas, contentPacks };
+	return { personas, contentPacksA: packsA, contentPacksB: packsB };
 }
 
 /**
@@ -130,7 +131,8 @@ export function buildSessionFromAssets(
 	return new GameSession(
 		PHASE_1_CONFIG,
 		assets.personas,
-		assets.contentPacks,
+		assets.contentPacksA,
+		assets.contentPacksB,
 		opts?.rng,
 	);
 }

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -33,7 +33,10 @@ export interface NewGameAssets {
 
 export interface SplitNewGameAssets {
 	personasPromise: Promise<Record<AiId, AiPersona>>;
-	contentPacksPromise: Promise<{ packsA: ContentPack[]; packsB: ContentPack[] }>;
+	contentPacksPromise: Promise<{
+		packsA: ContentPack[];
+		packsB: ContentPack[];
+	}>;
 }
 
 export interface BootstrapOpts {

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -13,7 +13,12 @@
  */
 
 import { applyDirection, CARDINAL_DIRECTIONS, inBounds } from "./direction.js";
-import { appendBroadcast, getActivePhase, swapActivePack, updateActivePhase } from "./engine.js";
+import {
+	appendBroadcast,
+	getActivePhase,
+	swapActivePack,
+	updateActivePhase,
+} from "./engine.js";
 import type {
 	ActiveComplication,
 	AiId,

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -13,7 +13,7 @@
  */
 
 import { applyDirection, CARDINAL_DIRECTIONS, inBounds } from "./direction.js";
-import { getActivePhase, updateActivePhase } from "./engine.js";
+import { appendBroadcast, getActivePhase, swapActivePack, updateActivePhase } from "./engine.js";
 import type {
 	ActiveComplication,
 	AiId,
@@ -379,7 +379,8 @@ export function decrementComplicationCountdown(game: GameState): GameState {
  * Apply a ComplicationResult to the game state:
  *   1. Reset the countdown via drawCountdown(rng, 5, 15).
  *   2. Mark settingShiftFired=true if the result is a setting_shift.
- *   3. Append to activeComplications for persistent kinds
+ *   3. For setting_shift: swap the active pack and broadcast the shift.
+ *   4. Append to activeComplications for persistent kinds
  *      (sysadmin_directive, tool_disable, chat_lockout).
  *
  * Call this every round when `tickComplication` returns non-null.
@@ -392,7 +393,8 @@ export function applyComplicationResult(
 	const newCountdown = drawCountdown(rng, 5, 15);
 	const { fired } = result;
 
-	return updateActivePhase(game, (phase) => {
+	// Update phase-level complication schedule and persistent complications
+	let state = updateActivePhase(game, (phase) => {
 		const settingShiftFired =
 			phase.complicationSchedule.settingShiftFired ||
 			fired.kind === "setting_shift";
@@ -427,7 +429,7 @@ export function applyComplicationResult(
 			};
 			activeComplications = [...activeComplications, entry];
 		}
-		// weather_change, obstacle_shift, setting_shift are transient — not appended
+		// weather_change, obstacle_shift, setting_shift are transient — not appended here
 
 		return {
 			...phase,
@@ -435,4 +437,16 @@ export function applyComplicationResult(
 			activeComplications,
 		};
 	});
+
+	// setting_shift: swap the active pack and broadcast the change to all Daemons
+	if (fired.kind === "setting_shift") {
+		state = swapActivePack(state);
+		const newPhase = getActivePhase(state);
+		state = appendBroadcast(
+			state,
+			`[SYSTEM] The setting has shifted. You are now in: ${newPhase.setting}.`,
+		);
+	}
+
+	return state;
 }

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -482,7 +482,9 @@ export function validateDualContentPacks(
 	}
 	const obj = raw as Record<string, unknown>;
 	if (!Array.isArray(obj.phases)) {
-		throw new ContentPackError("Dual content pack response missing phases array");
+		throw new ContentPackError(
+			"Dual content pack response missing phases array",
+		);
 	}
 	if (obj.phases.length !== input.phases.length) {
 		throw new ContentPackError(
@@ -499,7 +501,9 @@ export function validateDualContentPacks(
 		const phaseObj = phaseRaw as Record<string, unknown>;
 		const phaseNumber = phaseObj.phaseNumber as 1 | 2 | 3;
 		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) {
-			throw new ContentPackError(`Invalid phaseNumber: ${String(phaseObj.phaseNumber)}`);
+			throw new ContentPackError(
+				`Invalid phaseNumber: ${String(phaseObj.phaseNumber)}`,
+			);
 		}
 		const inputPhase = input.phases.find((p) => p.phaseNumber === phaseNumber);
 		if (!inputPhase) {
@@ -509,8 +513,18 @@ export function validateDualContentPacks(
 		// Validate each pack independently, collecting IDs to verify parity
 		const allIdsA = new Set<string>();
 		const allIdsB = new Set<string>();
-		const packA = validateSinglePack(phaseObj.packA, inputPhase, allIdsA, "packA");
-		const packB = validateSinglePack(phaseObj.packB, inputPhase, allIdsB, "packB");
+		const packA = validateSinglePack(
+			phaseObj.packA,
+			inputPhase,
+			allIdsA,
+			"packA",
+		);
+		const packB = validateSinglePack(
+			phaseObj.packB,
+			inputPhase,
+			allIdsB,
+			"packB",
+		);
 
 		// Enforce entity ID parity between packA and packB
 		const idsA = [...allIdsA].sort();
@@ -587,11 +601,19 @@ function validateSinglePack(
 	const objectivePairs: ObjectivePair[] = [];
 	for (const pairRaw of pack.objectivePairs as unknown[]) {
 		if (pairRaw == null || typeof pairRaw !== "object") {
-			throw new ContentPackError(`${label}: objectivePair entry is not an object`);
+			throw new ContentPackError(
+				`${label}: objectivePair entry is not an object`,
+			);
 		}
 		const pair = pairRaw as Record<string, unknown>;
 		const space = validateEntity(pair.space, "objective_space", allIds, false);
-		const object = validateEntity(pair.object, "objective_object", allIds, true, {});
+		const object = validateEntity(
+			pair.object,
+			"objective_object",
+			allIds,
+			true,
+			{},
+		);
 		if (object.pairsWithSpaceId !== space.id) {
 			throw new ContentPackError(
 				`${label}: object ${object.id} pairsWithSpaceId "${object.pairsWithSpaceId}" does not match space id "${space.id}"`,
@@ -607,7 +629,9 @@ function validateSinglePack(
 
 	const interestingObjects: WorldEntity[] = [];
 	for (const itemRaw of pack.interestingObjects as unknown[]) {
-		interestingObjects.push(validateEntity(itemRaw, "interesting_object", allIds, true));
+		interestingObjects.push(
+			validateEntity(itemRaw, "interesting_object", allIds, true),
+		);
 	}
 
 	const obstacles: WorldEntity[] = [];

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -5,8 +5,13 @@
  * MockContentPackProvider (tests).
  *
  * The browser provider makes one non-streaming JSON-mode chat-completions call
- * to generate three per-phase content packs (setting-flavored entities without
- * placements). On transient failure it retries once. CapHitError surfaces immediately.
+ * to generate content packs (setting-flavored entities without placements). On
+ * transient failure it retries once. CapHitError surfaces immediately.
+ *
+ * Issue #302: added `generateDualContentPacks` for A/B pack generation — one
+ * call that produces two setting-variants of the same entity structure. Entity
+ * IDs are identical across packs A and B; only names, descriptions, and flavor
+ * strings differ.
  */
 
 import { CapHitError, chatCompletionJson } from "../llm-client.js";
@@ -115,6 +120,94 @@ export interface ContentPackProvider {
 	generateContentPacks(
 		input: ContentPackProviderInput,
 	): Promise<ContentPackProviderResult>;
+	generateDualContentPacks(
+		input: DualContentPackProviderInput,
+	): Promise<DualContentPackProviderResult>;
+}
+
+// ── Dual-pack types (issue #302) ──────────────────────────────────────────────
+
+export const DUAL_CONTENT_PACK_SYSTEM_PROMPT = `You generate paired content packs for a text-based grid game. You are given phases, each with two settings (settingA and settingB), a shared item theme, and entity counts (k objective pairs, n interesting objects, m obstacles). For each phase produce TWO packs — Pack A (settingA) and Pack B (settingB) — where entity IDs are IDENTICAL across both packs but names and descriptions are re-flavored for the alternate setting.
+
+For each phase produce packA and packB with the following rules:
+- Entity IDs (id fields) MUST be identical between packA and packB. Choose the ids once and reuse them.
+- Entity structural relationships (pairsWithSpaceId, kind) MUST be identical between packA and packB.
+- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, landmark shortName, landmark horizonPhrase.
+- The setting field at pack level MUST match settingA for packA and settingB for packB.
+
+Entity rules (same as always):
+- Generate exactly k OBJECTIVE PAIRS per pack. Each pair:
+  - objective_object: id, kind="objective_object", name (2-4 words thematic to setting+theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 stateless sentence; MUST NOT imply contact with paired space), pairsWithSpaceId (matches space id), placementFlavor (1 sentence with literal "{actor}"), proximityFlavor (1 sentence; daemon's POV sensory experience; no "{actor}"; no placing/coupling language). Must be a portable physical item.
+  - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences). Fixed location or surface.
+- Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 stateless sentence). Must be portable.
+- Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence). Fixed and impassable.
+- Generate exactly 4 HORIZON LANDMARKS per pack (north/south/east/west): shortName (2-5 words), horizonPhrase (evocative clause; no cardinal direction words; no positional phrases implying viewer relationship).
+
+Global constraints:
+- All ids must be unique within a pack (across phases within the same call).
+- Theme ("mundane"/"technological"/"magical") governs objective_objects, objective_spaces, and interesting_objects only.
+- placementFlavor MUST contain literal string "{actor}".
+- pairsWithSpaceId MUST match the paired space's id.
+- Each objective_object's examineDescription MUST contain the paired space's name or an unambiguous noun-phrase synonym.
+- horizonPhrase MUST NOT contain: north, south, east, west, ahead, behind, in front, to your left, to your right, on the horizon, beneath you, above you.
+
+Return ONLY valid JSON (no markdown, no preamble):
+{
+  "phases": [
+    {
+      "phaseNumber": <1|2|3>,
+      "packA": {
+        "setting": "<settingA>",
+        "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "..." } }],
+        "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "..." }],
+        "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "..." }],
+        "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
+      },
+      "packB": {
+        "setting": "<settingB>",
+        "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "..." } }],
+        "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "..." }],
+        "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "..." }],
+        "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
+      }
+    }
+  ]
+}`;
+
+/** Input for dual-pack (A/B) generation. */
+export interface DualContentPackProviderInput {
+	phases: Array<{
+		phaseNumber: 1 | 2 | 3;
+		settingA: string;
+		settingB: string;
+		theme: string;
+		k: number;
+		n: number;
+		m: number;
+	}>;
+}
+
+/** One phase's A+B pack pair (no placements, no weather/timeOfDay). */
+type UnplacedPack = Omit<ContentPack, "aiStarts" | "weather" | "timeOfDay"> & {
+	aiStarts: Record<AiId, never>;
+};
+
+export interface DualContentPackProviderResult {
+	phases: Array<{
+		phaseNumber: 1 | 2 | 3;
+		packA: UnplacedPack;
+		packB: UnplacedPack;
+	}>;
+}
+
+export function buildDualContentPackUserMessage(
+	input: DualContentPackProviderInput,
+): string {
+	const lines = input.phases.map(
+		(p) =>
+			`Phase ${p.phaseNumber}: settingA="${p.settingA}", settingB="${p.settingB}", theme="${p.theme}", k=${p.k} objective pairs, n=${p.n} interesting objects, m=${p.m} obstacles`,
+	);
+	return `Generate dual A/B content packs for these phases:\n${lines.join("\n")}`;
 }
 
 // ── Prose-tell check ──────────────────────────────────────────────────────────
@@ -376,6 +469,175 @@ export function validateContentPacks(
 	return { packs };
 }
 
+/**
+ * Validate a dual-pack LLM response. Ensures each phase has packA and packB
+ * with identical entity IDs and matching structural relationships.
+ */
+export function validateDualContentPacks(
+	raw: unknown,
+	input: DualContentPackProviderInput,
+): DualContentPackProviderResult {
+	if (raw == null || typeof raw !== "object") {
+		throw new ContentPackError("Dual content pack response is not an object");
+	}
+	const obj = raw as Record<string, unknown>;
+	if (!Array.isArray(obj.phases)) {
+		throw new ContentPackError("Dual content pack response missing phases array");
+	}
+	if (obj.phases.length !== input.phases.length) {
+		throw new ContentPackError(
+			`Expected ${input.phases.length} phases, got ${obj.phases.length}`,
+		);
+	}
+
+	const resultPhases: DualContentPackProviderResult["phases"] = [];
+
+	for (const phaseRaw of obj.phases) {
+		if (phaseRaw == null || typeof phaseRaw !== "object") {
+			throw new ContentPackError("Phase entry is not an object");
+		}
+		const phaseObj = phaseRaw as Record<string, unknown>;
+		const phaseNumber = phaseObj.phaseNumber as 1 | 2 | 3;
+		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) {
+			throw new ContentPackError(`Invalid phaseNumber: ${String(phaseObj.phaseNumber)}`);
+		}
+		const inputPhase = input.phases.find((p) => p.phaseNumber === phaseNumber);
+		if (!inputPhase) {
+			throw new ContentPackError(`Unexpected phaseNumber: ${phaseNumber}`);
+		}
+
+		// Validate each pack independently, collecting IDs to verify parity
+		const allIdsA = new Set<string>();
+		const allIdsB = new Set<string>();
+		const packA = validateSinglePack(phaseObj.packA, inputPhase, allIdsA, "packA");
+		const packB = validateSinglePack(phaseObj.packB, inputPhase, allIdsB, "packB");
+
+		// Enforce entity ID parity between packA and packB
+		const idsA = [...allIdsA].sort();
+		const idsB = [...allIdsB].sort();
+		if (JSON.stringify(idsA) !== JSON.stringify(idsB)) {
+			const onlyA = idsA.filter((id) => !allIdsB.has(id));
+			const onlyB = idsB.filter((id) => !allIdsA.has(id));
+			throw new ContentPackError(
+				`Phase ${phaseNumber}: entity IDs mismatch between packA and packB. ` +
+					`Only in A: [${onlyA.join(", ")}]. Only in B: [${onlyB.join(", ")}].`,
+			);
+		}
+
+		// Enforce pairsWithSpaceId parity
+		const pairingsA = new Map(
+			packA.objectivePairs.map((p) => [p.object.id, p.object.pairsWithSpaceId]),
+		);
+		const pairingsB = new Map(
+			packB.objectivePairs.map((p) => [p.object.id, p.object.pairsWithSpaceId]),
+		);
+		for (const [objId, spaceId] of pairingsA) {
+			if (pairingsB.get(objId) !== spaceId) {
+				throw new ContentPackError(
+					`Phase ${phaseNumber}: pairsWithSpaceId mismatch for object "${objId}" between packA and packB`,
+				);
+			}
+		}
+
+		resultPhases.push({ phaseNumber, packA, packB });
+	}
+
+	return { phases: resultPhases };
+}
+
+/** Validate a single pack within a dual-pack response. */
+function validateSinglePack(
+	raw: unknown,
+	inputPhase: DualContentPackProviderInput["phases"][number],
+	allIds: Set<string>,
+	label: string,
+): UnplacedPack {
+	if (raw == null || typeof raw !== "object") {
+		throw new ContentPackError(`${label} is not an object`);
+	}
+	const pack = raw as Record<string, unknown>;
+	if (typeof pack.setting !== "string" || pack.setting.length === 0) {
+		throw new ContentPackError(`${label}: missing setting`);
+	}
+	if (
+		!Array.isArray(pack.objectivePairs) ||
+		pack.objectivePairs.length !== inputPhase.k
+	) {
+		throw new ContentPackError(
+			`${label}: expected ${inputPhase.k} objectivePairs, got ${Array.isArray(pack.objectivePairs) ? pack.objectivePairs.length : "non-array"}`,
+		);
+	}
+	if (
+		!Array.isArray(pack.interestingObjects) ||
+		pack.interestingObjects.length !== inputPhase.n
+	) {
+		throw new ContentPackError(
+			`${label}: expected ${inputPhase.n} interestingObjects, got ${Array.isArray(pack.interestingObjects) ? pack.interestingObjects.length : "non-array"}`,
+		);
+	}
+	if (
+		!Array.isArray(pack.obstacles) ||
+		pack.obstacles.length !== inputPhase.m
+	) {
+		throw new ContentPackError(
+			`${label}: expected ${inputPhase.m} obstacles, got ${Array.isArray(pack.obstacles) ? pack.obstacles.length : "non-array"}`,
+		);
+	}
+
+	const objectivePairs: ObjectivePair[] = [];
+	for (const pairRaw of pack.objectivePairs as unknown[]) {
+		if (pairRaw == null || typeof pairRaw !== "object") {
+			throw new ContentPackError(`${label}: objectivePair entry is not an object`);
+		}
+		const pair = pairRaw as Record<string, unknown>;
+		const space = validateEntity(pair.space, "objective_space", allIds, false);
+		const object = validateEntity(pair.object, "objective_object", allIds, true, {});
+		if (object.pairsWithSpaceId !== space.id) {
+			throw new ContentPackError(
+				`${label}: object ${object.id} pairsWithSpaceId "${object.pairsWithSpaceId}" does not match space id "${space.id}"`,
+			);
+		}
+		if (!examineMentionsPairedSpace(object.examineDescription, space.name)) {
+			throw new ContentPackError(
+				`${label}: object ${object.id} examineDescription does not mention paired space "${space.name}"`,
+			);
+		}
+		objectivePairs.push({ object, space });
+	}
+
+	const interestingObjects: WorldEntity[] = [];
+	for (const itemRaw of pack.interestingObjects as unknown[]) {
+		interestingObjects.push(validateEntity(itemRaw, "interesting_object", allIds, true));
+	}
+
+	const obstacles: WorldEntity[] = [];
+	for (const obsRaw of pack.obstacles as unknown[]) {
+		obstacles.push(validateEntity(obsRaw, "obstacle", allIds, false));
+	}
+
+	const landmarksRaw = pack.landmarks;
+	if (landmarksRaw == null || typeof landmarksRaw !== "object") {
+		throw new ContentPackError(`${label}: missing or invalid landmarks`);
+	}
+	const lm = landmarksRaw as Record<string, unknown>;
+	const landmarks: ContentPack["landmarks"] = {
+		north: validateLandmark(lm.north, inputPhase.phaseNumber, "north"),
+		south: validateLandmark(lm.south, inputPhase.phaseNumber, "south"),
+		east: validateLandmark(lm.east, inputPhase.phaseNumber, "east"),
+		west: validateLandmark(lm.west, inputPhase.phaseNumber, "west"),
+	};
+
+	return {
+		phaseNumber: inputPhase.phaseNumber,
+		setting: pack.setting,
+		objectivePairs,
+		interestingObjects,
+		obstacles,
+		landmarks,
+		aiStarts: {} as Record<AiId, never>,
+	};
+}
+
 /** Validate a single landmark entry from the LLM response. */
 function validateLandmark(
 	raw: unknown,
@@ -450,20 +712,72 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 			return await attempt();
 		}
 	}
+
+	async generateDualContentPacks(
+		input: DualContentPackProviderInput,
+	): Promise<DualContentPackProviderResult> {
+		const messages = [
+			{ role: "system" as const, content: DUAL_CONTENT_PACK_SYSTEM_PROMPT },
+			{
+				role: "user" as const,
+				content: buildDualContentPackUserMessage(input),
+			},
+		];
+
+		const attempt = async (): Promise<DualContentPackProviderResult> => {
+			const { content, reasoning } = await chatCompletionJson({
+				messages,
+				disableReasoning: this.disableReasoning,
+			});
+
+			const raw = content !== null && content !== "" ? content : reasoning;
+			if (raw === null || raw === "") {
+				throw new ContentPackError(
+					"dual content-pack response has neither content nor reasoning",
+				);
+			}
+
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				throw new ContentPackError(
+					`dual content-pack JSON parse failed: ${raw}`,
+				);
+			}
+
+			return validateDualContentPacks(parsed, input);
+		};
+
+		try {
+			return await attempt();
+		} catch (err) {
+			if (err instanceof CapHitError) throw err;
+			return await attempt();
+		}
+	}
 }
 
 // ── MockContentPackProvider ───────────────────────────────────────────────────
 
 export class MockContentPackProvider implements ContentPackProvider {
 	readonly calls: ContentPackProviderInput[] = [];
+	readonly dualCalls: DualContentPackProviderInput[] = [];
 	private readonly fn: (
 		input: ContentPackProviderInput,
 	) => ContentPackProviderResult;
+	private readonly dualFn: (
+		input: DualContentPackProviderInput,
+	) => DualContentPackProviderResult;
 
 	constructor(
 		fn: (input: ContentPackProviderInput) => ContentPackProviderResult,
+		dualFn?: (
+			input: DualContentPackProviderInput,
+		) => DualContentPackProviderResult,
 	) {
 		this.fn = fn;
+		this.dualFn = dualFn ?? (() => ({ phases: [] }));
 	}
 
 	async generateContentPacks(
@@ -471,5 +785,12 @@ export class MockContentPackProvider implements ContentPackProvider {
 	): Promise<ContentPackProviderResult> {
 		this.calls.push(input);
 		return this.fn(input);
+	}
+
+	async generateDualContentPacks(
+		input: DualContentPackProviderInput,
+	): Promise<DualContentPackProviderResult> {
+		this.dualCalls.push(input);
+		return this.dualFn(input);
 	}
 }

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -91,14 +91,17 @@ export function updateActivePhase(
 
 export function createGame(
 	personas: Record<string, AiPersona>,
-	contentPacks: ContentPack[] = [],
+	contentPacksA: ContentPack[] = [],
+	contentPacksB: ContentPack[] = [],
 ): GameState {
 	return {
 		currentPhase: 1,
 		phases: [],
 		personas: personas as Record<AiId, AiPersona>,
 		isComplete: false,
-		contentPacks,
+		contentPacksA,
+		contentPacksB,
+		activePackId: "A",
 	};
 }
 
@@ -122,10 +125,10 @@ export function startPhase(
 		conversationLogs[aiId] = [];
 	}
 
-	// Look up the ContentPack for this phase from game.contentPacks
-	const pack = game.contentPacks.find(
-		(p) => p.phaseNumber === config.phaseNumber,
-	);
+	// Look up the ContentPack for this phase from the active pack set
+	const activePacks =
+		game.activePackId === "B" ? game.contentPacksB : game.contentPacksA;
+	const pack = activePacks.find((p) => p.phaseNumber === config.phaseNumber);
 
 	const aiGoals = resolveAiGoals(config, rng, aiIds, pack);
 
@@ -239,6 +242,39 @@ export function getActivePhase(game: GameState): PhaseState {
 	const phase = game.phases[game.phases.length - 1];
 	if (!phase) throw new Error("No active phase");
 	return phase;
+}
+
+/**
+ * Returns the active ContentPack for the current phase, honoring `activePackId`.
+ * Falls back to the phase's embedded `contentPack` if no matching pack is found
+ * in the A/B arrays (e.g. in tests that construct GameState directly).
+ */
+export function getActivePack(game: GameState): ContentPack {
+	const phase = getActivePhase(game);
+	const packs =
+		game.activePackId === "B" ? game.contentPacksB : game.contentPacksA;
+	return (
+		packs.find((p) => p.phaseNumber === phase.phaseNumber) ?? phase.contentPack
+	);
+}
+
+/**
+ * Swap `activePackId` from "A" to "B". Updates the active phase's `contentPack`
+ * reference to the B-side pack so prompt builders and dispatchers see the new
+ * names/descriptions immediately. Entity positions in `PhaseState.world` are
+ * unchanged — world state is keyed by entity ID, which is stable across packs.
+ */
+export function swapActivePack(game: GameState): GameState {
+	const phase = getActivePhase(game);
+	const bPack = game.contentPacksB.find(
+		(p) => p.phaseNumber === phase.phaseNumber,
+	);
+	if (!bPack) return game; // No B pack for this phase; no-op
+	return updateActivePhase({ ...game, activePackId: "B" }, (p) => ({
+		...p,
+		contentPack: bPack,
+		setting: bPack.setting,
+	}));
 }
 
 export function advanceRound(game: GameState): GameState {

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -56,10 +56,11 @@ export class GameSession {
 	constructor(
 		phaseConfig: PhaseConfig,
 		personas: Record<AiId, AiPersona>,
-		contentPacks?: ContentPack[],
+		contentPacksA?: ContentPack[],
+		contentPacksB?: ContentPack[],
 		rng?: () => number,
 	) {
-		const game = createGame(personas, contentPacks ?? []);
+		const game = createGame(personas, contentPacksA ?? [], contentPacksB ?? []);
 		this.state = startPhase(game, phaseConfig, rng);
 	}
 

--- a/src/spa/game/pending-bootstrap.ts
+++ b/src/spa/game/pending-bootstrap.ts
@@ -26,7 +26,10 @@ export type PendingBootstrapStatus =
 
 export interface PendingBootstrap {
 	personasPromise: Promise<Record<AiId, AiPersona>>;
-	contentPacksPromise: Promise<{ packsA: ContentPack[]; packsB: ContentPack[] }>;
+	contentPacksPromise: Promise<{
+		packsA: ContentPack[];
+		packsB: ContentPack[];
+	}>;
 	status: PendingBootstrapStatus;
 	error?: unknown;
 }

--- a/src/spa/game/pending-bootstrap.ts
+++ b/src/spa/game/pending-bootstrap.ts
@@ -26,7 +26,7 @@ export type PendingBootstrapStatus =
 
 export interface PendingBootstrap {
 	personasPromise: Promise<Record<AiId, AiPersona>>;
-	contentPacksPromise: Promise<ContentPack[]>;
+	contentPacksPromise: Promise<{ packsA: ContentPack[]; packsB: ContentPack[] }>;
 	status: PendingBootstrapStatus;
 	error?: unknown;
 }

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -18,12 +18,12 @@
  */
 
 import { availableTools } from "./available-tools";
-import { COMPLICATIONS } from "./complications";
 import {
 	applyComplicationResult,
 	decrementComplicationCountdown,
 	tickComplication,
 } from "./complication-engine";
+import { COMPLICATIONS } from "./complications";
 import { dispatchAiTurn } from "./dispatcher";
 import {
 	advancePhase,

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -19,6 +19,11 @@
 
 import { availableTools } from "./available-tools";
 import { COMPLICATIONS } from "./complications";
+import {
+	applyComplicationResult,
+	decrementComplicationCountdown,
+	tickComplication,
+} from "./complication-engine";
 import { dispatchAiTurn } from "./dispatcher";
 import {
 	advancePhase,
@@ -506,6 +511,8 @@ export async function runRound(
 	}
 
 	// 5. Mid-phase complication
+	// complicationConfig is a legacy test-only injection path (triggers at a specific round).
+	// In production the complication engine drives the schedule automatically every round.
 	if (complicationConfig) {
 		const { rng, triggerRound } = complicationConfig;
 		const currentRound = getActivePhase(state).round;
@@ -514,6 +521,15 @@ export async function runRound(
 			// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
 			const complication = COMPLICATIONS[compIdx]!;
 			state = complication.apply(state, rng);
+		}
+	} else {
+		// Real complication engine path: tick the countdown every round and
+		// dispatch when it reaches zero.
+		const compResult = tickComplication(state, Math.random);
+		if (compResult !== null) {
+			state = applyComplicationResult(state, compResult, Math.random);
+		} else {
+			state = decrementComplicationCountdown(state);
 		}
 	}
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -320,8 +320,12 @@ export interface GameState {
 	phases: PhaseState[];
 	personas: Record<AiId, AiPersona>;
 	isComplete: boolean;
-	/** All three content packs generated at game start. */
-	contentPacks: ContentPack[];
+	/** Setting A content packs — one per phase, generated at game start. */
+	contentPacksA: ContentPack[];
+	/** Setting B content packs — same entity IDs as A, different names/descriptions. */
+	contentPacksB: ContentPack[];
+	/** Which setting is currently active. Starts as "A"; swapped to "B" by Setting Shift. */
+	activePackId: "A" | "B";
 }
 
 export type ToolName =

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -617,12 +617,12 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
-	it("SESSION_SCHEMA_VERSION is 6", () => {
+	it("SESSION_SCHEMA_VERSION is 7", () => {
 		const game = makeFreshGame();
 		const files = serializeSession(game, NOW, CREATED_AT);
 		if (!files.engine) throw new Error("engine should not be null");
 		const rawJson = deobfuscate(files.engine);
 		const sealed = JSON.parse(rawJson);
-		expect(sealed.schemaVersion).toBe(6);
+		expect(sealed.schemaVersion).toBe(7);
 	});
 });

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -308,10 +308,9 @@ export function deserializeSession(
 
 		const contentPacksA = sealed.contentPacksA ?? [];
 		const contentPacksB = sealed.contentPacksB ?? [];
-		const contentPack =
-			(sealed.activePackId === "B"
-				? contentPacksB.find((p) => p.phaseNumber === epochPhase)
-				: contentPacksA.find((p) => p.phaseNumber === epochPhase)) ??
+		const contentPack = (sealed.activePackId === "B"
+			? contentPacksB.find((p) => p.phaseNumber === epochPhase)
+			: contentPacksA.find((p) => p.phaseNumber === epochPhase)) ??
 			contentPacksA[0] ?? {
 				phaseNumber: epochPhase,
 				setting: "",

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -60,8 +60,14 @@ import {
  *     weather change complications). Broadcast entries ride along in the
  *     existing per-Daemon `conversationLog` array and round-trip automatically;
  *     no additional structural deserialization changes required.
+ *
+ * v7 (issue #302): A/B dual content-pack generation.
+ *   - `contentPackA`/`contentPackB` (single-pack scalars) replaced by
+ *     `contentPacksA`/`contentPacksB` (full pack arrays, one entry per phase).
+ *   - `activePackId: "A" | "B"` now persisted correctly (was hardcoded "A").
+ *   - Old v6 saves surface `version-mismatch` — no migration provided.
  */
-export const SESSION_SCHEMA_VERSION = 6 as const;
+export const SESSION_SCHEMA_VERSION = 7 as const;
 
 // ── Phase config lookup ────────────────────────────────────────────────────────
 
@@ -106,8 +112,10 @@ export interface SealedEngine {
 	budgets: Record<AiId, AiBudget>;
 	lockedOut: AiId[];
 	personaSpatial: Record<AiId, PersonaSpatialState>;
-	contentPackA: ContentPack;
-	contentPackB: ContentPack;
+	/** All Setting A content packs (one per phase). */
+	contentPacksA: ContentPack[];
+	/** All Setting B content packs (one per phase, same entity IDs as A). */
+	contentPacksB: ContentPack[];
 	activePackId: "A" | "B";
 	weather: string;
 	objectives: Objective[];
@@ -178,29 +186,15 @@ export function serializeSession(
 		daemons[aiId] = JSON.stringify(daemonFile, null, 2);
 	}
 
-	const contentPackB: ContentPack = state.contentPacks.find(
-		(p) => p.phaseNumber !== activePhase.phaseNumber,
-	) ?? {
-		phaseNumber: 2,
-		setting: "",
-		weather: "",
-		timeOfDay: "",
-		objectivePairs: [],
-		interestingObjects: [],
-		obstacles: [],
-		landmarks: DEFAULT_LANDMARKS,
-		aiStarts: {},
-	};
-
 	const sealedPayload: SealedEngine = {
 		schemaVersion: SESSION_SCHEMA_VERSION,
 		world: structuredClone(activePhase.world),
 		budgets: { ...activePhase.budgets },
 		lockedOut: Array.from(activePhase.lockedOut) as AiId[],
 		personaSpatial: structuredClone(activePhase.personaSpatial),
-		contentPackA: structuredClone(activePhase.contentPack),
-		contentPackB: structuredClone(contentPackB),
-		activePackId: "A",
+		contentPacksA: structuredClone(state.contentPacksA),
+		contentPacksB: structuredClone(state.contentPacksB),
+		activePackId: state.activePackId,
 		weather: activePhase.weather,
 		objectives: [],
 		complicationSchedule: activePhase.complicationSchedule,
@@ -312,7 +306,23 @@ export function deserializeSession(
 			aiGoals[aiId] = "";
 		}
 
-		const contentPack = sealed.contentPackA;
+		const contentPacksA = sealed.contentPacksA ?? [];
+		const contentPacksB = sealed.contentPacksB ?? [];
+		const contentPack =
+			(sealed.activePackId === "B"
+				? contentPacksB.find((p) => p.phaseNumber === epochPhase)
+				: contentPacksA.find((p) => p.phaseNumber === epochPhase)) ??
+			contentPacksA[0] ?? {
+				phaseNumber: epochPhase,
+				setting: "",
+				weather: "",
+				timeOfDay: "",
+				objectivePairs: [],
+				interestingObjects: [],
+				obstacles: [],
+				landmarks: DEFAULT_LANDMARKS,
+				aiStarts: {},
+			};
 		const setting = contentPack.setting;
 		const weather = sealed.weather;
 		const timeOfDay = contentPack.timeOfDay ?? "";
@@ -359,7 +369,9 @@ export function deserializeSession(
 			isComplete: sealed.isComplete,
 			personas,
 			phases: [phase],
-			contentPacks: [sealed.contentPackA, sealed.contentPackB],
+			contentPacksA,
+			contentPacksB,
+			activePackId: sealed.activePackId,
 		};
 
 		return {

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -625,9 +625,10 @@ export function renderGame(
 				renderLoadingTopInfo("generating-room");
 				startSpinners();
 				startBrightnessWipe();
-				return pending.contentPacksPromise.then((packs) => ({
+				return pending.contentPacksPromise.then(({ packsA, packsB }) => ({
 					personas,
-					contentPacks: packs,
+					contentPacksA: packsA,
+					contentPacksB: packsB,
 				}));
 			})
 			.then((assets) => {


### PR DESCRIPTION
## Summary

- `generateDualContentPacks` produces Pack A and Pack B in one LLM call; Pack B entities share identical IDs and grid positions with Pack A (placement parity)
- `GameState` gains `contentPacksA[]`, `contentPacksB[]`, `activePackId: "A" | "B"` — replaces the old single `contentPacks` array
- `swapActivePack` in `engine.ts` flips `activePackId` A→B and updates the active phase's `contentPack` and `setting` string
- Setting Shift complication calls `swapActivePack` then appends a broadcast entry to every daemon's conversation log announcing the new setting
- Session codec bumped to **schema v7**: `SealedEngine` stores full A/B pack arrays (one per phase) so all phases survive save/load and phase advancement
- All callsites updated: bootstrap, game-session, routes, save-serializer, pending-bootstrap

## Test plan

- [ ] `generateDualContentPacks` — entity IDs identical per phase between A and B
- [ ] `generateDualContentPacks` — Pack A and Pack B have different settings
- [ ] `generateDualContentPacks` — Pack B entities have same holder positions as Pack A
- [ ] `generateDualContentPacks` — exactly one LLM call made
- [ ] `generateDualContentPacks` — throws when setting pool has fewer than 6 entries
- [ ] `applyComplicationResult` setting_shift — `activePackId` flips to "B"
- [ ] `applyComplicationResult` setting_shift — `phase.contentPack.setting` updates to B-side pack
- [ ] `applyComplicationResult` setting_shift — `phase.setting` string updates
- [ ] `applyComplicationResult` setting_shift — world entity positions unchanged
- [ ] `applyComplicationResult` setting_shift — broadcast appended to every daemon's log containing new setting name
- [ ] `applyComplicationResult` non-shift — `activePackId` stays "A"
- [ ] Session codec round-trip with v7 schema (both pack arrays survive serialize/deserialize)
- [ ] All 1227 existing tests pass (`pnpm test`)

https://claude.ai/code/session_01EzxNFpH22g7K1is3Vpw6TW

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzxNFpH22g7K1is3Vpw6TW)_