### PR TITLE
Use-Item: pre/post LLM-authored flavor on interesting_object (#334)

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import {
 	CONTENT_PACK_SYSTEM_PROMPT,
 	examineMentionsPairedSpace,
+	examineMentionsUseTell,
 	validateContentPacks,
 } from "../content-pack-provider.js";
 
@@ -472,5 +473,209 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 				inputWithPair,
 			),
 		).toThrow(/convergenceTier1Flavor/);
+	});
+});
+
+// ── examineMentionsUseTell helper (issue #334) ────────────────────────────────
+
+describe("examineMentionsUseTell", () => {
+	it("matches a verb-of-activation like 'press'", () => {
+		expect(
+			examineMentionsUseTell(
+				"A small brass dial mounted on a panel. It looks like it should be pressed to open the chamber.",
+			),
+		).toBe(true);
+	});
+
+	it("matches the bare verb 'use'", () => {
+		expect(
+			examineMentionsUseTell(
+				"A peculiar device. You wonder if it could be used.",
+			),
+		).toBe(true);
+	});
+
+	it("matches a control noun like 'lever' even without an activation verb", () => {
+		expect(
+			examineMentionsUseTell(
+				"A heavy iron lever bolted to the wall, weathered by years of damp.",
+			),
+		).toBe(true);
+	});
+
+	it("rejects an examine with no verb or control-noun cue", () => {
+		expect(
+			examineMentionsUseTell(
+				"A small porcelain figurine, chipped along one edge but otherwise intact.",
+			),
+		).toBe(false);
+	});
+
+	it("does not match 'use' inside a longer word like 'fuse'", () => {
+		expect(
+			examineMentionsUseTell(
+				"A scorched copper fuse, brittle and discoloured.",
+			),
+		).toBe(false);
+	});
+
+	it("is case-insensitive", () => {
+		expect(examineMentionsUseTell("PRESS the BUTTON to begin.")).toBe(true);
+	});
+});
+
+// ── interesting_object Use-Item flavor field validation (issue #334) ──────────
+
+describe("validateContentPacks — interesting_object Use-Item flavor validation", () => {
+	const inputWithInteresting = {
+		phases: [
+			{
+				phaseNumber: 1 as const,
+				setting: "abandoned subway station",
+				theme: "mundane",
+				k: 0,
+				n: 1,
+				m: 0,
+			},
+		],
+	};
+
+	function buildInterestingResponse(overrides: Record<string, unknown>) {
+		const item: Record<string, unknown> = {
+			id: "item1",
+			kind: "interesting_object",
+			name: "Brass Switch",
+			examineDescription:
+				"A small brass switch mounted on a panel. It looks like it should be pressed.",
+			useOutcome: "The switch clicks under your finger but nothing changes.",
+			activationFlavor:
+				"The switch flips home with a hard mechanical thunk and a single amber light pulses on.",
+			postExamineDescription:
+				"The switch sits locked in its on position, the amber light steady behind it.",
+			postLookFlavor: "an amber pinpoint of light glows beside the panel",
+			...overrides,
+		};
+		return {
+			packs: [
+				{
+					phaseNumber: 1,
+					setting: "abandoned subway station",
+					objectivePairs: [],
+					interestingObjects: [item],
+					obstacles: [],
+					landmarks: {
+						north: {
+							shortName: "the signal tower",
+							horizonPhrase: "rises above the platform",
+						},
+						south: {
+							shortName: "the collapsed entrance",
+							horizonPhrase: "gapes like a wound in the dark",
+						},
+						east: {
+							shortName: "the rusted fan shaft",
+							horizonPhrase: "spins slowly in the stale air",
+						},
+						west: {
+							shortName: "the flooded tunnel",
+							horizonPhrase: "disappears into still black water",
+						},
+					},
+				},
+			],
+		};
+	}
+
+	it("accepts an interesting_object with all Use-Item flavor fields", () => {
+		const result = validateContentPacks(
+			buildInterestingResponse({}),
+			inputWithInteresting,
+		);
+		const item = result.packs[0]?.interestingObjects[0];
+		expect(item?.activationFlavor).toContain("mechanical thunk");
+		expect(item?.postExamineDescription).toContain("locked in its on position");
+		expect(item?.postLookFlavor).toContain("amber pinpoint");
+	});
+
+	it("rejects an examineDescription with no verb-of-activation or control-noun cue", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({
+					examineDescription:
+						"A small porcelain figurine, chipped along one edge but otherwise intact.",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/verb-of-activation cue|control noun/);
+	});
+
+	it("rejects a missing activationFlavor", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({ activationFlavor: undefined }),
+				inputWithInteresting,
+			),
+		).toThrow(/activationFlavor/);
+	});
+
+	it("rejects an empty activationFlavor", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({ activationFlavor: "" }),
+				inputWithInteresting,
+			),
+		).toThrow(/activationFlavor/);
+	});
+
+	it("rejects an activationFlavor that contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({
+					activationFlavor: "{actor} flips the switch home.",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/activationFlavor/);
+	});
+
+	it("rejects a missing postExamineDescription", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({ postExamineDescription: undefined }),
+				inputWithInteresting,
+			),
+		).toThrow(/postExamineDescription/);
+	});
+
+	it("rejects a postExamineDescription that contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({
+					postExamineDescription: "{actor} sees the switch locked on.",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/postExamineDescription/);
+	});
+
+	it("rejects a postLookFlavor that contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildInterestingResponse({
+					postLookFlavor: "{actor} glances at the amber light",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/postLookFlavor/);
+	});
+
+	it("accepts an interesting_object with postLookFlavor omitted (optional)", () => {
+		const result = validateContentPacks(
+			buildInterestingResponse({ postLookFlavor: undefined }),
+			inputWithInteresting,
+		);
+		const item = result.packs[0]?.interestingObjects[0];
+		expect(item?.activationFlavor).toBeDefined();
+		expect(item?.postLookFlavor).toBeUndefined();
 	});
 });

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -1640,3 +1640,161 @@ describe("dispatchAiTurn — use on objective_space witnesses satisfactionFlavor
 		}
 	});
 });
