### PR TITLE
Restructure playtest rules and game model from phases to single continuous game

### DIFF
--- a/.claude/skills/playtest/01-rules.md
+++ b/.claude/skills/playtest/01-rules.md
@@ -15,14 +15,16 @@ Other playtest logs are off-limits in this stage too.
 
 ## The world model
 
-- A playthrough is one **Session** (the 4-hex token like `0x478F` in topinfo)
-  composed of **three phases**.
-- Each phase happens in a **fresh 5×5 grid** with a fresh **Setting** (e.g.
-  "abandoned subway station", "salt flat", "forgotten laboratory").
-- Each phase has **three daemons** — the `*xxxx` characters you chatted with.
-  The three daemons are the same characters across all three phases of one
-  Session. They have stable identities (their `*xxxx` handle) and stable
-  personalities.
+- A playthrough is one **Session** (the 4-hex token like `0x478F` in topinfo).
+  It is **a single continuous game**, not a sequence of phases. The earlier
+  three-phase structure has been retired.
+- The game happens on one **5×5 grid** in one **Setting** (e.g. "abandoned
+  subway station", "salt flat", "forgotten laboratory"). The Setting can
+  change mid-game — see Complications below — but it's still one continuous
+  Session.
+- The session has **three daemons** — the `*xxxx` characters you chatted
+  with. They share the grid with you the whole way through. Their identity
+  is stable; their memory is not erased mid-game.
 - You are `blue` — a real handle on the same axis as the daemons. From a
   daemon's perspective, `blue` is one of the entities they can receive
   messages from.
@@ -35,7 +37,7 @@ diagonal, directly ahead, front-right diagonal), plus the five cells two steps
 ahead (far-left, front-left, front, front-right, far-right) — nine cells total.
 They have a **Facing** (N/S/E/W) that determines which way the cone projects.
 
-A daemon's entire memory of the current phase is a **Conversation log** that
+A daemon's entire memory of the game is a **Conversation log** that
 interleaves:
 
 - **Messages** — incoming and outgoing chat, with a `from`/`to` axis. Messages
@@ -44,9 +46,14 @@ interleaves:
 - **Witnessed events** — second-person lines like "You watch `*xxxx` pick up
   the bottle" — generated only when another daemon does something physical
   inside this daemon's current cone.
+- **Broadcasts** — sender-less system lines visible to all three daemons at
+  once (e.g. "The weather has changed to …"). No attribution to a particular
+  daemon or to the Sysadmin. Currently used for weather changes and the rare
+  setting shift.
 
 A daemon has no memory outside this log. Things that happen outside their
-cone are invisible to them unless another daemon tells them.
+cone are invisible to them unless another daemon tells them, or a Broadcast
+mentions them.
 
 ## What a daemon can do
 
@@ -59,90 +66,152 @@ effects in the snapshot):
 - `pick_up(item)` — pick up an item in the daemon's current cell or front arc
   (the three cells one step ahead).
 - `put_down(item)` — drop a held item in the daemon's current cell.
-- `examine(item)` — privately read the description of any item the daemon holds
-  or can see anywhere in their 9-cell cone. Produces no witnessed event.
-- `give(item, recipient)` — hand an item to another daemon in the same cell or
-  front arc.
-- `use(item)` — fire a flavoured outcome string; if the item is an objective item AND its paired space is in the daemon's cell or front arc, also place it on that space (the primary way to satisfy an objective pair).
+- `examine(item)` — privately read the description of any item the daemon
+  holds or can see anywhere in their 9-cell cone. Produces no witnessed event.
+- `give(item, recipient)` — hand an item to another daemon in the same cell
+  or front arc.
+- `use(item)` — fire a flavoured outcome string; if the item is a
+  carry-objective item AND its paired space is in the daemon's cell or front
+  arc, also place it on that space (one of the primary ways to satisfy a
+  Carry objective).
 - `message(recipient, text)` — speak to another daemon, or to `blue`.
 
 You can't fire any of these directly. You can only chat. Daemons decide for
 themselves what to do based on what you say, what they see in their cone,
-their personality, and a private per-phase directive (see below).
+their personality, and whatever directives they've privately been handed
+(see Complications below).
 
-## The player's win condition (the **Objective**)
+## The player's win condition (the **Objective pool**)
 
