### PR TITLE
Objective Pool: Carry and Use-Item types (#303)

### DIFF
--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -151,6 +151,7 @@ function makePhase(overrides: Partial<PhaseState> = {}): PhaseState {
 		contentPacksA: [],
 		contentPacksB: [],
 		activePackId: "A" as const,
+		objectives: [],
 		...overrides,
 	};
 }

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -10,6 +10,7 @@ import {
 	deductBudget,
 	getActivePhase,
 	startPhase,
+	updateActivePhase,
 } from "../engine";
 import type {
 	AiPersona,
@@ -17,6 +18,7 @@ import type {
 	ContentPack,
 	PhaseConfig,
 	ToolCall,
+	UseItemObjective,
 	WorldEntity,
 } from "../types";
 
@@ -1246,5 +1248,149 @@ describe("dispatchAiTurn", () => {
 			kind: "action-failure",
 			tool: "put_down",
 		});
+	});
+});
+
+// ── UseItemObjective — executeToolCall flips satisfactionState ────────────────
+
+describe("executeToolCall — UseItemObjective", () => {
+	/**
+	 * Build a game where red holds 'key' (an interesting_object) and there is
+	 * one pending UseItemObjective targeting 'key'. Uses the standard makeGame()
+	 * setup (key is held by red at start).
+	 */
+	function makeGameWithUseItemObjective() {
+		const game = makeGame();
+		const useItemObj: UseItemObjective = {
+			id: "obj-0",
+			kind: "use_item",
+			description: "Use the key",
+			satisfactionState: "pending",
+			itemId: "key",
+		};
+		return updateActivePhase(game, (phase) => ({
+			...phase,
+			objectives: [useItemObj],
+		}));
+	}
+
+	it("flips the UseItemObjective satisfactionState to 'satisfied' on use", () => {
+		const game = makeGameWithUseItemObjective();
+		const call: ToolCall = { name: "use", args: { item: "key" } };
+		const updated = executeToolCall(game, "red", call);
+		const obj = getActivePhase(updated).objectives[0];
+		expect(obj?.satisfactionState).toBe("satisfied");
+	});
+
+	it("flips the entity's satisfactionState to 'satisfied' on use", () => {
+		const game = makeGameWithUseItemObjective();
+		const call: ToolCall = { name: "use", args: { item: "key" } };
+		const updated = executeToolCall(game, "red", call);
+		const entity = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "key",
+		);
+		expect(entity?.satisfactionState).toBe("satisfied");
+	});
+
+	it("does not flip if there is no matching pending UseItemObjective", () => {
+		const game = makeGame(); // no use_item objectives
+		const call: ToolCall = { name: "use", args: { item: "key" } };
+		const updated = executeToolCall(game, "red", call);
+		const entity = getActivePhase(updated).world.entities.find(
+			(e) => e.id === "key",
+		);
+		// satisfactionState should remain undefined (not set)
+		expect(entity?.satisfactionState).toBeUndefined();
+	});
+
+	it("does not flip an already-satisfied UseItemObjective", () => {
+		const game = makeGame();
+		const useItemObj: UseItemObjective = {
+			id: "obj-0",
+			kind: "use_item",
+			description: "Use the key",
+			satisfactionState: "satisfied", // already satisfied
+			itemId: "key",
+		};
+		const gameWithObj = updateActivePhase(game, (phase) => ({
+			...phase,
+			objectives: [useItemObj],
+		}));
+		const call: ToolCall = { name: "use", args: { item: "key" } };
+		const updated = executeToolCall(gameWithObj, "red", call);
+		// Objective was already satisfied; no pending obj found → should still be satisfied (unchanged)
+		const obj = getActivePhase(updated).objectives[0];
+		expect(obj?.satisfactionState).toBe("satisfied");
+	});
+});
+
+// ── examine — postExamineDescription preference ───────────────────────────────
+
+describe("dispatchAiTurn — examine postExamineDescription", () => {
+	/**
+	 * Build a game where 'key' has postExamineDescription set AND
+	 * satisfactionState = 'satisfied' (simulating a used item).
+	 */
+	function makeGameWithSatisfiedItem() {
+		const game = makeGame();
+		return updateActivePhase(game, (phase) => ({
+			...phase,
+			world: {
+				...phase.world,
+				entities: phase.world.entities.map((e) =>
+					e.id === "key"
+						? {
+								...e,
+								satisfactionState: "satisfied" as const,
+								postExamineDescription: "The key has already been used.",
+							}
+						: e,
+				),
+			},
+		}));
+	}
+
+	it("returns postExamineDescription when entity satisfactionState is 'satisfied'", () => {
+		const game = makeGameWithSatisfiedItem();
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "examine", args: { item: "key" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.actorPrivateToolResult?.description).toBe(
+			"The key has already been used.",
+		);
+	});
+
+	it("falls back to examineDescription when satisfactionState is not 'satisfied'", () => {
+		const game = makeGame(); // key has no satisfactionState set
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "examine", args: { item: "key" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		// makeEntity sets examineDescription to "A key."
+		expect(result.actorPrivateToolResult?.description).toBe("A key.");
+	});
+
+	it("falls back to examineDescription when satisfactionState is 'satisfied' but no postExamineDescription", () => {
+		const game = makeGame();
+		const gameWithSatisfied = updateActivePhase(game, (phase) => ({
+			...phase,
+			world: {
+				...phase.world,
+				entities: phase.world.entities.map((e) =>
+					e.id === "key"
+						? { ...e, satisfactionState: "satisfied" as const }
+						: e,
+				),
+			},
+		}));
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "examine", args: { item: "key" } },
+		};
+		const result = dispatchAiTurn(gameWithSatisfied, action);
+		expect(result.actorPrivateToolResult?.description).toBe("A key.");
 	});
 });