+
+// ── UseItem activationFlavor on interesting_object (issue #334) ────────────────
+
+describe("dispatchAiTurn — UseItemObjective activationFlavor on interesting_object", () => {
+	/** Build a game where red holds 'key' (interesting_object) with activation
+	 * flavor configured, plus a pending UseItemObjective targeting 'key'. */
+	function makeGameWithUseItemActivation() {
+		const game = makeGame();
+		const withItemFlavors = updateActivePhase(game, (phase) => ({
+			...phase,
+			world: {
+				...phase.world,
+				entities: phase.world.entities.map((e) =>
+					e.id === "key"
+						? {
+								...e,
+								useOutcome: "The key sits inert in your palm.",
+								activationFlavor:
+									"The key flares briefly with a steady amber light as something in the wall clicks.",
+								postExamineDescription:
+									"The key has dimmed; whatever it was for is finished.",
+								postLookFlavor: "the spent key gives off a faint warmth",
+							}
+						: e,
+				),
+			},
+		}));
+		const useItemObj: UseItemObjective = {
+			id: "obj-0",
+			kind: "use_item",
+			description: "Use the key",
+			satisfactionState: "pending",
+			itemId: "key",
+		};
+		return updateActivePhase(withItemFlavors, (phase) => ({
+			...phase,
+			objectives: [useItemObj],
+		}));
+	}
+
+	it("returns activationFlavor as the actor's tool-success description on the satisfying use", () => {
+		const game = makeGameWithUseItemActivation();
+		const action: AiTurnAction = {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		};
+		const result = dispatchAiTurn(game, action);
+		expect(result.rejected).toBe(false);
+		const success = result.records.find((r) => r.kind === "tool_success");
+		expect(success?.description).toBe(
+			"The key flares briefly with a steady amber light as something in the wall clicks.",
+		);
+	});
+
+	it("falls back to useOutcome on a subsequent use after the objective is already satisfied", () => {
+		const game = makeGameWithUseItemActivation();
+		// First use — satisfies and emits activationFlavor.
+		const after = dispatchAiTurn(game, {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		});
+		expect(after.rejected).toBe(false);
+		// Second use — should fall back to useOutcome.
+		const second = dispatchAiTurn(after.game, {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		});
+		const success = second.records.find((r) => r.kind === "tool_success");
+		expect(success?.description).toBe("The key sits inert in your palm.");
+	});
+
+	it("does not emit activationFlavor when there is no pending UseItemObjective", () => {
+		// No use_item objective wired up.
+		const game = updateActivePhase(makeGame(), (phase) => ({
+			...phase,
+			world: {
+				...phase.world,
+				entities: phase.world.entities.map((e) =>
+					e.id === "key"
+						? {
+								...e,
+								useOutcome: "You weigh the key in your hand.",
+								activationFlavor:
+									"The key flares briefly with a steady amber light.",
+							}
+						: e,
+				),
+			},
+		}));
+		const result = dispatchAiTurn(game, {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		});
+		const success = result.records.find((r) => r.kind === "tool_success");
+		// Should fall back to useOutcome — activation only fires when a
+		// UseItemObjective transitions from pending → satisfied.
+		expect(success?.description).toBe("You weigh the key in your hand.");
+	});
+
+	it("fans out activationFlavor as the witnessed-event useOutcome on the satisfying call", () => {
+		// Reposition: put red and green in the same cell so green's cone covers red.
+		const game = makeGameWithUseItemActivation();
+		const lookedEast = executeToolCall(game, "red", {
+			name: "look",
+			args: { direction: "east" },
+		});
+		// red at (0,0) facing east; green at (0,1) facing north.
+		// green's cone (facing north from (0,1)) does NOT include (0,0),
+		// so green won't witness. Instead, move green so its cone covers red.
+		// Simplest: have green face west from (0,1) — front arc covers (0,0).
+		const greenWest = executeToolCall(lookedEast, "green", {
+			name: "look",
+			args: { direction: "west" },
+		});
+		const result = dispatchAiTurn(greenWest, {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		});
+		expect(result.rejected).toBe(false);
+		const greenLog = result.game.conversationLogs.green ?? [];
+		const useEvent = greenLog.find(
+			(e) => e.kind === "witnessed-event" && e.actionKind === "use",
+		);
+		expect(useEvent).toBeDefined();
+		if (useEvent?.kind === "witnessed-event") {
+			expect(useEvent.useOutcome).toBe(
+				"The key flares briefly with a steady amber light as something in the wall clicks.",
+			);
+		}
+	});
+
+	it("fans out useOutcome to witnesses on a post-satisfaction subsequent use", () => {
+		const game = makeGameWithUseItemActivation();
+		const greenWest = executeToolCall(game, "green", {
+			name: "look",
+			args: { direction: "west" },
+		});
+		// First use satisfies + emits activationFlavor.
+		const after = dispatchAiTurn(greenWest, {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		});
+		// Second use — witness should see useOutcome.
+		const second = dispatchAiTurn(after.game, {
+			aiId: "red",
+			toolCall: { name: "use", args: { item: "key" } },
+		});
+		const greenLog = second.game.conversationLogs.green ?? [];
+		const useEvents = greenLog.filter(
+			(e) => e.kind === "witnessed-event" && e.actionKind === "use",
+		);
+		// Last event should carry useOutcome, not activationFlavor.
+		const last = useEvents[useEvents.length - 1];
+		if (last?.kind === "witnessed-event") {
+			expect(last.useOutcome).toBe("The key sits inert in your palm.");
+		}
+	});
+});

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -1444,3 +1444,80 @@ describe("activeDirectives — buildAiContext and system prompt injection", () =
 		expect(prompt).toMatch(/do not reveal|private/i);
 	});
 });