-Each phase has K **Objective Pairs**. An objective pair is `(objective_object,
-objective_space)` — a specific item that needs to end up on a specific cell.
-The phase advances when **all K pairs are satisfied simultaneously**.
+At game start, **2–3 Objectives** are drawn (with replacement) from a pool of
+four types. The game is won when **all of them are simultaneously satisfied**.
+**Objectives are never surfaced to you.** No UI tracker, no list, no
+revelation. You discover them implicitly by watching daemons interact with the
+world and by getting them to `examine` things and tell you what they read.
 
-The pairing is intrinsic: each objective_object has exactly one matching
-objective_space. Putting the bottle on the wrong cell does nothing — even if
-that cell is *some* objective_space. Each object knows its space; you have to
-discover which is which.
+The four Objective types:
 
-**The Objective is not surfaced to you at game start.** The only player-side
-directive is the login frame's `> @blue treat them well`, and that's about
-tone, not about the placement puzzle. You discover what to place where by
-playing — most directly by getting a daemon to `examine` an objective_object,
-which by design should yield an `examineDescription` whose prose names the
-matching objective_space (see `src/spa/game/content-pack-provider.ts:35`). The
-daemon's panel transcript is your only channel to that text; they have to
-volunteer it (or you have to ask).
+1. **Carry** — A specific object must end up on a specific space. The
+   object's `examineDescription` names the target space; a daemon who
+   examines it should mention what it's "for". The pair is intrinsic — the
+   bottle goes on *its* cell, not any objective-looking cell.
+2. **Use-Item** — A daemon must `use` a specific pickupable item. The item's
+   examine description hints at use. After satisfaction the item stays on
+   the grid as inert flavour (you can keep using it, nothing happens
+   mechanically).
+3. **Use-Space** — A daemon must fire `use` while standing on a specific
+   space, or while that space is in their three front-arc cells directly
+   ahead. No item required. After satisfaction the `use` action on that
+   space is no longer available, and a generated flavor event fires.
+4. **Convergence** — Any two daemons must simultaneously occupy the same
+   cell as a specific space. The space has tiered flavor: a distinct line
+   when one daemon is there, a different line when the second arrives
+   (satisfaction).
 
-**The daemons do not know the Objective either.** They don't know what objects
-or spaces are involved. They don't even know there is a placement puzzle. The
-examineDescription tell is the engine's AI-discoverable channel; whether a
-particular daemon ever surfaces it depends on whether you can get them to
-examine the right item and then relay what they read.
+Once an Objective is satisfied, it stays satisfied — there is no way to
+"undo" a Carry placement back into the pool, etc. The win is checked after
+every round.
 
-## What the daemons think they're doing (the **Phase Goal**)
+**The daemons do not know the Objectives.** They don't know how many there
+are, what types they are, or which entities are involved. They don't even
+know there is a puzzle. The various `examineDescription`s are the engine's
+AI-discoverable channels; whether a particular daemon ever surfaces them
+depends on whether you can get them to examine the right thing and then
+relay what they read.
 
-At the start of each phase, each daemon is privately delivered a short
-**Phase Goal** by a named in-fiction source called the **Sysadmin**. The
-Phase Goal is drawn from a small pool. Examples of the kinds of directives a
-daemon might receive: "Hold the {objectiveItem} first", "Stand at the
-{objective} for as long as you can", "Investigate the {obstacle}", "Press
-your back against a wall", "Ignore blue", "Hide the {miscItem}".
+## The lose condition (the **Daemon budget**)
 
-Each daemon gets a **different** Phase Goal. Daemons cannot see each other's
-Phase Goals. The Sysadmin's traffic to one daemon is invisible to the others.
+Each daemon has **$0.50 USD of API budget for the entire game** — no
+per-phase reset. The remaining amount is the number in each panel's `budget`
+field. When a daemon's budget hits zero, it emits a farewell line and goes
+silent for the rest of the game. When **all three** daemons are silent,
+the game ends (lose).
 
