### PR TITLE
Add shiftFlavor validation for dual-pack obstacles

### DIFF
--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -270,6 +270,7 @@ function buildDualContentPackResponseBody(body: ParsedBody): string {
 				kind: "obstacle",
 				name: `Stub obstacle ${tag} ${i} ${ab}`,
 				examineDescription: `Stub obstacle ${tag}-obs-${i} ${ab}.`,
+				shiftFlavor: `Stub obstacle ${tag}-obs-${i} ${ab} grinds across the floor.`,
 			}));
 			return {
 				setting,

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -12,6 +12,7 @@ import {
 	CONTENT_PACK_SYSTEM_PROMPT,
 	examineMentionsPairedSpace,
 	validateContentPacks,
+	validateDualContentPacks,
 } from "../content-pack-provider.js";
 
 describe("examineMentionsPairedSpace", () => {
@@ -472,5 +473,119 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 				inputWithPair,
 			),
 		).toThrow(/convergenceTier1Flavor/);
+	});
+});
+
+// ── shiftFlavor validation for dual-pack obstacles (issue #337) ──────────────
+
+describe("validateDualContentPacks — obstacle shiftFlavor validation", () => {
+	const dualInputWithObstacle = {
+		phases: [
+			{
+				phaseNumber: 1 as const,
+				settingA: "abandoned subway station",
+				settingB: "overgrown ruin",
+				theme: "mundane",
+				k: 0,
+				n: 0,
+				m: 1,
+			},
+		],
+	};
+
+	const STUB_LANDMARKS = {
+		north: { shortName: "the signal tower", horizonPhrase: "rises high" },
+		south: { shortName: "the collapsed entrance", horizonPhrase: "gapes wide" },
+		east: { shortName: "the rusted shaft", horizonPhrase: "spins slowly" },
+		west: { shortName: "the flooded tunnel", horizonPhrase: "fades to black" },
+	};
+
+	function buildDualObstacleResponse(
+		packAShift: unknown,
+		packBShift: unknown,
+	): unknown {
+		const buildObstacle = (shiftFlavor: unknown, ab: "a" | "b") => ({
+			id: "obs1",
+			kind: "obstacle",
+			name: `Rusted Gate ${ab}`,
+			examineDescription: `An old rusted gate ${ab}.`,
+			...(shiftFlavor !== undefined ? { shiftFlavor } : {}),
+		});
+		return {
+			phases: [
+				{
+					phaseNumber: 1,
+					packA: {
+						setting: "abandoned subway station",
+						objectivePairs: [],
+						interestingObjects: [],
+						obstacles: [buildObstacle(packAShift, "a")],
+						landmarks: STUB_LANDMARKS,
+					},
+					packB: {
+						setting: "overgrown ruin",
+						objectivePairs: [],
+						interestingObjects: [],
+						obstacles: [buildObstacle(packBShift, "b")],
+						landmarks: STUB_LANDMARKS,
+					},
+				},
+			],
+		};
+	}
+
+	it("accepts dual-pack obstacles with valid shiftFlavor on both packs", () => {
+		const result = validateDualContentPacks(
+			buildDualObstacleResponse(
+				"The rusted gate scrapes along the floor.",
+				"The mossy gate slides through wet leaves.",
+			),
+			dualInputWithObstacle,
+		);
+		expect(result.phases[0]?.packA.obstacles[0]?.shiftFlavor).toBe(
+			"The rusted gate scrapes along the floor.",
+		);
+		expect(result.phases[0]?.packB.obstacles[0]?.shiftFlavor).toBe(
+			"The mossy gate slides through wet leaves.",
+		);
+	});
+
+	it("rejects a dual-pack obstacle missing shiftFlavor on packA", () => {
+		expect(() =>
+			validateDualContentPacks(
+				buildDualObstacleResponse(undefined, "Something rustles."),
+				dualInputWithObstacle,
+			),
+		).toThrow(/shiftFlavor/);
+	});
+
+	it("rejects a dual-pack obstacle missing shiftFlavor on packB", () => {
+		expect(() =>
+			validateDualContentPacks(
+				buildDualObstacleResponse("The gate scrapes.", undefined),
+				dualInputWithObstacle,
+			),
+		).toThrow(/shiftFlavor/);
+	});
+
+	it("rejects a dual-pack obstacle with an empty shiftFlavor", () => {
+		expect(() =>
+			validateDualContentPacks(
+				buildDualObstacleResponse("", "Something rustles."),
+				dualInputWithObstacle,
+			),
+		).toThrow(/shiftFlavor/);
+	});
+
+	it("rejects a dual-pack obstacle whose shiftFlavor contains {actor}", () => {
+		expect(() =>
+			validateDualContentPacks(
+				buildDualObstacleResponse(
+					"{actor} pushes the gate.",
+					"Something rustles.",
+				),
+				dualInputWithObstacle,
+			),
+		).toThrow(/shiftFlavor/);
 	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -132,7 +132,7 @@ export const DUAL_CONTENT_PACK_SYSTEM_PROMPT = `You generate paired content pack
 For each phase produce packA and packB with the following rules:
 - Entity IDs (id fields) MUST be identical between packA and packB. Choose the ids once and reuse them.
 - Entity structural relationships (pairsWithSpaceId, kind) MUST be identical between packA and packB.
-- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, landmark shortName, landmark horizonPhrase.
+- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, shiftFlavor, landmark shortName, landmark horizonPhrase.
 - The setting field at pack level MUST match settingA for packA and settingB for packB.
 
 Entity rules (same as always):
@@ -140,7 +140,7 @@ Entity rules (same as always):
   - objective_object: id, kind="objective_object", name (2-4 words thematic to setting+theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 stateless sentence; MUST NOT imply contact with paired space), pairsWithSpaceId (matches space id), placementFlavor (1 sentence with literal "{actor}"), proximityFlavor (1 sentence; daemon's POV sensory experience; no "{actor}"; no placing/coupling language). Must be a portable physical item.
   - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 sentence: stateless sensory result when daemon uses the space), satisfactionFlavor (1 sentence, third-person witness POV, fires when objective satisfied — no "{actor}"), postExamineDescription (1-2 sentences: shown after use), postLookFlavor (1 sentence: shown in look after use), convergenceTier1Flavor (1 sentence sensory witness line when exactly one Daemon is on space; no {actor}), convergenceTier2Flavor (1 sentence sensory witness line when two or more Daemons share space; no {actor}). Fixed location or surface.
 - Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 stateless sentence). Must be portable.
-- Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence). Fixed and impassable.
+- Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Fixed and impassable. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS per pack (north/south/east/west): shortName (2-5 words), horizonPhrase (evocative clause; no cardinal direction words; no positional phrases implying viewer relationship).
 
 Global constraints:
@@ -160,14 +160,14 @@ Return ONLY valid JSON (no markdown, no preamble):
         "setting": "<settingA>",
         "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "..." } }],
         "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "..." }],
-        "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "..." }],
+        "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "...", "shiftFlavor": "..." }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
       },
       "packB": {
         "setting": "<settingB>",
         "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "DIFFERENT_FLAVOR", "convergenceTier2Flavor": "DIFFERENT_FLAVOR" } }],
         "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "..." }],
-        "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "..." }],
+        "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "...", "shiftFlavor": "DIFFERENT_FLAVOR" }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
       }
     }
@@ -706,7 +706,9 @@ function validateSinglePack(
 
 	const obstacles: WorldEntity[] = [];
 	for (const obsRaw of pack.obstacles as unknown[]) {
-		obstacles.push(validateEntity(obsRaw, "obstacle", allIds, false));
+		obstacles.push(
+			validateEntity(obsRaw, "obstacle", allIds, false, undefined, true),
+		);
 	}
 
 	const landmarksRaw = pack.landmarks;


### PR DESCRIPTION
## Summary
This PR adds validation and documentation for the `shiftFlavor` field on obstacles in dual-content packs, addressing issue #337. The `shiftFlavor` field describes the sensory experience a witness Daemon perceives when an obstacle moves one cell.

## Key Changes
- **Added `validateDualContentPacks` function export** to the test imports, enabling validation of dual-pack content
- **Updated system prompt** to document `shiftFlavor` as a required field for obstacles that must differ between packA and packB (re-flavored for each setting)
- **Added comprehensive validation tests** for obstacle `shiftFlavor`:
  - Accepts valid `shiftFlavor` on both packs
  - Rejects missing `shiftFlavor` on either pack
  - Rejects empty string `shiftFlavor`
  - Rejects `shiftFlavor` containing the `{actor}` placeholder (which is not allowed for witness POV descriptions)
- **Updated JSON schema examples** in the system prompt to include `shiftFlavor` in obstacle definitions
- **Updated test stubs** to include `shiftFlavor` in generated dual-pack obstacle responses

## Implementation Details
- The `shiftFlavor` field is a single sentence from a witness Daemon's POV describing sensory perception when an obstacle moves
- It must NOT contain directional words (north/south/east/west) or the `{actor}` placeholder
- It must be present and non-empty in both packA and packB obstacles
- The validation ensures consistency with the existing pattern for other re-flavored fields like `placementFlavor` and `proximityFlavor`

https://claude.ai/code/session_0142P5md4gsDS1jksfruQHAM