### PR TITLE
fix(persistence): round-trip GameState.objectives through session-codec

### DIFF
--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -490,6 +490,37 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
+	it("round-trips objectives unchanged", () => {
+		const game = makeFreshGame();
+
+		const objectives: import("../../game/types.js").Objective[] = [
+			{
+				id: "obj-0",
+				kind: "carry",
+				description: "Bring the flower to the altar.",
+				satisfactionState: "pending",
+				objectId: "ent-flower",
+				spaceId: "ent-altar",
+			},
+			{
+				id: "obj-1",
+				kind: "use_item",
+				description: "Use the key.",
+				satisfactionState: "satisfied",
+				itemId: "ent-key",
+			},
+		];
+
+		const modified: GameState = { ...game, objectives };
+
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			expect(result.state.objectives).toEqual(objectives);
+		}
+	});
+
 	it("round-trips complicationSchedule and activeComplications unchanged", () => {
 		const game = makeFreshGame();
 

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -189,7 +189,7 @@ export function serializeSession(
 		contentPacksB: structuredClone(state.contentPacksB),
 		activePackId: state.activePackId,
 		weather: state.weather,
-		objectives: [],
+		objectives: structuredClone(state.objectives),
 		complicationSchedule: state.complicationSchedule,
 		activeComplications: structuredClone(state.activeComplications),
 		isComplete: state.isComplete,
@@ -340,6 +340,7 @@ export function deserializeSession(
 			contentPacksA,
 			contentPacksB,
 			activePackId: sealed.activePackId ?? "A",
+			objectives: structuredClone(sealed.objectives ?? []),
 		};
 
 		return {


### PR DESCRIPTION
## Summary

- Save/restore was silently dropping `state.objectives`. `serializeSession` wrote `objectives: []` hard-coded into the sealed engine blob, and `deserializeSession` never copied the field onto the restored `GameState`.
- After any page reload, `state.objectives` came back `undefined`. The next round's `checkWinCondition` (`round-coordinator.ts:559`) does `for (const o of objectives)` and threw on the iteration — surfaced to the player as "the daemons stuttered — try again", and `meta.round` never advanced.
- Fix is two lines: serialize `state.objectives` (cloned) and restore it on the other side (defaulting to `[]` for legacy blobs).

## How it was found

`witnessed-event-reload.spec.ts` failed at `waitForRound` on `first-restructure`. The probe traced the failure to a synchronously-caught throw in the round dispatch, which turned out to be `checkWinCondition` iterating over `undefined`. Minimal repro: any session that boots → reloads → sends a message that produces a tool call.

## Test plan

- [x] Added `round-trips objectives unchanged` to `session-codec.test.ts` covering carry + use_item with mixed `satisfactionState`.
- [x] `witnessed-event-reload.spec.ts` passes (was the failure that surfaced the bug).
- [x] Full non-live e2e suite passes (42/42).
- [x] Full vitest suite passes (1336/1336) via pre-push hook.

https://claude.ai/code/session_01XsZ7y9nBm1g35UVTGDWbid

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZ7y9nBm1g35UVTGDWbid)_