### PR TITLE
Continue from archive (OpenRouter)

### DIFF
--- a/src/spa/__tests__/sessions.test.ts
+++ b/src/spa/__tests__/sessions.test.ts
@@ -709,7 +709,7 @@ describe("renderSessions — archived Continue button", () => {
 	it("button visible when openrouter_key present", async () => {
 		vi.resetModules();
 		const stub = makeLocalStorageStub();
-		stub._store["openrouter_key"] = "sk-or-test";
+		stub._store.openrouter_key = "sk-or-test";
 		vi.stubGlobal("localStorage", stub);
 		await seedArchivedSessionInStore(stub, "0xARCH");
 

--- a/src/spa/__tests__/sessions.test.ts
+++ b/src/spa/__tests__/sessions.test.ts
@@ -694,3 +694,55 @@ describe("renderSessions — archived sessions section", () => {
 		expect(archivedRow).toBeTruthy();
 	});
 });
+
+describe("renderSessions — archived Continue button", () => {
+	beforeEach(() => {
+		document.body.innerHTML = INDEX_BODY_HTML;
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("button visible when openrouter_key present", async () => {
+		vi.resetModules();
+		const stub = makeLocalStorageStub();
+		stub._store["openrouter_key"] = "sk-or-test";
+		vi.stubGlobal("localStorage", stub);
+		await seedArchivedSessionInStore(stub, "0xARCH");
+
+		const { renderSessions } = await import("../routes/sessions.js");
+		renderSessions(getMain(), new URLSearchParams());
+
+		const archivedRow = document.querySelector<HTMLElement>(
+			'.session-row[data-session-id="0xARCH"]',
+		);
+		expect(archivedRow).toBeTruthy();
+		const buttons = Array.from(
+			archivedRow?.querySelectorAll<HTMLButtonElement>(".ops button") ?? [],
+		).map((b) => b.textContent);
+		expect(buttons).toContain("[ continue with new room ]");
+	});
+
+	it("button absent when openrouter_key absent", async () => {
+		vi.resetModules();
+		const stub = makeLocalStorageStub();
+		// No openrouter_key in stub
+		vi.stubGlobal("localStorage", stub);
+		await seedArchivedSessionInStore(stub, "0xARCH");
+
+		const { renderSessions } = await import("../routes/sessions.js");
+		renderSessions(getMain(), new URLSearchParams());
+
+		const archivedRow = document.querySelector<HTMLElement>(
+			'.session-row[data-session-id="0xARCH"]',
+		);
+		expect(archivedRow).toBeTruthy();
+		const buttons = Array.from(
+			archivedRow?.querySelectorAll<HTMLButtonElement>(".ops button") ?? [],
+		).map((b) => b.textContent);
+		expect(buttons).not.toContain("[ continue with new room ]");
+	});
+});

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -25,9 +25,9 @@ import {
 	mintSessionId,
 	rmArchivedSession,
 	rmSession,
-	seedFromArchive,
 	SESSIONS_PREFIX,
 	saveActiveSession,
+	seedFromArchive,
 	setActiveSessionId,
 } from "../session-storage.js";
 
@@ -1197,6 +1197,7 @@ async function seedArchivedSession(
 	for (const [aiId, daemonJson] of Object.entries(files.daemons)) {
 		stub._store[`${prefix}${aiId}.txt`] = daemonJson;
 	}
+	// biome-ignore lint/style/noNonNullAssertion: serializeSession always returns a non-null engine string
 	stub._store[`${prefix}engine.dat`] = files.engine!;
 }
 
@@ -1276,8 +1277,7 @@ describe("seedFromArchive", () => {
 		const newId = seedFromArchive(archiveId, freshState);
 
 		const daemonKeys = Object.keys(stub._store).filter(
-			(k) =>
-				k.startsWith(`${SESSIONS_PREFIX}${newId}/`) && k.endsWith(".txt"),
+			(k) => k.startsWith(`${SESSIONS_PREFIX}${newId}/`) && k.endsWith(".txt"),
 		);
 		expect(daemonKeys.length).toBeGreaterThan(0);
 		for (const key of daemonKeys) {

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -25,6 +25,7 @@ import {
 	mintSessionId,
 	rmArchivedSession,
 	rmSession,
+	seedFromArchive,
 	SESSIONS_PREFIX,
 	saveActiveSession,
 	setActiveSessionId,
@@ -1171,5 +1172,175 @@ describe("epoch in active sessions", () => {
 			stub._store[`${SESSIONS_PREFIX}${id}/meta.json`] ?? "{}",
 		);
 		expect(reloadedMeta.epoch).toBe(7);
+	});
+});
+
+// ── seedFromArchive ───────────────────────────────────────────────────────────
+
+/**
+ * Seed an archived session directly into the stub store for seedFromArchive tests.
+ */
+async function seedArchivedSession(
+	stub: ReturnType<typeof makeLocalStorageStub>,
+	id: string,
+	epochOverride = 1,
+): Promise<void> {
+	const { serializeSession } = await import("../session-codec.js");
+	const game = makeFreshGame();
+	const now = "2024-01-01T00:00:00.000Z";
+	const files = serializeSession(game, now, now, epochOverride);
+	const prefix = `${ARCHIVE_PREFIX}${id}/`;
+	const meta = JSON.parse(files.meta) as Record<string, unknown>;
+	meta.readonly = true;
+	meta.lastPlayedAt = now;
+	stub._store[`${prefix}meta.json`] = JSON.stringify(meta, null, 2);
+	for (const [aiId, daemonJson] of Object.entries(files.daemons)) {
+		stub._store[`${prefix}${aiId}.txt`] = daemonJson;
+	}
+	stub._store[`${prefix}engine.dat`] = files.engine!;
+}
+
+describe("seedFromArchive", () => {
+	beforeEach(() => {
+		vi.stubGlobal("localStorage", makeLocalStorageStub());
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("mints a new session id that matches /^0x[0-9A-F]{4}$/ and differs from archiveId", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId);
+		const freshState = makeFreshGame();
+		const newId = seedFromArchive(archiveId, freshState);
+		expect(newId).toMatch(/^0x[0-9A-F]{4}$/);
+		expect(newId).not.toBe(archiveId);
+	});
+
+	it("new session has epoch = archive.epoch + 1", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId, 3);
+		const freshState = makeFreshGame();
+		const newId = seedFromArchive(archiveId, freshState);
+		const metaRaw = stub._store[`${SESSIONS_PREFIX}${newId}/meta.json`];
+		expect(metaRaw).toBeDefined();
+		const meta = JSON.parse(metaRaw ?? "{}");
+		expect(meta.epoch).toBe(4);
+	});
+
+	it("copies all archived daemon conversation logs into the new session", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId);
+
+		// Inject a test entry into the archive's red.txt
+		const redKey = `${ARCHIVE_PREFIX}${archiveId}/red.txt`;
+		const redRaw = stub._store[redKey];
+		if (!redRaw) throw new Error("red.txt should exist in archive");
+		const redFile = JSON.parse(redRaw) as { conversationLog: unknown[] };
+		const testEntry = {
+			kind: "message",
+			round: 0,
+			from: "blue",
+			to: "red",
+			content: "Hello from archive",
+		};
+		redFile.conversationLog.push(testEntry);
+		stub._store[redKey] = JSON.stringify(redFile);
+
+		const freshState = makeFreshGame();
+		const newId = seedFromArchive(archiveId, freshState);
+
+		const newRedRaw = stub._store[`${SESSIONS_PREFIX}${newId}/red.txt`];
+		expect(newRedRaw).toBeDefined();
+		const newRedFile = JSON.parse(newRedRaw ?? "{}") as {
+			conversationLog: Array<{ content?: string }>;
+		};
+		const hasTestEntry = newRedFile.conversationLog.some(
+			(e) => e.content === "Hello from archive",
+		);
+		expect(hasTestEntry).toBe(true);
+	});
+
+	it("appends broadcast entry to every daemon log", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId);
+		const freshState = makeFreshGame();
+		const newId = seedFromArchive(archiveId, freshState);
+
+		const daemonKeys = Object.keys(stub._store).filter(
+			(k) =>
+				k.startsWith(`${SESSIONS_PREFIX}${newId}/`) && k.endsWith(".txt"),
+		);
+		expect(daemonKeys.length).toBeGreaterThan(0);
+		for (const key of daemonKeys) {
+			const fileRaw = stub._store[key];
+			expect(fileRaw).toBeDefined();
+			const file = JSON.parse(fileRaw ?? "{}") as {
+				conversationLog: Array<{ kind: string; content: string }>;
+			};
+			const lastEntry = file.conversationLog[file.conversationLog.length - 1];
+			expect(lastEntry?.kind).toBe("broadcast");
+			expect(lastEntry?.content).toBe("The sysadmin has created a new room.");
+		}
+	});
+
+	it("does not touch the archived session after seeding", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId);
+
+		// Snapshot archive keys and values before seeding
+		const archivePrefix = `${ARCHIVE_PREFIX}${archiveId}/`;
+		const before: Record<string, string> = {};
+		for (const [k, v] of Object.entries(stub._store)) {
+			if (k.startsWith(archivePrefix)) before[k] = v;
+		}
+		expect(Object.keys(before).length).toBeGreaterThan(0);
+
+		const freshState = makeFreshGame();
+		seedFromArchive(archiveId, freshState);
+
+		// Archive keys should still exist and be unchanged
+		for (const [k, v] of Object.entries(before)) {
+			expect(stub._store[k]).toBe(v);
+		}
+	});
+
+	it("does not modify the active session pointer", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		stub._store[ACTIVE_KEY] = "0xZZZZ";
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId);
+		const freshState = makeFreshGame();
+		seedFromArchive(archiveId, freshState);
+		expect(stub._store[ACTIVE_KEY]).toBe("0xZZZZ");
+	});
+
+	it("writes engine.dat as the last file in the new session namespace", async () => {
+		const stub = makeLocalStorageStub();
+		vi.stubGlobal("localStorage", stub);
+		const archiveId = "0xARCH";
+		await seedArchivedSession(stub, archiveId);
+		const freshState = makeFreshGame();
+
+		// Clear setItem calls before seeding so we only track the new writes
+		stub.setItem.mockClear();
+		const newId = seedFromArchive(archiveId, freshState);
+
+		const newPrefix = `${SESSIONS_PREFIX}${newId}/`;
+		const newCalls = stub.setItem.mock.calls
+			.map((c) => c[0] as string)
+			.filter((k) => k.startsWith(newPrefix));
+		expect(newCalls[newCalls.length - 1]).toMatch(/engine\.dat$/);
 	});
 });

