### PR TITLE
fix: prevent bootstrap from overwriting stale session on old-save load

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -2630,7 +2630,7 @@ describe("renderGame — version-mismatch session with pending bootstrap (regres
 		const saveSpy = vi.spyOn(sessionStorage, "saveActiveSession");
 
 		const { renderGame } = await import("../routes/game.js");
-		await renderGame(document.querySelector<HTMLElement>("main")!);
+		await renderGame(getEl<HTMLElement>("main"));
 
 		// The stale session must be cleared and the route redirected away.
 		expect(location.hash).toBe("#/start?reason=version-mismatch");

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -2540,3 +2540,104 @@ describe("renderGame — round error surfacing (issue #231)", () => {
 		expect(pipAfter?.className).toBe("ok");
 	});
 });
+
+// ── Regression: old-save session ID clobber ───────────────────────────────────
+//
+// When a version-mismatch session is active AND a pending bootstrap exists
+// (because the start screen ran first), renderGame must NOT call
+// renderBootstrapLoadingFlow — that would save new content packs and daemons
+// under the stale session ID.
+//
+// Issue: fix-old-save-diagnosis
+describe("renderGame — version-mismatch session with pending bootstrap (regression)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("redirects to #/start and does not overwrite the old session when a bootstrap is pending", async () => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+
+		// Build a localStorage stub seeded with a version-mismatch session.
+		// The session files are present but the engine.dat carries a stale
+		// schemaVersion so loadActiveSession() returns { kind: "version-mismatch" }.
+		// Use stub._store to populate data — makeLocalStorageStub spreads a copy
+		// of initialData, so direct mutations to an outer reference don't take.
+		vi.resetModules();
+		const { obfuscate } = await import("../persistence/sealed-blob-codec.js");
+
+		const stub = makeLocalStorageStub();
+
+		const SESSION_ID = "0xDEAD";
+		const prefix = `hi-blue:sessions/${SESSION_ID}/`;
+		stub._store["hi-blue:active-session"] = SESSION_ID;
+
+		stub._store[`${prefix}meta.json`] = JSON.stringify({
+			createdAt: "2024-01-01T00:00:00.000Z",
+			lastSavedAt: "2024-01-01T00:00:00.000Z",
+			phase: 1,
+			round: 0,
+			personaOrder: ["red", "green", "cyan"],
+		});
+
+		const daemonPhases = {
+			"1": { phaseGoal: "", conversationLog: [] },
+			"2": { phaseGoal: "", conversationLog: [] },
+			"3": { phaseGoal: "", conversationLog: [] },
+		};
+		for (const aiId of ["red", "green", "cyan"] as const) {
+			stub._store[`${prefix}${aiId}.txt`] = JSON.stringify({
+				aiId,
+				persona: STATIC_PERSONAS[aiId],
+				phases: daemonPhases,
+			});
+		}
+
+		// Engine.dat with a stale schemaVersion (4 instead of current 5).
+		const staleEnginePayload = {
+			schemaVersion: 4,
+			world: {
+				1: { entities: [] },
+				2: { entities: [] },
+				3: { entities: [] },
+			},
+			contentPacks: [],
+			budgets: { 1: {}, 2: {}, 3: {} },
+			lockouts: {
+				1: { lockedOut: [], chatLockouts: [] },
+				2: { lockedOut: [], chatLockouts: [] },
+				3: { lockedOut: [], chatLockouts: [] },
+			},
+			currentPhase: 1,
+			isComplete: false,
+			personaSpatial: { 1: {}, 2: {}, 3: {} },
+		};
+		stub._store[`${prefix}engine.dat`] = obfuscate(
+			JSON.stringify(staleEnginePayload),
+		);
+
+		vi.stubGlobal("localStorage", stub);
+
+		// Simulate the start screen having run: kick off a pending bootstrap.
+		const { startBootstrap } = await import("../game/pending-bootstrap.js");
+		startBootstrap();
+
+		// Spy on saveActiveSession — it must NOT be called during this render.
+		const sessionStorage = await import("../persistence/session-storage.js");
+		const saveSpy = vi.spyOn(sessionStorage, "saveActiveSession");
+
+		const { renderGame } = await import("../routes/game.js");
+		await renderGame(document.querySelector<HTMLElement>("main")!);
+
+		// The stale session must be cleared and the route redirected away.
+		expect(location.hash).toBe("#/start?reason=version-mismatch");
+		expect(stub.getItem("hi-blue:active-session")).toBeNull();
+
+		// The bootstrap must NOT have saved new content packs/daemons under the
+		// old session id.
+		expect(saveSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -2557,7 +2557,7 @@ describe("renderGame — version-mismatch session with pending bootstrap (regres
 		document.body.innerHTML = "";
 	});
 
-	it("redirects to #/start and does not overwrite the old session when a bootstrap is pending", async () => {
+	it("redirects to #/sessions and does not overwrite the old session when a bootstrap is pending", async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
 		document.body.innerHTML = INDEX_BODY_HTML;
 
@@ -2632,12 +2632,72 @@ describe("renderGame — version-mismatch session with pending bootstrap (regres
 		const { renderGame } = await import("../routes/game.js");
 		await renderGame(getEl<HTMLElement>("main"));
 
-		// The stale session must be cleared and the route redirected away.
-		expect(location.hash).toBe("#/start?reason=version-mismatch");
-		expect(stub.getItem("hi-blue:active-session")).toBeNull();
-
+		// The route must redirect to the sessions picker with the reason.
+		expect(location.hash).toBe("#/sessions?reason=version-mismatch");
+		// The active-session pointer must NOT be cleared — only the sessions
+		// picker (or an explicit user action) should touch it.
+		expect(stub.getItem("hi-blue:active-session")).toBe(SESSION_ID);
+		// The pending bootstrap must be cleared so a subsequent navigation
+		// doesn't re-enter the bootstrap loading flow.
+		const { getPendingBootstrap } = await import(
+			"../game/pending-bootstrap.js"
+		);
+		expect(getPendingBootstrap()).toBeUndefined();
 		// The bootstrap must NOT have saved new content packs/daemons under the
 		// old session id.
+		expect(saveSpy).not.toHaveBeenCalled();
+	});
+
+	it("redirects to #/sessions and clears pending bootstrap when session is broken", async () => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		document.body.innerHTML = INDEX_BODY_HTML;
+
+		vi.resetModules();
+		const stub = makeLocalStorageStub();
+
+		const SESSION_ID = "0xBEEF";
+		const prefix = `hi-blue:sessions/${SESSION_ID}/`;
+		stub._store["hi-blue:active-session"] = SESSION_ID;
+
+		stub._store[`${prefix}meta.json`] = JSON.stringify({
+			createdAt: "2024-01-01T00:00:00.000Z",
+			lastSavedAt: "2024-01-01T00:00:00.000Z",
+			phase: 1,
+			round: 0,
+			personaOrder: ["red", "green", "cyan"],
+		});
+
+		const daemonPhases = {
+			"1": { phaseGoal: "", conversationLog: [] },
+			"2": { phaseGoal: "", conversationLog: [] },
+			"3": { phaseGoal: "", conversationLog: [] },
+		};
+		for (const aiId of ["red", "green", "cyan"] as const) {
+			stub._store[`${prefix}${aiId}.txt`] = JSON.stringify({
+				aiId,
+				persona: STATIC_PERSONAS[aiId],
+				phases: daemonPhases,
+			});
+		}
+		// engine.dat is intentionally absent → loadActiveSession returns { kind: "broken" }.
+
+		vi.stubGlobal("localStorage", stub);
+
+		const { startBootstrap } = await import("../game/pending-bootstrap.js");
+		startBootstrap();
+
+		const sessionStorage = await import("../persistence/session-storage.js");
+		const saveSpy = vi.spyOn(sessionStorage, "saveActiveSession");
+
+		const { renderGame } = await import("../routes/game.js");
+		await renderGame(getEl<HTMLElement>("main"));
+
+		expect(location.hash).toBe("#/sessions?reason=broken");
+		expect(stub.getItem("hi-blue:active-session")).toBe(SESSION_ID);
+		const { getPendingBootstrap } = await import(
+			"../game/pending-bootstrap.js"
+		);
+		expect(getPendingBootstrap()).toBeUndefined();
 		expect(saveSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/spa/main.ts
+++ b/src/spa/main.ts
@@ -90,9 +90,20 @@ function withDispatcher(
 				location.hash = "#/game";
 				return;
 			}
+			// Stale sessions belong on the picker — never render the start screen
+			// (which kicks off a bootstrap) while a broken or version-mismatch
+			// session owns the active pointer.  Rendering start would let the user
+			// click CONNECT and then have the bootstrap save new content under the
+			// old session id.
+			if (
+				verdict.reason === "broken" ||
+				verdict.reason === "version-mismatch"
+			) {
+				location.hash = `#/sessions?reason=${verdict.reason}`;
+				return;
+			}
 			// Otherwise, fall through to renderer — pass reason (legacy-save-discarded)
-			// as query param if not already present. broken/version-mismatch now route
-			// to #/sessions instead of #/start.
+			// as query param if not already present.
 			let effectiveParams = params;
 			if (!effectiveParams.get("reason")) {
 				if (legacySaveDiscarded) {
@@ -109,8 +120,14 @@ function withDispatcher(
 		// Render when the session is populated, OR when a fresh bootstrap is
 		// in flight (the player just submitted CONNECT but content packs
 		// haven't landed yet — the game route owns the progressive-loading UI).
+		// Never allow a pending bootstrap to bypass a stale session redirect:
+		// that would let the bootstrap overwrite the old save under the same id.
 		if (verdict.reason !== "populated") {
-			if (getPendingBootstrap() !== undefined) {
+			if (
+				getPendingBootstrap() !== undefined &&
+				verdict.reason !== "version-mismatch" &&
+				verdict.reason !== "broken"
+			) {
 				return renderer(root, params);
 			}
 			if (

--- a/src/spa/main.ts
+++ b/src/spa/main.ts
@@ -125,8 +125,7 @@ function withDispatcher(
 		if (verdict.reason !== "populated") {
 			if (
 				getPendingBootstrap() !== undefined &&
-				verdict.reason !== "version-mismatch" &&
-				verdict.reason !== "broken"
+				(verdict.reason === "empty" || verdict.reason === "no-active-pointer")
 			) {
 				return renderer(root, params);
 			}

--- a/src/spa/persistence/active-session-dispatcher.ts
+++ b/src/spa/persistence/active-session-dispatcher.ts
@@ -62,7 +62,6 @@ export function dispatchActiveSession(
 			return { route: "#/sessions", reason: "broken", needsMint: false };
 
 		case "version-mismatch":
-			// TODO(#146): version-mismatch handling
 			return {
 				route: "#/sessions",
 				reason: "version-mismatch",

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -639,6 +639,15 @@ export function renderGame(
 				);
 				built = applyTestAffordances(built, effectiveParams);
 
+				// Defensive: if the active session is no longer empty, another
+				// navigation invalidated the bootstrap mid-flight. Abort rather
+				// than overwriting state under the wrong session id.
+				if (loadActiveSession().kind !== "none") {
+					clearPendingBootstrap();
+					location.hash = "#/sessions";
+					return;
+				}
+
 				const saveResult = saveActiveSession(built.getState());
 				if (!saveResult.ok) {
 					showPersistenceWarning(saveResult.reason);
@@ -696,18 +705,21 @@ export function renderGame(
 		const pendingBootstrap = getPendingBootstrap();
 		if (pendingBootstrap) {
 			// Only use the bootstrap when the active session is genuinely empty
-			// (just minted, no data yet). If there is a stale session under the
-			// active pointer (version-mismatch / broken), running the bootstrap
-			// would overwrite the old save with new content under the same
-			// session id. Clear the bootstrap and let the redirect path below
-			// handle the stale session correctly.
-			const staleCheckId = getActiveSessionId();
-			const staleCheckResult =
-				staleCheckId !== null ? loadActiveSession() : { kind: "none" as const };
-			if (staleCheckResult.kind === "none") {
+			// (just minted, no data yet). loadActiveSession() returns { kind: "none" }
+			// for both a null pointer and a minted-but-unsaved session, which are
+			// the only states where it's safe to build and save a new game.
+			// A stale session (version-mismatch / broken) must redirect to the
+			// sessions picker instead — not start generating content that would
+			// be saved under the old session id.
+			const loadCheck = loadActiveSession();
+			if (loadCheck.kind === "none") {
 				return renderBootstrapLoadingFlow(pendingBootstrap);
 			}
 			clearPendingBootstrap();
+			const reason =
+				loadCheck.kind === "version-mismatch" ? "version-mismatch" : "broken";
+			location.hash = `#/sessions?reason=${reason}`;
+			return Promise.resolve();
 		}
 
 		// Feature-detect localStorage availability (SecurityError in privacy mode).

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -642,9 +642,13 @@ export function renderGame(
 				// Defensive: if the active session is no longer empty, another
 				// navigation invalidated the bootstrap mid-flight. Abort rather
 				// than overwriting state under the wrong session id.
-				if (loadActiveSession().kind !== "none") {
+				const midFlightCheck = loadActiveSession();
+				if (midFlightCheck.kind !== "none") {
 					clearPendingBootstrap();
-					location.hash = "#/sessions";
+					// If a concurrent save landed a valid session, send the player to
+					// the game rather than the sessions picker.
+					location.hash =
+						midFlightCheck.kind === "ok" ? "#/game" : "#/sessions";
 					return;
 				}
 
@@ -706,19 +710,22 @@ export function renderGame(
 		if (pendingBootstrap) {
 			// Only use the bootstrap when the active session is genuinely empty
 			// (just minted, no data yet). loadActiveSession() returns { kind: "none" }
-			// for both a null pointer and a minted-but-unsaved session, which are
-			// the only states where it's safe to build and save a new game.
-			// A stale session (version-mismatch / broken) must redirect to the
-			// sessions picker instead — not start generating content that would
-			// be saved under the old session id.
+			// for a minted-but-unsaved session, which is the only state where it's
+			// safe to build and save a new game. A stale or already-populated session
+			// must be handled without writing new content under the existing id.
 			const loadCheck = loadActiveSession();
 			if (loadCheck.kind === "none") {
 				return renderBootstrapLoadingFlow(pendingBootstrap);
 			}
 			clearPendingBootstrap();
-			const reason =
-				loadCheck.kind === "version-mismatch" ? "version-mismatch" : "broken";
-			location.hash = `#/sessions?reason=${reason}`;
+			if (loadCheck.kind === "ok") {
+				// Session is already populated (e.g. restored concurrently); play it.
+				location.hash = "#/game";
+			} else {
+				const reason =
+					loadCheck.kind === "version-mismatch" ? "version-mismatch" : "broken";
+				location.hash = `#/sessions?reason=${reason}`;
+			}
 			return Promise.resolve();
 		}
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -695,7 +695,21 @@ export function renderGame(
 		// the main screen with progressive loading rather than stuck on dial-up.
 		const pendingBootstrap = getPendingBootstrap();
 		if (pendingBootstrap) {
-			return renderBootstrapLoadingFlow(pendingBootstrap);
+			// Only use the bootstrap when the active session is genuinely empty
+			// (just minted, no data yet). If there is a stale session under the
+			// active pointer (version-mismatch / broken), running the bootstrap
+			// would overwrite the old save with new content under the same
+			// session id. Clear the bootstrap and let the redirect path below
+			// handle the stale session correctly.
+			const staleCheckId = getActiveSessionId();
+			const staleCheckResult =
+				staleCheckId !== null
+					? loadActiveSession()
+					: { kind: "none" as const };
+			if (staleCheckResult.kind === "none") {
+				return renderBootstrapLoadingFlow(pendingBootstrap);
+			}
+			clearPendingBootstrap();
 		}
 
 		// Feature-detect localStorage availability (SecurityError in privacy mode).

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -703,9 +703,7 @@ export function renderGame(
 			// handle the stale session correctly.
 			const staleCheckId = getActiveSessionId();
 			const staleCheckResult =
-				staleCheckId !== null
-					? loadActiveSession()
-					: { kind: "none" as const };
+				staleCheckId !== null ? loadActiveSession() : { kind: "none" as const };
 			if (staleCheckResult.kind === "none") {
 				return renderBootstrapLoadingFlow(pendingBootstrap);
 			}


### PR DESCRIPTION
## Problem

Opening an old save (stale `schemaVersion` in `engine.dat`) was silently treated as a fresh game start — the bootstrap flow generated new content packs and daemons and saved them under the existing session id, destroying the old save rather than redirecting to the sessions picker.

Three cooperating gaps allowed this:
1. `#/start` dispatcher didn't redirect `broken`/`version-mismatch` sessions to `#/sessions`
2. `#/game` dispatcher allowed the bootstrap flow for any non-`broken`/non-`version-mismatch` reason (blacklist, not whitelist)
3. `renderGame`'s bootstrap entry guard didn't re-check session freshness before calling `renderBootstrapLoadingFlow`

## Fix

Three independent guards, each sufficient alone, now cooperate:

- **`main.ts` (`#/start`)**: redirect `broken`/`version-mismatch` sessions to `#/sessions` before the start screen can mint a pending bootstrap
- **`main.ts` (`#/game`)**: convert bootstrap-bypass from a blacklist to a whitelist — only `empty` and `no-active-pointer` reasons allow it; future `DispatcherReason` additions are safe by default
- **`game.ts` (bootstrap entry guard)**: re-check `loadActiveSession()` before entering `renderBootstrapLoadingFlow`; stale sessions redirect to `#/sessions`, already-populated sessions go to `#/game`
- **`game.ts` (save-site guard)**: defensive re-check immediately before `saveActiveSession()` in the async completion callback, catches any race where a bootstrap survives to the `.then()` callback despite a mid-flight pointer change

## Tests

Regression tests added for both `version-mismatch` and `broken` sessions with a pending bootstrap: assert `#/sessions?reason=…` redirect, active-session pointer preserved, bootstrap cleared, `saveActiveSession` never called.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ysDoHekXbNJ4gB1FgiKGs)_