### PR TITLE
Convergence: prose-tell on examine + actor-side tier flavors (#336)

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -93,6 +93,9 @@ describe("CONTENT_PACK_SYSTEM_PROMPT", () => {
 	});
 });
 
+/** Sentinel so a test can request that a field be omitted from the LLM response. */
+const OMIT = Symbol("OMIT");
+
 describe("validateContentPacks — prose tell contract", () => {
 	const input = {
 		phases: [
@@ -111,9 +114,28 @@ describe("validateContentPacks — prose tell contract", () => {
 		objectExamine: string,
 		spaceName = "Brass Pedestal",
 		proximityFlavor = "The key hums faintly, resonating with the pedestal nearby.",
-		convergenceTier1Flavor = "A lone figure stands at the pedestal, silhouetted against the dim light.",
-		convergenceTier2Flavor = "Two figures converge at the pedestal, their presences mingling in the shadow.",
+		convergenceTier1Flavor: unknown = "A lone figure stands at the pedestal, silhouetted against the dim light.",
+		convergenceTier2Flavor: unknown = "Two figures converge at the pedestal, their presences mingling in the shadow.",
+		convergenceTier1ActorFlavor: unknown = "You linger at the pedestal; the place feels poised for company.",
+		convergenceTier2ActorFlavor: unknown = "You share the pedestal with another presence; the runes thrum.",
 	): unknown {
+		const spaceFields: Record<string, unknown> = {
+			id: "space1",
+			kind: "objective_space",
+			name: spaceName,
+			examineDescription:
+				"A sturdy mount. Press a relic onto it to activate the brass pedestal; the surface awaits a shared presence.",
+			activationFlavor:
+				"The pedestal's runes ignite and warm air rises from its surface.",
+		};
+		if (convergenceTier1Flavor !== OMIT)
+			spaceFields.convergenceTier1Flavor = convergenceTier1Flavor;
+		if (convergenceTier2Flavor !== OMIT)
+			spaceFields.convergenceTier2Flavor = convergenceTier2Flavor;
+		if (convergenceTier1ActorFlavor !== OMIT)
+			spaceFields.convergenceTier1ActorFlavor = convergenceTier1ActorFlavor;
+		if (convergenceTier2ActorFlavor !== OMIT)
+			spaceFields.convergenceTier2ActorFlavor = convergenceTier2ActorFlavor;
 		return {
 			packs: [
 				{
@@ -131,17 +153,7 @@ describe("validateContentPacks — prose tell contract", () => {
 								placementFlavor: "{actor} sets the key on its mount.",
 								proximityFlavor,
 							},
-							space: {
-								id: "space1",
-								kind: "objective_space",
-								name: spaceName,
-								examineDescription:
-									"A sturdy mount. Press a relic onto it to activate the brass pedestal.",
-								activationFlavor:
-									"The pedestal's runes ignite and warm air rises from its surface.",
-								convergenceTier1Flavor,
-								convergenceTier2Flavor,
-							},
+							space: spaceFields,
 						},
 					],
 					interestingObjects: [],
@@ -345,24 +357,28 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 	};
 
 	function buildConvergenceResponse(
-		convergenceTier1Flavor?: unknown,
-		convergenceTier2Flavor?: unknown,
+		convergenceTier1Flavor: unknown = "A lone figure stands at the pedestal.",
+		convergenceTier2Flavor: unknown = "Two figures converge at the pedestal.",
+		convergenceTier1ActorFlavor: unknown = "You linger at the pedestal; the place feels poised for company.",
+		convergenceTier2ActorFlavor: unknown = "You share the pedestal with another presence; the runes thrum.",
 	): unknown {
 		const spaceFields: Record<string, unknown> = {
 			id: "space1",
 			kind: "objective_space",
 			name: "Brass Pedestal",
 			examineDescription:
-				"A sturdy brass pedestal. Press an item onto it to activate the mechanism.",
+				"A sturdy brass pedestal. Press an item onto it to activate the mechanism; the space awaits a shared presence.",
 			activationFlavor:
 				"The pedestal hums to life and its surface flushes with warmth.",
 		};
-		if (convergenceTier1Flavor !== undefined) {
+		if (convergenceTier1Flavor !== OMIT)
 			spaceFields.convergenceTier1Flavor = convergenceTier1Flavor;
-		}
-		if (convergenceTier2Flavor !== undefined) {
+		if (convergenceTier2Flavor !== OMIT)
 			spaceFields.convergenceTier2Flavor = convergenceTier2Flavor;
-		}
+		if (convergenceTier1ActorFlavor !== OMIT)
+			spaceFields.convergenceTier1ActorFlavor = convergenceTier1ActorFlavor;
+		if (convergenceTier2ActorFlavor !== OMIT)
+			spaceFields.convergenceTier2ActorFlavor = convergenceTier2ActorFlavor;
 		return {
 			packs: [
 				{
@@ -429,10 +445,7 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 	it("throws ContentPackError when convergenceTier1Flavor is missing", () => {
 		expect(() =>
 			validateContentPacks(
-				buildConvergenceResponse(
-					undefined,
-					"Two figures converge at the pedestal.",
-				),
+				buildConvergenceResponse(OMIT, "Two figures converge at the pedestal."),
 				inputWithPair,
 			),
 		).toThrow(/convergenceTier1Flavor/);
@@ -441,10 +454,7 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 	it("throws ContentPackError when convergenceTier2Flavor is missing", () => {
 		expect(() =>
 			validateContentPacks(
-				buildConvergenceResponse(
-					"A lone figure stands at the pedestal.",
-					undefined,
-				),
+				buildConvergenceResponse("A lone figure stands at the pedestal.", OMIT),
 				inputWithPair,
 			),
 		).toThrow(/convergenceTier2Flavor/);
@@ -481,6 +491,100 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 				inputWithPair,
 			),
 		).toThrow(/convergenceTier1Flavor/);
+	});
+
+	// ── actor-side tier flavors (issue #336) ────────────────────────────────────
+
+	it("accepts a pack with all four tier flavors and persists the actor variants", () => {
+		const result = validateContentPacks(
+			buildConvergenceResponse(),
+			inputWithPair,
+		);
+		const space = result.packs[0]?.objectivePairs[0]?.space;
+		expect(space?.convergenceTier1ActorFlavor).toBe(
+			"You linger at the pedestal; the place feels poised for company.",
+		);
+		expect(space?.convergenceTier2ActorFlavor).toBe(
+			"You share the pedestal with another presence; the runes thrum.",
+		);
+	});
+
+	it("throws ContentPackError when convergenceTier1ActorFlavor is missing", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(undefined, undefined, OMIT),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1ActorFlavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier2ActorFlavor is missing", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(undefined, undefined, undefined, OMIT),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2ActorFlavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier1ActorFlavor is empty", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(undefined, undefined, ""),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1ActorFlavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier2ActorFlavor is empty", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(undefined, undefined, undefined, ""),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2ActorFlavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier1ActorFlavor contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(
+					undefined,
+					undefined,
+					"{actor} stands alone at the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1ActorFlavor/);
+	});
+
+	it("throws ContentPackError when convergenceTier2ActorFlavor contains {actor}", () => {
+		expect(() =>
+			validateContentPacks(
+				buildConvergenceResponse(
+					undefined,
+					undefined,
+					undefined,
+					"{actor} and another share the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2ActorFlavor/);
+	});
+});
+
+// ── prompt rules (issue #336) ─────────────────────────────────────────────────
+
+describe("CONTENT_PACK_SYSTEM_PROMPT — convergence actor + prose-tell rules", () => {
+	it("documents the new convergenceTier1ActorFlavor and convergenceTier2ActorFlavor fields", () => {
+		expect(CONTENT_PACK_SYSTEM_PROMPT).toContain("convergenceTier1ActorFlavor");
+		expect(CONTENT_PACK_SYSTEM_PROMPT).toContain("convergenceTier2ActorFlavor");
+	});
+
+	it("requires the convergence shared-presence prose-tell hint on examineDescription", () => {
+		expect(CONTENT_PACK_SYSTEM_PROMPT).toMatch(
+			/MUST[\s\S]*(shared occupancy|another presence)/,
+		);
 	});
 });
 
@@ -767,6 +871,10 @@ describe("validateContentPacks — objective_space activationFlavor & prose tell
 								name: "Brass Pedestal",
 								convergenceTier1Flavor: "A lone figure stands at the pedestal.",
 								convergenceTier2Flavor: "Two figures converge at the pedestal.",
+								convergenceTier1ActorFlavor:
+									"You linger at the pedestal; the place feels poised for company.",
+								convergenceTier2ActorFlavor:
+									"You share the pedestal with another presence.",
 								...spaceFields,
 							},
 						},
@@ -970,6 +1078,8 @@ describe("validateDualContentPacks — objective_space activationFlavor", () => 
 						activationFlavor: activation,
 						convergenceTier1Flavor: `A lone figure stands at the ${spaceName.toLowerCase()}.`,
 						convergenceTier2Flavor: `Two figures converge at the ${spaceName.toLowerCase()}.`,
+						convergenceTier1ActorFlavor: `You linger at the ${spaceName.toLowerCase()}.`,
+						convergenceTier2ActorFlavor: `You share the ${spaceName.toLowerCase()} with another presence.`,
 					},
 				},
 			],

--- a/src/spa/game/__tests__/objective-pool.test.ts
+++ b/src/spa/game/__tests__/objective-pool.test.ts
@@ -13,7 +13,10 @@ import type {
 
 // ── helpers for convergence tests ─────────────────────────────────────────────
 
-function makeObjectivePairWithConvergenceFlavors(id: string): ObjectivePair {
+function makeObjectivePairWithConvergenceFlavors(
+	id: string,
+	spaceOverrides?: Partial<WorldEntity>,
+): ObjectivePair {
 	const obj: WorldEntity = {
 		id: `${id}_obj`,
 		kind: "objective_object",
@@ -22,6 +25,9 @@ function makeObjectivePairWithConvergenceFlavors(id: string): ObjectivePair {
 		holder: { row: 0, col: 0 },
 		pairsWithSpaceId: `${id}_space`,
 	};
+	// All four tier-flavor fields must be present for the inclusion guard (#336)
+	// to admit the convergence candidate. Tests of negative paths override
+	// individual fields via `spaceOverrides`.
 	const space: WorldEntity = {
 		id: `${id}_space`,
 		kind: "objective_space",
@@ -30,6 +36,9 @@ function makeObjectivePairWithConvergenceFlavors(id: string): ObjectivePair {
 		holder: { row: 4, col: 4 },
 		convergenceTier1Flavor: `A single presence lingers at the ${id} space.`,
 		convergenceTier2Flavor: `Two presences converge at the ${id} space.`,
+		convergenceTier1ActorFlavor: `You linger at the ${id} space.`,
+		convergenceTier2ActorFlavor: `You share the ${id} space with another presence.`,
+		...spaceOverrides,
 	};
 	return { object: obj, space };
 }
@@ -321,13 +330,13 @@ describe("drawObjectives — convergence objectives", () => {
 			landmarks: DEFAULT_LANDMARKS,
 			aiStarts: {},
 		};
-		// Pool: [carry(altar), use_item(torch), convergence(altar)] — 3 candidates
+		// Pool: [carry(altar), use_space(altar), use_item(torch), convergence(altar)] — 4 candidates
 		// rngZero → always index 0 → carry
 		const allDrawn = drawObjectives(packMixed, rngZero, 3);
 		// All three should be carry since rngZero always picks index 0
 		expect(allDrawn[0]?.kind).toBe("carry");
 
-		// With rngLast, index = Math.floor(0.999 * 3) = 2 → convergence
+		// With rngLast, index = Math.floor(0.999 * 4) = 3 → convergence
 		const [lastObj] = drawObjectives(packMixed, rngLast, 1);
 		expect(lastObj?.kind).toBe("convergence");
 
@@ -335,5 +344,77 @@ describe("drawObjectives — convergence objectives", () => {
 		if (lastObj?.kind === "convergence") {
 			expect(lastObj.description).toContain("altar space");
 		}
+	});
+});
+
+// ── convergence inclusion guard — requires all four flavor fields (#336) ─────
+
+describe("drawObjectives — convergence inclusion guard requires all four flavor fields", () => {
+	const FIELDS = [
+		"convergenceTier1Flavor",
+		"convergenceTier2Flavor",
+		"convergenceTier1ActorFlavor",
+		"convergenceTier2ActorFlavor",
+	] as const;
+
+	for (const field of FIELDS) {
+		it(`excludes convergence from the pool when ${field} is missing`, () => {
+			const pair = makeObjectivePairWithConvergenceFlavors("gem", {
+				[field]: undefined,
+			});
+			const pack: ContentPack = {
+				setting: "test",
+				weather: "",
+				timeOfDay: "",
+				objectivePairs: [pair],
+				interestingObjects: [],
+				obstacles: [],
+				landmarks: DEFAULT_LANDMARKS,
+				aiStarts: {},
+			};
+			// Pool should be [carry(gem), use_space(gem)] — size 2, no convergence.
+			let call = 0;
+			const cyclingRng = () => (call++ % 2) / 2;
+			const drawn = drawObjectives(pack, cyclingRng, 10);
+			expect(drawn.every((o) => o.kind !== "convergence")).toBe(true);
+			expect(drawn.map((o) => o.kind)).toContain("carry");
+			expect(drawn.map((o) => o.kind)).toContain("use_space");
+		});
+
+		it(`excludes convergence from the pool when ${field} is an empty string`, () => {
+			const pair = makeObjectivePairWithConvergenceFlavors("gem", {
+				[field]: "",
+			});
+			const pack: ContentPack = {
+				setting: "test",
+				weather: "",
+				timeOfDay: "",
+				objectivePairs: [pair],
+				interestingObjects: [],
+				obstacles: [],
+				landmarks: DEFAULT_LANDMARKS,
+				aiStarts: {},
+			};
+			const drawn = drawObjectives(pack, rngZero, 10);
+			expect(drawn.every((o) => o.kind !== "convergence")).toBe(true);
+		});
+	}
+
+	it("admits convergence into the pool when all four flavor fields are present", () => {
+		const pack: ContentPack = {
+			setting: "test",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [makeObjectivePairWithConvergenceFlavors("gem")],
+			interestingObjects: [],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		// Draw enough to cycle through all pool indices.
+		let call = 0;
+		const cyclingRng = () => (call++ % 3) / 3;
+		const drawn = drawObjectives(pack, cyclingRng, 9);
+		expect(drawn.map((o) => o.kind)).toContain("convergence");
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator-convergence.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-convergence.test.ts
@@ -64,6 +64,10 @@ const CONVERGENCE_SPACE: WorldEntity = {
 	holder: { row: 4, col: 4 },
 	convergenceTier1Flavor: "A single presence lingers at the Stone Altar.",
 	convergenceTier2Flavor: "Two presences converge at the Stone Altar.",
+	convergenceTier1ActorFlavor:
+		"You linger at the Stone Altar; the air seems to wait.",
+	convergenceTier2ActorFlavor:
+		"You stand at the Stone Altar; another presence shares the place.",
 };
 
 // Paired object (required by ContentPack.objectivePairs).
@@ -167,7 +171,9 @@ describe("runRound — convergence evaluation (step 4d)", () => {
 		if (entry?.kind === "witnessed-convergence") {
 			expect(entry.tier).toBe(1);
 			expect(entry.spaceId).toBe("altar_space");
-			expect(entry.flavor).toBe(CONVERGENCE_SPACE.convergenceTier1Flavor);
+			// red is the sole occupant → first-person actor flavor (#336).
+			expect(entry.audience).toBe("actor");
+			expect(entry.flavor).toBe(CONVERGENCE_SPACE.convergenceTier1ActorFlavor);
 		}
 	});
 
@@ -236,14 +242,20 @@ describe("runRound — convergence evaluation (step 4d)", () => {
 		expect(redConvergence).toHaveLength(1);
 		if (redConvergence[0]?.kind === "witnessed-convergence") {
 			expect(redConvergence[0].tier).toBe(2);
+			// red is an occupant → first-person actor flavor (#336).
+			expect(redConvergence[0].audience).toBe("actor");
 			expect(redConvergence[0].flavor).toBe(
-				CONVERGENCE_SPACE.convergenceTier2Flavor,
+				CONVERGENCE_SPACE.convergenceTier2ActorFlavor,
 			);
 		}
 
 		expect(greenConvergence).toHaveLength(1);
 		if (greenConvergence[0]?.kind === "witnessed-convergence") {
 			expect(greenConvergence[0].tier).toBe(2);
+			expect(greenConvergence[0].audience).toBe("actor");
+			expect(greenConvergence[0].flavor).toBe(
+				CONVERGENCE_SPACE.convergenceTier2ActorFlavor,
+			);
 		}
 
 		// cyan's cone at (0,2) facing south does not include (4,4).
@@ -301,5 +313,97 @@ describe("runRound — convergence evaluation (step 4d)", () => {
 			(e) => e.kind === "witnessed-convergence",
 		).length;
 		expect(redCountAfterRound2).toBe(redCountAfterRound1);
+	});
+});
+
+describe("runRound — convergence split fan-out (actor vs witness) — #336", () => {
+	it("tier-1: the sole occupant gets the actor flavor; a non-occupant cone-witness gets the witness flavor", async () => {
+		// red on the space at (4,4). Move cyan to (3,4) facing south so cyan's
+		// cone covers (4,4) but cyan is NOT on the cell. green stays at (0,0)
+		// facing south — out of cone.
+		const baseGame = makeBaseGame();
+		const game = {
+			...baseGame,
+			personaSpatial: {
+				...baseGame.personaSpatial,
+				cyan: { position: { row: 3, col: 4 }, facing: "south" as const },
+			},
+		};
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		const redEntry = (nextState.conversationLogs.red ?? []).find(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		expect(redEntry).toBeDefined();
+		if (redEntry?.kind === "witnessed-convergence") {
+			expect(redEntry.audience).toBe("actor");
+			expect(redEntry.flavor).toBe(
+				CONVERGENCE_SPACE.convergenceTier1ActorFlavor,
+			);
+		}
+
+		const cyanEntry = (nextState.conversationLogs.cyan ?? []).find(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		expect(cyanEntry).toBeDefined();
+		if (cyanEntry?.kind === "witnessed-convergence") {
+			expect(cyanEntry.audience).toBe("witness");
+			expect(cyanEntry.flavor).toBe(CONVERGENCE_SPACE.convergenceTier1Flavor);
+		}
+	});
+
+	it("tier-2: every occupant gets the actor flavor; a non-occupant cone-witness gets the witness flavor", async () => {
+		// red and green both at (4,4). cyan at (3,4) facing south — cone covers (4,4)
+		// but cyan is not on the cell.
+		const baseGame = makeBaseGame();
+		const game = {
+			...baseGame,
+			personaSpatial: {
+				red: { position: { row: 4, col: 4 }, facing: "north" as const },
+				green: { position: { row: 4, col: 4 }, facing: "north" as const },
+				cyan: { position: { row: 3, col: 4 }, facing: "south" as const },
+			},
+		};
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		for (const aiId of ["red", "green"] as const) {
+			const entry = (nextState.conversationLogs[aiId] ?? []).find(
+				(e) => e.kind === "witnessed-convergence",
+			);
+			expect(entry).toBeDefined();
+			if (entry?.kind === "witnessed-convergence") {
+				expect(entry.audience).toBe("actor");
+				expect(entry.flavor).toBe(
+					CONVERGENCE_SPACE.convergenceTier2ActorFlavor,
+				);
+			}
+		}
+
+		const cyanEntry = (nextState.conversationLogs.cyan ?? []).find(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		expect(cyanEntry).toBeDefined();
+		if (cyanEntry?.kind === "witnessed-convergence") {
+			expect(cyanEntry.audience).toBe("witness");
+			expect(cyanEntry.flavor).toBe(CONVERGENCE_SPACE.convergenceTier2Flavor);
+		}
+	});
+
+	it("no double-emission: a Daemon standing on the space receives exactly one entry (the actor variant)", async () => {
+		// red is on the space and faces north so red's own cone trivially covers
+		// (4,4) too — verify red does NOT receive both actor and witness entries.
+		const game = makeBaseGame();
+
+		const { nextState } = await runRound(game, "red", "hi", makeProvider());
+
+		const redConvergence = (nextState.conversationLogs.red ?? []).filter(
+			(e) => e.kind === "witnessed-convergence",
+		);
+		expect(redConvergence).toHaveLength(1);
+		if (redConvergence[0]?.kind === "witnessed-convergence") {
+			expect(redConvergence[0].audience).toBe("actor");
+		}
 	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -30,7 +30,7 @@ export const CONTENT_PACK_SYSTEM_PROMPT = `You generate content packs for a text
 For each phase:
 - Generate exactly k OBJECTIVE PAIRS. Each pair has:
   - An objective_object with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; MUST NOT reference or imply contact with the paired space, since the actor can be anywhere on the grid when using the item), pairsWithSpaceId (must match the paired space's id), placementFlavor (1 sentence containing the literal string "{actor}", fires when the object is placed on its space), proximityFlavor (1 sentence; in-fiction sensory description of what the daemon perceives when they are holding this item AND its paired space is in their own cell or directly in front of them. Written from the daemon's POV. Does NOT contain "{actor}" and MUST NOT reference placing or coupling the item.). objective_objects MUST be portable physical items a single person can pick up and carry (e.g. a tool, instrument, artifact, container) — never furniture, architecture, or fixed structures.
-  - An objective_space with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences describing the space; MUST contain at least one activation/use cue word such as "use", "activate", "press", "trigger", "engage", "operate", "lever", "button", "switch", "control", "panel", "console", "dial", "knob", "channel", "invoke", "summon", "ignite", "pull", "turn", "interact", or "mechanism" — this is the AI-discoverable prose tell that the space is "use"-able as an objective), activationFlavor (1 sentence, world-meaningful, third-person from the world's POV — describes what happens in the world when the space is activated. Fires as the actor's "use" tool result on the satisfying call. Does NOT contain "{actor}". MUST NOT say "the objective is complete" or otherwise meta-narrate progress.), satisfactionFlavor (1 sentence, third-person from a witness POV, fires as a witnessed event when the space is successfully used to satisfy the objective — does NOT contain "{actor}"), postExamineDescription (1-2 sentences: alternate examine description shown after the space has been used), postLookFlavor (1 sentence: alternate look flavor shown after the space has been used), convergenceTier1Flavor (1 sentence, in-fiction sensory line a witness Daemon perceives when exactly one Daemon occupies this space; third person from witness POV; does NOT contain {actor}), convergenceTier2Flavor (1 sentence, in-fiction sensory line a witness Daemon perceives when two or more Daemons share this space; third person from witness POV; does NOT contain {actor}). objective_spaces are fixed locations or surfaces, not items.
+  - An objective_space with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences describing the space; MUST contain at least one activation/use cue word such as "use", "activate", "press", "trigger", "engage", "operate", "lever", "button", "switch", "control", "panel", "console", "dial", "knob", "channel", "invoke", "summon", "ignite", "pull", "turn", "interact", or "mechanism" — this is the AI-discoverable prose tell that the space is "use"-able as an objective; AND MUST also hint that the space's meaning depends on shared occupancy or another presence — e.g. "a meeting place", "where two are needed", "becomes significant when shared", "a gathering point", "the space awaits company" — this second hint is the AI-discoverable signal for the Convergence Objective. Both prose tells must be present), activationFlavor (1 sentence, world-meaningful, third-person from the world's POV — describes what happens in the world when the space is activated. Fires as the actor's "use" tool result on the satisfying call. Does NOT contain "{actor}". MUST NOT say "the objective is complete" or otherwise meta-narrate progress.), satisfactionFlavor (1 sentence, third-person from a witness POV, fires as a witnessed event when the space is successfully used to satisfy the objective — does NOT contain "{actor}"), postExamineDescription (1-2 sentences: alternate examine description shown after the space has been used), postLookFlavor (1 sentence: alternate look flavor shown after the space has been used), convergenceTier1Flavor (1 sentence, third-person witness POV, fires as a witnessed event when exactly one Daemon occupies this space; does NOT contain "{actor}". MUST NOT name a specific other Daemon. MUST NOT say the objective is complete), convergenceTier2Flavor (1 sentence, third-person witness POV, fires as a witnessed event when two or more Daemons share this space; does NOT contain "{actor}". MUST NOT name a specific other Daemon), convergenceTier1ActorFlavor (1 sentence, first-person actor POV using "you", delivered to the Daemon standing alone on this space at Tier 1 — the "I am here, and the space anticipates company" beat. Does NOT contain "{actor}". MUST NOT name a specific other Daemon. MUST NOT say the objective is complete), convergenceTier2ActorFlavor (1 sentence, first-person actor POV using "you", delivered to every Daemon standing on the space when two or more share it at Tier 2 — the moment-of-convergence sensory beat. Does NOT contain "{actor}". MUST NOT name a specific other Daemon. MUST NOT explicitly state that the objective is complete; sensory only). objective_spaces are fixed locations or surfaces, not items.
 - Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences; MUST hint that the item is meant to be used or activated — include a verb-of-activation cue such as "use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger", or a clear noun-phrase tell like "control", "switch", "lever", "trigger", "button"; the prose tell is the only AI-discoverable channel that distinguishes a Use-Item target from a plain decorative item, so it cannot be omitted; MUST NOT contain "{actor}" and MUST NOT say the item is already used or that an objective is complete), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; returned post-satisfaction; MUST NOT say the objective is complete), activationFlavor (1 sentence; world-meaningful third-person description of what happens at the moment the item is activated for the first time — same string returned to actor and to witnesses; MUST NOT contain "{actor}"; MUST NOT say the objective is complete; MUST NOT reference placing or coupling the item with anything else), postExamineDescription (1-2 sentences shown by examine after the item has been activated; describes the post-activation state of the item itself; MUST NOT contain "{actor}"; MUST NOT reference the actor; MUST NOT say the objective is complete), postLookFlavor (1 sentence appended to look output after the item has been activated; in-fiction sensory line a witness perceives; MUST NOT contain "{actor}"). interesting_objects MUST be portable physical items a single person can pick up and carry — never furniture, architecture, or fixed structures.
 - Generate exactly m OBSTACLES with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1 sentence describing the impassable object), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Obstacles are fixed and impassable — never portable items. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS — one anchoring each cardinal direction (north, south, east, west). Each landmark is distant, unreachable, distinctive, mutually visually distinguishable, and consistent with the setting, atmosphere, and weather. Each landmark has: shortName (2-5 words, e.g. "the rusted radio tower"), horizonPhrase (a short evocative clause describing what the landmark itself looks like — its form, condition, materials — NOT where it sits relative to any viewer. The phrase is slotted into "On the horizon ahead: <shortName> — <horizonPhrase>." so it must read coherently as a continuation. Good: "rises above the platform, antenna bent toward the dark". Bad: "looms behind you in the dark" (implies position) or "stands to your left" (implies relative direction).
@@ -59,7 +59,7 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
       "objectivePairs": [
         {
           "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." },
-          "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "activationFlavor": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "..." }
+          "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "activationFlavor": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "...", "convergenceTier1ActorFlavor": "...", "convergenceTier2ActorFlavor": "..." }
         }
       ],
       "interestingObjects": [
@@ -135,13 +135,13 @@ export const DUAL_CONTENT_PACK_SYSTEM_PROMPT = `You generate paired content pack
 For each phase produce packA and packB with the following rules:
 - Entity IDs (id fields) MUST be identical between packA and packB. Choose the ids once and reuse them.
 - Entity structural relationships (pairsWithSpaceId, kind) MUST be identical between packA and packB.
-- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, activationFlavor (for objective_space AND interesting_object), satisfactionFlavor (for objective_space), postExamineDescription, postLookFlavor (for interesting_object), shiftFlavor (for obstacles), landmark shortName, landmark horizonPhrase.
+- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, activationFlavor (for objective_space AND interesting_object), satisfactionFlavor (for objective_space), convergenceTier1Flavor, convergenceTier2Flavor, convergenceTier1ActorFlavor, convergenceTier2ActorFlavor (for objective_space), postExamineDescription, postLookFlavor (for objective_space AND interesting_object), shiftFlavor (for obstacles), landmark shortName, landmark horizonPhrase.
 - The setting field at pack level MUST match settingA for packA and settingB for packB.
 
 Entity rules (same as always):
 - Generate exactly k OBJECTIVE PAIRS per pack. Each pair:
   - objective_object: id, kind="objective_object", name (2-4 words thematic to setting+theme), examineDescription (1-2 sentences naming the paired space), useOutcome (1 stateless sentence; MUST NOT imply contact with paired space), pairsWithSpaceId (matches space id), placementFlavor (1 sentence with literal "{actor}"), proximityFlavor (1 sentence; daemon's POV sensory experience; no "{actor}"; no placing/coupling language). Must be a portable physical item.
-  - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences; MUST contain at least one activation/use cue word such as "use", "activate", "press", "trigger", "engage", "operate", "lever", "button", "switch", "control", "panel", "console", "dial", "knob", "channel", "invoke", "summon", "ignite", "pull", "turn", "interact", or "mechanism" — AI-discoverable prose tell that the space is "use"-able as an objective), activationFlavor (1 sentence, world-meaningful, third-person world POV, fires as actor's "use" tool result on the satisfying call. No "{actor}" token. MUST NOT meta-narrate objective progress.), satisfactionFlavor (1 sentence, third-person witness POV, fires when objective satisfied — no "{actor}"), postExamineDescription (1-2 sentences: shown after use), postLookFlavor (1 sentence: shown in look after use), convergenceTier1Flavor (1 sentence sensory witness line when exactly one Daemon is on space; no {actor}), convergenceTier2Flavor (1 sentence sensory witness line when two or more Daemons share space; no {actor}). Fixed location or surface.
+  - objective_space: id, kind="objective_space", name (2-4 words), examineDescription (1-2 sentences; MUST contain at least one activation/use cue word such as "use", "activate", "press", "trigger", "engage", "operate", "lever", "button", "switch", "control", "panel", "console", "dial", "knob", "channel", "invoke", "summon", "ignite", "pull", "turn", "interact", or "mechanism" — AI-discoverable prose tell that the space is "use"-able as an objective; AND MUST also hint that the space's meaning depends on shared occupancy or another presence — discoverable signal for the Convergence Objective. Both tells must be present), activationFlavor (1 sentence, world-meaningful, third-person world POV, fires as actor's "use" tool result on the satisfying call. No "{actor}" token. MUST NOT meta-narrate objective progress.), satisfactionFlavor (1 sentence, third-person witness POV, fires when objective satisfied — no "{actor}"), postExamineDescription (1-2 sentences: shown after use), postLookFlavor (1 sentence: shown in look after use), convergenceTier1Flavor (1 sentence, third-person witness POV, fires when exactly one Daemon is on this space — no "{actor}"; MUST NOT name a specific other Daemon; MUST NOT say the objective is complete), convergenceTier2Flavor (1 sentence, third-person witness POV, fires when two or more Daemons share this space — no "{actor}"; MUST NOT name a specific other Daemon), convergenceTier1ActorFlavor (1 sentence, first-person actor POV using "you", delivered to the Daemon standing alone on this space at Tier 1 — no "{actor}"; MUST NOT name a specific other Daemon; MUST NOT say the objective is complete), convergenceTier2ActorFlavor (1 sentence, first-person actor POV using "you", delivered to every Daemon on the space at Tier 2 — no "{actor}"; MUST NOT name a specific other Daemon; sensory only, MUST NOT explicitly state that the objective is complete). Fixed location or surface.
 - Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences; MUST contain a verb-of-activation cue ("use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger") or a clear control noun ("control", "switch", "lever", "trigger", "button", "dial", "handle", "crank") — the only AI-discoverable Use-Item tell; MUST NOT contain "{actor}"; MUST NOT say the item is already used or the objective is complete), useOutcome (1 stateless sentence; returned post-satisfaction; MUST NOT say the objective is complete), activationFlavor (1 sentence; world-meaningful third-person line returned to actor and witnesses on the use call that satisfies the UseItemObjective; MUST NOT contain "{actor}"; MUST NOT say the objective is complete; MUST NOT reference placing or coupling), postExamineDescription (1-2 sentences shown by examine after activation; MUST NOT contain "{actor}"; MUST NOT reference the actor), postLookFlavor (1 sentence appended to look output after activation; MUST NOT contain "{actor}"). Must be portable.
 - Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Fixed and impassable. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS per pack (north/south/east/west): shortName (2-5 words), horizonPhrase (evocative clause; no cardinal direction words; no positional phrases implying viewer relationship).
@@ -164,14 +164,14 @@ Return ONLY valid JSON (no markdown, no preamble):
       "phaseNumber": <1|2|3>,
       "packA": {
         "setting": "<settingA>",
-        "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "activationFlavor": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "..." } }],
+        "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "activationFlavor": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "...", "convergenceTier1ActorFlavor": "...", "convergenceTier2ActorFlavor": "..." } }],
         "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." }],
         "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "...", "shiftFlavor": "..." }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
       },
       "packB": {
         "setting": "<settingB>",
-        "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "activationFlavor": "DIFFERENT_FLAVOR", "satisfactionFlavor": "DIFFERENT_FLAVOR", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "DIFFERENT_FLAVOR", "convergenceTier2Flavor": "DIFFERENT_FLAVOR" } }],
+        "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "activationFlavor": "DIFFERENT_FLAVOR", "satisfactionFlavor": "DIFFERENT_FLAVOR", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "DIFFERENT_FLAVOR", "convergenceTier2Flavor": "DIFFERENT_FLAVOR", "convergenceTier1ActorFlavor": "DIFFERENT_FLAVOR", "convergenceTier2ActorFlavor": "DIFFERENT_FLAVOR" } }],
         "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "DIFFERENT_FLAVOR", "postExamineDescription": "DIFFERENT_DESCRIPTION", "postLookFlavor": "DIFFERENT_FLAVOR" }],
         "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "...", "shiftFlavor": "DIFFERENT_FLAVOR" }],
         "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
@@ -370,6 +370,29 @@ export function examineMentionsUseTell(examineDescription: string): boolean {
 	return false;
 }
 
+/**
+ * Convergence prose-tell strategy (issue #336):
+ *
+ * Convergence objectives also need an AI-discoverable signal that the
+ * objective_space's meaning depends on shared occupancy — parallel to the
+ * `examineMentionsUseTell` rule for Use-Space and `examineMentionsPairedSpace`
+ * for Carry. Enforcement here is **prompt-only**: the system prompts MUST the
+ * property ("examineDescription MUST hint that the space's meaning depends on
+ * shared occupancy or another presence"), but no programmatic validator is
+ * applied.
+ *
+ * A curated keyword list (e.g. meet/converge/gather/presence/together/share)
+ * was considered but rejected: the same `examineDescription` is shared across
+ * Carry, Use-Space, and Convergence draws (the pool composition is decided
+ * after pack generation), so adding a hard convergence-keyword validator on
+ * top of the existing Use-cue and paired-space rules would over-constrain
+ * spaces that never end up drawn for convergence.
+ *
+ * The pool inclusion guard in `objective-pool.ts` enforces the structural
+ * preconditions (all four flavor fields present) so a Convergence candidate
+ * cannot be drawn against a space that lacks the LLM-authored tier flavors.
+ */
+
 // ── Validation ────────────────────────────────────────────────────────────────
 
 function validateEntity(
@@ -514,6 +537,26 @@ function validateEntity(
 				`Objective space ${e.id}: convergenceTier2Flavor must be a non-empty string that does not contain "{actor}"`,
 			);
 		}
+		// First-person actor variants (#336): delivered to Daemons standing on
+		// the space; existing tier1/2 flavors fan out to non-occupant cone-witnesses.
+		if (
+			typeof e.convergenceTier1ActorFlavor !== "string" ||
+			e.convergenceTier1ActorFlavor.length === 0 ||
+			e.convergenceTier1ActorFlavor.includes("{actor}")
+		) {
+			throw new ContentPackError(
+				`Objective space ${e.id}: convergenceTier1ActorFlavor must be a non-empty string that does not contain "{actor}"`,
+			);
+		}
+		if (
+			typeof e.convergenceTier2ActorFlavor !== "string" ||
+			e.convergenceTier2ActorFlavor.length === 0 ||
+			e.convergenceTier2ActorFlavor.includes("{actor}")
+		) {
+			throw new ContentPackError(
+				`Objective space ${e.id}: convergenceTier2ActorFlavor must be a non-empty string that does not contain "{actor}"`,
+			);
+		}
 	}
 
 	// Build entity — holder is not set here (placement done later)
@@ -567,6 +610,12 @@ function validateEntity(
 	}
 	if (typeof e.convergenceTier2Flavor === "string") {
 		entity.convergenceTier2Flavor = e.convergenceTier2Flavor;
+	}
+	if (typeof e.convergenceTier1ActorFlavor === "string") {
+		entity.convergenceTier1ActorFlavor = e.convergenceTier1ActorFlavor;
+	}
+	if (typeof e.convergenceTier2ActorFlavor === "string") {
+		entity.convergenceTier2ActorFlavor = e.convergenceTier2ActorFlavor;
 	}
 	// interesting_object Use-Item flavor fields (issue #334)
 	if (e.kind === "interesting_object") {

--- a/src/spa/game/objective-pool.ts
+++ b/src/spa/game/objective-pool.ts
@@ -69,11 +69,19 @@ export function drawObjectives(
 
 	for (const pair of contentPack.objectivePairs) {
 		const { space } = pair;
+		// Convergence inclusion guard (#336): the space must have ALL four
+		// tier-flavor fields (witness + actor for each of Tier 1 and Tier 2)
+		// authored. Spaces missing any field are excluded from the convergence
+		// pool — they remain eligible for Carry / Use-Space draws.
 		if (
 			typeof space.convergenceTier1Flavor === "string" &&
 			space.convergenceTier1Flavor.length > 0 &&
 			typeof space.convergenceTier2Flavor === "string" &&
-			space.convergenceTier2Flavor.length > 0
+			space.convergenceTier2Flavor.length > 0 &&
+			typeof space.convergenceTier1ActorFlavor === "string" &&
+			space.convergenceTier1ActorFlavor.length > 0 &&
+			typeof space.convergenceTier2ActorFlavor === "string" &&
+			space.convergenceTier2ActorFlavor.length > 0
 		) {
 			const convergence: ConvergenceObjective = {
 				id: "", // placeholder; will be replaced with assigned id

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -602,31 +602,45 @@ export async function runRound(
 
 		if (!spaceCell) continue;
 
-		const flavor =
+		// Split fan-out (#336): Daemons standing on the space cell receive the
+		// first-person actor flavor on a dedicated channel; cone-witnesses NOT
+		// on the cell receive the third-person witness flavor. No Daemon
+		// receives both.
+		const witnessFlavor =
 			tier === 1
 				? (spaceEntity?.convergenceTier1Flavor ?? "Something stirs here.")
 				: (spaceEntity?.convergenceTier2Flavor ?? "Two presences converge.");
+		const actorFlavor =
+			tier === 1
+				? (spaceEntity?.convergenceTier1ActorFlavor ??
+					"You linger here; the place feels poised for company.")
+				: (spaceEntity?.convergenceTier2ActorFlavor ??
+					"You stand here; another presence shares the place with you.");
 
-		const entry: Extract<ConversationEntry, { kind: "witnessed-convergence" }> =
-			{
-				kind: "witnessed-convergence",
-				round: state.round,
-				spaceId,
-				tier,
-				flavor,
-			};
-
-		// Fan out to every Daemon whose cone contains the space cell.
 		for (const [daemonId, spatial] of Object.entries(state.personaSpatial)) {
+			const isOccupant =
+				spatial.position.row === spaceCell.row &&
+				spatial.position.col === spaceCell.col;
 			const cone = projectCone(spatial.position, spatial.facing);
 			const witnessesCell = cone.some(
 				(cell) =>
 					cell.position.row === spaceCell.row &&
 					cell.position.col === spaceCell.col,
 			);
-			if (witnessesCell) {
-				state = appendWitnessedConvergence(state, daemonId, entry);
-			}
+			if (!isOccupant && !witnessesCell) continue;
+
+			const entry: Extract<
+				ConversationEntry,
+				{ kind: "witnessed-convergence" }
+			> = {
+				kind: "witnessed-convergence",
+				round: state.round,
+				spaceId,
+				tier,
+				flavor: isOccupant ? actorFlavor : witnessFlavor,
+				audience: isOccupant ? "actor" : "witness",
+			};
+			state = appendWitnessedConvergence(state, daemonId, entry);
 		}
 
 		// Tier 2: satisfy the objective immediately.

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -41,10 +41,14 @@ export interface WorldEntity {
 	proximityFlavor?: string;
 	/** For obstacle: 1-sentence sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT contain {actor}. */
 	shiftFlavor?: string;
-	/** For objective_space used as a Convergence target: tier-1 flavor (exactly one Daemon on space). Does NOT contain {actor}. */
+	/** For objective_space used as a Convergence target: tier-1 witness flavor (exactly one Daemon on space). Third-person witness POV. Does NOT contain {actor}. */
 	convergenceTier1Flavor?: string;
-	/** For objective_space used as a Convergence target: tier-2 flavor (two or more Daemons share space). Does NOT contain {actor}. */
+	/** For objective_space used as a Convergence target: tier-2 witness flavor (two or more Daemons share space). Third-person witness POV. Does NOT contain {actor}. */
 	convergenceTier2Flavor?: string;
+	/** For objective_space: first-person actor flavor delivered to the Daemon standing alone on the space at Tier 1. Does NOT contain {actor}. */
+	convergenceTier1ActorFlavor?: string;
+	/** For objective_space: first-person actor flavor delivered to every Daemon standing on the space when Tier 2 fires. Does NOT contain {actor}. */
+	convergenceTier2ActorFlavor?: string;
 	/** AiId when held by an AI; GridPosition when resting on a cell. */
 	holder: AiId | GridPosition;
 	/** Tracks whether this entity has been "used" for a UseItem objective. Defaults to "pending" when omitted. */
@@ -338,6 +342,12 @@ export type ConversationEntry =
 			spaceId: string;
 			tier: 1 | 2;
 			flavor: string;
+			/**
+			 * "actor" — receiver was standing on the space; flavor is the first-person actor line.
+			 * "witness" — receiver's cone covered the space but they were NOT on it; flavor is the third-person witness line.
+			 * Optional for backward-compat with saves written before #336 (treat as "witness").
+			 */
+			audience?: "actor" | "witness";
 	  };
 
 export interface AiBudget {

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -659,6 +659,77 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
+	it("round-trips witnessed-convergence ConversationEntries with audience tag (#336)", () => {
+		const game = makeFreshGame();
+		const actorEntry: ConversationEntry = {
+			kind: "witnessed-convergence",
+			round: 3,
+			spaceId: "ent-shrine",
+			tier: 1,
+			flavor: "You linger at the shrine; the place feels poised for company.",
+			audience: "actor",
+		};
+		const witnessEntry: ConversationEntry = {
+			kind: "witnessed-convergence",
+			round: 3,
+			spaceId: "ent-shrine",
+			tier: 2,
+			flavor: "Two figures converge at the shrine.",
+			audience: "witness",
+		};
+		const modified: GameState = {
+			...game,
+			conversationLogs: {
+				...game.conversationLogs,
+				red: [actorEntry],
+				green: [witnessEntry],
+			},
+		};
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			expect(result.state.conversationLogs.red?.[0]).toEqual(actorEntry);
+			expect(result.state.conversationLogs.green?.[0]).toEqual(witnessEntry);
+		}
+	});
+
+	it("round-trips convergenceTier1ActorFlavor and convergenceTier2ActorFlavor on objective_space entities (#336)", () => {
+		const game = makeFreshGame();
+		const space: import("../../game/types.js").WorldEntity = {
+			id: "ent-shrine",
+			kind: "objective_space",
+			name: "Mossy Shrine",
+			examineDescription:
+				"A round altar; the air seems to wait for another presence. Pull the lever to use it.",
+			holder: { row: 2, col: 2 },
+			convergenceTier1Flavor: "A lone figure lingers at the mossy shrine.",
+			convergenceTier2Flavor: "Two figures converge at the mossy shrine.",
+			convergenceTier1ActorFlavor:
+				"You linger at the mossy shrine; the place feels poised.",
+			convergenceTier2ActorFlavor:
+				"You share the mossy shrine with another presence.",
+		};
+		const modified: GameState = {
+			...game,
+			world: { entities: [space] },
+		};
+		const files = serializeSession(modified, NOW, CREATED_AT);
+		const result = deserializeSession(files);
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			const restored = result.state.world.entities.find(
+				(e) => e.id === "ent-shrine",
+			);
+			expect(restored?.convergenceTier1ActorFlavor).toBe(
+				"You linger at the mossy shrine; the place feels poised.",
+			);
+			expect(restored?.convergenceTier2ActorFlavor).toBe(
+				"You share the mossy shrine with another presence.",
+			);
+		}
+	});
+
 	it("SESSION_SCHEMA_VERSION is 7", () => {
 		const game = makeFreshGame();
 		const files = serializeSession(game, NOW, CREATED_AT);


### PR DESCRIPTION
## Summary

Closes #336. Adds two first-person actor-side tier flavors to `objective_space` and splits the round-coordinator's convergence fan-out so Daemons standing on the space receive the actor variant on a dedicated channel while cone-witnesses not on the cell continue to receive the existing third-person witness variant. A convergence shared-presence prose-tell clause is added to the `examineDescription` rule on both single-pack and dual-pack system prompts (alongside the activation-cue-word rule from #335).

## What changed

**`objective_space` schema (`types.ts`)**
- `convergenceTier1ActorFlavor?: string` and `convergenceTier2ActorFlavor?: string` — first-person sensory lines, no `{actor}` token.
- `ConversationEntry.witnessed-convergence` gets an optional `audience: "actor" | "witness"` discriminator. Optional for back-compat with saves written before this PR.

**Content-pack prompts + validator (`content-pack-provider.ts`)**
- Single-pack prompt: the `objective_space.examineDescription` rule now MUSTs two prose tells together — the existing activation cue-word AND a shared-occupancy / another-presence hint for the Convergence Objective. The two new actor-flavor fields are documented with the Carry / `objective_object` template (sentence count, POV, `{actor}` policy, trigger, MUST NOT clauses).
- Dual-pack prompt: same actor-field documentation; the four convergence flavors are added to the MUST-differ delta list.
- JSON shape examples updated.
- `validateEntity` enforces non-empty + no-`{actor}` on both new fields (parallel to the existing tier1/tier2 checks).
- Prose-tell validator strategy documented as **prompt-only** in a docblock near `examineMentionsUseTell` — `examineDescription` is shared across Carry / Use-Space / Convergence draws, so adding a hard convergence-keyword validator on top of the existing use-tell + paired-space rules would over-constrain spaces that never end up drawn for convergence.

**Fan-out split (`round-coordinator.ts` step 4d, ~line 565)**
- Per pending Convergence objective, compute `tier` once; then for each Daemon, classify as occupant vs non-occupant cone-witness and emit the matching flavor. No Daemon receives both lines.
- Hardcoded safety-net fallbacks remain in place for missing flavors (unreachable when the pool inclusion guard does its job, but kept for defence in depth).

**Pool inclusion guard (`objective-pool.ts`)**
- The convergence candidate is only pushed when ALL four flavor fields (tier1/tier2 × witness/actor) are authored on the paired space. Spaces missing any field remain eligible for Carry / Use-Space draws.

## Acceptance criteria

- [x] `objective_space.examineDescription` is authored with a tell signalling shared-presence significance; validator strategy is documented (prompt-only — comment in `content-pack-provider.ts`)
- [x] `convergenceTier1ActorFlavor` and `convergenceTier2ActorFlavor` are LLM-authored, non-empty, no `{actor}` token; validator enforces all three
- [x] On tier 1: Daemon standing on the space receives `convergenceTier1ActorFlavor` on their channel; cone-witnesses not on the space continue to receive `convergenceTier1Flavor`
- [x] On tier 2: every Daemon standing on the space receives `convergenceTier2ActorFlavor`; cone-witnesses not on the space receive `convergenceTier2Flavor`; objective satisfies as today
- [x] No double-emission (a Daemon on the space does not also receive the witness line) — covered by `round-coordinator-convergence.test.ts` "no double-emission" case
- [x] `objective-pool.ts` inclusion guard requires all four tier flavor fields — one test per omitted field × two error modes (missing / empty)
- [x] New fields and the new ConversationEntry shape round-trip through the session codec
- [x] Single-pack and dual-pack generation both produce the new fields; dual-pack "MUST differ" delta list includes them
- [x] Prompt rules for the new fields follow the Carry / `objective_object` template
- [x] Unit tests cover: validator (six paths for the two new fields), tier-1 actor + witness split, tier-2 actor + witness split, pool inclusion guard, codec round-trip

## QA steps

1. Start a new game and confirm content packs generate without validator errors — the LLM is now asked for the two new fields and the second prose-tell clause.
2. In a game with a Convergence objective visible, walk one Daemon to the convergence space at round end. Confirm that Daemon's log gains a `witnessed-convergence` entry with `audience: "actor"` (rendered as a first-person "You …" line). A second Daemon whose cone covers the cell but who is NOT standing on it should see the existing third-person witness line.
3. Walk a second Daemon to the same cell next round. Both occupants should receive the Tier 2 actor flavor; any non-occupant cone-witness should receive the Tier 2 witness flavor; the objective flips to satisfied.

## Automated coverage

- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- `pnpm test` — 1440/1440 across 60 files (added: 7 actor-flavor validator tests, 2 prompt-rule tests, 3 split-fan-out round-coordinator tests, 9 pool-inclusion-guard tests, 2 codec round-trip tests).

## Base branch

This PR targets `first-restructure`, not `main` — convergence and the surrounding restructure work (#303, #305, #328, #329, #335, …) lives there until the restructure merges wholesale. The branch was rebased onto current `first-restructure` so it sits as a single commit on top.

https://claude.ai/code/session_01UZMWZ4epVrx4wP4rTMgoyV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZMWZ4epVrx4wP4rTMgoyV)_