### PR TITLE
Make chat lockout events silent to the player

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -1266,7 +1266,7 @@ describe("renderGame — chat_lockout event", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("chat_lockout appends the lockout message to the locked AI's transcript", async () => {
+	it("chat_lockout silently locks the panel without appending a transcript message", async () => {
 		vi.stubGlobal(
 			"fetch",
 			makeThreeAiFetchMock(PASS_ACTION, PASS_ACTION, PASS_ACTION),
@@ -1315,9 +1315,10 @@ describe("renderGame — chat_lockout event", () => {
 
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		// The chat_lockout event should have appended the message to red's transcript.
+		// The chat_lockout event should NOT append any message to the transcript —
+		// complications are silent to the player.
 		const redTranscript = getEl<HTMLElement>('[data-transcript="red"]');
-		expect(redTranscript.textContent).toContain("[Ember is unresponsive…]");
+		expect(redTranscript.textContent).not.toContain("[Ember is unresponsive…]");
 
 		// After the chat_lockout fires for red, typing *Ember should leave Send disabled.
 		const sendBtn = getEl<HTMLButtonElement>("#send");

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1257,7 +1257,6 @@ export function renderGame(
 
 					case "chat_lockout":
 						setChatLockout(event.aiId, true);
-						appendStandaloneLine(event.aiId, `[${event.message}]\n`);
 						break;
 
 					case "chat_lockout_resolved":


### PR DESCRIPTION
## Summary
Chat lockout events are now handled silently without appending a message to the AI's transcript. This aligns with the design decision that complications should not be visible to the player.

## Changes
- Removed the transcript message append when a `chat_lockout` event occurs
- Updated test expectations to verify that no lockout message is added to the transcript
- Updated test description and comments to reflect the silent behavior

## Implementation Details
The `chat_lockout` event now only triggers the internal `setChatLockout()` function to disable the chat panel, without calling `appendStandaloneLine()` to add a visible message. This keeps the lockout mechanism transparent to the player while still preventing further interaction with the locked AI.

https://claude.ai/code/session_01PjjoW3EbokQEPbAQn6uFK4