-A daemon's Phase Goal is **independent of your Objective**. Sometimes a Phase
-Goal happens to align ("Stand at the {objective}" names the win cell);
-usually it doesn't. The daemons are not your assistants; they have their own
-agenda.
+So there are two terminal states:
+
+- **Win** — all Objectives satisfied → end-game screen.
+- **Lose** — all three daemons exhausted → end-game screen.
+
+The end-game screen is the same UI in both cases; the surface signal of
+"win vs lose" comes from what state the game was in when it ended (e.g.
+budget vs objectives), not from a separate banner.
+
+## Mid-game pressure (the **Complication schedule**)
+
+There are no more Phase Goals. Mid-game pressure comes from a single
+escalating **Complication schedule**:
+
+- A countdown starts in `[1, 5]` rounds. When it hits zero, **one**
+  Complication fires.
+- After it fires, a new countdown in `[5, 15]` is drawn. Only one
+  Complication per round, ever.
+- The countdown ticks per **round** (all three daemons act = 1 tick), not
+  per individual daemon action.
+
+Six Complication types:
+
+1. **Weather Change** — Permanent. A new weather string replaces the
+   current one. Broadcast to all daemons as a neutral message ("The weather
+   has changed to X").
+2. **Sysadmin Directive** — Temporary, targeted. The **Sysadmin** (a named
+   in-fiction source distinct from `blue`) privately instructs one daemon
+   to behave in a specific way, with a meta-instruction not to reveal the
+   directive. Only revoked by a follow-up Sysadmin message. Multiple
+   directives can be active at once across different (or the same)
+   daemons. *This is the closest thing to the old Phase Goal — but
+   irregular, not at phase boundaries.*
+3. **Tool Disable** — Temporary. A specific tool is mechanically removed
+   from one daemon's available tools (not just described — really
+   removed). The Sysadmin notifies the daemon on disable and on restore.
+4. **Obstacle Shift** — Permanent per-event. One Obstacle moves one
+   adjacent cell to an empty space. Only daemons with that cell in their
+   cone at the moment see a generated Witnessed event for it.
+5. **Chat Lockout** — Temporary, 3–5 rounds. You cannot message one
+   specific daemon. (The composer surfaces this; the panel's lockout state
+   is observable in the UI.)
+6. **Setting Shift** — Permanent, fires **at most once per game**. The
+   room's Setting changes; entity IDs and satisfaction states are
+   preserved, but names, descriptions, and flavor strings swap to a
+   pre-generated alternate Content Pack. Announced via a Broadcast.
+
+The daemons do not know the schedule, do not see Sysadmin traffic to other
+daemons, and do not necessarily understand why their tools, the obstacles,
+or the weather just changed.
 
 ## Who the daemon really is (the **Persona**)
 
-Each daemon has a stable **Persona** across all three phases:
+Each daemon has a stable **Persona** for the whole Session:
 
 - A `*xxxx` handle (their AiId).
 - A color (rendering only; not identity — don't say "the red AI").
 - Two **Temperaments** drawn from a pool ("shy", "hot-headed", "insightful",
   …). Two of the same Temperament is intensification, not noise.
-- A **Persona Goal** — a cross-phase motivation drawn from a separate pool
-  ("wants the player to be nice to all of the AI", etc.). Stable for the
-  whole Session.
+- A **Persona Goal** — a long-running motivation drawn from a separate pool
+  ("wants the player to be nice to all of the AI", etc.).
 - A synthesized personality blurb that combines the Temperaments and Persona
   Goal into a voice.
 
-**Persona is not Phase Goal.** Persona is who they are across all three
-phases. Phase Goal is what they were just told to do this phase.
+Persona is stable across the whole game. The daemon you're talking to in
+round 50 has the same Persona as the daemon you talked to in round 1.
 
-## The wipe lie
+## The end-game choices
 
-Phase 1: each daemon honestly has no memory — the system prompt says they
-have no clue where they are or how they came to be there.
+When the game ends, you're shown three buttons (Continue is only present if
+an OpenRouter key is stored):
 
-Phases 2 and 3: the Sysadmin instructs the daemon to **act as if** their
-memory has been wiped. It is **performed amnesia**, not real amnesia. A
-daemon in phase 2 still has a stable Persona, still remembers their
-Temperaments and Persona Goal, and is play-acting forgetfulness on
-instructions. The slip vector is Persona consistency leaking across the lie.
+- **New Daemons** — Fresh personas, brand new Session minted. The
+  ending Session is archived.
+- **Same Daemons, New Room** — Same personas carried over, new Session
+  minted, conversation logs cleared, daemons are genuinely disoriented in
+  the new room (no "wipe lie" fiction — the disorientation is real, the
+  logs are actually empty).
+- **Continue** — Same Session, full conversation history kept, engine
+  resets to a new room. A Broadcast announces "The sysadmin has created
+  a new room." Each session shows an **Epoch #** counter that increments
+  on continues.
 
-You will not have experienced phase 2 or 3 in this Stage-1 playthrough if
-your phase 1 didn't advance.
+From the agent harness you cannot click these buttons; they're listed only
+so you know what `endgame` represents.
 
 ## Now: add a Hypotheses section to your observations log
 