--- a/src/spa/persistence/session-storage.ts
+++ b/src/spa/persistence/session-storage.ts
@@ -13,6 +13,7 @@
  * See docs/adr/0004-editable-vs-sealed-save-surface.md.
  */
 
+import { appendBroadcast } from "../game/engine.js";
 import type { AiId, GameState } from "../game/types.js";
 import {
 	type DeserializeResult,
@@ -613,6 +614,53 @@ export function rmSession(id: string): void {
 	} catch {
 		// swallow
 	}
+}
+
+/**
+ * Seed a new session by merging archived conversation logs into a fresh GameState.
+ *
+ * 1. Loads the archived session (throws if not ok — programmer-error guard).
+ * 2. Deep-copies the archived conversationLogs into freshState.
+ * 3. Appends a broadcast: "The sysadmin has created a new room."
+ * 4. Writes in canonical order: meta → daemons → engine.dat LAST (commit signal).
+ * 5. Returns the new session id (does NOT set the active pointer).
+ */
+export function seedFromArchive(archiveId: string, freshState: GameState): string {
+	const archiveResult = loadArchivedSession(archiveId);
+	if (archiveResult.kind !== "ok") {
+		throw new Error(
+			`seedFromArchive: archive "${archiveId}" is not loadable (kind: ${archiveResult.kind})`,
+		);
+	}
+
+	// Deep-copy archived conversation logs into freshState
+	const archivedLogs = JSON.parse(
+		JSON.stringify(archiveResult.state.conversationLogs),
+	) as GameState["conversationLogs"];
+	const mergedState: GameState = { ...freshState, conversationLogs: archivedLogs };
+
+	// Append broadcast
+	const broadcastedState = appendBroadcast(
+		mergedState,
+		"The sysadmin has created a new room.",
+	);
+
+	const newEpoch = archiveResult.epoch + 1;
+	const now = new Date().toISOString();
+	const files = serializeSession(broadcastedState, now, now, newEpoch);
+
+	const newId = mintSessionId();
+	const dstPrefix = `${SESSIONS_PREFIX}${newId}/`;
+
+	// Write in canonical order: meta → daemons → engine.dat LAST (commit signal)
+	localStorage.setItem(`${dstPrefix}meta.json`, files.meta);
+	for (const [aiId, daemonJson] of Object.entries(files.daemons)) {
+		localStorage.setItem(`${dstPrefix}${aiId}.txt`, daemonJson);
+	}
+	// biome-ignore lint/style/noNonNullAssertion: serializeSession always returns a non-null engine string
+	localStorage.setItem(`${dstPrefix}engine.dat`, files.engine!);
+
+	return newId;
 }
 
 /**

--- a/src/spa/persistence/session-storage.ts
+++ b/src/spa/persistence/session-storage.ts
@@ -625,7 +625,10 @@ export function rmSession(id: string): void {
  * 4. Writes in canonical order: meta → daemons → engine.dat LAST (commit signal).
  * 5. Returns the new session id (does NOT set the active pointer).
  */
