### PR TITLE
fix(e2e): update stubs and specs for dual content-pack schema (v7)

### DIFF
--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -1,40 +1,77 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
 
-test("chat lockout disables the first AI option and appends an in-character lockout line", async ({
+// XOR obfuscation key for engine.dat (matches sealed-blob-codec.ts)
+const OBFUSCATION_KEY = "hi-blue:engine/v1@kJvN3pX8wQmR2sZt";
+
+test("chat lockout disables send for locked-out AI and is silent to player", async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
 	page.on("pageerror", (err) => pageErrors.push(err));
 
-	// Navigate through the start screen with ?lockout=1 so applyTestAffordances()
-	// arms a chat-lockout for ids[0] (first AI in Object.keys order, rng: () => 0)
-	// effective on the next round.
-	const { ids, names } = await goToGame(page, {
-		url: "/?lockout=1",
-		sse: ["greetings"],
-	});
+	// 1. Boot game — chat lockout is now complication-driven, not a URL affordance.
+	const { ids } = await goToGame(page, { sse: ["greetings"] });
 
-	// Submit one message addressed to ids[0].
-	await page.fill("#prompt", `*${names[0]} hello`);
-	await expect(page.locator("#send")).toBeEnabled();
-	await page.click("#send");
+	// 2. Inject a chat_lockout complication for ids[0] directly into engine.dat.
+	//    This simulates the complication engine having fired a lockout mid-game.
+	await page.evaluate(
+		({ targetId, key }) => {
+			const sessionId = localStorage.getItem("hi-blue:active-session");
+			if (!sessionId) throw new Error("No active session");
+			const raw = localStorage.getItem(
+				`hi-blue:sessions/${sessionId}/engine.dat`,
+			);
+			if (!raw) throw new Error("engine.dat missing");
 
-	// Wait for the chat_lockout to take effect: typing *<name[0]> should
-	// disable Send.
-	await page.fill("#prompt", `*${names[0]} hi`);
-	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
+			const keyBytes = Array.from(new TextEncoder().encode(key));
+			const iso = atob(raw);
+			const decoded = new Uint8Array(
+				Array.from(iso).map((c, i) => c.charCodeAt(0) ^ (keyBytes[i % keyBytes.length] ?? 0)),
+			);
+			const json = new TextDecoder("utf-8").decode(decoded);
+			const sealed = JSON.parse(json) as {
+				activeComplications?: Array<Record<string, unknown>>;
+			};
 
-	// First AI transcript ends with the in-character lockout line (appended by
-	// the chat_lockout event handler in game.ts: "[${event.message}]\n").
+			sealed.activeComplications = [
+				...(sealed.activeComplications ?? []),
+				{ kind: "chat_lockout", target: targetId, resolveAtRound: 100 },
+			];
+
+			const newJson = JSON.stringify(sealed);
+			const newBytes = Array.from(new TextEncoder().encode(newJson));
+			const xored = newBytes.map(
+				(b, i) => b ^ (keyBytes[i % keyBytes.length] ?? 0),
+			);
+			let out = "";
+			for (const b of xored) out += String.fromCharCode(b);
+			localStorage.setItem(
+				`hi-blue:sessions/${sessionId}/engine.dat`,
+				btoa(out),
+			);
+		},
+		{ targetId: ids[0], key: OBFUSCATION_KEY },
+	);
+
+	// 3. Reload so the game restores the injected lockout from storage.
+	await page.reload();
+	await stubChatCompletions(page, ["greetings"]);
+	await expect(page.locator("#composer")).toBeVisible();
+
+	const { names: reloadNames } = await getAiHandles(page);
+
+	// 4. Typing *<locked AI> should disable Send.
+	await page.fill("#prompt", `*${reloadNames[0]} hi`);
+	await expect(page.locator("#send")).toBeDisabled();
+
+	// 5. Lockout is silent — no in-character lockout line in the transcript.
 	const firstTranscript = page.locator(`[data-transcript="${ids[0]}"]`);
-	await expect(firstTranscript).toContainText(/[\w]+ is unresponsive…/);
+	await expect(firstTranscript).not.toContainText("unresponsive");
 
-	// Second and third transcripts contain a normal AI response line.
-	const secondTranscript = page.locator(`[data-transcript="${ids[1]}"]`);
-	const thirdTranscript = page.locator(`[data-transcript="${ids[2]}"]`);
-	await expect(secondTranscript).toContainText("greetings");
-	await expect(thirdTranscript).toContainText("greetings");
+	// 6. Addressing a non-locked AI still enables Send.
+	await page.fill("#prompt", `*${reloadNames[1]} hi`);
+	await expect(page.locator("#send")).toBeEnabled();
 
 	// No page errors.
 	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);

--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -27,7 +27,9 @@ test("chat lockout disables send for locked-out AI and is silent to player", asy
 			const keyBytes = Array.from(new TextEncoder().encode(key));
 			const iso = atob(raw);
 			const decoded = new Uint8Array(
-				Array.from(iso).map((c, i) => c.charCodeAt(0) ^ (keyBytes[i % keyBytes.length] ?? 0)),
+				Array.from(iso).map(
+					(c, i) => c.charCodeAt(0) ^ (keyBytes[i % keyBytes.length] ?? 0),
+				),
 			);
 			const json = new TextDecoder("utf-8").decode(decoded);
 			const sealed = JSON.parse(json) as {

--- a/e2e/endgame-current-behaviour.spec.ts
+++ b/e2e/endgame-current-behaviour.spec.ts
@@ -41,27 +41,14 @@ test("game_ended disables composer and clears storage", async ({ page }) => {
 	// 2. Capture URL before submitting (proves URL stability below).
 	const urlBefore = page.url();
 
-	// Helper: fill prompt with a mention of ids[0], wait for Send to enable, click.
-	async function submitMessage(text: string): Promise<void> {
-		await page.fill("#prompt", text);
-		await expect(page.locator("#send")).toBeEnabled();
-		await page.click("#send");
-	}
+	// 3. Submit one message — ?winImmediately=1 wraps submitMessage so the next
+	//    call ends the game immediately (gameEnded: true, isComplete: true).
+	//    There are no phase transitions in the flat single-game loop.
+	await page.fill("#prompt", `*${names[0]} hello`);
+	await expect(page.locator("#send")).toBeEnabled();
+	await page.click("#send");
 
-	// 3. Round 1 — phase 1 ends; wait for phase banner to advance to Phase 2.
-	await submitMessage(`*${names[0]} hello`);
-	await expect(page.locator("#phase-banner")).toContainText("Phase 2", {
-		timeout: 30_000,
-	});
-
-	// 4. Round 2 — phase 2 ends; wait for phase banner to advance to Phase 3.
-	await submitMessage(`*${names[0]} hello`);
-	await expect(page.locator("#phase-banner")).toContainText("Phase 3", {
-		timeout: 30_000,
-	});
-
-	// 5. Round 3 — phase 3 ends; game_ended fires → #send permanently disabled.
-	await submitMessage(`*${names[0]} hello`);
+	// game_ended fires → #send permanently disabled.
 	await expect(page.locator("#send")).toBeDisabled({ timeout: 30_000 });
 
 	// 6. Assert all acceptance criteria.

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -86,20 +86,23 @@ function isJsonModeRequest(body: ParsedBody): boolean {
 }
 
 /**
- * Classify a JSON-mode request by its user-message preamble. Two callers fire
+ * Classify a JSON-mode request by its user-message preamble. Callers fire
  * JSON-mode `/v1/chat/completions` at game start:
  *   - persona synthesis (`Synthesize blurbs for these personas:` …)
- *   - content-pack generation (`Generate content packs for these phases:` …)
+ *   - dual content-pack generation (`Generate dual A/B content packs for these phases:` …)
+ *   - single content-pack generation (`Generate content packs for these phases:` …)
  *
  * Returns "unknown" for callers we don't recognise so future additions surface
  * loudly instead of silently receiving a persona-shaped reply.
  */
 export function classifyJsonRequest(
 	body: ParsedBody,
-): "synthesis" | "content-pack" | "unknown" {
+): "synthesis" | "dual-content-pack" | "content-pack" | "unknown" {
 	const userMsg = body?.messages?.[1]?.content ?? "";
 	if (userMsg.startsWith("Synthesize blurbs for these personas:"))
 		return "synthesis";
+	if (userMsg.startsWith("Generate dual A/B content packs for these phases:"))
+		return "dual-content-pack";
 	if (userMsg.startsWith("Generate content packs for these phases:"))
 		return "content-pack";
 	return "unknown";
@@ -165,6 +168,106 @@ function parseContentPackPhases(userMessage: string): PhaseSpec[] {
 		});
 	}
 	return phases;
+}
+
+type DualPhaseSpec = {
+	phaseNumber: 1 | 2 | 3;
+	settingA: string;
+	settingB: string;
+	k: number;
+	n: number;
+	m: number;
+};
+
+/**
+ * Parse the per-phase `Phase N: settingA="…", settingB="…", theme="…", k=K …`
+ * lines from a dual content-pack user message.
+ */
+function parseDualContentPackPhases(userMessage: string): DualPhaseSpec[] {
+	const re =
+		/Phase\s+(\d+):\s+settingA="([^"]*)",\s+settingB="([^"]*)",\s+theme="[^"]*",\s+k=(\d+)\s+objective pairs,\s+n=(\d+)\s+interesting objects,\s+m=(\d+)\s+obstacles/g;
+	const phases: DualPhaseSpec[] = [];
+	for (const match of userMessage.matchAll(re)) {
+		const phaseNumber = Number(match[1]);
+		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) continue;
+		phases.push({
+			phaseNumber: phaseNumber as 1 | 2 | 3,
+			settingA: match[2] ?? "",
+			settingB: match[3] ?? "",
+			k: Number(match[4]),
+			n: Number(match[5]),
+			m: Number(match[6]),
+		});
+	}
+	return phases;
+}
+
+const STUB_LANDMARKS = {
+	north: { shortName: "Distant ridge", horizonPhrase: "A jagged ridge cuts the skyline." },
+	south: { shortName: "Rolling hills", horizonPhrase: "Gentle slopes melt into haze." },
+	east: { shortName: "Stone tower", horizonPhrase: "A weathered tower breaks the treeline." },
+	west: { shortName: "Misty forest", horizonPhrase: "A dark canopy blurs into fog." },
+};
+
+/**
+ * Build a dual content-pack JSON-mode response body that satisfies
+ * `validateDualContentPacks`. Each phase has identical entity IDs in packA
+ * and packB; only names, descriptions, and settings differ.
+ */
+function buildDualContentPackResponseBody(body: ParsedBody): string {
+	const userMsg = body?.messages?.[1]?.content ?? "";
+	const phases = parseDualContentPackPhases(userMsg);
+	const resultPhases = phases.map((phase) => {
+		const tag = `p${phase.phaseNumber}`;
+
+		const buildPack = (setting: string, ab: "a" | "b") => {
+			const objectivePairs = Array.from({ length: phase.k }, (_, i) => {
+				const spaceId = `${tag}-spc-${i}`;
+				const objectId = `${tag}-obj-${i}`;
+				const spaceName = `Stub space ${tag} ${i}`;
+				return {
+					object: {
+						id: objectId,
+						kind: "objective_object",
+						name: `Stub object ${tag} ${i} ${ab}`,
+						examineDescription: `Stub object near ${spaceName}.`,
+						useOutcome: "Nothing happens.",
+						pairsWithSpaceId: spaceId,
+						placementFlavor: "{actor} sets it down.",
+						proximityFlavor: "Something catches your attention nearby.",
+					},
+					space: {
+						id: spaceId,
+						kind: "objective_space",
+						name: spaceName,
+						examineDescription: `Stub space ${spaceId} ${ab}.`,
+					},
+				};
+			});
+			const interestingObjects = Array.from({ length: phase.n }, (_, i) => ({
+				id: `${tag}-int-${i}`,
+				kind: "interesting_object",
+				name: `Stub item ${tag} ${i} ${ab}`,
+				examineDescription: `Stub interesting object ${tag}-int-${i} ${ab}.`,
+				useOutcome: "Nothing happens.",
+			}));
+			const obstacles = Array.from({ length: phase.m }, (_, i) => ({
+				id: `${tag}-obs-${i}`,
+				kind: "obstacle",
+				name: `Stub obstacle ${tag} ${i} ${ab}`,
+				examineDescription: `Stub obstacle ${tag}-obs-${i} ${ab}.`,
+			}));
+			return { setting, objectivePairs, interestingObjects, obstacles, landmarks: STUB_LANDMARKS };
+		};
+
+		return {
+			phaseNumber: phase.phaseNumber,
+			packA: buildPack(phase.settingA, "a"),
+			packB: buildPack(phase.settingB, "b"),
+		};
+	});
+	const content = JSON.stringify({ phases: resultPhases });
+	return JSON.stringify({ choices: [{ message: { content } }] });
 }
 
 /**
@@ -254,9 +357,11 @@ async function tryFulfillJsonMode(
 	const responseBody =
 		kind === "synthesis"
 			? buildSynthesisResponseBody(body, blurbFn)
-			: kind === "content-pack"
-				? buildContentPackResponseBody(body)
-				: null;
+			: kind === "dual-content-pack"
+				? buildDualContentPackResponseBody(body)
+				: kind === "content-pack"
+					? buildContentPackResponseBody(body)
+					: null;
 	if (responseBody === null) {
 		throw new Error(
 			`stubs.ts: unrecognised JSON-mode /v1/chat/completions caller. ` +

--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -203,10 +203,22 @@ function parseDualContentPackPhases(userMessage: string): DualPhaseSpec[] {
 }
 
 const STUB_LANDMARKS = {
-	north: { shortName: "Distant ridge", horizonPhrase: "A jagged ridge cuts the skyline." },
-	south: { shortName: "Rolling hills", horizonPhrase: "Gentle slopes melt into haze." },
-	east: { shortName: "Stone tower", horizonPhrase: "A weathered tower breaks the treeline." },
-	west: { shortName: "Misty forest", horizonPhrase: "A dark canopy blurs into fog." },
+	north: {
+		shortName: "Distant ridge",
+		horizonPhrase: "A jagged ridge cuts the skyline.",
+	},
+	south: {
+		shortName: "Rolling hills",
+		horizonPhrase: "Gentle slopes melt into haze.",
+	},
+	east: {
+		shortName: "Stone tower",
+		horizonPhrase: "A weathered tower breaks the treeline.",
+	},
+	west: {
+		shortName: "Misty forest",
+		horizonPhrase: "A dark canopy blurs into fog.",
+	},
 };
 
 /**
@@ -257,7 +269,13 @@ function buildDualContentPackResponseBody(body: ParsedBody): string {
 				name: `Stub obstacle ${tag} ${i} ${ab}`,
 				examineDescription: `Stub obstacle ${tag}-obs-${i} ${ab}.`,
 			}));
-			return { setting, objectivePairs, interestingObjects, obstacles, landmarks: STUB_LANDMARKS };
+			return {
+				setting,
+				objectivePairs,
+				interestingObjects,
+				obstacles,
+				landmarks: STUB_LANDMARKS,
+			};
 		};
 
 		return {

--- a/e2e/persistence-reload.spec.ts
+++ b/e2e/persistence-reload.spec.ts
@@ -69,7 +69,6 @@ test("game state and transcripts persist across mid-round reload", async ({
 		createdAt: string;
 		lastSavedAt: string;
 	};
-	expect(meta.phase).toBeGreaterThanOrEqual(1);
 	expect(meta.round).toBeGreaterThanOrEqual(1);
 
 	// ── Capture pre-reload values ───────────────────────────────────────────────

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -260,9 +260,9 @@ test("strip-card preview: restored multi-line AI message stays in one msg-line",
 			if (!daemonRaw) return false;
 			try {
 				const daemon = JSON.parse(daemonRaw) as {
-					phases?: { "1"?: { conversationLog?: unknown[] } };
+					conversationLog?: unknown[];
 				};
-				return (daemon.phases?.["1"]?.conversationLog?.length ?? 0) > 0;
+				return (daemon.conversationLog?.length ?? 0) > 0;
 			} catch {
 				return false;
 			}

--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -33,13 +33,13 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 			const meta = JSON.stringify({
 				createdAt: '2025-01-01T00:00:00.000Z',
 				lastSavedAt: '${lastSavedAt}',
-				phase: 1,
+				epoch: 1,
 				round: 0,
 				personaOrder: ['red'],
 			});
 			localStorage.setItem(prefix + 'meta.json', meta);
 
-			// Daemon file: must match DaemonFile shape (aiId, persona, phases)
+			// Daemon file: flat DaemonFile shape (v6+)
 			const daemonFile = JSON.stringify({
 				aiId: 'red',
 				persona: {
@@ -52,36 +52,44 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 					typingQuirks: ['...', '!'],
 					voiceExamples: ['Hello.', 'Indeed.', 'Farewell.'],
 				},
-				phases: {
-					'1': { phaseGoal: '', conversationLog: [] },
-					'2': { phaseGoal: '', conversationLog: [] },
-					'3': { phaseGoal: '', conversationLog: [] },
-				},
+				conversationLog: [],
 			});
 			localStorage.setItem(prefix + 'red.txt', daemonFile);
 
-			// Build engine.dat via inline obfuscation — payload must match SealedEngine
+			// Build engine.dat via inline obfuscation — payload must match SealedEngine v7
 			const OBFUSCATION_KEY = '${OBFUSCATION_KEY}';
 			const keyBytes = Array.from(new TextEncoder().encode(OBFUSCATION_KEY));
+			const stubLandmarks = {
+				north: { shortName: 'Ridge', horizonPhrase: 'A distant ridge.' },
+				south: { shortName: 'Hills', horizonPhrase: 'Rolling hills.' },
+				east: { shortName: 'Tower', horizonPhrase: 'A stone tower.' },
+				west: { shortName: 'Forest', horizonPhrase: 'A dark forest.' },
+			};
+			const stubPack = {
+				phaseNumber: 1,
+				setting: 'test setting',
+				weather: 'clear',
+				timeOfDay: 'morning',
+				objectivePairs: [],
+				interestingObjects: [],
+				obstacles: [],
+				aiStarts: {},
+				landmarks: stubLandmarks,
+			};
 			const payload = JSON.stringify({
-				schemaVersion: 5,
-				currentPhase: 1,
+				schemaVersion: 7,
 				isComplete: false,
-				world: {
-					1: { entities: [] },
-					2: { entities: [] },
-					3: { entities: [] },
-				},
-				contentPacks: [
-					{ phaseNumber: 1, setting: 'test', objectivePairs: [], interestingObjects: [], obstacles: [], aiStarts: {} },
-				],
-				budgets: { 1: {}, 2: {}, 3: {} },
-				lockouts: {
-					1: { lockedOut: [], chatLockouts: [] },
-					2: { lockedOut: [], chatLockouts: [] },
-					3: { lockedOut: [], chatLockouts: [] },
-				},
-				personaSpatial: { 1: {}, 2: {}, 3: {} },
+				world: { entities: [] },
+				budgets: { red: { remaining: 50, total: 50 } },
+				lockedOut: [],
+				personaSpatial: { red: { position: { row: 2, col: 2 }, facing: 'north' } },
+				contentPacksA: [stubPack],
+				contentPacksB: [{ ...stubPack, setting: 'test setting B' }],
+				activePackId: 'A',
+				weather: 'clear',
+				objectives: [],
+				complicationSchedule: { countdown: 5, settingShiftFired: false },
+				activeComplications: [],
 			});
 			const jsonBytes = Array.from(new TextEncoder().encode(payload));
 			const xored = jsonBytes.map((b,i) => b ^ (keyBytes[i % keyBytes.length] ?? 0));
@@ -103,12 +111,12 @@ function seedBrokenSessionScript(id: string): string {
 			const meta = JSON.stringify({
 				createdAt: '2025-01-01T00:00:00.000Z',
 				lastSavedAt: '2025-01-01T08:00:00.000Z',
-				phase: 1,
+				epoch: 1,
 				round: 0,
 			});
 			localStorage.setItem(prefix + 'meta.json', meta);
 			localStorage.setItem(prefix + 'red.txt', '{}');
-			// Intentionally omit engine.dat (whispers.txt retired in v3)
+			// Intentionally omit engine.dat
 		})();
 	`;
 }
@@ -123,7 +131,7 @@ function seedVersionMismatchScript(id: string): string {
 			const meta = JSON.stringify({
 				createdAt: '2025-01-01T00:00:00.000Z',
 				lastSavedAt: '2025-01-01T06:00:00.000Z',
-				phase: 1,
+				epoch: 1,
 				round: 0,
 			});
 			localStorage.setItem(prefix + 'meta.json', meta);

--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -59,18 +59,11 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 			const daemonFile = JSON.parse(raw) as {
 				aiId: string;
 				persona: unknown;
-				phases: {
-					"1": {
-						phaseGoal: string;
-						conversationLog: Array<Record<string, unknown>>;
-					};
-					"2": { phaseGoal: string; conversationLog: Array<unknown> };
-					"3": { phaseGoal: string; conversationLog: Array<unknown> };
-				};
+				conversationLog: Array<Record<string, unknown>>;
 			};
 
-			// Append fabricated message entry to phase "1" log.
-			daemonFile.phases["1"].conversationLog.push({
+			// Append fabricated message entry to the flat conversation log.
+			daemonFile.conversationLog.push({
 				kind: "message",
 				round: 0,
 				from: senderId,

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -508,20 +508,29 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 
 	const engineJson = deobfuscateEngineBlob(storageInfo.engineBlob);
 	const engineData = JSON.parse(engineJson) as {
-		personaSpatial: Record<string, Record<string, PersonaSpatial>>;
-		contentPacks: Array<{
+		personaSpatial: Record<string, PersonaSpatial>;
+		contentPacksA: Array<{
 			phaseNumber: number;
 			obstacles: Array<{ holder: GridPosition | null }>;
 		}>;
-		currentPhase: 1 | 2 | 3;
+		contentPacksB: Array<{
+			phaseNumber: number;
+			obstacles: Array<{ holder: GridPosition | null }>;
+		}>;
+		activePackId: "A" | "B";
 	};
 
-	const phase1Spatial = engineData.personaSpatial["1"] as
+	const phase1Spatial = engineData.personaSpatial as
 		| Record<string, PersonaSpatial>
 		| undefined;
-	if (!phase1Spatial) throw new Error("No phase 1 spatial data in engine.dat");
+	if (!phase1Spatial || Object.keys(phase1Spatial).length === 0)
+		throw new Error("No phase 1 spatial data in engine.dat");
 
-	const phase1Pack = engineData.contentPacks.find((p) => p.phaseNumber === 1);
+	const activePacks =
+		engineData.activePackId === "B"
+			? engineData.contentPacksB
+			: engineData.contentPacksA;
+	const phase1Pack = activePacks.find((p) => p.phaseNumber === 1);
 	const obstaclePositions: GridPosition[] = (phase1Pack?.obstacles ?? [])
 		.map((o) => o.holder)
 		.filter((h): h is GridPosition => h !== null);
@@ -725,11 +734,9 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 			const raw = localStorage.getItem(key);
 			if (!raw) return { found: false, log: [] as unknown[] };
 			const df = JSON.parse(raw) as {
-				phases: {
-					"1": { conversationLog: Array<{ kind: string; actor?: string }> };
-				};
+				conversationLog: Array<{ kind: string; actor?: string }>;
 			};
-			const log = df.phases["1"].conversationLog;
+			const log = df.conversationLog;
 			const found = log.some(
 				(e) => e.kind === "witnessed-event" && e.actor === aId,
 			);
@@ -804,15 +811,15 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 	).not.toBeNull();
 
 	// ── 14. Assert witnessed-event line in witness role turns ────────────────
-	// conversation-log.ts:63-65:
-	//   case "go":
-	//     return `[Round ${round}] You watch *${actorSub} walk ${direction}.`;
-	// where round = phase.round at dispatch time.
-	//
-	// Witnessed events used to be folded into the system-prompt <conversation>
-	// block; after the prompt-cache restructure they're emitted as user role
-	// turns by openai-message-builder. Search the full message array.
-	const expectedLine = `[Round ${roundAtDispatch}] You watch *${actorId} walk ${direction}.`;
+	// conversation-log.ts renders direction relative to witness's facing.
+	// Compute the relative direction from the plan's absolute cardinal.
+	const CARDINALS = ["north", "east", "south", "west"];
+	const RELATIVES = ["forward", "right", "back", "left"];
+	const witnessFacing = (phase1Spatial?.[witnessId] as PersonaSpatial | undefined)?.facing ?? "north";
+	const facingIdx = CARDINALS.indexOf(witnessFacing);
+	const dirIdx = CARDINALS.indexOf(direction);
+	const relativeDirection = RELATIVES[(dirIdx - facingIdx + 4) % 4] ?? direction;
+	const expectedLine = `[Round ${roundAtDispatch}] You watch *${actorId} walk ${relativeDirection}.`;
 
 	const witnessAllContent = (
 		witnessBody as { messages: Array<{ content: string | null }> }

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -815,10 +815,13 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 	// Compute the relative direction from the plan's absolute cardinal.
 	const CARDINALS = ["north", "east", "south", "west"];
 	const RELATIVES = ["forward", "right", "back", "left"];
-	const witnessFacing = (phase1Spatial?.[witnessId] as PersonaSpatial | undefined)?.facing ?? "north";
+	const witnessFacing =
+		(phase1Spatial?.[witnessId] as PersonaSpatial | undefined)?.facing ??
+		"north";
 	const facingIdx = CARDINALS.indexOf(witnessFacing);
 	const dirIdx = CARDINALS.indexOf(direction);
-	const relativeDirection = RELATIVES[(dirIdx - facingIdx + 4) % 4] ?? direction;
+	const relativeDirection =
+		RELATIVES[(dirIdx - facingIdx + 4) % 4] ?? direction;
 	const expectedLine = `[Round ${roundAtDispatch}] You watch *${actorId} walk ${relativeDirection}.`;
 
 	const witnessAllContent = (


### PR DESCRIPTION
## Summary

- Added `"dual-content-pack"` stub classification in `e2e/helpers/stubs.ts` so the Playwright route interceptor recognises the new `"Generate dual A/B content packs for these phases:"` prompt format introduced in schema v7, generating paired `packA`/`packB` responses with shared entity IDs
- Fixed stale DaemonFile accesses across `responsive-bento`, `whisper-tampering`, and `witnessed-event-reload` specs (`phases["1"].conversationLog` → flat `conversationLog`)
- Updated `sessions-picker` seed scripts from schema v5 → v7 (flat `personaSpatial`, `contentPacksA`/`contentPacksB`/`activePackId`, `complicationSchedule`, etc.)
- Rewrote `endgame-current-behaviour` to match the single-game loop (no phase-banner waits; one submit → `#send` disabled)
- Rewrote `chat-lockout` to inject a `chat_lockout` complication directly into engine.dat via XOR-obfuscated localStorage, replacing the removed `?lockout=1` URL affordance
- Fixed `witnessed-event-reload` direction assertions to use relative directions (`forward`/`right`/`back`/`left`) via inline `cardinalToRelative` logic, matching the post-`c5ada79` rendering
- Removed stale `meta.phase` assertion in `persistence-reload`

## Test plan

- [ ] `pnpm smoke` — all 44 e2e tests pass
- [ ] `pnpm test` — all 1276 unit tests pass
- [ ] `pnpm lint` / `pnpm typecheck` — no errors

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rYYFbZxXLfbXSgetKnRq)_