### PR TITLE
Objective Pool: Convergence type

### DIFF
--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -253,6 +253,8 @@ function buildDualContentPackResponseBody(body: ParsedBody): string {
 						kind: "objective_space",
 						name: spaceName,
 						examineDescription: `Stub space ${spaceId} ${ab}.`,
+						convergenceTier1Flavor: `A presence lingers at the ${spaceName}.`,
+						convergenceTier2Flavor: `Two presences converge at the ${spaceName}.`,
 					},
 				};
 			});
@@ -321,6 +323,8 @@ function buildContentPackResponseBody(body: ParsedBody): string {
 					kind: "objective_space",
 					name: `Stub space ${tag}-${i}`,
 					examineDescription: `Stub objective space ${spaceId}.`,
+					convergenceTier1Flavor: `A presence lingers at stub space ${tag}-${i}.`,
+					convergenceTier2Flavor: `Two presences converge at stub space ${tag}-${i}.`,
 				},
 			};
 		});

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -378,10 +378,22 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 					interestingObjects: [],
 					obstacles: [],
 					landmarks: {
-						north: { shortName: "the signal tower", horizonPhrase: "rises above the platform" },
-						south: { shortName: "the collapsed entrance", horizonPhrase: "gapes like a wound in the dark" },
-						east: { shortName: "the rusted fan shaft", horizonPhrase: "spins slowly in the stale air" },
-						west: { shortName: "the flooded tunnel", horizonPhrase: "disappears into still black water" },
+						north: {
+							shortName: "the signal tower",
+							horizonPhrase: "rises above the platform",
+						},
+						south: {
+							shortName: "the collapsed entrance",
+							horizonPhrase: "gapes like a wound in the dark",
+						},
+						east: {
+							shortName: "the rusted fan shaft",
+							horizonPhrase: "spins slowly in the stale air",
+						},
+						west: {
+							shortName: "the flooded tunnel",
+							horizonPhrase: "disappears into still black water",
+						},
 					},
 				},
 			],

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -108,6 +108,8 @@ describe("validateContentPacks — prose tell contract", () => {
 		objectExamine: string,
 		spaceName = "Brass Pedestal",
 		proximityFlavor = "The key hums faintly, resonating with the pedestal nearby.",
+		convergenceTier1Flavor = "A lone figure stands at the pedestal, silhouetted against the dim light.",
+		convergenceTier2Flavor = "Two figures converge at the pedestal, their presences mingling in the shadow.",
 	): unknown {
 		return {
 			packs: [
@@ -131,6 +133,8 @@ describe("validateContentPacks — prose tell contract", () => {
 								kind: "objective_space",
 								name: spaceName,
 								examineDescription: "A sturdy mount for a small relic.",
+								convergenceTier1Flavor,
+								convergenceTier2Flavor,
 							},
 						},
 					],
@@ -315,5 +319,146 @@ describe("validateContentPacks — obstacle shiftFlavor validation", () => {
 		);
 		const obstacle = result.packs[0]?.obstacles[0];
 		expect(obstacle?.shiftFlavor).toBe(flavor);
+	});
+});
+
+// ── convergenceTier flavor validation for objective_space ─────────────────────
+
+describe("validateContentPacks — convergence tier flavor validation", () => {
+	const inputWithPair = {
+		phases: [
+			{
+				phaseNumber: 1 as const,
+				setting: "abandoned subway station",
+				theme: "mundane",
+				k: 1,
+				n: 0,
+				m: 0,
+			},
+		],
+	};
+
+	function buildConvergenceResponse(
+		convergenceTier1Flavor?: unknown,
+		convergenceTier2Flavor?: unknown,
+	): unknown {
+		const spaceFields: Record<string, unknown> = {
+			id: "space1",
+			kind: "objective_space",
+			name: "Brass Pedestal",
+			examineDescription: "A sturdy brass pedestal.",
+		};
+		if (convergenceTier1Flavor !== undefined) {
+			spaceFields.convergenceTier1Flavor = convergenceTier1Flavor;
+		}
+		if (convergenceTier2Flavor !== undefined) {
+			spaceFields.convergenceTier2Flavor = convergenceTier2Flavor;
+		}
+		return {
+			packs: [
+				{
+					phaseNumber: 1,
+					setting: "abandoned subway station",
+					objectivePairs: [
+						{
+							object: {
+								id: "obj1",
+								kind: "objective_object",
+								name: "Iron Key",
+								examineDescription:
+									"An iron key. It belongs on the brass pedestal.",
+								useOutcome: "You turn the key over in your hands.",
+								pairsWithSpaceId: "space1",
+								placementFlavor: "{actor} sets the key on its mount.",
+								proximityFlavor: "The key hums faintly near the pedestal.",
+							},
+							space: spaceFields,
+						},
+					],
+					interestingObjects: [],
+					obstacles: [],
+					landmarks: {
+						north: { shortName: "the signal tower", horizonPhrase: "rises above the platform" },
+						south: { shortName: "the collapsed entrance", horizonPhrase: "gapes like a wound in the dark" },
+						east: { shortName: "the rusted fan shaft", horizonPhrase: "spins slowly in the stale air" },
+						west: { shortName: "the flooded tunnel", horizonPhrase: "disappears into still black water" },
+					},
+				},
+			],
+		};
+	}
+
+	it("accepts a content pack with valid convergence tier flavors", () => {
+		const result = validateContentPacks(
+			buildConvergenceResponse(
+				"A lone figure stands at the pedestal.",
+				"Two figures converge at the pedestal.",
+			),
+			inputWithPair,
+		);
+		const space = result.packs[0]?.objectivePairs[0]?.space;
+		expect(space?.convergenceTier1Flavor).toBe(
+			"A lone figure stands at the pedestal.",
+		);
+		expect(space?.convergenceTier2Flavor).toBe(
+			"Two figures converge at the pedestal.",
+		);
+	});
+
+	it("throws ContentPackError when convergenceTier1Flavor is missing", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(
+					undefined,
+					"Two figures converge at the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1Flavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier2Flavor is missing", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(
+					"A lone figure stands at the pedestal.",
+					undefined,
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2Flavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier1Flavor contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(
+					"{actor} stands at the pedestal.",
+					"Two figures converge at the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1Flavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier2Flavor contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(
+					"A lone figure stands at the pedestal.",
+					"{actor} and another figure converge.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2Flavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier1Flavor is an empty string", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse("", "Two figures converge at the pedestal."),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1Flavor/);
 	});
 });

--- a/src/spa/game/__tests__/objective-pool.test.ts
+++ b/src/spa/game/__tests__/objective-pool.test.ts
@@ -11,6 +11,29 @@ import type {
 	WorldEntity,
 } from "../types";
 
+// ── helpers for convergence tests ─────────────────────────────────────────────
+
+function makeObjectivePairWithConvergenceFlavors(id: string): ObjectivePair {
+	const obj: WorldEntity = {
+		id: `${id}_obj`,
+		kind: "objective_object",
+		name: `${id} object`,
+		examineDescription: `The ${id} object belongs on the ${id} space.`,
+		holder: { row: 0, col: 0 },
+		pairsWithSpaceId: `${id}_space`,
+	};
+	const space: WorldEntity = {
+		id: `${id}_space`,
+		kind: "objective_space",
+		name: `${id} space`,
+		examineDescription: `The ${id} space.`,
+		holder: { row: 4, col: 4 },
+		convergenceTier1Flavor: `A single presence lingers at the ${id} space.`,
+		convergenceTier2Flavor: `Two presences converge at the ${id} space.`,
+	};
+	return { object: obj, space };
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 function makeObjectivePair(id: string): ObjectivePair {
@@ -244,5 +267,73 @@ describe("drawObjectives — use_space objectives", () => {
 		const rngIdx1 = () => 0.5; // picks use_space
 		const [obj] = drawObjectives(pack, rngIdx1, 1);
 		expect(obj?.description).toContain("gem space");
+	});
+});
+
+// ── convergence objectives ────────────────────────────────────────────────────
+
+describe("drawObjectives — convergence objectives", () => {
+	it("includes a ConvergenceObjective when the pack has a space with both tier flavors", () => {
+		const packWithConvergence: ContentPack = {
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [makeObjectivePairWithConvergenceFlavors("relic")],
+			interestingObjects: [],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		// pool: [carry(relic), convergence(relic)] — rng=last → index 1 → convergence
+		const [obj] = drawObjectives(packWithConvergence, rngLast, 1);
+		expect(obj?.kind).toBe("convergence");
+		if (obj?.kind === "convergence") {
+			expect(obj.spaceId).toBe("relic_space");
+			expect(obj.satisfactionState).toBe("pending");
+			expect(obj.id).toBe("obj-0");
+		}
+	});
+
+	it("does NOT include a ConvergenceObjective when space lacks tier flavor fields", () => {
+		const packWithoutFlavors: ContentPack = {
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [makeObjectivePair("gem")], // no convergence flavors
+			interestingObjects: [],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		// Pool is [carry(gem)] only — no convergence
+		const drawn = drawObjectives(packWithoutFlavors, rngZero, 10);
+		expect(drawn.every((o) => o.kind !== "convergence")).toBe(true);
+	});
+
+	it("builds a mixed pool with carry + use_item + convergence from a well-flavored pack", () => {
+		const packMixed: ContentPack = {
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [makeObjectivePairWithConvergenceFlavors("altar")],
+			interestingObjects: [makeInterestingObject("torch")],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		// Pool: [carry(altar), use_item(torch), convergence(altar)] — 3 candidates
+		// rngZero → always index 0 → carry
+		const allDrawn = drawObjectives(packMixed, rngZero, 3);
+		// All three should be carry since rngZero always picks index 0
+		expect(allDrawn[0]?.kind).toBe("carry");
+
+		// With rngLast, index = Math.floor(0.999 * 3) = 2 → convergence
+		const [lastObj] = drawObjectives(packMixed, rngLast, 1);
+		expect(lastObj?.kind).toBe("convergence");
+
+		// Confirm description mentions the space name
+		if (lastObj?.kind === "convergence") {
+			expect(lastObj.description).toContain("altar space");
+		}
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator-convergence.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-convergence.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for the round-coordinator's end-of-round convergence evaluation
+ * block (step 4d).
+ *
+ * Issue #305: ConvergenceObjective — fans witnessed-convergence entries to every
+ * Daemon whose cone contains the space cell, flips satisfactionState to
+ * "satisfied" on tier-2, and guards against re-triggering already-satisfied
+ * objectives.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LANDMARKS } from "../direction";
+import { createGame, startPhase } from "../engine";
+import { runRound } from "../round-coordinator";
+import { MockRoundLLMProvider } from "../round-llm-provider";
+import type {
+	AiPersona,
+	ContentPack,
+	ConvergenceObjective,
+	PhaseConfig,
+	WorldEntity,
+} from "../types";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "Hold the flower at phase end.",
+		typingQuirks: ["Fragments.", "Em-dashes."],
+		blurb: "Ember is hot-headed and zealous.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "#81b29a",
+		temperaments: ["meticulous", "meticulous"],
+		personaGoal: "Ensure items are evenly distributed.",
+		typingQuirks: ["Ellipses.", "ALL-CAPS."],
+		blurb: "Sage is meticulous.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+	cyan: {
+		id: "cyan",
+		name: "Frost",
+		color: "#5fa8d3",
+		temperaments: ["laconic", "diffident"],
+		personaGoal: "Hold the key at phase end.",
+		typingQuirks: ["No contractions.", "Ends with a question."],
+		blurb: "Frost is laconic and diffident.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+};
+
+// Space entity at (4,4) — used as the convergence point.
+const CONVERGENCE_SPACE: WorldEntity = {
+	id: "altar_space",
+	kind: "objective_space",
+	name: "Stone Altar",
+	examineDescription: "A weathered stone altar.",
+	holder: { row: 4, col: 4 },
+	convergenceTier1Flavor: "A single presence lingers at the Stone Altar.",
+	convergenceTier2Flavor: "Two presences converge at the Stone Altar.",
+};
+
+// Paired object (required by ContentPack.objectivePairs).
+const CONVERGENCE_OBJECT: WorldEntity = {
+	id: "altar_obj",
+	kind: "objective_object",
+	name: "Altar Stone",
+	examineDescription: "A small stone for the Stone Altar.",
+	holder: { row: 0, col: 0 },
+	pairsWithSpaceId: "altar_space",
+	placementFlavor: "{actor} places it on the altar.",
+};
+
+const TEST_CONTENT_PACK: ContentPack = {
+	phaseNumber: 1,
+	setting: "",
+	weather: "",
+	timeOfDay: "",
+	objectivePairs: [
+		{ object: CONVERGENCE_OBJECT, space: CONVERGENCE_SPACE },
+	],
+	interestingObjects: [],
+	obstacles: [],
+	landmarks: DEFAULT_LANDMARKS,
+	// red at (4,4), green at (0,0), cyan at (0,2)
+	// cyan faces south so (4,4) is not in its cone.
+	aiStarts: {
+		red: { position: { row: 4, col: 4 }, facing: "north" },
+		green: { position: { row: 0, col: 0 }, facing: "south" },
+		cyan: { position: { row: 0, col: 2 }, facing: "south" },
+	},
+};
+
+const TEST_PHASE_CONFIG: PhaseConfig = {
+	phaseNumber: 1,
+	kRange: [0, 0],
+	nRange: [0, 0],
+	mRange: [0, 0],
+	aiGoalPool: ["test goal"],
+	budgetPerAi: 99,
+};
+
+/** A ConvergenceObjective pointing at altar_space. */
+const CONVERGENCE_OBJECTIVE: ConvergenceObjective = {
+	id: "obj-conv",
+	kind: "convergence",
+	description: "Two Daemons must share the Stone Altar.",
+	satisfactionState: "pending",
+	spaceId: "altar_space",
+};
+
+function makeProvider() {
+	return new MockRoundLLMProvider([
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+	]);
+}
+
+/**
+ * Build a base game state via the standard createGame + startPhase path, then
+ * overlay the objectives and spatial positions we need.
+ *
+ * - red at (4,4) facing north  → red's own cell = space cell; red witnesses
+ * - green at (0,0) facing south → cone is (0,0)…(2,2); does NOT contain (4,4)
+ * - cyan at (0,2) facing south  → cone is (0,2)…(2,4); does NOT contain (4,4)
+ */
+function makeBaseGame() {
+	const base = startPhase(
+		createGame(TEST_PERSONAS, [TEST_CONTENT_PACK]),
+		TEST_PHASE_CONFIG,
+	);
+	// Override objectives with the convergence one.
+	return {
+		...base,
+		objectives: [CONVERGENCE_OBJECTIVE],
+		// Ensure world has the space entity at its known cell.
+		world: {
+			entities: [CONVERGENCE_OBJECT, CONVERGENCE_SPACE],
+		},
+		// Use the aiStarts layout from TEST_CONTENT_PACK (startPhase already applied
+		// these from aiStarts, but we re-assert them here for clarity / safety).
+		personaSpatial: TEST_CONTENT_PACK.aiStarts as typeof base.personaSpatial,
+	};
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("runRound — convergence evaluation (step 4d)", () => {
+	it("tier-1: one Daemon on the space → witnessed-convergence tier-1 entry in their log", async () => {
+		// red at (4,4) — on the space.  green + cyan elsewhere and facing away.
+		const game = makeBaseGame();
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		const redLog = nextState.conversationLogs.red ?? [];
+		const convergenceEntries = redLog.filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		expect(convergenceEntries).toHaveLength(1);
+		const entry = convergenceEntries[0];
+		expect(entry?.kind).toBe("witnessed-convergence");
+		if (entry?.kind === "witnessed-convergence") {
+			expect(entry.tier).toBe(1);
+			expect(entry.spaceId).toBe("altar_space");
+			expect(entry.flavor).toBe(CONVERGENCE_SPACE.convergenceTier1Flavor);
+		}
+	});
+
+	it("tier-1: a Daemon whose cone does NOT contain the space cell does NOT receive an entry", async () => {
+		// green at (0,0) facing south; cyan at (0,2) facing south.
+		// Neither cone reaches (4,4).
+		const game = makeBaseGame();
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		const greenLog = nextState.conversationLogs.green ?? [];
+		const cyanLog = nextState.conversationLogs.cyan ?? [];
+
+		const greenConvergence = greenLog.filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		const cyanConvergence = cyanLog.filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+
+		expect(greenConvergence).toHaveLength(0);
+		expect(cyanConvergence).toHaveLength(0);
+	});
+
+	it("tier-1: satisfactionState remains 'pending' after one Daemon on the space", async () => {
+		const game = makeBaseGame();
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		const convergenceObj = nextState.objectives.find(
+			(o) => o.kind === "convergence",
+		);
+		expect(convergenceObj?.satisfactionState).toBe("pending");
+	});
+
+	it("tier-2: two Daemons on the space → witnessed-convergence tier-2 entries and satisfactionState flips to 'satisfied'", async () => {
+		// Move green to (4,4) as well so we have two Daemons on the space.
+		const baseGame = makeBaseGame();
+		const game = {
+			...baseGame,
+			personaSpatial: {
+				...baseGame.personaSpatial,
+				// red at (4,4) facing north (from base), green also at (4,4) facing north
+				green: { position: { row: 4, col: 4 }, facing: "north" as const },
+				// cyan stays at (0,2) facing south — cone doesn't reach (4,4)
+			},
+		};
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		// Both red and green are on the space — both should witness tier-2.
+		const redLog = nextState.conversationLogs.red ?? [];
+		const greenLog = nextState.conversationLogs.green ?? [];
+		const cyanLog = nextState.conversationLogs.cyan ?? [];
+
+		const redConvergence = redLog.filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		const greenConvergence = greenLog.filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		const cyanConvergence = cyanLog.filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+
+		expect(redConvergence).toHaveLength(1);
+		if (redConvergence[0]?.kind === "witnessed-convergence") {
+			expect(redConvergence[0].tier).toBe(2);
+			expect(redConvergence[0].flavor).toBe(
+				CONVERGENCE_SPACE.convergenceTier2Flavor,
+			);
+		}
+
+		expect(greenConvergence).toHaveLength(1);
+		if (greenConvergence[0]?.kind === "witnessed-convergence") {
+			expect(greenConvergence[0].tier).toBe(2);
+		}
+
+		// cyan's cone at (0,2) facing south does not include (4,4).
+		expect(cyanConvergence).toHaveLength(0);
+
+		// satisfactionState must flip to "satisfied".
+		const convergenceObj = nextState.objectives.find(
+			(o) => o.kind === "convergence",
+		);
+		expect(convergenceObj?.satisfactionState).toBe("satisfied");
+	});
+
+	it("re-trigger guard: a third round with both Daemons still on the space does NOT add new convergence entries", async () => {
+		// Round 1: two Daemons on the space → objective satisfied.
+		const baseGame = makeBaseGame();
+		const gameTwoOnSpace = {
+			...baseGame,
+			personaSpatial: {
+				...baseGame.personaSpatial,
+				green: { position: { row: 4, col: 4 }, facing: "north" as const },
+			},
+		};
+
+		const { nextState: afterRound1 } = await runRound(
+			gameTwoOnSpace,
+			"red",
+			"hi",
+			makeProvider(),
+		);
+
+		// Confirm satisfied after round 1.
+		const obj1 = afterRound1.objectives.find((o) => o.kind === "convergence");
+		expect(obj1?.satisfactionState).toBe("satisfied");
+
+		// Count convergence entries after round 1.
+		const redCountAfterRound1 = (afterRound1.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "witnessed-convergence",
+		).length;
+		expect(redCountAfterRound1).toBeGreaterThanOrEqual(1);
+
+		// Round 2: run again with same spatial layout (both still on the space).
+		const { nextState: afterRound2 } = await runRound(
+			afterRound1,
+			"red",
+			"hi",
+			makeProvider(),
+		);
+
+		// Objective must still be satisfied, not re-triggered.
+		const obj2 = afterRound2.objectives.find((o) => o.kind === "convergence");
+		expect(obj2?.satisfactionState).toBe("satisfied");
+
+		// No NEW convergence entries must have been appended.
+		const redCountAfterRound2 = (afterRound2.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "witnessed-convergence",
+		).length;
+		expect(redCountAfterRound2).toBe(redCountAfterRound1);
+	});
+});

--- a/src/spa/game/__tests__/round-coordinator-convergence.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-convergence.test.ts
@@ -82,9 +82,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	setting: "",
 	weather: "",
 	timeOfDay: "",
-	objectivePairs: [
-		{ object: CONVERGENCE_OBJECT, space: CONVERGENCE_SPACE },
-	],
+	objectivePairs: [{ object: CONVERGENCE_OBJECT, space: CONVERGENCE_SPACE }],
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -14,14 +14,17 @@ import type {
 	AiTurnAction,
 	CarryObjective,
 	ContentPack,
+	ConvergenceObjective,
 	Objective,
 	ObjectivePair,
+	PersonaSpatialState,
 	UseItemObjective,
 	UseSpaceObjective,
 	WorldEntity,
 	WorldState,
 } from "../types";
 import {
+	checkConvergenceTier,
 	checkLoseCondition,
 	checkPlacementFlavor,
 	checkWinCondition,
@@ -646,5 +649,131 @@ describe("checkWinCondition with UseSpaceObjective", () => {
 		};
 		const objectives: Objective[] = [carryObj, useSpaceObj];
 		expect(checkWinCondition(world, objectives)).toBe(false);
+	});
+});
+
+// ── checkConvergenceTier ──────────────────────────────────────────────────────
+
+describe("checkConvergenceTier", () => {
+	const spaceId = "conv-space";
+
+	function makeConvergenceObjective(): ConvergenceObjective {
+		return {
+			id: "obj-conv",
+			kind: "convergence",
+			description: "Converge on the space",
+			satisfactionState: "pending",
+			spaceId,
+		};
+	}
+
+	function makeWorldWithSpace(
+		cell: { row: number; col: number } | null,
+	): WorldState {
+		if (cell === null) {
+			// World has no space entity
+			return { entities: [] };
+		}
+		const space: WorldEntity = {
+			id: spaceId,
+			kind: "objective_space",
+			name: "Test Space",
+			examineDescription: "A test convergence space.",
+			holder: cell,
+		};
+		return { entities: [space] };
+	}
+
+	function makeSpatial(
+		positions: Array<{ row: number; col: number }>,
+	): Record<string, PersonaSpatialState> {
+		const result: Record<string, PersonaSpatialState> = {};
+		for (let i = 0; i < positions.length; i++) {
+			// biome-ignore lint/style/noNonNullAssertion: bounded index
+			result[`ai-${i}`] = { position: positions[i]!, facing: "north" };
+		}
+		return result;
+	}
+
+	it("returns tier 0 when space entity is absent from world", () => {
+		const objective = makeConvergenceObjective();
+		const world = makeWorldWithSpace(null);
+		const personaSpatial = makeSpatial([{ row: 2, col: 2 }]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(0);
+		expect(result.spaceId).toBe(spaceId);
+	});
+
+	it("returns tier 0 when space entity holder is an AiId (not a GridPosition)", () => {
+		const objective = makeConvergenceObjective();
+		const space: WorldEntity = {
+			id: spaceId,
+			kind: "objective_space",
+			name: "Test Space",
+			examineDescription: "A test convergence space.",
+			holder: "some-ai-id", // AiId, not GridPosition
+		};
+		const world = { entities: [space] };
+		const personaSpatial = makeSpatial([{ row: 2, col: 2 }]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(0);
+	});
+
+	it("returns tier 0 when no Daemon is on the space cell", () => {
+		const objective = makeConvergenceObjective();
+		const world = makeWorldWithSpace({ row: 3, col: 3 });
+		// All daemons are elsewhere
+		const personaSpatial = makeSpatial([
+			{ row: 0, col: 0 },
+			{ row: 1, col: 1 },
+			{ row: 4, col: 4 },
+		]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(0);
+	});
+
+	it("returns tier 1 when exactly one Daemon is on the space cell", () => {
+		const objective = makeConvergenceObjective();
+		const world = makeWorldWithSpace({ row: 3, col: 3 });
+		const personaSpatial = makeSpatial([
+			{ row: 3, col: 3 }, // on the space
+			{ row: 0, col: 0 }, // elsewhere
+			{ row: 1, col: 1 }, // elsewhere
+		]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(1);
+		expect(result.spaceId).toBe(spaceId);
+	});
+
+	it("returns tier 2 when exactly two Daemons share the space cell", () => {
+		const objective = makeConvergenceObjective();
+		const world = makeWorldWithSpace({ row: 3, col: 3 });
+		const personaSpatial = makeSpatial([
+			{ row: 3, col: 3 }, // on the space
+			{ row: 3, col: 3 }, // on the space
+			{ row: 1, col: 1 }, // elsewhere
+		]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(2);
+	});
+
+	it("returns tier 2 (clamped) when all three Daemons share the space cell", () => {
+		const objective = makeConvergenceObjective();
+		const world = makeWorldWithSpace({ row: 2, col: 2 });
+		const personaSpatial = makeSpatial([
+			{ row: 2, col: 2 },
+			{ row: 2, col: 2 },
+			{ row: 2, col: 2 },
+		]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(2);
+	});
+
+	it("returns tier 0 when space is present but no personas at all", () => {
+		const objective = makeConvergenceObjective();
+		const world = makeWorldWithSpace({ row: 3, col: 3 });
+		const personaSpatial = makeSpatial([]);
+		const result = checkConvergenceTier(objective, world, personaSpatial);
+		expect(result.tier).toBe(0);
 	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -30,7 +30,7 @@ export const CONTENT_PACK_SYSTEM_PROMPT = `You generate content packs for a text
 For each phase:
 - Generate exactly k OBJECTIVE PAIRS. Each pair has:
   - An objective_object with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; MUST NOT reference or imply contact with the paired space, since the actor can be anywhere on the grid when using the item), pairsWithSpaceId (must match the paired space's id), placementFlavor (1 sentence containing the literal string "{actor}", fires when the object is placed on its space), proximityFlavor (1 sentence; in-fiction sensory description of what the daemon perceives when they are holding this item AND its paired space is in their own cell or directly in front of them. Written from the daemon's POV. Does NOT contain "{actor}" and MUST NOT reference placing or coupling the item.). objective_objects MUST be portable physical items a single person can pick up and carry (e.g. a tool, instrument, artifact, container) — never furniture, architecture, or fixed structures.
-  - An objective_space with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences describing the space), useOutcome (1 sentence: what the daemon perceives when they activate/use this space — a stateless sensory result, first person. Does NOT say the objective is complete), satisfactionFlavor (1 sentence, third-person from a witness POV, fires as a witnessed event when the space is successfully used to satisfy the objective — does NOT contain "{actor}"), postExamineDescription (1-2 sentences: alternate examine description shown after the space has been used), postLookFlavor (1 sentence: alternate look flavor shown after the space has been used). objective_spaces are fixed locations or surfaces, not items.
+  - An objective_space with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences describing the space), useOutcome (1 sentence: what the daemon perceives when they activate/use this space — a stateless sensory result, first person. Does NOT say the objective is complete), satisfactionFlavor (1 sentence, third-person from a witness POV, fires as a witnessed event when the space is successfully used to satisfy the objective — does NOT contain "{actor}"), postExamineDescription (1-2 sentences: alternate examine description shown after the space has been used), postLookFlavor (1 sentence: alternate look flavor shown after the space has been used), convergenceTier1Flavor (1 sentence, in-fiction sensory line a witness Daemon perceives when exactly one Daemon occupies this space; third person from witness POV; does NOT contain {actor}), convergenceTier2Flavor (1 sentence, in-fiction sensory line a witness Daemon perceives when two or more Daemons share this space; third person from witness POV; does NOT contain {actor}). objective_spaces are fixed locations or surfaces, not items.
 - Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes). interesting_objects MUST be portable physical items a single person can pick up and carry — never furniture, architecture, or fixed structures.
 - Generate exactly m OBSTACLES with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1 sentence describing the impassable object), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Obstacles are fixed and impassable — never portable items. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS — one anchoring each cardinal direction (north, south, east, west). Each landmark is distant, unreachable, distinctive, mutually visually distinguishable, and consistent with the setting, atmosphere, and weather. Each landmark has: shortName (2-5 words, e.g. "the rusted radio tower"), horizonPhrase (a short evocative clause describing what the landmark itself looks like — its form, condition, materials — NOT where it sits relative to any viewer. The phrase is slotted into "On the horizon ahead: <shortName> — <horizonPhrase>." so it must read coherently as a continuation. Good: "rises above the platform, antenna bent toward the dark". Bad: "looms behind you in the dark" (implies position) or "stands to your left" (implies relative direction).
@@ -56,7 +56,7 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
       "objectivePairs": [
         {
           "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." },
-          "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." }
+          "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "..." }
         }
       ],
       "interestingObjects": [
@@ -138,7 +138,7 @@ For each phase produce packA and packB with the following rules:
 Entity rules (same as always):
 - Generate exactly k OBJECTIVE PAIRS per pack. Each pair:
   - objective_object: id, kind="objective_object", name (2-4 words thematic to setting+theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 stateless sentence; MUST NOT imply contact with paired space), pairsWithSpaceId (matches space id), placementFlavor (1 sentence with literal "{actor}"), proximityFlavor (1 sentence; daemon's POV sensory experience; no "{actor}"; no placing/coupling language). Must be a portable physical item.
-  - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 sentence: stateless sensory result when daemon uses the space), satisfactionFlavor (1 sentence, third-person witness POV, fires when objective satisfied — no "{actor}"), postExamineDescription (1-2 sentences: shown after use), postLookFlavor (1 sentence: shown in look after use). Fixed location or surface.
+  - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 sentence: stateless sensory result when daemon uses the space), satisfactionFlavor (1 sentence, third-person witness POV, fires when objective satisfied — no "{actor}"), postExamineDescription (1-2 sentences: shown after use), postLookFlavor (1 sentence: shown in look after use), convergenceTier1Flavor (1 sentence sensory witness line when exactly one Daemon is on space; no {actor}), convergenceTier2Flavor (1 sentence sensory witness line when two or more Daemons share space; no {actor}). Fixed location or surface.
 - Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 stateless sentence). Must be portable.
 - Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence). Fixed and impassable.
 - Generate exactly 4 HORIZON LANDMARKS per pack (north/south/east/west): shortName (2-5 words), horizonPhrase (evocative clause; no cardinal direction words; no positional phrases implying viewer relationship).
@@ -158,14 +158,14 @@ Return ONLY valid JSON (no markdown, no preamble):
       "phaseNumber": <1|2|3>,
       "packA": {
         "setting": "<settingA>",
-        "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." } }],
+        "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "..." } }],
         "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "..." }],
         "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "..." }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
       },
       "packB": {
         "setting": "<settingB>",
-        "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." } }],
+        "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "DIFFERENT_FLAVOR", "convergenceTier2Flavor": "DIFFERENT_FLAVOR" } }],
         "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "..." }],
         "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "..." }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
@@ -244,6 +244,7 @@ function validateEntity(
 	requireUseOutcome: boolean,
 	requirePairing?: { pairsWithSpaceId?: string },
 	requireShiftFlavor?: boolean,
+	requireConvergenceFlavors?: boolean,
 ): WorldEntity {
 	if (raw == null || typeof raw !== "object") {
 		throw new ContentPackError(
@@ -317,6 +318,27 @@ function validateEntity(
 		}
 	}
 
+	if (requireConvergenceFlavors) {
+		if (
+			typeof e.convergenceTier1Flavor !== "string" ||
+			e.convergenceTier1Flavor.length === 0 ||
+			e.convergenceTier1Flavor.includes("{actor}")
+		) {
+			throw new ContentPackError(
+				`Objective space ${e.id}: convergenceTier1Flavor must be a non-empty string that does not contain "{actor}"`,
+			);
+		}
+		if (
+			typeof e.convergenceTier2Flavor !== "string" ||
+			e.convergenceTier2Flavor.length === 0 ||
+			e.convergenceTier2Flavor.includes("{actor}")
+		) {
+			throw new ContentPackError(
+				`Objective space ${e.id}: convergenceTier2Flavor must be a non-empty string that does not contain "{actor}"`,
+			);
+		}
+	}
+
 	// Build entity — holder is not set here (placement done later)
 	const entity: WorldEntity = {
 		id: e.id,
@@ -352,6 +374,12 @@ function validateEntity(
 		if (typeof e.postLookFlavor === "string") {
 			entity.postLookFlavor = e.postLookFlavor;
 		}
+	}
+	if (typeof e.convergenceTier1Flavor === "string") {
+		entity.convergenceTier1Flavor = e.convergenceTier1Flavor;
+	}
+	if (typeof e.convergenceTier2Flavor === "string") {
+		entity.convergenceTier2Flavor = e.convergenceTier2Flavor;
 	}
 	return entity;
 }
@@ -435,6 +463,9 @@ export function validateContentPacks(
 				"objective_space",
 				allIds,
 				false,
+				undefined,
+				false,
+				true,
 			);
 			const object = validateEntity(
 				pair.object,
@@ -637,7 +668,15 @@ function validateSinglePack(
 			);
 		}
 		const pair = pairRaw as Record<string, unknown>;
-		const space = validateEntity(pair.space, "objective_space", allIds, false);
+		const space = validateEntity(
+			pair.space,
+			"objective_space",
+			allIds,
+			false,
+			undefined,
+			false,
+			true,
+		);
 		const object = validateEntity(
 			pair.object,
 			"objective_object",

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -146,6 +146,10 @@ export function renderEntry(
 			return `[Round ${round}] ${entry.flavor}`;
 		}
 
+		case "witnessed-convergence": {
+			return `[Round ${round}] ${entry.flavor}`;
+		}
+
 		case "broadcast": {
 			return `[Round ${round}] ${entry.content}`;
 		}

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -273,6 +273,25 @@ export function appendWitnessedEvent(
 }
 
 /**
+ * Append a `kind: "witnessed-convergence"` ConversationEntry to a single
+ * witness's per-Daemon log. Called by the Round Coordinator's end-of-round
+ * convergence evaluation for each Daemon whose cone contains the space cell.
+ */
+export function appendWitnessedConvergence(
+	game: GameState,
+	witnessId: AiId,
+	entry: Extract<ConversationEntry, { kind: "witnessed-convergence" }>,
+): GameState {
+	return {
+		...game,
+		conversationLogs: {
+			...game.conversationLogs,
+			[witnessId]: [...(game.conversationLogs[witnessId] ?? []), entry],
+		},
+	};
+}
+
+/**
  * Append a `kind: "witnessed-obstacle-shift"` ConversationEntry to a single
  * witness's per-Daemon log. Called by the Obstacle Shift complication handler
  * for each Daemon whose cone contained the obstacle's origin cell.

--- a/src/spa/game/objective-pool.ts
+++ b/src/spa/game/objective-pool.ts
@@ -15,6 +15,7 @@
 import type {
 	CarryObjective,
 	ContentPack,
+	ConvergenceObjective,
 	Objective,
 	UseItemObjective,
 	UseSpaceObjective,
@@ -64,6 +65,25 @@ export function drawObjectives(
 			itemId: obj.id,
 		};
 		pool.push(useItem);
+	}
+
+	for (const pair of contentPack.objectivePairs) {
+		const { space } = pair;
+		if (
+			typeof space.convergenceTier1Flavor === "string" &&
+			space.convergenceTier1Flavor.length > 0 &&
+			typeof space.convergenceTier2Flavor === "string" &&
+			space.convergenceTier2Flavor.length > 0
+		) {
+			const convergence: ConvergenceObjective = {
+				id: "", // placeholder; will be replaced with assigned id
+				kind: "convergence",
+				description: `Converge on the ${space.name}`,
+				satisfactionState: "pending",
+				spaceId: space.id,
+			};
+			pool.push(convergence);
+		}
 	}
 
 	if (pool.length === 0) {

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -22,6 +22,8 @@
  *        — "[Round N] You watch *X do Y."
  *      - kind=witnessed-obstacle-shift: { role: "user", content: renderEntry(...) }
  *        — "[Round N] <shiftFlavor>."
+ *      - kind=witnessed-convergence: { role: "user", content: renderEntry(...) }
+ *        — "[Round N] <flavor>."
  *      - kind=action-failure:    { role: "user",      content: renderEntry(...) }
  *        — "[Round N] Your `<tool>` action failed: <reason>."
  *        Actor-only; surfaced as a user turn so the Daemon sees its own past
@@ -123,6 +125,16 @@ export function buildOpenAiMessages(
 				),
 			});
 		} else if (entry.kind === "witnessed-obstacle-shift") {
+			messages.push({
+				role: "user",
+				content: renderEntry(
+					entry,
+					ctx.aiId,
+					ctx.worldSnapshot.entities,
+					witnessState,
+				),
+			});
+		} else if (entry.kind === "witnessed-convergence") {
 			messages.push({
 				role: "user",
 				content: renderEntry(

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -24,6 +24,7 @@ import {
 	resolveExpiredChatLockouts,
 	tickComplication,
 } from "./complication-engine";
+import { projectCone } from "./cone-projector";
 import { dispatchAiTurn } from "./dispatcher";
 import {
 	advanceRound,
@@ -35,7 +36,6 @@ import {
 	resolveToolDisables,
 } from "./engine";
 import { buildOpenAiMessages } from "./openai-message-builder";
-import { projectCone } from "./cone-projector";
 import { buildAiContext, buildConeSnapshot } from "./prompt-builder";
 import type { OpenAiMessage, RoundLLMProvider } from "./round-llm-provider";
 import {
@@ -55,7 +55,11 @@ import type {
 	ToolName,
 	ToolRoundtripMessage,
 } from "./types";
-import { checkConvergenceTier, checkLoseCondition, checkWinCondition } from "./win-condition";
+import {
+	checkConvergenceTier,
+	checkLoseCondition,
+	checkWinCondition,
+} from "./win-condition";
 
 // Match the SPA dev-host gate used in src/spa/routes/game.ts. The
 // `typeof` guard keeps this safe in test environments that don't stub
@@ -587,13 +591,14 @@ export async function runRound(
 				? (spaceEntity?.convergenceTier1Flavor ?? "Something stirs here.")
 				: (spaceEntity?.convergenceTier2Flavor ?? "Two presences converge.");
 
-		const entry: Extract<ConversationEntry, { kind: "witnessed-convergence" }> = {
-			kind: "witnessed-convergence",
-			round: state.round,
-			spaceId,
-			tier,
-			flavor,
-		};
+		const entry: Extract<ConversationEntry, { kind: "witnessed-convergence" }> =
+			{
+				kind: "witnessed-convergence",
+				round: state.round,
+				spaceId,
+				tier,
+				flavor,
+			};
 
 		// Fan out to every Daemon whose cone contains the space cell.
 		for (const [daemonId, spatial] of Object.entries(state.personaSpatial)) {

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -29,11 +29,13 @@ import {
 	advanceRound,
 	appendMessage,
 	appendPrivateSystemNotice,
+	appendWitnessedConvergence,
 	FAREWELL_LINE,
 	isAiLockedOut,
 	resolveToolDisables,
 } from "./engine";
 import { buildOpenAiMessages } from "./openai-message-builder";
+import { projectCone } from "./cone-projector";
 import { buildAiContext, buildConeSnapshot } from "./prompt-builder";
 import type { OpenAiMessage, RoundLLMProvider } from "./round-llm-provider";
 import {
@@ -45,13 +47,15 @@ import { parseToolCallArguments } from "./tool-registry";
 import type {
 	AiId,
 	AiTurnAction,
+	ConversationEntry,
 	GameState,
+	GridPosition,
 	RoundActionRecord,
 	RoundResult,
 	ToolName,
 	ToolRoundtripMessage,
 } from "./types";
-import { checkLoseCondition, checkWinCondition } from "./win-condition";
+import { checkConvergenceTier, checkLoseCondition, checkWinCondition } from "./win-condition";
 
 // Match the SPA dev-host gate used in src/spa/routes/game.ts. The
 // `typeof` guard keeps this safe in test environments that don't stub
@@ -551,6 +555,69 @@ export async function runRound(
 		state = stateAfterResolve;
 		if (resolvedAiIds.length > 0) {
 			chatLockoutsResolved = resolvedAiIds;
+		}
+	}
+
+	// 4d. End-of-round convergence evaluation.
+	// Walk pending convergence objectives; compute tier; fan out witnessed-convergence entries.
+	for (const objective of state.objectives) {
+		if (objective.kind !== "convergence") continue;
+		if (objective.satisfactionState !== "pending") continue;
+
+		const { tier, spaceId } = checkConvergenceTier(
+			objective,
+			state.world,
+			state.personaSpatial,
+		);
+
+		if (tier === 0) continue;
+
+		const spaceEntity = state.world.entities.find((e) => e.id === spaceId);
+		const spaceCell =
+			spaceEntity &&
+			typeof spaceEntity.holder === "object" &&
+			spaceEntity.holder !== null
+				? (spaceEntity.holder as GridPosition)
+				: null;
+
+		if (!spaceCell) continue;
+
+		const flavor =
+			tier === 1
+				? (spaceEntity?.convergenceTier1Flavor ?? "Something stirs here.")
+				: (spaceEntity?.convergenceTier2Flavor ?? "Two presences converge.");
+
+		const entry: Extract<ConversationEntry, { kind: "witnessed-convergence" }> = {
+			kind: "witnessed-convergence",
+			round: state.round,
+			spaceId,
+			tier,
+			flavor,
+		};
+
+		// Fan out to every Daemon whose cone contains the space cell.
+		for (const [daemonId, spatial] of Object.entries(state.personaSpatial)) {
+			const cone = projectCone(spatial.position, spatial.facing);
+			const witnessesCell = cone.some(
+				(cell) =>
+					cell.position.row === spaceCell.row &&
+					cell.position.col === spaceCell.col,
+			);
+			if (witnessesCell) {
+				state = appendWitnessedConvergence(state, daemonId, entry);
+			}
+		}
+
+		// Tier 2: satisfy the objective immediately.
+		if (tier === 2) {
+			state = {
+				...state,
+				objectives: state.objectives.map((o) =>
+					o.id === objective.id
+						? { ...o, satisfactionState: "satisfied" as const }
+						: o,
+				),
+			};
 		}
 	}
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -41,6 +41,10 @@ export interface WorldEntity {
 	proximityFlavor?: string;
 	/** For obstacle: 1-sentence sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT contain {actor}. */
 	shiftFlavor?: string;
+	/** For objective_space used as a Convergence target: tier-1 flavor (exactly one Daemon on space). Does NOT contain {actor}. */
+	convergenceTier1Flavor?: string;
+	/** For objective_space used as a Convergence target: tier-2 flavor (two or more Daemons share space). Does NOT contain {actor}. */
+	convergenceTier2Flavor?: string;
 	/** AiId when held by an AI; GridPosition when resting on a cell. */
 	holder: AiId | GridPosition;
 	/** Tracks whether this entity has been "used" for a UseItem objective. Defaults to "pending" when omitted. */
@@ -132,6 +136,8 @@ export interface ConvergenceObjective {
 	kind: "convergence";
 	description: string;
 	satisfactionState: "pending" | "satisfied";
+	/** The id of the objective_space that acts as the convergence point. */
+	spaceId: string;
 }
 
 export type Objective =
@@ -303,6 +309,13 @@ export type ConversationEntry =
 			obstacleId: string;
 			fromCell: GridPosition;
 			toCell: GridPosition;
+			flavor: string;
+	  }
+	| {
+			kind: "witnessed-convergence";
+			round: number;
+			spaceId: string;
+			tier: 1 | 2;
 			flavor: string;
 	  };
 

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -16,8 +16,10 @@ import type {
 	AiTurnAction,
 	CarryObjective,
 	ContentPack,
+	ConvergenceObjective,
 	GridPosition,
 	Objective,
+	PersonaSpatialState,
 	UseItemObjective,
 	UseSpaceObjective,
 	WorldState,
@@ -74,6 +76,39 @@ export function isUseSpaceObjectiveSatisfied(
 	objective: UseSpaceObjective,
 ): boolean {
 	return objective.satisfactionState === "satisfied";
+}
+
+/**
+ * Returns the convergence tier for the given ConvergenceObjective:
+ *  - tier 0: space entity missing, or its holder is not a GridPosition, or zero Daemons on the space cell
+ *  - tier 1: exactly one Daemon on the space cell
+ *  - tier 2: two or more Daemons share the space cell (clamped to 2)
+ *
+ * Also returns the spaceId for the caller's convenience.
+ */
+export function checkConvergenceTier(
+	objective: ConvergenceObjective,
+	world: WorldState,
+	personaSpatial: Record<AiId, PersonaSpatialState>,
+): { tier: 0 | 1 | 2; spaceId: string } {
+	const spaceId = objective.spaceId;
+	const spaceEntity = world.entities.find((e) => e.id === spaceId);
+	if (!spaceEntity) return { tier: 0, spaceId };
+
+	if (!isGridPosition(spaceEntity.holder)) return { tier: 0, spaceId };
+
+	const spaceCell = spaceEntity.holder;
+
+	let count = 0;
+	for (const spatial of Object.values(personaSpatial)) {
+		if (positionsEqual(spatial.position, spaceCell)) {
+			count++;
+		}
+	}
+
+	if (count === 0) return { tier: 0, spaceId };
+	if (count === 1) return { tier: 1, spaceId };
+	return { tier: 2, spaceId };
 }
 
 /**


### PR DESCRIPTION
## What this fixes

Adds the `ConvergenceObjective` type to the objective pool. The objective is satisfied the moment any two Daemons share the same grid cell as a designated `objective_space` entity. The satisfaction check runs end-of-round in `round-coordinator.ts` (new step 4d) against all Daemon positions via the pure `checkConvergenceTier()` function in `win-condition.ts`. Tier 1 (exactly one Daemon on the space) fires a `witnessed-convergence` ConversationEntry — cone-gated to Daemons whose field of view includes the space cell — using the space's `convergenceTier1Flavor`. Tier 2 (two or more Daemons) fans out the tier-2 flavor then flips `objective.satisfactionState` to `"satisfied"`; the guard at the top of the loop prevents re-triggering. Both flavor strings are generated by the content-pack LLM (system-prompt updated in `content-pack-provider.ts`) and validated as non-empty, `{actor}`-free strings. The `session-codec.ts` sealer was also fixed to actually persist `state.objectives` (it was hardcoded to `[]`), which would have broken the re-trigger guard on session restore for all objective types.

**Files changed:**
- `src/spa/game/types.ts` — `ConvergenceObjective.spaceId`, `WorldEntity` tier flavor fields, `witnessed-convergence` entry variant
- `src/spa/game/win-condition.ts` — `checkConvergenceTier()` pure predicate
- `src/spa/game/engine.ts` — `appendWitnessedConvergence()` helper
- `src/spa/game/round-coordinator.ts` — step 4d convergence evaluation block
- `src/spa/game/objective-pool.ts` — adds ConvergenceObjective per eligible pair
- `src/spa/game/content-pack-provider.ts` — prompt + validation for tier flavor fields
- `src/spa/game/conversation-log.ts`, `openai-message-builder.ts` — render `witnessed-convergence`
- `src/spa/persistence/session-codec.ts` — fix objectives serialization
- `e2e/helpers/stubs.ts` — tier flavor fields added to both stub builders

## QA steps for the human

1. Start a new game and confirm it loads (no cap-hit overlay) — verifies the content-pack stub fix.
2. In a game with a Convergence objective visible in the round log, confirm that walking one Daemon to the convergence space triggers a tier-1 witnessed entry in that Daemon's log, and the objective remains pending.
3. Walk a second Daemon to the same cell in the next round — verify the tier-2 entry fires, the objective flips to satisfied, and the game ends if all other objectives are also satisfied.
4. Confirm a third round on the same cell produces no new convergence entries.

(Steps 2–4 are fully covered by `round-coordinator-convergence.test.ts` — manual verification is optional but recommended for the first real content-pack game.)

## Automated coverage

`pnpm typecheck` clean; `pnpm test:unit` 1356/1356 pass (60 test files, including 5 new round-coordinator-convergence tests and expanded win-condition, objective-pool, and content-pack-provider suites); `pnpm test:e2e` 42/44 pass (2 pre-existing failures unrelated to this branch: `witnessed-event-reload` direction flake + `cents-live-smoke` live-network test).

Closes #305

https://claude.ai/code/session_01YZzVpPonD1pMjagj4KHmAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZzVpPonD1pMjagj4KHmAt)_