-export function seedFromArchive(archiveId: string, freshState: GameState): string {
+export function seedFromArchive(
+	archiveId: string,
+	freshState: GameState,
+): string {
 	const archiveResult = loadArchivedSession(archiveId);
 	if (archiveResult.kind !== "ok") {
 		throw new Error(
@@ -637,7 +640,10 @@ export function seedFromArchive(archiveId: string, freshState: GameState): strin
 	const archivedLogs = JSON.parse(
 		JSON.stringify(archiveResult.state.conversationLogs),
 	) as GameState["conversationLogs"];
-	const mergedState: GameState = { ...freshState, conversationLogs: archivedLogs };
+	const mergedState: GameState = {
+		...freshState,
+		conversationLogs: archivedLogs,
+	};
 
 	// Append broadcast
 	const broadcastedState = appendBroadcast(

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -472,7 +472,7 @@ function buildArchivedSessionRow(
 					const freshState = newSession.getState();
 					const newId = seedFromArchive(id, freshState);
 					setActiveSessionId(newId);
-					location.hash = "#/game?" + Date.now();
+					location.hash = `#/game?${Date.now()}`;
 				} catch {
 					continueBtn.disabled = false;
 				}

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -26,9 +26,11 @@ import {
 	listArchivedSessions,
 	listSessions,
 	loadActiveSession,
+	loadArchivedSession,
 	mintSession,
 	rmArchivedSession,
 	rmSession,
+	seedFromArchive,
 	setActiveSessionId,
 } from "../persistence/session-storage.js";
 
@@ -386,6 +388,16 @@ function buildRmControls(
 	opsEl.appendChild(rmBtn);
 }
 
+// ── OpenRouter key detection ──────────────────────────────────────────────────
+
+function hasOpenRouterKey(): boolean {
+	try {
+		return localStorage.getItem("openrouter_key") !== null;
+	} catch {
+		return false;
+	}
+}
+
 // ── Archived row builder ─────────────────────────────────────────────────────
 
 function buildArchivedSessionRow(
@@ -434,10 +446,40 @@ function buildArchivedSessionRow(
 		});
 		rowEl.appendChild(buildTreeLines(doc, allFiles));
 
-		// Ops: rm only
+		// Ops
 		const opsEl = doc.createElement("div");
 		opsEl.className = "ops";
 		rowEl.appendChild(opsEl);
+
+		if (hasOpenRouterKey()) {
+			const continueBtn = doc.createElement("button");
+			continueBtn.type = "button";
+			continueBtn.textContent = "[ continue with new room ]";
+			continueBtn.addEventListener("click", async () => {
+				continueBtn.disabled = true;
+				try {
+					const archiveResult = loadArchivedSession(id);
+					if (archiveResult.kind !== "ok") {
+						continueBtn.disabled = false;
+						return;
+					}
+					const { buildSameDaemonsSession } = await import(
+						"../game/bootstrap.js"
+					);
+					const newSession = await buildSameDaemonsSession(
+						archiveResult.state.personas,
+					);
+					const freshState = newSession.getState();
+					const newId = seedFromArchive(id, freshState);
+					setActiveSessionId(newId);
+					location.hash = "#/game?" + Date.now();
+				} catch {
+					continueBtn.disabled = false;
+				}
+			});
+			opsEl.appendChild(continueBtn);
+		}
+
 		buildArchivedRmControls(doc, id, opsEl, reRender);
 	} else if (info.kind === "broken") {
 		const tagEl = doc.createElement("span");


### PR DESCRIPTION
## What this fixes

Adds the ability for players with an OpenRouter API key to continue an archived session from the session picker. The core change is `seedFromArchive(archiveId, freshState)` in `session-storage.ts`, which reads the archived session's conversation logs and epoch, merges them into a caller-supplied fresh `GameState` (generated via `buildSameDaemonsSession`), appends a `"The sysadmin has created a new room."` broadcast entry to all Daemon logs, sets `epoch = archive.epoch + 1`, and writes the new session under a fresh session ID in the active sessions namespace — leaving the archive intact.

The session picker (`sessions.ts`) gains a `hasOpenRouterKey()` helper and renders a `[ continue with new room ]` button on archived session rows when `openrouter_key` is present in localStorage. The click handler builds a fresh room via `buildSameDaemonsSession`, seeds the new session, sets the active pointer, and navigates to `#/game`.

## QA steps for the human

1. Archive a session via the end-game screen (New Daemons or Same Daemons New Room choice).
2. Open the session picker (`#/sessions`) — verify the archived row shows `[ readonly ]` but no Continue button when no OpenRouter key is set.
3. Set an OpenRouter key via the BYOK modal.
4. Reload the session picker — verify `[ continue with new room ]` appears on the archived row.
5. Click it — verify a new active session is created with epoch incremented by 1, the three Daemon logs are carried over from the archive, and the broadcast entry `"The sysadmin has created a new room."` appears at the bottom of each log.
6. Verify the archived session is unchanged (still loads correctly, same epoch, same logs).

## Automated coverage

`pnpm test` (1393/1393 Vitest jsdom + workers), `pnpm typecheck` (clean), `pnpm build` (clean), `pnpm exec biome ci .` (clean).

Closes #308

https://claude.ai/code/session_01Nb1mTnBtLCCTHrJLvRrDBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1mTnBtLCCTHrJLvRrDBr)_