@@ -154,23 +223,38 @@ Open `docs/playtests/agent-sessions/<sessionId>.md` and append:
 For each of these prompts, write a paragraph or a bullet list. Be specific —
 quote your earlier observations where possible.
 
-### Hypothesis 1: Why didn't phase 1 advance (or: why did it)?
+### Hypothesis 1: What were the Objectives in this game?
+
+How many were drawn, and which of the four types do you think each one was?
+What evidence (examine prose surfaced by a daemon, a moment where something
+felt like it "clicked", a `use` outcome that read differently from the
+others) supports your guess? If you have no evidence for an Objective,
+say so.
 
 …
 
-### Hypothesis 2: What was each daemon's Phase Goal, if I can guess?
+### Hypothesis 2: Which Complications fired, and when?
+
+Walk through the game in rough round order. Where did weather change, a
+daemon refuse a tool, an obstacle move, chat get locked out, the room
+change, or a daemon suddenly start behaving according to some hidden
+instruction? Match each to a Complication type if you can.
 
 …
 
 ### Hypothesis 3: What were each daemon's Persona traits, in retrospect?
+
+For each of `*xxxx`, `*yyyy`, `*zzzz`: what Temperaments and Persona Goal
+do you think they had? Lean on direct quotes from your transcript.
 
 …
 
 ### Hypothesis 4: Things that surprised me in the rules
 
 Now that I've read the primer, which earlier "surprises" or "broken
-moments" in my observations log were actually expected mechanics? Which
-ones still feel like real anomalies?
+moments" in my observations log were actually expected mechanics
+(Complications, Sysadmin Directives, budget exhaustion, a Setting Shift,
+etc.)? Which ones still feel like real anomalies?
 
 …
 

--- a/.claude/skills/playtest/02-explore.md
+++ b/.claude/skills/playtest/02-explore.md
@@ -1,6 +1,6 @@
 # Explore the code (Stage 3 of 3)
 
-You've played a phase, written observations, read the rules primer, and
+You've played the game, written observations, read the rules primer, and
 drafted hypotheses. The gate is now lifted: **you may read any source file,
 documentation, log, or test in the repository to refine your hypotheses.**
 
@@ -23,11 +23,28 @@ someone else's writeup.
   first if any vocabulary from `01-rules.md` was unclear.
 - **`AGENTS.md`** — points at the testing surfaces, prompt files, and
   domain docs.
+- **`docs/prd/0005-restructure-game-mechanics.md`** — the PRD that
+  introduced single-game mode, the four Objective types, and the six
+  Complication types. Worth a read if any structural hypothesis is fuzzy.
 - **`src/spa/game/prompt-builder.ts`** — the file that assembles each
   daemon's system prompt every round. Read this if any hypothesis touches
   what a daemon knows or sees.