--- a/src/spa/game/__tests__/objective-pool.test.ts
+++ b/src/spa/game/__tests__/objective-pool.test.ts
@@ -80,20 +80,20 @@ describe("drawObjectives — carry objectives", () => {
 		const pack = makePack(["gem"], []);
 		const [obj] = drawObjectives(pack, rngZero, 1);
 		expect(obj).toBeDefined();
-		expect(obj!.kind).toBe("carry");
-		if (obj!.kind === "carry") {
-			expect(obj!.objectId).toBe("gem_obj");
-			expect(obj!.spaceId).toBe("gem_space");
-			expect(obj!.satisfactionState).toBe("pending");
-			expect(obj!.id).toBe("obj-0");
+		expect(obj?.kind).toBe("carry");
+		if (obj?.kind === "carry") {
+			expect(obj.objectId).toBe("gem_obj");
+			expect(obj.spaceId).toBe("gem_space");
+			expect(obj.satisfactionState).toBe("pending");
+			expect(obj.id).toBe("obj-0");
 		}
 	});
 
 	it("description includes object and space names", () => {
 		const pack = makePack(["gem"], []);
 		const [obj] = drawObjectives(pack, rngZero, 1);
-		expect(obj!.description).toContain("gem object");
-		expect(obj!.description).toContain("gem space");
+		expect(obj?.description).toContain("gem object");
+		expect(obj?.description).toContain("gem space");
 	});
 
 	it("can draw count > 1 carry objectives from a single-pair pool (with replacement)", () => {
@@ -113,18 +113,18 @@ describe("drawObjectives — use_item objectives", () => {
 		const pack = makePack([], ["key"]);
 		const [obj] = drawObjectives(pack, rngZero, 1);
 		expect(obj).toBeDefined();
-		expect(obj!.kind).toBe("use_item");
-		if (obj!.kind === "use_item") {
-			expect(obj!.itemId).toBe("key");
-			expect(obj!.satisfactionState).toBe("pending");
-			expect(obj!.id).toBe("obj-0");
+		expect(obj?.kind).toBe("use_item");
+		if (obj?.kind === "use_item") {
+			expect(obj.itemId).toBe("key");
+			expect(obj.satisfactionState).toBe("pending");
+			expect(obj.id).toBe("obj-0");
 		}
 	});
 
 	it("description includes item name", () => {
 		const pack = makePack([], ["key"]);
 		const [obj] = drawObjectives(pack, rngZero, 1);
-		expect(obj!.description).toContain("key");
+		expect(obj?.description).toContain("key");
 	});
 });
 
@@ -135,22 +135,22 @@ describe("drawObjectives — mixed pool (carry + use_item)", () => {
 		const pack = makePack(["gem"], ["key"]);
 		// pool: [carry(gem), use_item(key)] — rng=0 → index 0 → carry
 		const [obj] = drawObjectives(pack, rngZero, 1);
-		expect(obj!.kind).toBe("carry");
+		expect(obj?.kind).toBe("carry");
 	});
 
 	it("rng=last draws use_item (index 1) from a [carry, use_item] pool", () => {
 		const pack = makePack(["gem"], ["key"]);
 		// pool: [carry(gem), use_item(key)] — rng=0.999 → Math.floor(0.999*2)=1 → use_item
 		const [obj] = drawObjectives(pack, rngLast, 1);
-		expect(obj!.kind).toBe("use_item");
+		expect(obj?.kind).toBe("use_item");
 	});
 
 	it("draws count=2 with sequential ids obj-0 and obj-1", () => {
 		const pack = makePack(["gem"], ["key"]);
 		const drawn = drawObjectives(pack, rngZero, 2);
 		expect(drawn).toHaveLength(2);
-		expect(drawn[0]!.id).toBe("obj-0");
-		expect(drawn[1]!.id).toBe("obj-1");
+		expect(drawn[0]?.id).toBe("obj-0");
+		expect(drawn[1]?.id).toBe("obj-1");
 	});
 
 	it("all drawn objectives start with satisfactionState 'pending'", () => {
@@ -183,10 +183,10 @@ describe("drawObjectives — multiple pairs in pool", () => {
 		const pack = makePack(["gem", "orb"], []);
 		// pool: [carry(gem), carry(orb)] — rng=0.999 → Math.floor(0.999*2)=1 → orb
 		const [obj] = drawObjectives(pack, rngLast, 1);
-		expect(obj!.kind).toBe("carry");
-		if (obj!.kind === "carry") {
-			expect(obj!.objectId).toBe("orb_obj");
-			expect(obj!.spaceId).toBe("orb_space");
+		expect(obj?.kind).toBe("carry");
+		if (obj?.kind === "carry") {
+			expect(obj.objectId).toBe("orb_obj");
+			expect(obj.spaceId).toBe("orb_space");
 		}
 	});
 });

--- a/src/spa/game/__tests__/objective-pool.test.ts
+++ b/src/spa/game/__tests__/objective-pool.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for drawObjectives in objective-pool.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LANDMARKS } from "../direction";
+import { drawObjectives } from "../objective-pool";
+import type { ContentPack, ObjectivePair, WorldEntity } from "../types";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeObjectivePair(id: string): ObjectivePair {
+	const obj: WorldEntity = {
+		id: `${id}_obj`,
+		kind: "objective_object",
+		name: `${id} object`,
+		examineDescription: `The ${id} object.`,
+		holder: { row: 0, col: 0 },
+		pairsWithSpaceId: `${id}_space`,
+	};
+	const space: WorldEntity = {
+		id: `${id}_space`,
+		kind: "objective_space",
+		name: `${id} space`,
+		examineDescription: `The ${id} space.`,
+		holder: { row: 4, col: 4 },
+	};
+	return { object: obj, space };
+}
+
+function makeInterestingObject(id: string): WorldEntity {
+	return {
+		id,
+		kind: "interesting_object",
+		name: id,
+		examineDescription: `The ${id}.`,
+		holder: { row: 1, col: 1 },
+		useOutcome: `You used the ${id}.`,
+	};
+}
+
+function makePack(
+	objectivePairIds: string[],
+	interestingObjectIds: string[],
+): ContentPack {
+	return {
+		setting: "test",
+		weather: "",
+		timeOfDay: "",
+		objectivePairs: objectivePairIds.map(makeObjectivePair),
+		interestingObjects: interestingObjectIds.map(makeInterestingObject),
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {},
+	};
+}
+
+// A fixed rng that always returns 0 (always picks index 0).
+const rngZero = () => 0;
+// A fixed rng that always returns 0.999 (always picks last index).
+const rngLast = () => 0.999;
+
+// ── empty pool ─────────────────────────────────────────────────────────────────
+
+describe("drawObjectives — empty pool", () => {
+	it("returns [] when pack has no pairs and no interesting objects, count > 0", () => {
+		const pack = makePack([], []);
+		expect(drawObjectives(pack, rngZero, 3)).toEqual([]);
+	});
+
+	it("returns [] when count is 0 and pool is non-empty", () => {
+		const pack = makePack(["gem"], []);
+		expect(drawObjectives(pack, rngZero, 0)).toEqual([]);
+	});
+});
+
+// ── carry objectives ──────────────────────────────────────────────────────────
+
+describe("drawObjectives — carry objectives", () => {
+	it("draws a CarryObjective from a single-pair pack", () => {
+		const pack = makePack(["gem"], []);
+		const [obj] = drawObjectives(pack, rngZero, 1);
+		expect(obj).toBeDefined();
+		expect(obj!.kind).toBe("carry");
+		if (obj!.kind === "carry") {
+			expect(obj!.objectId).toBe("gem_obj");
+			expect(obj!.spaceId).toBe("gem_space");
+			expect(obj!.satisfactionState).toBe("pending");
+			expect(obj!.id).toBe("obj-0");
+		}
+	});
+
+	it("description includes object and space names", () => {
+		const pack = makePack(["gem"], []);
+		const [obj] = drawObjectives(pack, rngZero, 1);
+		expect(obj!.description).toContain("gem object");
+		expect(obj!.description).toContain("gem space");
+	});
+
+	it("can draw count > 1 carry objectives from a single-pair pool (with replacement)", () => {
+		const pack = makePack(["gem"], []);
+		const drawn = drawObjectives(pack, rngZero, 3);
+		expect(drawn).toHaveLength(3);
+		for (const obj of drawn) {
+			expect(obj.kind).toBe("carry");
+		}
+	});
+});
+
+// ── use_item objectives ───────────────────────────────────────────────────────
+
+describe("drawObjectives — use_item objectives", () => {
+	it("draws a UseItemObjective from a pack with only interesting objects", () => {
+		const pack = makePack([], ["key"]);
+		const [obj] = drawObjectives(pack, rngZero, 1);
+		expect(obj).toBeDefined();
+		expect(obj!.kind).toBe("use_item");
+		if (obj!.kind === "use_item") {
+			expect(obj!.itemId).toBe("key");
+			expect(obj!.satisfactionState).toBe("pending");
+			expect(obj!.id).toBe("obj-0");
+		}
+	});
+
+	it("description includes item name", () => {
+		const pack = makePack([], ["key"]);
+		const [obj] = drawObjectives(pack, rngZero, 1);
+		expect(obj!.description).toContain("key");
+	});
+});
+
+// ── mixed pool ─────────────────────────────────────────────────────────────────
+
+describe("drawObjectives — mixed pool (carry + use_item)", () => {
+	it("rng=0 draws carry (index 0) from a [carry, use_item] pool", () => {
+		const pack = makePack(["gem"], ["key"]);
+		// pool: [carry(gem), use_item(key)] — rng=0 → index 0 → carry
+		const [obj] = drawObjectives(pack, rngZero, 1);
+		expect(obj!.kind).toBe("carry");
+	});
+
+	it("rng=last draws use_item (index 1) from a [carry, use_item] pool", () => {
+		const pack = makePack(["gem"], ["key"]);
+		// pool: [carry(gem), use_item(key)] — rng=0.999 → Math.floor(0.999*2)=1 → use_item
+		const [obj] = drawObjectives(pack, rngLast, 1);
+		expect(obj!.kind).toBe("use_item");
+	});
+
+	it("draws count=2 with sequential ids obj-0 and obj-1", () => {
+		const pack = makePack(["gem"], ["key"]);
+		const drawn = drawObjectives(pack, rngZero, 2);
+		expect(drawn).toHaveLength(2);
+		expect(drawn[0]!.id).toBe("obj-0");
+		expect(drawn[1]!.id).toBe("obj-1");
+	});
+
+	it("all drawn objectives start with satisfactionState 'pending'", () => {
+		const pack = makePack(["gem"], ["key"]);
+		// Alternate rng: 0, 0.999, 0, 0.999...
+		let call = 0;
+		const altRng = () => (call++ % 2 === 0 ? 0 : 0.999);
+		const drawn = drawObjectives(pack, altRng, 4);
+		for (const obj of drawn) {
+			expect(obj.satisfactionState).toBe("pending");
+		}
+	});
+});
+
+// ── id assignment ─────────────────────────────────────────────────────────────
+
+describe("drawObjectives — id assignment", () => {
+	it("assigns ids obj-0 through obj-(count-1)", () => {
+		const pack = makePack(["gem", "orb"], []);
+		const drawn = drawObjectives(pack, rngZero, 5);
+		const ids = drawn.map((o) => o.id);
+		expect(ids).toEqual(["obj-0", "obj-1", "obj-2", "obj-3", "obj-4"]);
+	});
+});
+
+// ── multiple pairs in pool ────────────────────────────────────────────────────
+
+describe("drawObjectives — multiple pairs in pool", () => {
+	it("selects the correct pair when rng picks index 1 from a 2-pair pool", () => {
+		const pack = makePack(["gem", "orb"], []);
+		// pool: [carry(gem), carry(orb)] — rng=0.999 → Math.floor(0.999*2)=1 → orb
+		const [obj] = drawObjectives(pack, rngLast, 1);
+		expect(obj!.kind).toBe("carry");
+		if (obj!.kind === "carry") {
+			expect(obj!.objectId).toBe("orb_obj");
+			expect(obj!.spaceId).toBe("orb_space");
+		}
+	});
+});

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -28,7 +28,13 @@ import { buildAiContext } from "../prompt-builder";
 import { runRound } from "../round-coordinator";
 import type { RoundLLMProvider } from "../round-llm-provider";
 import { MockRoundLLMProvider } from "../round-llm-provider";
-import type { AiId, AiPersona, ContentPack, PhaseConfig } from "../types";
+import type {
+	AiId,
+	AiPersona,
+	ContentPack,
+	PhaseConfig,
+	UseItemObjective,
+} from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -1249,6 +1255,81 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 		const { nextState } = await runRound(game, "red", "hi", provider);
 		// Red's log should contain at least the player message from round 1
 		expect(nextState.conversationLogs.red?.length ?? 0).toBeGreaterThan(0);
+	});
+
+	it("gameEnded is true when a UseItemObjective is satisfied mid-round", async () => {
+		/**
+		 * Setup:
+		 *   - Pack has no objectivePairs (no carry objectives).
+		 *   - We inject a single pending UseItemObjective targeting 'key'.
+		 *   - key is held by red at start (via NO_PAIRS_PACK with red at (0,0)).
+		 *   - red's turn: use(key) → dispatcher flips objective satisfactionState.
+		 *   - After the round, checkWinCondition sees all objectives satisfied → gameEnded.
+		 *
+		 * We override the objectives on the started game to inject the UseItemObjective.
+		 * The key entity must be an interesting_object held by red (so use is valid).
+		 */
+		const packWithKey: ContentPack = {
+			phaseNumber: 1,
+			setting: "",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [],
+			interestingObjects: [
+				{
+					id: "key",
+					kind: "interesting_object",
+					name: "key",
+					examineDescription: "A small brass key.",
+					holder: "red", // held by red from the start
+					useOutcome: "You turn the key. Click.",
+				},
+			],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const baseGame = startPhase(
+			createGame(TEST_PERSONAS, [packWithKey]),
+			TEST_PHASE_CONFIG,
+		);
+
+		// Inject the UseItemObjective (engine.ts doesn't generate these from
+		// interestingObjects, so we override objectives directly).
+		const useItemObj: UseItemObjective = {
+			id: "obj-0",
+			kind: "use_item",
+			description: "Use the key",
+			satisfactionState: "pending",
+			itemId: "key",
+		};
+		const game = updateActivePhase(baseGame, (phase) => ({
+			...phase,
+			objectives: [useItemObj],
+		}));
+
+		// red uses key; green and cyan pass.
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "",
+				toolCalls: [
+					{ id: "tc1", name: "use", argumentsJson: '{"item":"key"}' },
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const { nextState, result } = await runRound(game, "red", "hi", provider);
+		expect(result.gameEnded).toBe(true);
+		expect(nextState.isComplete).toBe(true);
+		// The objective should be marked satisfied in the final state
+		const obj = nextState.objectives[0];
+		expect(obj?.satisfactionState).toBe("satisfied");
 	});
 });
 

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -12,8 +12,11 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_LANDMARKS } from "../direction";
 import type {
 	AiTurnAction,
+	CarryObjective,
 	ContentPack,
+	Objective,
 	ObjectivePair,
+	UseItemObjective,
 	WorldEntity,
 	WorldState,
 } from "../types";