+
+// ── postLookFlavor on satisfied interesting_object (issue #334) ───────────────
+
+describe("postLookFlavor swap covers satisfied interesting_object", () => {
+	const POST_LOOK_CONFIG = makeConfig(1);
+
+	function buildPackWithSatisfiedItem(
+		opts: { withPostLook: boolean } = { withPostLook: true },
+	): ContentPack {
+		const item: WorldEntity = {
+			id: "switch",
+			kind: "interesting_object",
+			name: "brass switch",
+			examineDescription: "A small brass switch ready to be pressed.",
+			useOutcome: "You toggle the switch.",
+			satisfactionState: "satisfied",
+			holder: { row: 1, col: 0 },
+			...(opts.withPostLook
+				? { postLookFlavor: "a steady amber glow lingers near the switch" }
+				: {}),
+		};
+		return {
+			phaseNumber: 1,
+			setting: "",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [],
+			interestingObjects: [item],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "south" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+	}
+
+	it("appends postLookFlavor to the cell line in <what_you_see> for a satisfied interesting_object", () => {
+		const pack = buildPackWithSatisfiedItem({ withPostLook: true });
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			POST_LOOK_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).toContain("Directly in front:");
+		expect(stateMsg).toContain("a steady amber glow lingers near the switch");
+	});
+
+	it("does NOT append postLookFlavor when entity is not satisfied", () => {
+		const pack = buildPackWithSatisfiedItem({ withPostLook: true });
+		// Flip satisfactionState back to pending.
+		const item = pack.interestingObjects[0];
+		if (item) item.satisfactionState = "pending";
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			POST_LOOK_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		expect(stateMsg).not.toContain(
+			"a steady amber glow lingers near the switch",
+		);
+	});
+
+	it("postLookFlavor also appears in buildConeSnapshot for satisfied interesting_object", () => {
+		const pack = buildPackWithSatisfiedItem({ withPostLook: true });
+		const game = startPhase(
+			createGame(TEST_PERSONAS, [pack]),
+			POST_LOOK_CONFIG,
+		);
+		const ctx = buildAiContext(game, "red");
+		const snapshot = buildConeSnapshot(ctx);
+		expect(snapshot).toContain("a steady amber glow lingers near the switch");
+	});
+});

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -31,7 +31,7 @@ For each phase:
 - Generate exactly k OBJECTIVE PAIRS. Each pair has:
   - An objective_object with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; MUST NOT reference or imply contact with the paired space, since the actor can be anywhere on the grid when using the item), pairsWithSpaceId (must match the paired space's id), placementFlavor (1 sentence containing the literal string "{actor}", fires when the object is placed on its space), proximityFlavor (1 sentence; in-fiction sensory description of what the daemon perceives when they are holding this item AND its paired space is in their own cell or directly in front of them. Written from the daemon's POV. Does NOT contain "{actor}" and MUST NOT reference placing or coupling the item.). objective_objects MUST be portable physical items a single person can pick up and carry (e.g. a tool, instrument, artifact, container) — never furniture, architecture, or fixed structures.
   - An objective_space with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences describing the space), useOutcome (1 sentence: what the daemon perceives when they activate/use this space — a stateless sensory result, first person. Does NOT say the objective is complete), satisfactionFlavor (1 sentence, third-person from a witness POV, fires as a witnessed event when the space is successfully used to satisfy the objective — does NOT contain "{actor}"), postExamineDescription (1-2 sentences: alternate examine description shown after the space has been used), postLookFlavor (1 sentence: alternate look flavor shown after the space has been used), convergenceTier1Flavor (1 sentence, in-fiction sensory line a witness Daemon perceives when exactly one Daemon occupies this space; third person from witness POV; does NOT contain {actor}), convergenceTier2Flavor (1 sentence, in-fiction sensory line a witness Daemon perceives when two or more Daemons share this space; third person from witness POV; does NOT contain {actor}). objective_spaces are fixed locations or surfaces, not items.
-- Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes). interesting_objects MUST be portable physical items a single person can pick up and carry — never furniture, architecture, or fixed structures.
+- Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences; MUST hint that the item is meant to be used or activated — include a verb-of-activation cue such as "use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger", or a clear noun-phrase tell like "control", "switch", "lever", "trigger", "button"; the prose tell is the only AI-discoverable channel that distinguishes a Use-Item target from a plain decorative item, so it cannot be omitted; MUST NOT contain "{actor}" and MUST NOT say the item is already used or that an objective is complete), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; returned post-satisfaction; MUST NOT say the objective is complete), activationFlavor (1 sentence; world-meaningful third-person description of what happens at the moment the item is activated for the first time — same string returned to actor and to witnesses; MUST NOT contain "{actor}"; MUST NOT say the objective is complete; MUST NOT reference placing or coupling the item with anything else), postExamineDescription (1-2 sentences shown by examine after the item has been activated; describes the post-activation state of the item itself; MUST NOT contain "{actor}"; MUST NOT reference the actor; MUST NOT say the objective is complete), postLookFlavor (1 sentence appended to look output after the item has been activated; in-fiction sensory line a witness perceives; MUST NOT contain "{actor}"). interesting_objects MUST be portable physical items a single person can pick up and carry — never furniture, architecture, or fixed structures.
 - Generate exactly m OBSTACLES with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1 sentence describing the impassable object), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Obstacles are fixed and impassable — never portable items. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS — one anchoring each cardinal direction (north, south, east, west). Each landmark is distant, unreachable, distinctive, mutually visually distinguishable, and consistent with the setting, atmosphere, and weather. Each landmark has: shortName (2-5 words, e.g. "the rusted radio tower"), horizonPhrase (a short evocative clause describing what the landmark itself looks like — its form, condition, materials — NOT where it sits relative to any viewer. The phrase is slotted into "On the horizon ahead: <shortName> — <horizonPhrase>." so it must read coherently as a continuation. Good: "rises above the platform, antenna bent toward the dark". Bad: "looms behind you in the dark" (implies position) or "stands to your left" (implies relative direction).
 
@@ -45,6 +45,8 @@ Names and descriptions must be thematically consistent with the setting noun, an
 placementFlavor MUST contain the literal string "{actor}".
 pairsWithSpaceId on each objective_object MUST equal the id of its paired objective_space.
 Each objective_object's examineDescription MUST contain the literal name of its paired objective_space (or an unambiguous noun-phrase synonym a player could match). Example: if the objective_space is named "Brass Pedestal", the object's examineDescription must contain "brass pedestal" or a clear synonym ("the pedestal", "the brass mount", etc.). The prose tell is the only AI-discoverable channel for the pairing, so it cannot be omitted.
+Each interesting_object's examineDescription MUST contain a verb-of-activation cue (e.g. "use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger") or a clear control noun ("control", "switch", "lever", "trigger", "button", "dial", "handle", "crank"). This is the only AI-discoverable signal that the item is a Use-Item target, parallel to the paired-space tell required on objective_object.
+activationFlavor MUST NOT contain "{actor}". postExamineDescription MUST NOT contain "{actor}". postLookFlavor MUST NOT contain "{actor}".
 Horizon landmark horizonPhrase MUST NOT contain any cardinal direction words (north, south, east, west) or positional phrases that imply where the landmark sits relative to the viewer (ahead, behind, in front, to your/the left, to your/the right, on the horizon, beneath you, above you).
 
 Return ONLY valid JSON with this exact shape (no markdown, no preamble):
@@ -60,7 +62,7 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
         }
       ],
       "interestingObjects": [
-        { "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "..." }
+        { "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." }
       ],
       "obstacles": [
         { "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "...", "shiftFlavor": "..." }
@@ -132,14 +134,14 @@ export const DUAL_CONTENT_PACK_SYSTEM_PROMPT = `You generate paired content pack
 For each phase produce packA and packB with the following rules:
 - Entity IDs (id fields) MUST be identical between packA and packB. Choose the ids once and reuse them.
 - Entity structural relationships (pairsWithSpaceId, kind) MUST be identical between packA and packB.
-- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, landmark shortName, landmark horizonPhrase.
+- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, activationFlavor, postExamineDescription, postLookFlavor (for interesting_objects), landmark shortName, landmark horizonPhrase.
 - The setting field at pack level MUST match settingA for packA and settingB for packB.
 
 Entity rules (same as always):
 - Generate exactly k OBJECTIVE PAIRS per pack. Each pair:
   - objective_object: id, kind="objective_object", name (2-4 words thematic to setting+theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 stateless sentence; MUST NOT imply contact with paired space), pairsWithSpaceId (matches space id), placementFlavor (1 sentence with literal "{actor}"), proximityFlavor (1 sentence; daemon's POV sensory experience; no "{actor}"; no placing/coupling language). Must be a portable physical item.
   - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 sentence: stateless sensory result when daemon uses the space), satisfactionFlavor (1 sentence, third-person witness POV, fires when objective satisfied — no "{actor}"), postExamineDescription (1-2 sentences: shown after use), postLookFlavor (1 sentence: shown in look after use), convergenceTier1Flavor (1 sentence sensory witness line when exactly one Daemon is on space; no {actor}), convergenceTier2Flavor (1 sentence sensory witness line when two or more Daemons share space; no {actor}). Fixed location or surface.
-- Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences), useOutcome (1 stateless sentence). Must be portable.
+- Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences; MUST contain a verb-of-activation cue ("use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger") or a clear control noun ("control", "switch", "lever", "trigger", "button", "dial", "handle", "crank") — the only AI-discoverable Use-Item tell; MUST NOT contain "{actor}"; MUST NOT say the item is already used or the objective is complete), useOutcome (1 stateless sentence; returned post-satisfaction; MUST NOT say the objective is complete), activationFlavor (1 sentence; world-meaningful third-person line returned to actor and witnesses on the use call that satisfies the UseItemObjective; MUST NOT contain "{actor}"; MUST NOT say the objective is complete; MUST NOT reference placing or coupling), postExamineDescription (1-2 sentences shown by examine after activation; MUST NOT contain "{actor}"; MUST NOT reference the actor), postLookFlavor (1 sentence appended to look output after activation; MUST NOT contain "{actor}"). Must be portable.
 - Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence). Fixed and impassable.
 - Generate exactly 4 HORIZON LANDMARKS per pack (north/south/east/west): shortName (2-5 words), horizonPhrase (evocative clause; no cardinal direction words; no positional phrases implying viewer relationship).
 
@@ -149,6 +151,8 @@ Global constraints:
 - placementFlavor MUST contain literal string "{actor}".
 - pairsWithSpaceId MUST match the paired space's id.
 - Each objective_object's examineDescription MUST contain the paired space's name or an unambiguous noun-phrase synonym.
+- Each interesting_object's examineDescription MUST contain a verb-of-activation cue or a clear control noun (see list above). Same tell rule applies to packA and packB.
+- activationFlavor / postExamineDescription / postLookFlavor MUST NOT contain "{actor}".
 - horizonPhrase MUST NOT contain: north, south, east, west, ahead, behind, in front, to your left, to your right, on the horizon, beneath you, above you.
 
 Return ONLY valid JSON (no markdown, no preamble):
@@ -159,14 +163,14 @@ Return ONLY valid JSON (no markdown, no preamble):
       "packA": {
         "setting": "<settingA>",
         "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "..." } }],
-        "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "..." }],
+        "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." }],
         "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "..." }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
       },
       "packB": {
         "setting": "<settingB>",
         "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "DIFFERENT_FLAVOR", "convergenceTier2Flavor": "DIFFERENT_FLAVOR" } }],
-        "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "..." }],
+        "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "DIFFERENT_FLAVOR", "postExamineDescription": "DIFFERENT_DESCRIPTION", "postLookFlavor": "DIFFERENT_FLAVOR" }],
         "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "..." }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
       }
@@ -235,6 +239,71 @@ export function examineMentionsPairedSpace(
 	return headNoun !== undefined && examineLc.includes(headNoun);
 }
 
+/**
+ * Returns true when an interesting_object's examineDescription contains at least
+ * one verb-of-activation cue or a clear control noun. The system prompt MUSTs
+ * this property because objective_objects get a paired-space prose tell (see
+ * `examineMentionsPairedSpace`), but interesting_objects have no equivalent —
+ * an activation tell is the only AI-discoverable signal that this item is a
+ * Use-Item target. Match is case-insensitive and uses word boundaries to avoid
+ * spurious substring hits (e.g. "trigger" matching inside "triggered" is fine,
+ * but "use" should not match inside "fuse" or "useless").
+ */
+const USE_TELL_KEYWORDS: readonly string[] = [
+	"activate",
+	"activated",
+	"activates",
+	"activating",
+	"button",
+	"crank",
+	"control",
+	"dial",
+	"engage",
+	"engaged",
+	"engaging",
+	"flip",
+	"flipped",
+	"flipping",
+	"handle",
+	"lever",
+	"press",
+	"pressed",
+	"pressing",
+	"pull",
+	"pulled",
+	"pulling",
+	"switch",
+	"switched",
+	"switching",
+	"trigger",
+	"triggered",
+	"triggers",
+	"triggering",
+	"turn",
+	"turned",
+	"turning",
+	"twist",
+	"twisted",
+	"twisting",
+	"use",
+	"used",
+	"uses",
+	"using",
+	"wind",
+	"winding",
+];
+
+export function examineMentionsUseTell(examineDescription: string): boolean {
+	const examineLc = examineDescription.toLowerCase();
+	for (const keyword of USE_TELL_KEYWORDS) {
+		// Word-boundary regex match so "use" doesn't match inside "fuse" or "abuse",
+		// but "used" / "uses" are caught by their own list entries.
+		const re = new RegExp(`\\b${keyword}\\b`);
+		if (re.test(examineLc)) return true;
+	}
+	return false;
+}
+
 // ── Validation ────────────────────────────────────────────────────────────────
 
 function validateEntity(
@@ -245,6 +314,7 @@ function validateEntity(
 	requirePairing?: { pairsWithSpaceId?: string },
 	requireShiftFlavor?: boolean,
 	requireConvergenceFlavors?: boolean,
+	requireUseItemFlavors?: boolean,
 ): WorldEntity {
 	if (raw == null || typeof raw !== "object") {
 		throw new ContentPackError(
@@ -318,6 +388,47 @@ function validateEntity(
 		}
 	}
 
+	if (requireUseItemFlavors) {
+		if (!examineMentionsUseTell(e.examineDescription as string)) {
+			throw new ContentPackError(
+				`Interesting object ${e.id}: examineDescription must contain a verb-of-activation cue or control noun (e.g. "use", "activate", "press", "pull", "turn", "twist", "switch", "lever", "trigger", "button") — the only AI-discoverable Use-Item tell.`,
+			);
+		}
+		if (
+			typeof e.activationFlavor !== "string" ||
+			e.activationFlavor.length === 0 ||
+			e.activationFlavor.includes("{actor}")
+		) {
+			throw new ContentPackError(
+				`Interesting object ${e.id}: activationFlavor must be a non-empty string that does not contain "{actor}"`,
+			);
+		}
+		if (
+			typeof e.postExamineDescription !== "string" ||
+			e.postExamineDescription.length === 0
+		) {
+			throw new ContentPackError(
+				`Interesting object ${e.id} missing postExamineDescription`,
+			);
+		}
+		if (e.postExamineDescription.includes("{actor}")) {
+			throw new ContentPackError(
+				`Interesting object ${e.id}: postExamineDescription must not contain "{actor}"`,
+			);
+		}
+		if (e.postLookFlavor !== undefined) {
+			if (
+				typeof e.postLookFlavor !== "string" ||
+				e.postLookFlavor.length === 0 ||
+				e.postLookFlavor.includes("{actor}")
+			) {
+				throw new ContentPackError(
+					`Interesting object ${e.id}: postLookFlavor must be a non-empty string that does not contain "{actor}" when present`,
+				);
+			}
+		}
+	}
+
 	if (requireConvergenceFlavors) {
 		if (
 			typeof e.convergenceTier1Flavor !== "string" ||
@@ -380,6 +491,18 @@ function validateEntity(
 	}
 	if (typeof e.convergenceTier2Flavor === "string") {
 		entity.convergenceTier2Flavor = e.convergenceTier2Flavor;
+	}
+	// interesting_object Use-Item flavor fields (issue #334)
+	if (e.kind === "interesting_object") {
+		if (typeof e.activationFlavor === "string") {
+			entity.activationFlavor = e.activationFlavor;
+		}
+		if (typeof e.postExamineDescription === "string") {
+			entity.postExamineDescription = e.postExamineDescription;
+		}
+		if (typeof e.postLookFlavor === "string") {
+			entity.postLookFlavor = e.postLookFlavor;
+		}
 	}
 	return entity;
 }
@@ -491,7 +614,16 @@ export function validateContentPacks(
 		const interestingObjects: WorldEntity[] = [];
 		for (const itemRaw of pack.interestingObjects as unknown[]) {
 			interestingObjects.push(
-				validateEntity(itemRaw, "interesting_object", allIds, true),
+				validateEntity(
+					itemRaw,
+					"interesting_object",
+					allIds,
+					true,
+					undefined,
+					false,
+					false,
+					true,
+				),
 			);
 		}
 
@@ -700,7 +832,16 @@ function validateSinglePack(
 	const interestingObjects: WorldEntity[] = [];
 	for (const itemRaw of pack.interestingObjects as unknown[]) {
 		interestingObjects.push(
-			validateEntity(itemRaw, "interesting_object", allIds, true),
+			validateEntity(
+				itemRaw,
+				"interesting_object",
+				allIds,
+				true,
+				undefined,
+				false,
+				false,
+				true,
+			),
 		);
 	}
 

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -27,7 +27,10 @@ import type {
 	ToolCall,
 	WorldEntity,
 } from "./types";
-import { checkPlacementFlavor } from "./win-condition.js";
+import {
+	checkPlacementFlavor,
+	checkUseItemActivation,
+} from "./win-condition.js";
 
 export interface ValidationResult {
 	valid: boolean;
@@ -563,6 +566,9 @@ export function dispatchAiTurn(
 			// Snapshot all AIs' spatial state BEFORE execution (used for witness context).
 			// For go: the actor's pre-move state is captured here; post-move state is
 			// captured from the post-execute phase below.
+			// Snapshot pre-execute world so the post-execute branch can compare
+			// satisfactionState transitions for activation-flavor detection.
+			const preExecuteWorld = state.world;
 			state = executeToolCall(state, aiId, action.toolCall);
 			// For put_down, check if the object landed on its paired space.
 			// If so, replace the default description with the per-pair placementFlavor.
@@ -570,8 +576,16 @@ export function dispatchAiTurn(
 				action.toolCall.name === "put_down" || action.toolCall.name === "use"
 					? checkPlacementFlavor(action, state.contentPack, state.world)
 					: null;
+			// For `use` on an interesting_object Use-Item target, surface
+			// activationFlavor on the call that just satisfied the objective.
+			const activationFlavor =
+				action.toolCall.name === "use"
+					? checkUseItemActivation(action, preExecuteWorld, state.world)
+					: null;
 			const successDescription =
-				flavorDescription ?? describeToolCall(state, aiId, action.toolCall);
+				activationFlavor ??
+				flavorDescription ??
+				describeToolCall(state, aiId, action.toolCall);
 			records.push({
 				round,
 				actor: aiId,
@@ -628,6 +642,10 @@ export function dispatchAiTurn(
 						);
 						if (spaceTarget) {
 							useOutcomeRaw = spaceTarget.satisfactionFlavor;
+						} else if (activationFlavor !== null) {
+							// Use-Item activation: witnesses get the activationFlavor verbatim
+							// (validator-enforced no-{actor} so no substitution needed).
+							useOutcomeRaw = activationFlavor;
 						} else {
 							const item = pickable.find((i) => i.id === call.args.item);
 							// Store raw (un-substituted) useOutcome for witness rendering

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -654,10 +654,12 @@ export function buildConeSnapshot(ctx: AiContext): string {
 		const contents =
 			contentParts.length > 0 ? [...contentParts].sort().join(", ") : "nothing";
 
-		// Append postLookFlavor for satisfied objective_space entities in this cell
-		const satisfiedSpaceFlavors = ctx.worldSnapshot.entities
+		// Append postLookFlavor for satisfied objective_space OR interesting_object
+		// entities resting in this cell. Same swap rule applies to both kinds.
+		const satisfiedFlavors = ctx.worldSnapshot.entities
 			.filter((e) => {
-				if (e.kind !== "objective_space") return false;
+				if (e.kind !== "objective_space" && e.kind !== "interesting_object")
+					return false;
 				if (e.satisfactionState !== "satisfied") return false;
 				if (!e.postLookFlavor) return false;
 				const h = e.holder;
@@ -666,7 +668,7 @@ export function buildConeSnapshot(ctx: AiContext): string {
 			.map((e) => e.postLookFlavor as string);
 
 		let cellLine = `at ${cell.phrasing}: ${contents}`;
-		for (const flavor of satisfiedSpaceFlavors) {
+		for (const flavor of satisfiedFlavors) {
 			cellLine += ` ${flavor}`;
 		}
 		lines.push(cellLine);
@@ -886,10 +888,12 @@ function renderCurrentState(ctx: AiContext): string {
 			const contents =
 				contentParts.length > 0 ? contentParts.join("; ") : "nothing";
 
-			// Append postLookFlavor for satisfied objective_space entities in this cell
-			const satisfiedSpaceFlavors = ctx.worldSnapshot.entities
+			// Append postLookFlavor for satisfied objective_space OR interesting_object
+			// entities in this cell.
+			const satisfiedFlavors = ctx.worldSnapshot.entities
 				.filter((e) => {
-					if (e.kind !== "objective_space") return false;
+					if (e.kind !== "objective_space" && e.kind !== "interesting_object")
+						return false;
 					if (e.satisfactionState !== "satisfied") return false;
 					if (!e.postLookFlavor) return false;
 					const h = e.holder;
@@ -900,7 +904,7 @@ function renderCurrentState(ctx: AiContext): string {
 			// Capitalise the phrasing for display
 			const label = phrasing.charAt(0).toUpperCase() + phrasing.slice(1);
 			let cellLine = `- ${label}: ${contents}`;
-			for (const flavor of satisfiedSpaceFlavors) {
+			for (const flavor of satisfiedFlavors) {
 				cellLine += ` ${flavor}`;
 			}
 			lines.push(cellLine);

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -53,6 +53,14 @@ export interface WorldEntity {
 	postExamineDescription?: string;
 	/** Alternate look flavor shown after satisfactionState flips to "satisfied". */
 	postLookFlavor?: string;
+	/**
+	 * For interesting_object used as a Use-Item target: 1-sentence flavor returned
+	 * (to actor AND witnesses) on the `use` call that satisfies the UseItemObjective.
+	 * Does NOT contain "{actor}" — third-person, world-meaningful description of the
+	 * activation event. Pre-satisfaction use that triggers the objective fires this
+	 * flavor; subsequent (post-satisfaction) `use` calls return `useOutcome` instead.
+	 */
+	activationFlavor?: string;
 	/** For objective_space: whether the `use` action is available on this space. Defaults to true when omitted. Set to false after a UseSpaceObjective is satisfied. */
 	useAvailable?: boolean;
 	/** For objective_space: flavor string emitted as a Witnessed event when a UseSpaceObjective is satisfied. */

--- a/src/spa/game/win-condition.ts
+++ b/src/spa/game/win-condition.ts
@@ -214,3 +214,42 @@ export function checkPlacementFlavor(
 	// Pair matched — return flavor with {actor} substituted to "you"
 	return placementFlavor.replace(/\{actor\}/g, "you");
 }
+
+/**
+ * Returns the activationFlavor string for the `use` call that satisfies a
+ * UseItemObjective on an interesting_object, or null otherwise.
+ *
+ * Detection compares pre-execute and post-execute world snapshots:
+ *  - The action must be a `use` on an interesting_object that has an
+ *    `activationFlavor` field.
+ *  - The entity's `satisfactionState` must have flipped from
+ *    pending / undefined (pre) to `"satisfied"` (post). Only the call that
+ *    just satisfied the objective returns activationFlavor; subsequent calls
+ *    on an already-satisfied item fall through to `useOutcome`.
+ *
+ * activationFlavor has no `{actor}` token (validator-enforced), so the same
+ * string is returned to the actor and used verbatim for the witness fan-out.
+ */
+export function checkUseItemActivation(
+	action: AiTurnAction,
+	preWorld: WorldState,
+	postWorld: WorldState,
+): string | null {
+	const toolCall = action.toolCall;
+	if (!toolCall || toolCall.name !== "use") return null;
+
+	const itemId = toolCall.args.item;
+	if (!itemId) return null;
+
+	const postEntity = postWorld.entities.find((e) => e.id === itemId);
+	if (!postEntity) return null;
+	if (postEntity.kind !== "interesting_object") return null;
+	if (!postEntity.activationFlavor) return null;
+	if (postEntity.satisfactionState !== "satisfied") return null;
+
+	const preEntity = preWorld.entities.find((e) => e.id === itemId);
+	// "just satisfied" means the pre-state was not yet satisfied
+	if (preEntity?.satisfactionState === "satisfied") return null;
+
+	return postEntity.activationFlavor;
+}

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -361,6 +361,40 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
+	it("round-trips interesting_object Use-Item flavor fields (issue #334)", () => {
+		const game = makeFreshGame();
+		const entity: WorldEntity = {
+			id: "switch",
+			kind: "interesting_object",
+			name: "Brass Switch",
+			examineDescription: "A brass switch waiting to be pressed.",
+			useOutcome: "The switch clicks under your finger.",
+			activationFlavor:
+				"The switch flips home with a hard thunk and an amber light pulses on.",
+			postExamineDescription:
+				"The switch sits locked in its on position, amber light steady.",
+			postLookFlavor: "an amber pinpoint of light glows beside the switch",
+			satisfactionState: "satisfied",
+			holder: { row: 1, col: 1 },
+		};
+		const modified: GameState = {
+			...game,
+			world: { entities: [entity] },
+		};
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			const restored = result.state.world.entities[0];
+			expect(restored?.activationFlavor).toBe(entity.activationFlavor);
+			expect(restored?.postExamineDescription).toBe(
+				entity.postExamineDescription,
+			);
+			expect(restored?.postLookFlavor).toBe(entity.postLookFlavor);
+			expect(restored?.satisfactionState).toBe("satisfied");
+		}
+	});
+
 	it("round-trips budgets", () => {
 		const game = makeFreshGame();
 		const modified: GameState = {


### PR DESCRIPTION
Closes #334.

## Summary

Brings `interesting_object` into line with `objective_space`'s pre/post pattern, and adds a Use-Item prose-tell rule parallel to objective_object's paired-space tell.

- New optional `activationFlavor` on `WorldEntity` — fires on the `use` call that satisfies a `UseItemObjective`, returned verbatim to actor and to witnesses.
- `postExamineDescription` and `postLookFlavor` (already declared on `WorldEntity`) are now LLM-authored and wired through examine + look for `interesting_object`.
- `examineDescription` for interesting_objects must carry a verb-of-activation cue or control noun — the only AI-discoverable Use-Item tell.

## Implementation

- **`types.ts`** — adds optional `activationFlavor` to `WorldEntity`.
- **`content-pack-provider.ts`** —
  - Single-pack + dual-pack system prompts expanded with the Carry-style rule block for interesting_object (sentence count, POV, `{actor}` policy, trigger, MUST NOT clauses).
  - JSON shape examples updated in both prompts; dual-pack "MUST differ" delta list includes the new fields.
  - New `examineMentionsUseTell` helper.
  - `validateEntity` gains a `requireUseItemFlavors` switch; wired in for both single-pack and dual-pack interesting_object paths. Enforces non-empty + no-`{actor}` on `activationFlavor` / `postExamineDescription` / `postLookFlavor`, plus the prose-tell on examineDescription.
- **`win-condition.ts`** — new `checkUseItemActivation(action, preWorld, postWorld)` returns activationFlavor iff this `use` just flipped an interesting_object from pending → satisfied.
- **`dispatcher.ts`** — snapshots pre-execute world, then routes `activationFlavor` into both the actor's tool-success description and the witness fan-out's `useOutcome` (no `{actor}` substitution needed). Subsequent uses fall through to the existing `useOutcome` path. Existing examine swap (`postExamineDescription` when satisfied) already worked for interesting_object.
- **`prompt-builder.ts`** — postLookFlavor swap in cone snapshot and `<what_you_see>` now matches both `objective_space` and `interesting_object`.

Session-codec needs no changes — `structuredClone` carries the new optional fields automatically.

## Why target `first-restructure`?

`main` reverted the PRD #292 restructure (#316), so the prerequisites for this work — `UseItemObjective`, `satisfactionState`, the flat single-game state — only live on `first-restructure`. Merging here keeps it adjacent to its dependencies (#303, #328) and ships when the restructure does.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run` — 1417/1417 pass (24 new tests added):
  - `examineMentionsUseTell` accept/reject cases (word-boundary on "use" vs "fuse" etc.)
  - Validator: rejects missing examine tell, missing / empty / `{actor}`-bearing `activationFlavor`, missing / `{actor}`-bearing `postExamineDescription`, `{actor}`-bearing `postLookFlavor`; accepts complete payloads and omitted-optional `postLookFlavor`.
  - Dispatcher: pre-sat use returns `activationFlavor` to actor; post-sat use returns `useOutcome`; no-objective case stays on useOutcome; witnesses get `activationFlavor` verbatim on the satisfying call and `useOutcome` on subsequent uses.
  - Prompt-builder: `postLookFlavor` renders in `<what_you_see>` and `buildConeSnapshot` for satisfied interesting_objects; not rendered when pending.
  - Codec: interesting_object's Use-Item flavor fields round-trip.

https://claude.ai/code/session_01C4oUGN51fRmDybFvTcK8b7

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4oUGN51fRmDybFvTcK8b7)_