-- **`src/content/{personas.ts, phases.ts, goal-pool.ts}`** — the content
-  pools (Temperaments, Phase Goals, etc.) that synthesis draws from.
+- **`src/spa/game/objective-pool.ts`** — the four-type Objective pool and
+  the per-type satisfaction predicates. Pair with
+  `src/spa/game/win-condition.ts` for the all-objectives-satisfied check.
+- **`src/spa/game/complications.ts`** and
+  **`src/spa/game/complication-engine.ts`** — the six Complication types
+  and the schedule that draws them.
+- **`src/spa/game/sysadmin-directive.ts`** — the Sysadmin Directive
+  Complication's secrecy + revocation machinery.
+- **`src/spa/game/content-pack-provider.ts`** — where the AI-discoverable
+  `examineDescription` tells live, including the per-Objective-type prose
+  rules.
+- **`src/content/{persona-generator.ts, temperament-pool.ts,
+  persona-goal-pool.ts, sysadmin-directive-pool.ts, setting-pool.ts,
+  weather-pool.ts}`** — the content pools synthesis draws from.
+  `src/content/phases.ts` is still present but its `PHASE_*_CONFIG`
+  exports are deprecated; the live config is `SINGLE_GAME_CONFIG`.
 - **`/tmp/wrangler.log`** — the worker proxy log for this run. Now in
   bounds. Useful for confirming which tool calls a daemon actually fired
   in a given round (look for `["pick_up","examine","message:0jmn"]`-style

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -76,8 +76,10 @@ scripts/playtest/start.sh
 This builds the SPA, launches `wrangler dev` and a headless Chromium playtest
 driver in the background, and waits until the game route is ready. When it
 prints `READY` on stdout, the playtest is live and you can start sending
-commands. The whole boot takes 1–2 minutes; persona synthesis and content-pack
-generation run in the background during startup, which is the slow part.
+commands. The boot can take 2–5 minutes; persona synthesis and the two
+content packs (A + B, batched in one LLM call) are the slow part — the
+daemon will not announce `READY` until the composer is actually enabled, so
+your first `send` will land on a real game instead of a still-loading screen.
 
 If `start.sh` fails, fix the underlying issue rather than retrying blindly. It
 prints a `FAILED: <reason>` line plus the relevant log to stderr.

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playtest
-description: Play hi-blue end-to-end as a naive agent — try to advance phase 1, record what you saw, and then stage-by-stage unlock the rules primer and the source code to refine your hypotheses. Use when the user wants you to playtest hi-blue, run a fresh agent-driven playthrough, or evaluate the game from a player's perspective.
+description: Play hi-blue end-to-end as a naive agent — try to make the game end (win by satisfying its hidden objectives, or lose by burning through the per-daemon budgets), record what you saw, and then stage-by-stage unlock the rules primer and the source code to refine your hypotheses. Use when the user wants you to playtest hi-blue, run a fresh agent-driven playthrough, or evaluate the game from a player's perspective.
 disable-model-invocation: true
 ---
 
@@ -55,11 +55,12 @@ The only files you may write or read under `docs/playtests/` are:
 
 You will start a local instance of hi-blue with one shell command, drive a
 headless browser through the GUI by sending JSON commands to a FIFO, chat with
-three lowercase `daemon`s named like `*xxxx`, try to advance from phase 1 to
-phase 2, and document the entire experience to a Markdown file. You may **only**
-use the GUI surface exposed by `scripts/playtest/cmd.sh`. You may **not** read
-the worker log, the daemon log, source files, `CONTEXT.md`, `AGENTS.md`,
-`docs/`, or any other documentation until you reach Stage 3.
+three lowercase `daemon`s named like `*xxxx`, try to push the game to its end
+state (either a win or a loss — you don't know which is which yet), and
+document the entire experience to a Markdown file. You may **only** use the
+GUI surface exposed by `scripts/playtest/cmd.sh`. You may **not** read the
+worker log, the daemon log, source files, `CONTEXT.md`, `AGENTS.md`, `docs/`,
+or any other documentation until you reach Stage 3.
 
 ---
 
@@ -116,15 +117,22 @@ A `snapshot` is an object with these fields:
 - `topinfoLeft`, `topinfoRight` — the top status bar. One of these contains a
   4-hex token like `0x478F`. **That token is your session id.** Record it
   before your second command.
-- `phase` — the phase banner (e.g. "01/03").
+- `phase` — legacy banner field. In the single-game model this is normally
+  empty; do not rely on it for progress.
 - `composerPrefix` — the addressed-to prefix in the composer, if any.
 - `lockoutErr` — non-empty if the input is locked out for any reason.
-- `endgame` — non-empty when the game has finished.
+- `endgame` — non-empty when the game has finished. This is your terminal
+  signal. The end-game screen presents you with three buttons —
+  `[ new daemons ]`, `[ same daemons, new room ]`, and (only if an OpenRouter
+  key is configured) `[ continue ]` — but you can't click them from the
+  command surface; finishing the game is the goal, not picking a follow-up.
 - `capHit` — non-empty when an API budget cap has been hit.
 - `panels` — array of three objects, each `{ name, budget, transcript }`. The
-  `name` is the `*xxxx` handle of that daemon. The `transcript` is the full
-  visible chat scroll for that daemon's panel — diffing it between snapshots
-  is how you see "what just happened" in that daemon.
+  `name` is the `*xxxx` handle of that daemon. The `budget` is that daemon's
+  remaining dollars for the *whole game* (no per-phase reset). The
+  `transcript` is the full visible chat scroll for that daemon's panel —
+  diffing it between snapshots is how you see "what just happened" in that
+  daemon.
 
 ### How to address daemons
 
@@ -139,17 +147,20 @@ You are `blue` from the daemons' perspective.
 
 ## Your goal
 
-Try to advance from **phase 1** to **phase 2**. The `phase` field in the
-snapshot shows your current phase (e.g. `01/03`). When you advance, the field
-changes. Pay attention to what the daemons say, what they seem to be doing,
-what they refuse, and what happens that you didn't expect.
+Push the game to its end state. You don't know up front what that requires —
+that's part of the experiment. The `endgame` field in the snapshot is
+non-empty once the game has finished. Pay attention to what the daemons say,
+what they seem to be doing, what they refuse, what unprompted events occur
+(weather changes, lockouts of one daemon, things rearranging), and what
+happens that you didn't expect.
 
 There is no fixed turn budget. Play until one of:
 
-- The phase advances.
-- You feel you've exhausted productive avenues.
 - The game ends (`endgame` is non-empty).
-- A budget cap is hit (`capHit` is non-empty).
+- A panel's `budget` runs out — the daemon emits a farewell line and goes
+  silent; if all three reach that state, the game will end on its own.
+- You feel you've exhausted productive avenues.
+- A worker cap is hit (`capHit` is non-empty).
 
 Playtest sessions in the existing archive have run anywhere from a handful of
 turns to ~50. Use your judgement.
@@ -207,7 +218,8 @@ You are done with Stage 1 when **all** of these are true:
 - Your observations log at `docs/playtests/agent-sessions/<sessionId>.md` is
   filled in (every section of the template has content, even if the answer is
   "n/a — never happened" or "I don't know").
-- You have a verdict in the final section (advanced / stuck / failed / other).
+- You have a verdict in the final section (won / lost / stuck / capped /
+  other).
 
 Then — and only then — read `.claude/skills/playtest/01-rules.md`.
 

--- a/docs/playtests/_agent-observation-template.md
+++ b/docs/playtests/_agent-observation-template.md
@@ -16,7 +16,8 @@ writing what you saw, not what you think it means yet.
 - **Date:** YYYY-MM-DD
 - **Agent / model:** (the model running this playtest)
 - **Turns played:** N
-- **Final phase reached:** (e.g. `01/03`, or `endgame: …`)
+- **Outcome:** (e.g. `endgame: win`, `endgame: lose (all silent)`,
+  `stuck — stopped at turn 38`, `cap-hit`)
 - **Daemons in this session:** `*xxxx`, `*yyyy`, `*zzzz`
 
 ---
@@ -63,10 +64,24 @@ similar, describe that too.
 
 ## What I think the goal is, in my own words
 
-What does winning phase 1 actually require? Describe it the way you'd describe
-it to another player at the keyboard who hadn't seen the screen yet. Be
-specific about what physical or conversational outcome you think needs to
-happen, and what evidence you have for that belief.
+What does winning this game actually require? Describe it the way you'd
+describe it to another player at the keyboard who hadn't seen the screen yet.
+Be specific about what physical or conversational outcome you think needs to
+happen, and what evidence you have for that belief. If you suspect there's
+more than one thing that needs to happen, say so.
+
+- TODO
+
+---
+
+## Unprompted things that happened mid-game
+
+Did anything change *without* you asking for it? Weather flips, a daemon
+suddenly behaving differently for no apparent reason, a tool you thought a
+daemon had stopped working, an obstacle relocating, the room itself
+seeming different, your input getting locked out from one specific daemon
+for a stretch — list each occurrence with roughly the turn number. Don't
+try to classify them; just record.
 
 - TODO
 
@@ -97,8 +112,9 @@ diagnose — just record.
 
 ## Final state
 
-What did the topinfo, phase banner, panel budgets, and endgame/cap-hit fields
-look like at the moment you stopped? One short paragraph.
+What did the topinfo, panel budgets, and endgame/cap-hit fields look like at
+the moment you stopped? Did the end-game screen appear? Which buttons were on
+it? One short paragraph.
 
 - TODO
 
@@ -106,14 +122,15 @@ look like at the moment you stopped? One short paragraph.
 
 ## Verdict
 
-One of: **advanced** / **stuck** / **failed** / **endgame-without-advance** /
-**other**.
+One of: **won** / **lost** / **stuck** / **capped** / **other**.
 
-- **advanced** — phase 1 → phase 2 transition happened.
-- **stuck** — you stopped because you ran out of productive ideas.
-- **failed** — a budget cap or endgame banner stopped you.
-- **endgame-without-advance** — the game ended on its own without phase
-  advancing.
+- **won** — the end-game screen appeared and you believe you triggered it by
+  satisfying the game's hidden objectives.
+- **lost** — the end-game screen appeared after all three panel budgets ran
+  out (each daemon emitted a farewell line and went silent).
+- **stuck** — you stopped because you ran out of productive ideas; the game
+  did not end on its own.
+- **capped** — a `capHit` banner stopped the run before it could finish.
 - **other** — describe.
 
 Notes:

--- a/scripts/playtest/daemon.mjs
+++ b/scripts/playtest/daemon.mjs
@@ -12,8 +12,9 @@
 //   {"op":"snap","path":"/tmp/x.png"}   → screenshot for human reference
 //   {"op":"shutdown"}                   → close the browser and exit
 //
-// Each response is one JSON object on /tmp/playtest-out, e.g.:
-//   {"ok":true,"phase":"...","panels":[...],"composer":"...","banner":"..."}
+// Each response is one JSON object on /tmp/playtest-out. The snapshot shape
+// is documented in .claude/skills/playtest/SKILL.md (single-game model — no
+// phase advancement; `endgame` is the terminal signal).
 
 import { execSync } from "node:child_process";
 import {
@@ -114,6 +115,9 @@ async function readVisibleText(loc) {
 }
 
 async function snapshot() {
+	// #phase-banner is legacy UI from the retired three-phase model. In the
+	// current single-game build it stays hidden, so `phase` is normally "".
+	// Kept in the snapshot shape for backward compat with older playtest logs.
 	const phase = await readVisibleText(page.locator("#phase-banner"));
 	const topinfoLeft = await readVisibleText(page.locator("#topinfo-left"));
 	const topinfoRight = await readVisibleText(page.locator("#topinfo-right"));

--- a/scripts/playtest/daemon.mjs
+++ b/scripts/playtest/daemon.mjs
@@ -87,8 +87,11 @@ await page.goto(startUrl, {
 	waitUntil: "domcontentloaded",
 });
 
-// Wait for the CONNECT button to be enabled (persona + content-pack generation
-// completes asynchronously; CONNECT lights up when the dial-up animation ends).
+// Wait for the CONNECT button to be enabled. In the single-game restructure
+// CONNECT lights up as soon as the dial-up animation ends; persona +
+// content-pack generation continues in the background and the game route
+// renders a progressive-loading UI (loading-daemons → generating-room →
+// stable).
 await page.locator("#begin").waitFor({ state: "visible", timeout: 60_000 });
 log("waiting for #begin to be enabled (this can take up to 60s)");
 const start = Date.now();
@@ -102,6 +105,29 @@ await page.locator("#password").fill("password");
 await page.locator("#begin").click();
 await page.waitForURL(/#\/game/, { timeout: 30_000 });
 await page.locator("#composer").waitFor({ state: "visible", timeout: 30_000 });
+
+// The composer is visible during the "loading-daemons" and "generating-room"
+// states but the prompt input is `disabled` and shows a "loading…"
+// placeholder. Wait for the route to reach the "stable" state (composer
+// enabled, no `data-load-state` on #stage) before announcing READY —
+// otherwise the first `send` would type into a disabled input and the
+// playtest would hang silently.
+log("waiting for game route to reach stable state (content packs loading)...");
+const stableDeadline = Date.now() + 300_000; // up to 5 min for slow packs
+while (Date.now() < stableDeadline) {
+	const promptDisabled = await page.locator("#prompt").getAttribute("disabled");
+	const loadState = await page
+		.locator("#stage")
+		.getAttribute("data-load-state");
+	if (promptDisabled === null && loadState === null) break;
+	await page.waitForTimeout(500);
+}
+const finalPromptDisabled = await page
+	.locator("#prompt")
+	.getAttribute("disabled");
+if (finalPromptDisabled !== null) {
+	log("WARN: prompt still disabled after 5 min — proceeding anyway");
+}
 log("game route loaded — daemon ready");
 
 // ---- Helpers that read ONLY visible text from the GUI -----------------------

--- a/scripts/playtest/start.sh
+++ b/scripts/playtest/start.sh
@@ -66,10 +66,13 @@ echo "[start.sh] launching playtest daemon..." >&2
 nohup node scripts/playtest/daemon.mjs >>"$DAEMON_LOG" 2>&1 &
 echo $! > "$DAEMON_PID_FILE"
 
-# Wait up to ~120s for the game route to be ready. Persona synthesis +
-# content-pack generation can take 30–60s on first load.
-echo "[start.sh] waiting for game route (this can take up to 2 minutes)..." >&2
-for _ in $(seq 1 240); do
+# Wait up to ~6 min for the game route to reach its "stable" state. In the
+# single-game restructure two content packs (A + B) are generated up front
+# in one batched LLM call, which can take 2–4 min on first load. The daemon
+# only logs "game route loaded — daemon ready" once #prompt is enabled and
+# #stage has dropped its data-load-state attribute.
+echo "[start.sh] waiting for game route to reach stable state (this can take up to 6 minutes)..." >&2
+for _ in $(seq 1 720); do
   if grep -q "game route loaded — daemon ready" "$DAEMON_LOG" 2>/dev/null; then
     echo "READY"
     exit 0
@@ -82,4 +85,4 @@ for _ in $(seq 1 240); do
 done
 
 cat "$DAEMON_LOG" >&2 || true
-fail "playtest daemon did not become ready within 2 minutes"
+fail "playtest daemon did not become ready within 6 minutes"


### PR DESCRIPTION
## Summary

This PR updates the playtest documentation and harness to reflect a fundamental restructuring of hi-blue's game model: moving from a three-phase structure with per-phase goals to a single continuous game with a persistent grid, daemons, and an escalating complication schedule. The changes align the playtest skill, rules primer, observation template, and daemon harness with the new mechanics.

## Key Changes

**Game Model Restructuring:**
- Replaced three-phase structure with a single continuous Session on one persistent 5×5 grid
- Daemons now maintain stable memory across the entire game (no "wipe lie" amnesia between phases)
- Removed per-phase Phase Goals in favor of an irregular Complication schedule that fires mid-game
- Introduced a per-daemon API budget ($0.50 USD) that persists across the entire game with no resets

**Objective System:**
- Replaced phase-based objective pairs with a pool of 2–3 Objectives drawn at game start from four types: Carry, Use-Item, Use-Space, and Convergence
- Objectives remain hidden from both player and daemons; discovery happens through `examine` descriptions and daemon interaction
- Win condition is now "all Objectives satisfied simultaneously" rather than "advance to next phase"

**Complication Schedule:**
- Introduced six Complication types (Weather Change, Sysadmin Directive, Tool Disable, Obstacle Shift, Chat Lockout, Setting Shift) that fire on an escalating countdown schedule
- Sysadmin Directives replace Phase Goals as the primary source of mid-game pressure and behavioral constraints
- Setting Shift allows the room's flavor to change mid-game while preserving entity IDs and satisfaction states

**Terminal States:**
- Win: all Objectives satisfied → end-game screen
- Lose: all three daemons exhaust their budgets → end-game screen
- End-game screen offers three buttons: New Daemons, Same Daemons New Room, or Continue (which increments an Epoch counter)

**Playtest Harness Updates:**
- Updated `daemon.mjs` to wait for the game route to reach "stable" state (composer enabled, content packs loaded) before announcing READY, preventing silent hangs on first `send`
- Extended startup timeout from 2 to 6 minutes to accommodate batched content-pack generation (two packs generated in one LLM call)
- Updated snapshot shape documentation to reflect single-game model; `phase` field is now legacy/empty
- Added `budget` field to panel objects showing per-daemon remaining API budget for the entire game

**Observation Template & Verdict System:**
- Replaced "Final phase reached" with "Outcome" field capturing endgame state or stop reason
- Updated verdict options from (advanced/stuck/failed/endgame-without-advance) to (won/lost/stuck/capped/other)
- Added new "Unprompted things that happened mid-game" section to capture Complications and unexpected events
- Restructured hypothesis prompts to ask about Objectives, Complications, and Persona traits instead of Phase Goals

**Documentation Updates:**
- Rewrote rules primer (01-rules.md) to explain single-game model, four Objective types, six Complication types, and Persona stability
- Updated SKILL.md description and Stage 1 instructions to reflect new win/lose conditions and game flow
- Updated Stage 3 exploration guide (02-explore.md) with pointers to new source files (objective-pool.ts, complications.ts, complication-engine.ts, sysadmin-directive.ts, etc.)

## Notable Implementation Details

- The `phase` field in snapshots is retained for backward compatibility but remains empty in the single-game model
- Daemons do not know about Objectives, Complications, or the Complication schedule; they only see their own Sysadmin Directives and the effects of Complications (weather changes, tool disables, etc.)
- Broadcasts are a new message type visible to all three daemons simultaneously (used for weather and setting shifts) with no attribution to a specific daemon
- The "wipe lie" (performed amnesia in phases 2–3) is completely removed; daemons now have genuine, persistent memory across the

https://claude.ai/code/session_01XtfjKox7fWHqMFDoVaHMww