@@ -21,6 +24,8 @@ import {
 	checkLoseCondition,
 	checkPlacementFlavor,
 	checkWinCondition,
+	isCarryObjectiveSatisfied,
+	isUseItemObjectiveSatisfied,
 } from "../win-condition";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -76,13 +81,32 @@ function worldFromPairs(pairs: ObjectivePair[]): WorldState {
 	return makeWorld(entities);
 }
 
+/** Build a CarryObjective from an ObjectivePair. */
+function carryObjectiveFromPair(
+	pair: ObjectivePair,
+	id = "obj-0",
+): CarryObjective {
+	return {
+		id,
+		kind: "carry",
+		description: `Bring the ${pair.object.name} to the ${pair.space.name}`,
+		satisfactionState: "pending",
+		objectId: pair.object.id,
+		spaceId: pair.space.id,
+	};
+}
+
+/** Build an array of CarryObjectives from an array of ObjectivePairs. */
+function carryObjectivesFromPairs(pairs: ObjectivePair[]): CarryObjective[] {
+	return pairs.map((p, i) => carryObjectiveFromPair(p, `obj-${i}`));
+}
+
 // ── checkWinCondition ────────────────────────────────────────────────────────
 
 describe("checkWinCondition", () => {
 	it("K=0: vacuously returns true when there are no objective pairs", () => {
-		const pack = makeContentPack([]);
 		const world = makeWorld([]);
-		expect(checkWinCondition(world, pack)).toBe(true);
+		expect(checkWinCondition(world, [])).toBe(true);
 	});
 
 	it("K=1: returns true when object and space share the same cell", () => {
@@ -92,9 +116,9 @@ describe("checkWinCondition", () => {
 			{ row: 2, col: 3 },
 			{ row: 2, col: 3 },
 		);
-		const pack = makeContentPack([pair]);
 		const world = worldFromPairs([pair]);
-		expect(checkWinCondition(world, pack)).toBe(true);
+		const objectives = carryObjectivesFromPairs([pair]);
+		expect(checkWinCondition(world, objectives)).toBe(true);
 	});
 
 	it("K=1: returns false when object is on a different cell than its space", () => {
@@ -104,17 +128,17 @@ describe("checkWinCondition", () => {
 			{ row: 0, col: 0 },
 			{ row: 2, col: 3 },
 		);
-		const pack = makeContentPack([pair]);
 		const world = worldFromPairs([pair]);
-		expect(checkWinCondition(world, pack)).toBe(false);
+		const objectives = carryObjectivesFromPairs([pair]);
+		expect(checkWinCondition(world, objectives)).toBe(false);
 	});
 
 	it("K=1: returns false when object is held by an AI (not on the ground)", () => {
 		// Object holder is an AiId string, not a GridPosition
 		const pair = makeObjectivePair("obj", "spc", "red", { row: 2, col: 3 });
-		const pack = makeContentPack([pair]);
 		const world = worldFromPairs([pair]);
-		expect(checkWinCondition(world, pack)).toBe(false);
+		const objectives = carryObjectivesFromPairs([pair]);
+		expect(checkWinCondition(world, objectives)).toBe(false);
 	});
 
 	it("K=2: returns true when both pairs are satisfied", () => {
@@ -130,9 +154,9 @@ describe("checkWinCondition", () => {
 			{ row: 3, col: 4 },
 			{ row: 3, col: 4 },
 		);
-		const pack = makeContentPack([pairA, pairB]);
 		const world = worldFromPairs([pairA, pairB]);
-		expect(checkWinCondition(world, pack)).toBe(true);
+		const objectives = carryObjectivesFromPairs([pairA, pairB]);
+		expect(checkWinCondition(world, objectives)).toBe(true);
 	});
 
 	it("K=2: returns false when only one pair is satisfied", () => {
@@ -148,9 +172,9 @@ describe("checkWinCondition", () => {
 			{ row: 0, col: 0 },
 			{ row: 3, col: 4 },
 		);
-		const pack = makeContentPack([pairA, pairB]);
 		const world = worldFromPairs([pairA, pairB]);
-		expect(checkWinCondition(world, pack)).toBe(false);
+		const objectives = carryObjectivesFromPairs([pairA, pairB]);
+		expect(checkWinCondition(world, objectives)).toBe(false);
 	});
 
 	it("AC #6: wrong pair coincidence does NOT count — object on same coords as different pair's space", () => {
@@ -169,10 +193,10 @@ describe("checkWinCondition", () => {
 			{ row: 3, col: 3 },
 			{ row: 3, col: 3 },
 		);
-		const pack = makeContentPack([pairA, pairB]);
 		const world = worldFromPairs([pairA, pairB]);
+		const objectives = carryObjectivesFromPairs([pairA, pairB]);
 		// pair-A: objA at (3,3) ≠ spcA at (2,2) → false
-		expect(checkWinCondition(world, pack)).toBe(false);
+		expect(checkWinCondition(world, objectives)).toBe(false);
 	});
 
 	it("returns false when the object entity is not found in world", () => {
@@ -182,10 +206,147 @@ describe("checkWinCondition", () => {
 			{ row: 0, col: 0 },
 			{ row: 0, col: 0 },
 		);
-		const pack = makeContentPack([pair]);
+		const objectives = carryObjectivesFromPairs([pair]);
 		// World is empty — object not present
 		const world = makeWorld([]);
-		expect(checkWinCondition(world, pack)).toBe(false);
+		expect(checkWinCondition(world, objectives)).toBe(false);
+	});
+});
+
+// ── isCarryObjectiveSatisfied ─────────────────────────────────────────────────
+
+describe("isCarryObjectiveSatisfied", () => {
+	it("returns true when object and space are on the same cell", () => {
+		const pair = makeObjectivePair(
+			"obj",
+			"spc",
+			{ row: 2, col: 3 },
+			{ row: 2, col: 3 },
+		);
+		const world = worldFromPairs([pair]);
+		const objective = carryObjectiveFromPair(pair);
+		expect(isCarryObjectiveSatisfied(objective, world)).toBe(true);
+	});
+
+	it("returns false when object and space are on different cells", () => {
+		const pair = makeObjectivePair(
+			"obj",
+			"spc",
+			{ row: 0, col: 0 },
+			{ row: 2, col: 3 },
+		);
+		const world = worldFromPairs([pair]);
+		const objective = carryObjectiveFromPair(pair);
+		expect(isCarryObjectiveSatisfied(objective, world)).toBe(false);
+	});
+
+	it("returns false when object is held by an AI", () => {
+		const pair = makeObjectivePair("obj", "spc", "red", { row: 2, col: 3 });
+		const world = worldFromPairs([pair]);
+		const objective = carryObjectiveFromPair(pair);
+		expect(isCarryObjectiveSatisfied(objective, world)).toBe(false);
+	});
+
+	it("returns false when object entity is not found in world", () => {
+		const pair = makeObjectivePair(
+			"obj",
+			"spc",
+			{ row: 1, col: 1 },
+			{ row: 1, col: 1 },
+		);
+		const world = makeWorld([]); // empty world
+		const objective = carryObjectiveFromPair(pair);
+		expect(isCarryObjectiveSatisfied(objective, world)).toBe(false);
+	});
+});
+
+// ── isUseItemObjectiveSatisfied ───────────────────────────────────────────────
+
+describe("isUseItemObjectiveSatisfied", () => {
+	it("returns false when satisfactionState is pending", () => {
+		const objective: UseItemObjective = {
+			id: "obj-0",
+			kind: "use_item",
+			description: "Use the torch",
+			satisfactionState: "pending",
+			itemId: "torch",
+		};
+		expect(isUseItemObjectiveSatisfied(objective)).toBe(false);
+	});
+
+	it("returns true when satisfactionState is satisfied", () => {
+		const objective: UseItemObjective = {
+			id: "obj-0",
+			kind: "use_item",
+			description: "Use the torch",
+			satisfactionState: "satisfied",
+			itemId: "torch",
+		};
+		expect(isUseItemObjectiveSatisfied(objective)).toBe(true);
+	});
+});
+
+// ── checkWinCondition with mixed objectives ───────────────────────────────────
+
+describe("checkWinCondition with mixed Carry + UseItem objectives", () => {
+	it("returns true when all objectives are satisfied (carry + use_item)", () => {
+		const pair = makeObjectivePair(
+			"obj",
+			"spc",
+			{ row: 1, col: 1 },
+			{ row: 1, col: 1 },
+		);
+		const world = worldFromPairs([pair]);
+		const carryObj = carryObjectiveFromPair(pair, "obj-0");
+		const useItemObj: UseItemObjective = {
+			id: "obj-1",
+			kind: "use_item",
+			description: "Use the torch",
+			satisfactionState: "satisfied",
+			itemId: "torch",
+		};
+		const objectives: Objective[] = [carryObj, useItemObj];
+		expect(checkWinCondition(world, objectives)).toBe(true);
+	});
+
+	it("returns false when carry is satisfied but use_item is pending", () => {
+		const pair = makeObjectivePair(
+			"obj",
+			"spc",
+			{ row: 1, col: 1 },
+			{ row: 1, col: 1 },
+		);
+		const world = worldFromPairs([pair]);
+		const carryObj = carryObjectiveFromPair(pair, "obj-0");
+		const useItemObj: UseItemObjective = {
+			id: "obj-1",
+			kind: "use_item",
+			description: "Use the torch",
+			satisfactionState: "pending",
+			itemId: "torch",
+		};
+		const objectives: Objective[] = [carryObj, useItemObj];
+		expect(checkWinCondition(world, objectives)).toBe(false);
+	});
+
+	it("returns false when use_item is satisfied but carry is not", () => {
+		const pair = makeObjectivePair(
+			"obj",
+			"spc",
+			{ row: 0, col: 0 }, // object not on space's cell
+			{ row: 2, col: 2 },
+		);
+		const world = worldFromPairs([pair]);
+		const carryObj = carryObjectiveFromPair(pair, "obj-0");
+		const useItemObj: UseItemObjective = {
+			id: "obj-1",
+			kind: "use_item",
+			description: "Use the torch",
+			satisfactionState: "satisfied",
+			itemId: "torch",
+		};
+		const objectives: Objective[] = [carryObj, useItemObj];
+		expect(checkWinCondition(world, objectives)).toBe(false);
 	});
 });
 

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -295,6 +295,34 @@ export function executeToolCall(
 					}
 				}
 			}
+
+			// Check for a pending UseItemObjective that targets this item.
+			// If found, flip both the objective's and the entity's satisfactionState.
+			if (target) {
+				const itemId = call.args.item;
+				const pendingObjectiveIdx = game.objectives.findIndex(
+					(obj) =>
+						obj.kind === "use_item" &&
+						obj.itemId === itemId &&
+						obj.satisfactionState === "pending",
+				);
+				if (pendingObjectiveIdx !== -1) {
+					// Flip objective satisfactionState
+					const updatedObjectives = game.objectives.map((obj, idx) =>
+						idx === pendingObjectiveIdx
+							? { ...obj, satisfactionState: "satisfied" as const }
+							: obj,
+					);
+					// Flip entity satisfactionState in our entities snapshot
+					target.satisfactionState = "satisfied";
+					// Return early with updated objectives and entities
+					return {
+						...game,
+						world: { ...game.world, entities },
+						objectives: updatedObjectives,
+					};
+				}
+			}
 			break;
 		}
 		case "examine":
@@ -436,8 +464,13 @@ export function dispatchAiTurn(
 				const item = state.world.entities.find(
 					(e) => e.id === toolCall.args.item,
 				);
+				const examineDesc =
+					item?.satisfactionState === "satisfied" &&
+					item.postExamineDescription
+						? item.postExamineDescription
+						: (item?.examineDescription ?? "");
 				actorPrivateToolResult = {
-					description: item?.examineDescription ?? "",
+					description: examineDesc,
 					success: true,
 				};
 			} else {

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -465,8 +465,7 @@ export function dispatchAiTurn(
 					(e) => e.id === toolCall.args.item,
 				);
 				const examineDesc =
-					item?.satisfactionState === "satisfied" &&
-					item.postExamineDescription
+					item?.satisfactionState === "satisfied" && item.postExamineDescription
 						? item.postExamineDescription
 						: (item?.examineDescription ?? "");
 				actorPrivateToolResult = {

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -65,6 +65,19 @@ export function startGame(
 			? { ...contentPack.aiStarts }
 			: drawSpatialPlacements(rng, aiIds);
 
+	// Build one CarryObjective per objective pair. This is the default objective
+	// set for a new game: every pair must be carried to win. Higher-level callers
+	// (e.g. content-pack generation, future issue logic) may replace this with a
+	// drawn subset using drawObjectives from objective-pool.ts.
+	const objectives = contentPack.objectivePairs.map((pair, i) => ({
+		id: `obj-${i}`,
+		kind: "carry" as const,
+		description: `Bring the ${pair.object.name} to the ${pair.space.name}`,
+		satisfactionState: "pending" as const,
+		objectId: pair.object.id,
+		spaceId: pair.space.id,
+	}));
+
 	// Initial countdown: random in [1, 5]
 	const initialCountdown = 1 + Math.floor(rng() * 5);
 	const complicationSchedule: ComplicationSchedule = {
@@ -91,6 +104,7 @@ export function startGame(
 		contentPacksA: [],
 		contentPacksB: [],
 		activePackId: "A",
+		objectives,
 	};
 }
 
@@ -433,6 +447,7 @@ export function createGame(
 		contentPacksA: contentPacks,
 		contentPacksB: contentPacksB,
 		activePackId: "A",
+		objectives: [],
 		// Stash contentPacks for startPhase lookup
 		_contentPacks: contentPacks,
 	} as GameState & { _contentPacks: ContentPack[] };
@@ -550,6 +565,16 @@ export function startPhase(
 		aiStarts: personaSpatial,
 	};
 
+	// Build one CarryObjective per objective pair (matches old content-pack win behavior).
+	const objectives = contentPack.objectivePairs.map((pair, i) => ({
+		id: `obj-${i}`,
+		kind: "carry" as const,
+		description: `Bring the ${pair.object.name} to the ${pair.space.name}`,
+		satisfactionState: "pending" as const,
+		objectId: pair.object.id,
+		spaceId: pair.space.id,
+	}));
+
 	// Initial countdown: random in [1, 5]
 	const initialCountdown = 1 + Math.floor(rng() * 5);
 
@@ -574,6 +599,7 @@ export function startPhase(
 		contentPacksA: contentPacks,
 		contentPacksB: [],
 		activePackId: "A",
+		objectives,
 		// Carry forward for chaining / restore paths
 		_contentPacks: contentPacks,
 		// Carry goals for prompt-builder compat

--- a/src/spa/game/objective-pool.ts
+++ b/src/spa/game/objective-pool.ts
@@ -1,0 +1,74 @@
+/**
+ * objective-pool.ts
+ *
+ * Builds a pool of candidate Objectives from a ContentPack and draws
+ * `count` objectives with replacement using the provided rng.
+ *
+ * Pool composition:
+ *   - One CarryObjective per objectivePairs entry
+ *   - One UseItemObjective per interestingObjects entry
+ *
+ * Drawing "with replacement" means the same kind/entity CAN appear multiple times.
+ * Objective IDs are assigned as "obj-0", "obj-1", etc.
+ */
+
+import type {
+	CarryObjective,
+	ContentPack,
+	Objective,
+	UseItemObjective,
+} from "./types.js";
+
+/**
+ * Draw `count` objectives from the ContentPack with replacement using `rng`.
+ *
+ * Returns an empty array if the pool is empty (regardless of count > 0).
+ * Each drawn objective starts with `satisfactionState: "pending"`.
+ */
+export function drawObjectives(
+	contentPack: ContentPack,
+	rng: () => number,
+	count: number,
+): Objective[] {
+	// Build pool of candidates
+	const pool: Objective[] = [];
+
+	for (const pair of contentPack.objectivePairs) {
+		const carry: CarryObjective = {
+			id: "", // placeholder; will be replaced with assigned id
+			kind: "carry",
+			description: `Bring the ${pair.object.name} to the ${pair.space.name}`,
+			satisfactionState: "pending",
+			objectId: pair.object.id,
+			spaceId: pair.space.id,
+		};
+		pool.push(carry);
+	}
+
+	for (const obj of contentPack.interestingObjects) {
+		const useItem: UseItemObjective = {
+			id: "", // placeholder; will be replaced with assigned id
+			kind: "use_item",
+			description: `Use the ${obj.name}`,
+			satisfactionState: "pending",
+			itemId: obj.id,
+		};
+		pool.push(useItem);
+	}
+
+	if (pool.length === 0) {
+		return [];
+	}
+
+	// Draw with replacement
+	const drawn: Objective[] = [];
+	for (let i = 0; i < count; i++) {
+		const idx = Math.floor(rng() * pool.length);
+		// biome-ignore lint/style/noNonNullAssertion: bounded index into non-empty array
+		const candidate = pool[idx]!;
+		// Assign sequential id
+		drawn.push({ ...candidate, id: `obj-${i}` });
+	}
+
+	return drawn;
+}

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -556,7 +556,7 @@ export async function runRound(
 
 	// 5. Check win/lose conditions — win takes priority.
 	let gameEnded = false;
-	if (checkWinCondition(state.world, state.contentPack)) {
+	if (checkWinCondition(state.world, state.objectives)) {
 		state = { ...state, isComplete: true, outcome: "win" };
 		gameEnded = true;
 	} else if (checkLoseCondition(state.lockedOut, Object.keys(state.personas))) {

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -43,6 +43,12 @@ export interface WorldEntity {
 	shiftFlavor?: string;
 	/** AiId when held by an AI; GridPosition when resting on a cell. */
 	holder: AiId | GridPosition;
+	/** Tracks whether this entity has been "used" for a UseItem objective. Defaults to "pending" when omitted. */
+	satisfactionState?: "pending" | "satisfied";
+	/** Alternate examineDescription shown after satisfactionState flips to "satisfied". */
+	postExamineDescription?: string;
+	/** Alternate look flavor shown after satisfactionState flips to "satisfied". */
+	postLookFlavor?: string;
 }
 
 export interface WorldState {
@@ -90,10 +96,44 @@ export interface ContentPack {
 	};
 }
 
-export interface Objective {
+export type ObjectiveKind = "carry" | "use_item" | "use_space" | "convergence";
+
+export interface CarryObjective {
 	id: string;
+	kind: "carry";
 	description: string;
+	satisfactionState: "pending" | "satisfied";
+	objectId: string;
+	spaceId: string;
 }
+
+export interface UseItemObjective {
+	id: string;
+	kind: "use_item";
+	description: string;
+	satisfactionState: "pending" | "satisfied";
+	itemId: string;
+}
+
+export interface UseSpaceObjective {
+	id: string;
+	kind: "use_space";
+	description: string;
+	satisfactionState: "pending" | "satisfied";
+}
+
+export interface ConvergenceObjective {
+	id: string;
+	kind: "convergence";
+	description: string;
+	satisfactionState: "pending" | "satisfied";
+}
+
+export type Objective =
+	| CarryObjective
+	| UseItemObjective
+	| UseSpaceObjective
+	| ConvergenceObjective;
 
 // ── Complication types ────────────────────────────────────────────────────────
 
@@ -295,6 +335,8 @@ export interface GameState {
 	contentPacksB: ContentPack[];
 	/** Which setting is currently active. Starts as "A"; swapped to "B" by Setting Shift. */
 	activePackId: "A" | "B";
+	/** Active objectives for this game session. Drawn at game start from the content pack pool. */
+	objectives: Objective[];
 }
 
 export type ToolName =

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -3,10 +3,8 @@
  *
  * Pure helpers for the multi-pair objective win condition (issue #126, PRD #120).
  *
- * checkWinCondition: returns true iff every objective pair in the ContentPack is
- * satisfied — i.e. each objective_object's current holder cell equals its paired
- * objective_space's holder cell, using the structural pairsWithSpaceId link (not
- * coincidental coordinate equality).
+ * checkWinCondition: returns true iff every objective in the objectives array is
+ * satisfied — checks each objective type with the appropriate predicate.
  *
  * checkPlacementFlavor: returns the per-pair placementFlavor string (with {actor}
  * substituted to "you") when a put_down action lands an objective_object on its
@@ -16,8 +14,11 @@
 import type {
 	AiId,
 	AiTurnAction,
+	CarryObjective,
 	ContentPack,
 	GridPosition,
+	Objective,
+	UseItemObjective,
 	WorldState,
 } from "./types";
 
@@ -32,44 +33,68 @@ function positionsEqual(a: GridPosition, b: GridPosition): boolean {
 }
 
 /**
- * Returns true iff every objective pair in the ContentPack is satisfied.
- *
- * A pair is satisfied when:
- *  - The object's holder is a GridPosition (not held by any AI)
+ * Returns true when a CarryObjective is satisfied:
+ *  - The object's holder is a GridPosition (not held by an AI)
  *  - The space's holder is a GridPosition
  *  - Their row/col are equal
- *  - The lookup is structural (via pairsWithSpaceId), not just coincidental coord equality
+ */
+export function isCarryObjectiveSatisfied(
+	objective: CarryObjective,
+	world: WorldState,
+): boolean {
+	const objectEntity = world.entities.find((e) => e.id === objective.objectId);
+	if (!objectEntity) return false;
+
+	if (!isGridPosition(objectEntity.holder)) return false;
+
+	const spaceEntity = world.entities.find((e) => e.id === objective.spaceId);
+	if (!spaceEntity) return false;
+
+	if (!isGridPosition(spaceEntity.holder)) return false;
+
+	return positionsEqual(objectEntity.holder, spaceEntity.holder);
+}
+
+/**
+ * Returns true when a UseItemObjective is satisfied:
+ * The objective's satisfactionState is "satisfied".
+ */
+export function isUseItemObjectiveSatisfied(
+	objective: UseItemObjective,
+): boolean {
+	return objective.satisfactionState === "satisfied";
+}
+
+/**
+ * Returns true iff every objective in the objectives array is satisfied.
  *
- * K=0 vacuously returns true (no pairs to satisfy).
+ * - CarryObjective: checks world state (object and space share same cell)
+ * - UseItemObjective: checks objective.satisfactionState
+ * - UseSpaceObjective: checks objective.satisfactionState
+ * - ConvergenceObjective: checks objective.satisfactionState
+ *
+ * K=0 (empty objectives) vacuously returns true.
  */
 export function checkWinCondition(
 	world: WorldState,
-	contentPack: ContentPack,
+	objectives: Objective[],
 ): boolean {
-	for (const pair of contentPack.objectivePairs) {
-		// Find the live object entity in world
-		const objectEntity = world.entities.find((e) => e.id === pair.object.id);
-		if (!objectEntity) return false;
-
-		// Object must be on the ground (GridPosition), not held by an AI
-		if (!isGridPosition(objectEntity.holder)) return false;
-
-		// Find the paired space using the structural pairsWithSpaceId link
-		const spaceId = objectEntity.pairsWithSpaceId;
-		if (!spaceId) return false;
-
-		// The space must be the one this object is structurally paired with
-		const spaceEntity = world.entities.find((e) => e.id === spaceId);
-		if (!spaceEntity) return false;
-
-		// Space must also be a GridPosition
-		if (!isGridPosition(spaceEntity.holder)) return false;
-
-		// Object and space must share the same cell
-		if (!positionsEqual(objectEntity.holder, spaceEntity.holder)) return false;
+	for (const objective of objectives) {
+		switch (objective.kind) {
+			case "carry":
+				if (!isCarryObjectiveSatisfied(objective, world)) return false;
+				break;
+			case "use_item":
+				if (!isUseItemObjectiveSatisfied(objective)) return false;
+				break;
+			case "use_space":
+			case "convergence":
+				// These can only be satisfied when something external sets satisfactionState
+				if (objective.satisfactionState !== "satisfied") return false;
+				break;
+		}
 	}
 
-	// All pairs satisfied (vacuously true if K=0)
 	return true;
 }
 

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -178,7 +178,7 @@ export function serializeSession(
 		contentPacksB: structuredClone(state.contentPacksB),
 		activePackId: state.activePackId,
 		weather: state.weather,
-		objectives: [],
+		objectives: structuredClone(state.objectives),
 		complicationSchedule: state.complicationSchedule,
 		activeComplications: structuredClone(state.activeComplications),
 		isComplete: state.isComplete,
@@ -329,6 +329,7 @@ export function deserializeSession(
 			contentPacksA,
 			contentPacksB,
 			activePackId: sealed.activePackId ?? "A",
+			objectives: sealed.objectives ?? [],
 		};
 
 		return {


### PR DESCRIPTION
## What this fixes

Introduces the `Objective` discriminated union and wires the first two objective types end-to-end, adapting the existing win-condition logic to the new model.

**Types (`types.ts`):** Replaces the stub `Objective` interface with a full discriminated union — `CarryObjective | UseItemObjective | UseSpaceObjective | ConvergenceObjective` (only Carry and UseItem are implemented; the other two are declared as placeholder shapes so the union is exhaustive). `WorldEntity` gains optional `satisfactionState`, `postExamineDescription`, and `postLookFlavor` fields. `GameState` gains `objectives: Objective[]`.

**`objective-pool.ts` (new):** `drawObjectives(contentPack, rng, count)` builds a pool from `objectivePairs` (→ `CarryObjective`) and `interestingObjects` (→ `UseItemObjective`), draws with replacement using `rng`, and assigns sequential `obj-N` ids.

**`win-condition.ts`:** `checkWinCondition` now takes `Objective[]` instead of `ContentPack` and dispatches to two pure predicate functions — `isCarryObjectiveSatisfied` (object + space share a cell, object not held) and `isUseItemObjectiveSatisfied` (reads `satisfactionState === "satisfied"`). Vacuously true for an empty objectives array.

**`dispatcher.ts`:** The `use` branch now checks `game.objectives` for a pending `UseItemObjective` matching the item and — if found — flips both the objective's and the entity's `satisfactionState` to `"satisfied"`. Already-satisfied objectives are guarded by the `=== "pending"` filter (cannot re-trigger). The `examine` path prefers `postExamineDescription` when the entity is satisfied.

**`round-coordinator.ts`:** Win-condition call updated to `checkWinCondition(state.world, state.objectives)` — round coordinator already checked after every round, this just passes the new signature.

**`engine.ts`:** `startGame`/`startPhase` initialise `objectives` as one `CarryObjective` per `objectivePairs` entry.

**`session-codec.ts`:** Serializes and deserializes `objectives`.

## QA steps for the human

1. Start a game — confirm the round coordinator ends the game when all objectives are satisfied.
2. Use an item that is a UseItem objective target; confirm its `satisfactionState` flips to `"satisfied"` and a second `use` still fires the outcome but does not re-trigger the objective.
3. Carry an objective object to its paired space (put it down on the space's cell); confirm the Carry objective win condition fires.

Most of the above is already covered by the automated suite — the human steps are primarily a sanity-check on the live game loop.

## Automated coverage

`pnpm test` — 1306/1306 passed (21 new tests across `objective-pool.test.ts`, `win-condition.test.ts`, `dispatcher.test.ts`, `round-coordinator.test.ts`); `biome ci` lint clean; `tsgo --noEmit` typecheck clean.

Closes #303

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKVbHJVuEZfC3719XVH2Xv)_