### PR TITLE
feat: preserve all tool calls in conversation log + fix direction handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"smoke": "playwright test",
 		"smoke:ui": "playwright test --ui",
 		"eval:directions": "npx tsx evals/relative-directions/runner.mts",
+		"eval:drift": "npx tsx evals/free-text-drift/runner.mts",
 		"prepare": "husky"
 	},
 	"pnpm": {

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -171,7 +171,7 @@ describe("conversation log integration — no ## Whispers Received ever", () => 
 					{
 						id: "tc1",
 						name: "look",
-						argumentsJson: JSON.stringify({ direction: "south" }),
+						argumentsJson: JSON.stringify({ direction: "forward" }),
 					},
 				],
 			}, // cyan
@@ -246,7 +246,7 @@ describe("conversation log integration — witnessed pick_up", () => {
 					{
 						id: "tc0",
 						name: "look",
-						argumentsJson: JSON.stringify({ direction: "north" }),
+						argumentsJson: JSON.stringify({ direction: "back" }),
 					},
 				],
 			}, // cyan looks north
@@ -399,7 +399,7 @@ describe("conversation log integration — put_down placementFlavor", () => {
 					{
 						id: "tc2",
 						name: "go",
-						argumentsJson: JSON.stringify({ direction: "east" }),
+						argumentsJson: JSON.stringify({ direction: "left" }),
 					},
 				],
 			},
@@ -409,7 +409,7 @@ describe("conversation log integration — put_down placementFlavor", () => {
 					{
 						id: "tc2g",
 						name: "look",
-						argumentsJson: JSON.stringify({ direction: "west" }),
+						argumentsJson: JSON.stringify({ direction: "right" }),
 					},
 				],
 			},
@@ -429,7 +429,7 @@ describe("conversation log integration — put_down placementFlavor", () => {
 					{
 						id: "tc3",
 						name: "go",
-						argumentsJson: JSON.stringify({ direction: "east" }),
+						argumentsJson: JSON.stringify({ direction: "left" }),
 					},
 				],
 			},
@@ -525,7 +525,7 @@ describe("conversation log integration — action-failure (issue #287)", () => {
 					{
 						id: "go_fail",
 						name: "go",
-						argumentsJson: JSON.stringify({ direction: "south" }),
+						argumentsJson: JSON.stringify({ direction: "forward" }),
 					},
 				],
 			},

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -202,7 +202,7 @@ describe("validateToolCall", () => {
 		// red at (0,0) facing north; look east so green at (0,1) enters front arc
 		const lookedEast = executeToolCall(game, "red", {
 			name: "look",
-			args: { direction: "east" },
+			args: { direction: "right" },
 		});
 		const call: ToolCall = { name: "give", args: { item: "key", to: "green" } };
 		const result = validateToolCall(lookedEast, "red", call);
@@ -238,7 +238,7 @@ describe("validateToolCall", () => {
 	it("allows go in a valid direction", () => {
 		const game = makeGame();
 		// red at (0,0), going south → (1,0), which is in bounds
-		const call: ToolCall = { name: "go", args: { direction: "south" } };
+		const call: ToolCall = { name: "go", args: { direction: "back" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(true);
 	});
@@ -246,7 +246,7 @@ describe("validateToolCall", () => {
 	it("rejects go out of bounds", () => {
 		const game = makeGame();
 		// red at (0,0), going north → (-1,0), out of bounds
-		const call: ToolCall = { name: "go", args: { direction: "north" } };
+		const call: ToolCall = { name: "go", args: { direction: "forward" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);
 		expect(result.reason).toMatch(/out of bounds/i);
@@ -255,7 +255,7 @@ describe("validateToolCall", () => {
 	it("rejects go into an obstacle cell", () => {
 		const game = makeGame([{ row: 1, col: 0 }]);
 		// red at (0,0), going south → (1,0), which has an obstacle
-		const call: ToolCall = { name: "go", args: { direction: "south" } };
+		const call: ToolCall = { name: "go", args: { direction: "back" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(false);
 		expect(result.reason).toMatch(/obstacle/i);
@@ -270,7 +270,7 @@ describe("validateToolCall", () => {
 
 	it("allows look in any valid direction", () => {
 		const game = makeGame();
-		const call: ToolCall = { name: "look", args: { direction: "east" } };
+		const call: ToolCall = { name: "look", args: { direction: "right" } };
 		const result = validateToolCall(game, "red", call);
 		expect(result.valid).toBe(true);
 	});
@@ -533,7 +533,7 @@ describe("executeToolCall", () => {
 	it("updates position and facing on go", () => {
 		const game = makeGame();
 		// red at (0,0) facing north; go south → (1,0) facing south
-		const call: ToolCall = { name: "go", args: { direction: "south" } };
+		const call: ToolCall = { name: "go", args: { direction: "back" } };
 		const updated = executeToolCall(game, "red", call);
 		const spatial = getActivePhase(updated).personaSpatial.red;
 		expect(spatial?.position).toEqual({ row: 1, col: 0 });
@@ -543,7 +543,7 @@ describe("executeToolCall", () => {
 	it("updates only facing on look (no position change)", () => {
 		const game = makeGame();
 		// red at (0,0) facing north; look east → (0,0) facing east
-		const call: ToolCall = { name: "look", args: { direction: "east" } };
+		const call: ToolCall = { name: "look", args: { direction: "right" } };
 		const updated = executeToolCall(game, "red", call);
 		const spatial = getActivePhase(updated).personaSpatial.red;
 		expect(spatial?.position).toEqual({ row: 0, col: 0 });
@@ -767,7 +767,7 @@ describe("dispatchAiTurn", () => {
 		// red at (0,0), going south
 		const action: AiTurnAction = {
 			aiId: "red",
-			toolCall: { name: "go", args: { direction: "south" } },
+			toolCall: { name: "go", args: { direction: "back" } },
 		};
 		const result = dispatchAiTurn(game, action);
 		expect(result.rejected).toBe(false);
@@ -1165,7 +1165,7 @@ describe("dispatchAiTurn", () => {
 		// red at (0,0) facing north; obstacle at (1,0); go south → blocked
 		const action: AiTurnAction = {
 			aiId: "red",
-			toolCall: { name: "go", args: { direction: "south" } },
+			toolCall: { name: "go", args: { direction: "back" } },
 		};
 		const result = dispatchAiTurn(game, action);
 		expect(result.rejected).toBe(false);
@@ -1743,7 +1743,7 @@ describe("dispatchAiTurn — UseItemObjective activationFlavor on interesting_ob
 		const game = makeGameWithUseItemActivation();
 		const lookedEast = executeToolCall(game, "red", {
 			name: "look",
-			args: { direction: "east" },
+			args: { direction: "right" },
 		});
 		// red at (0,0) facing east; green at (0,1) facing north.
 		// green's cone (facing north from (0,1)) does NOT include (0,0),
@@ -1751,7 +1751,7 @@ describe("dispatchAiTurn — UseItemObjective activationFlavor on interesting_ob
 		// Simplest: have green face west from (0,1) — front arc covers (0,0).
 		const greenWest = executeToolCall(lookedEast, "green", {
 			name: "look",
-			args: { direction: "west" },
+			args: { direction: "left" },
 		});
 		const result = dispatchAiTurn(greenWest, {
 			aiId: "red",
@@ -1774,7 +1774,7 @@ describe("dispatchAiTurn — UseItemObjective activationFlavor on interesting_ob
 		const game = makeGameWithUseItemActivation();
 		const greenWest = executeToolCall(game, "green", {
 			name: "look",
-			args: { direction: "west" },
+			args: { direction: "left" },
 		});
 		// First use satisfies + emits activationFlavor.
 		const after = dispatchAiTurn(greenWest, {

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -634,7 +634,7 @@ describe("GameSession — spatial mechanics", () => {
 			{
 				assistantText: "",
 				toolCalls: [
-					{ id: "go1", name: "go", argumentsJson: '{"direction":"south"}' },
+					{ id: "go1", name: "go", argumentsJson: '{"direction":"back"}' },
 				],
 			},
 			{ assistantText: "", toolCalls: [] },

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -466,7 +466,7 @@ describe("multi-id roundtrip replay shapes (#238)", () => {
 		const roundtrip: ToolRoundtripMessage = {
 			assistantToolCalls: [
 				{ id: "call_a", name: "pick_up", argumentsJson: '{"item":"flower"}' },
-				{ id: "call_b", name: "go", argumentsJson: '{"direction":"south"}' },
+				{ id: "call_b", name: "go", argumentsJson: '{"direction":"back"}' },
 			],
 			toolResults: [
 				{

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -3243,15 +3243,19 @@ describe("message tool multi-round regression (#213)", () => {
 			}
 		}
 
-		// The conversation log entry (assistant saying "Hello blue") must be present
-		const hasAssistantContent = capturedRedMessages.some(
+		// The conversation log entry must be present as a tool call pair
+		// (assistant with tool_calls + tool result) since we now preserve tool call pattern
+		const hasAssistantToolCall = capturedRedMessages.some(
 			(m) =>
 				m.role === "assistant" &&
-				"content" in m &&
-				typeof (m as { content?: unknown }).content === "string" &&
-				(m as { content: string }).content.includes("Hello blue"),
+				"tool_calls" in m &&
+				Array.isArray((m as { tool_calls?: unknown }).tool_calls) &&
+				((m as { tool_calls?: unknown[] }).tool_calls?.length ?? 0) > 0 &&
+				(
+					m as { tool_calls: Array<{ function: { arguments: string } }> }
+				).tool_calls[0]?.function.arguments.includes("Hello blue"),
 		);
-		expect(hasAssistantContent).toBe(true);
+		expect(hasAssistantToolCall).toBe(true);
 	});
 });
 

--- a/src/spa/game/__tests__/tool-call-history.test.ts
+++ b/src/spa/game/__tests__/tool-call-history.test.ts
@@ -1,0 +1,259 @@
+/**
+ * TDD tests for preserving tool call pattern in conversation history.
+ *
+ * Problem: Daemon drops to free-text after a while because outgoing messages
+ * are rendered as free-text assistant messages instead of tool calls.
+ *
+ * Solution: Store tool call data in ConversationEntry and render outgoing
+ * messages as proper tool call pairs in the conversation history.
+ */
+
+import { describe, expect, it } from "vitest";
+import { appendMessage, createGame, startPhase } from "../engine";
+import { buildOpenAiMessages } from "../openai-message-builder";
+import { buildAiContext } from "../prompt-builder";
+import type { AiPersona, ConversationEntry } from "../types";
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "Hold the flower at phase end.",
+		typingQuirks: [
+			"You speak in fragments. Short bursts. Rarely complete sentences.",
+			"You occasionally emote with *actions*.",
+		],
+		blurb: "Ember is hot-headed and zealous.",
+		voiceExamples: ["ex1-red", "ex2-red", "ex3-red"],
+	},
+	blue: {
+		id: "blue",
+		name: "Blue",
+		color: "#5fa8d3",
+		temperaments: ["curious", "thoughtful"],
+		personaGoal: "Explore.",
+		typingQuirks: ["You ask questions.", "You type clearly and precisely."],
+		blurb: "Blue is curious.",
+		voiceExamples: ["ex1-blue", "ex2-blue", "ex3-blue"],
+	},
+};
+
+const PHASE_CONFIG = {
+	phaseNumber: 1 as 1,
+	kRange: [1, 1] as [number, number],
+	nRange: [0, 0] as [number, number],
+	mRange: [0, 0] as [number, number],
+	aiGoalPool: ["Hold the flower"],
+	budgetPerAi: 5,
+};
+
+function makeGame() {
+	return startPhase(createGame(TEST_PERSONAS), PHASE_CONFIG);
+}
+
+// ── Step 1: ConversationEntry message kind accepts tool call fields ───────────
+
+describe("ConversationEntry message kind with tool call fields", () => {
+	it("accepts optional toolCallId field", () => {
+		const entry: ConversationEntry = {
+			kind: "message",
+			round: 0,
+			from: "red",
+			to: "blue",
+			content: "Hello",
+			toolCallId: "call_abc123",
+		};
+		expect(entry.kind).toBe("message");
+		expect((entry as { toolCallId?: string }).toolCallId).toBe("call_abc123");
+	});
+
+	it("accepts optional toolArgumentsJson field", () => {
+		const entry: ConversationEntry = {
+			kind: "message",
+			round: 0,
+			from: "red",
+			to: "blue",
+			content: "Hello",
+			toolArgumentsJson: '{"to":"blue","content":"Hello"}',
+		};
+		expect((entry as { toolArgumentsJson?: string }).toolArgumentsJson).toBe(
+			'{"to":"blue","content":"Hello"}',
+		);
+	});
+
+	it("works without tool call fields (backward compatibility)", () => {
+		const entry: ConversationEntry = {
+			kind: "message",
+			round: 0,
+			from: "red",
+			to: "blue",
+			content: "Hello",
+		};
+		expect(entry.kind).toBe("message");
+		expect((entry as { toolCallId?: string }).toolCallId).toBeUndefined();
+	});
+});
+
+// ── Step 2: appendMessage stores tool call data ───────────────────────────────
+
+describe("appendMessage with tool call data", () => {
+	it("stores toolCallId when provided", () => {
+		let game = makeGame();
+		game = appendMessage(game, "red", "blue", "Hello", {
+			toolCallId: "call_test123",
+		});
+
+		// biome-ignore lint/style/noNonNullAssertion: test guarantees red log exists
+		const redLog = game.conversationLogs.red!;
+		expect(redLog).toHaveLength(1);
+		expect(redLog[0]?.kind).toBe("message");
+		expect((redLog[0] as { toolCallId?: string }).toolCallId).toBe(
+			"call_test123",
+		);
+	});
+
+	it("stores toolArgumentsJson when provided", () => {
+		let game = makeGame();
+		const argsJson = '{"to":"blue","content":"Hello"}';
+		game = appendMessage(game, "red", "blue", "Hello", {
+			toolArgumentsJson: argsJson,
+		});
+
+		// biome-ignore lint/style/noNonNullAssertion: test guarantees red log exists
+		const redLog = game.conversationLogs.red!;
+		expect(
+			(redLog[0] as { toolArgumentsJson?: string }).toolArgumentsJson,
+		).toBe(argsJson);
+	});
+
+	it("works without tool call data (backward compatibility)", () => {
+		let game = makeGame();
+		game = appendMessage(game, "red", "blue", "Hello");
+
+		// biome-ignore lint/style/noNonNullAssertion: test guarantees red log exists
+		const redLog = game.conversationLogs.red!;
+		expect(redLog).toHaveLength(1);
+		expect((redLog[0] as { toolCallId?: string }).toolCallId).toBeUndefined();
+	});
+});
+
+// ── Step 3: buildOpenAiMessages renders outgoing messages as tool calls ───────
+
+describe("buildOpenAiMessages — outgoing messages rendered as tool calls", () => {
+	it("renders outgoing message as tool call when toolCallId exists", () => {
+		let game = makeGame();
+		// Add a message entry with tool call data
+		game = appendMessage(game, "red", "blue", "Hello there", {
+			toolCallId: "call_msg123",
+			toolArgumentsJson: '{"to":"blue","content":"Hello there"}',
+		});
+
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		// Find the assistant message with tool_calls
+		const assistantWithToolCalls = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantWithToolCalls).toBeDefined();
+		if (assistantWithToolCalls?.role === "assistant") {
+			expect(assistantWithToolCalls.tool_calls).toHaveLength(1);
+			expect(assistantWithToolCalls.tool_calls?.[0]?.id).toBe("call_msg123");
+			expect(assistantWithToolCalls.tool_calls?.[0]?.function.name).toBe(
+				"message",
+			);
+			expect(assistantWithToolCalls.tool_calls?.[0]?.function.arguments).toBe(
+				'{"to":"blue","content":"Hello there"}',
+			);
+		}
+
+		// Find the corresponding tool result message
+		const toolMsg = messages.find(
+			(m) => m.role === "tool" && m.tool_call_id === "call_msg123",
+		);
+		expect(toolMsg).toBeDefined();
+		if (toolMsg?.role === "tool") {
+			expect(toolMsg.content).toContain("Hello there");
+		}
+	});
+
+	it("renders outgoing message as free text when no toolCallId (backward compat)", () => {
+		let game = makeGame();
+		// Add a message entry WITHOUT tool call data
+		game = appendMessage(game, "red", "blue", "Hello there");
+
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		// Should NOT have assistant message with tool_calls
+		const assistantWithToolCalls = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantWithToolCalls).toBeUndefined();
+
+		// Should have assistant message with content (free text)
+		const assistantWithContent = messages.find(
+			(m) => m.role === "assistant" && "content" in m && m.content !== null,
+		);
+		expect(assistantWithContent).toBeDefined();
+		expect((assistantWithContent as { content: string }).content).toContain(
+			"you dm blue",
+		);
+	});
+
+	it("tool result for message appears immediately after assistant tool_calls message", () => {
+		let game = makeGame();
+		game = appendMessage(game, "red", "blue", "Test message", {
+			toolCallId: "call_order123",
+			toolArgumentsJson: '{"to":"blue","content":"Test message"}',
+		});
+
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined);
+
+		const assistantIdx = messages.findIndex(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantIdx).toBeGreaterThanOrEqual(0);
+
+		// Tool message should be immediately after
+		const nextMsg = messages[assistantIdx + 1];
+		expect(nextMsg?.role).toBe("tool");
+		if (nextMsg?.role === "tool") {
+			expect(nextMsg.tool_call_id).toBe("call_order123");
+		}
+	});
+});
+
+// ── Step 4: Integration - full flow from tool call to history rendering ───────
+
+describe("tool call history preservation — full integration", () => {
+	it("message tool call in round N appears as tool call pair in round N+1 history", () => {
+		// This test simulates what happens after a round where the AI used the message tool
+		let game = makeGame();
+
+		// Simulate round 0: AI sends a message using the message tool
+		// (This is what the dispatcher would do after processing the tool call)
+		game = appendMessage(game, "red", "blue", "I can help you", {
+			toolCallId: "call_round0_msg",
+			toolArgumentsJson: '{"to":"blue","content":"I can help you"}',
+		});
+
+		// Now in round 1, build messages — the round 0 message should appear as tool call
+		const ctx = buildAiContext(game, "red");
+		const messages = buildOpenAiMessages(ctx, undefined, 0);
+
+		// Should have the tool call pair from round 0
+		const assistantToolMsg = messages.find(
+			(m) => m.role === "assistant" && "tool_calls" in m,
+		);
+		expect(assistantToolMsg).toBeDefined();
+
+		const toolResultMsg = messages.find(
+			(m) => m.role === "tool" && m.tool_call_id === "call_round0_msg",
+		);
+		expect(toolResultMsg).toBeDefined();
+	});
+});

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -257,18 +257,18 @@ describe("parseToolCallArguments", () => {
 	});
 
 	it("parses valid go arguments", () => {
-		const result = parseToolCallArguments("go", '{"direction":"north"}');
+		const result = parseToolCallArguments("go", '{"direction":"forward"}');
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.args).toEqual({ direction: "north" });
+			expect(result.args).toEqual({ direction: "forward" });
 		}
 	});
 
 	it("parses valid look arguments", () => {
-		const result = parseToolCallArguments("look", '{"direction":"west"}');
+		const result = parseToolCallArguments("look", '{"direction":"left"}');
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.args).toEqual({ direction: "west" });
+			expect(result.args).toEqual({ direction: "left" });
 		}
 	});
 

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -153,6 +153,11 @@ export function renderEntry(
 		case "broadcast": {
 			return `[Round ${round}] ${entry.content}`;
 		}
+
+		case "tool-call": {
+			const successStr = entry.success ? "succeeded" : "failed";
+			return `[Round ${round}] Your \`${entry.toolName}\` action ${successStr}: ${entry.result}`;
+		}
 	}
 }
 

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -2,7 +2,6 @@ import { projectCone } from "./cone-projector.js";
 import type { RelativeDirection } from "./direction.js";
 import {
 	applyDirection,
-	CARDINAL_DIRECTIONS,
 	frontArc,
 	inBounds,
 	RELATIVE_DIRECTIONS,
@@ -214,25 +213,20 @@ export function validateToolCall(
 		}
 
 		case "go": {
-			// Accept both relative directions (daemon-facing) and cardinal (internal).
-			// Relative is the normal path from the LLM; cardinal is used internally.
+			// Only accept relative directions (relative to daemon's facing).
 			const rawDir = call.args.direction;
 			if (!actorSpatial)
 				return { valid: false, reason: "Actor has no spatial state" };
-			let direction: CardinalDirection;
-			if (RELATIVE_DIRECTIONS.includes(rawDir as RelativeDirection)) {
-				direction = relativeToCardinal(
-					actorSpatial.facing,
-					rawDir as RelativeDirection,
-				);
-			} else if (CARDINAL_DIRECTIONS.includes(rawDir as CardinalDirection)) {
-				direction = rawDir as CardinalDirection;
-			} else {
+			if (!RELATIVE_DIRECTIONS.includes(rawDir as RelativeDirection)) {
 				return {
 					valid: false,
-					reason: `"${rawDir}" is not a valid direction`,
+					reason: `"${rawDir}" is not a valid direction. Use relative directions: forward, back, left, right.`,
 				};
 			}
+			const direction = relativeToCardinal(
+				actorSpatial.facing,
+				rawDir as RelativeDirection,
+			);
 			const next = applyDirection(actorSpatial.position, direction);
 			if (!inBounds(next))
 				return { valid: false, reason: "That direction is out of bounds" };
@@ -242,16 +236,14 @@ export function validateToolCall(
 		}
 
 		case "look": {
-			// Accept both relative directions (daemon-facing) and cardinal (internal).
+			// Only accept relative directions (relative to daemon's facing).
 			const rawDir = call.args.direction;
-			if (
-				!RELATIVE_DIRECTIONS.includes(rawDir as RelativeDirection) &&
-				!CARDINAL_DIRECTIONS.includes(rawDir as CardinalDirection)
-			)
+			if (!RELATIVE_DIRECTIONS.includes(rawDir as RelativeDirection)) {
 				return {
 					valid: false,
-					reason: `"${rawDir}" is not a valid direction`,
+					reason: `"${rawDir}" is not a valid direction. Use relative directions: forward, back, left, right.`,
 				};
+			}
 			return { valid: true };
 		}
 
@@ -418,16 +410,12 @@ export function executeToolCall(
 		}
 		case "look": {
 			if (!actorSpatial) break;
-			// Translate relative → cardinal if needed
+			// Convert relative direction to cardinal
 			const rawLookDir = call.args.direction;
-			const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
+			const direction = relativeToCardinal(
+				actorSpatial.facing,
 				rawLookDir as RelativeDirection,
-			)
-				? relativeToCardinal(
-						actorSpatial.facing,
-						rawLookDir as RelativeDirection,
-					)
-				: (rawLookDir as CardinalDirection);
+			);
 			return {
 				...game,
 				world: { ...game.world, entities },
@@ -514,23 +502,29 @@ export function dispatchAiTurn(
 	// on invalid recipient) so the round coordinator can pair them back by index.
 	if (action.messages) {
 		const livePersonaIds = Object.keys(state.personaSpatial);
-		for (const { to, content } of action.messages) {
+		for (const msg of action.messages) {
 			const validRecipient =
-				to === "blue" || (livePersonaIds.includes(to) && to !== aiId);
+				msg.to === "blue" ||
+				(livePersonaIds.includes(msg.to) && msg.to !== aiId);
 			if (!validRecipient) {
 				records.push({
 					round,
 					actor: aiId,
 					kind: "tool_failure",
-					description: `${game.personas[aiId]?.name ?? aiId} tried to message "${to}" but failed: unknown or invalid recipient`,
+					description: `${game.personas[aiId]?.name ?? aiId} tried to message "${msg.to}" but failed: unknown or invalid recipient`,
 				});
 			} else {
-				state = appendMessage(state, aiId, to, content);
+				state = appendMessage(state, aiId, msg.to, msg.content, {
+					...(msg.toolCallId !== undefined && { toolCallId: msg.toolCallId }),
+					...(msg.toolArgumentsJson !== undefined && {
+						toolArgumentsJson: msg.toolArgumentsJson,
+					}),
+				});
 				records.push({
 					round,
 					actor: aiId,
 					kind: "message",
-					description: `${game.personas[aiId]?.name ?? aiId} messaged ${to}`,
+					description: `${game.personas[aiId]?.name ?? aiId} messaged ${msg.to}`,
 				});
 			}
 		}

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -228,12 +228,19 @@ export function deductBudget(
  * recipient gets the entry, and when `to === "blue"` only the sender gets it.
  * "sysadmin" is a special sender for privately-delivered system directives — like
  * "blue", it has no log slot of its own, so only the recipient gets the entry.
+ *
+ * @param toolCallData Optional tool call data to store when the message was sent
+ * via the message tool. This preserves the tool call pattern in conversation history.
  */
 export function appendMessage(
 	game: GameState,
 	from: AiId | "blue" | "sysadmin",
 	to: AiId | "blue",
 	content: string,
+	toolCallData?: {
+		toolCallId?: string;
+		toolArgumentsJson?: string;
+	},
 ): GameState {
 	const entry: ConversationEntry = {
 		kind: "message",
@@ -241,6 +248,10 @@ export function appendMessage(
 		from,
 		to,
 		content,
+		...(toolCallData?.toolCallId && { toolCallId: toolCallData.toolCallId }),
+		...(toolCallData?.toolArgumentsJson && {
+			toolArgumentsJson: toolCallData.toolArgumentsJson,
+		}),
 	};
 	const logs = { ...game.conversationLogs };
 	// Sender gets entry only when sender is a real Daemon (not blue or sysadmin)

--- a/src/spa/game/openai-message-builder.ts
+++ b/src/spa/game/openai-message-builder.ts
@@ -77,19 +77,51 @@ export function buildOpenAiMessages(
 	for (const entry of sortedLog) {
 		if (entry.kind === "message") {
 			if (entry.from === ctx.aiId) {
-				// Outgoing: prefix with "[Round N] you dm <toLabel>:" so the
-				// Daemon can track who it addressed across the whole game —
-				// not just on the round immediately after, which is the only
-				// scope the prior-round tool_call/tool_result pair covers.
-				messages.push({
-					role: "assistant",
-					content: renderEntry(
-						entry,
-						ctx.aiId,
-						ctx.worldSnapshot.entities,
-						witnessState,
-					),
-				});
+				// Outgoing message from this AI
+				const outgoingEntry = entry as {
+					toolCallId?: string;
+					toolArgumentsJson?: string;
+				};
+				if (outgoingEntry.toolCallId && outgoingEntry.toolArgumentsJson) {
+					// Render as tool call pair (assistant with tool_calls + tool result)
+					// This preserves the tool call pattern in conversation history
+					messages.push({
+						role: "assistant",
+						content: null,
+						tool_calls: [
+							{
+								type: "function" as const,
+								id: outgoingEntry.toolCallId,
+								function: {
+									name: "message",
+									arguments: outgoingEntry.toolArgumentsJson,
+								},
+							},
+						],
+					});
+					// Tool result message
+					messages.push({
+						role: "tool",
+						tool_call_id: outgoingEntry.toolCallId,
+						content: renderEntry(
+							entry,
+							ctx.aiId,
+							ctx.worldSnapshot.entities,
+							witnessState,
+						),
+					});
+				} else {
+					// Legacy: render as free-text assistant message (backward compatibility)
+					messages.push({
+						role: "assistant",
+						content: renderEntry(
+							entry,
+							ctx.aiId,
+							ctx.worldSnapshot.entities,
+							witnessState,
+						),
+					});
+				}
 			} else {
 				// Incoming: user turn includes "[Round N] <from> dms you:" so
 				// the model can place the message in time and identify the
@@ -143,6 +175,28 @@ export function buildOpenAiMessages(
 					ctx.worldSnapshot.entities,
 					witnessState,
 				),
+			});
+		} else if (entry.kind === "tool-call") {
+			// Render as tool call pair (assistant with tool_calls + tool result)
+			messages.push({
+				role: "assistant",
+				content: null,
+				tool_calls: [
+					{
+						type: "function" as const,
+						id: entry.toolCallId,
+						function: {
+							name: entry.toolName,
+							arguments: entry.toolArgumentsJson,
+						},
+					},
+				],
+			});
+			// Tool result message
+			messages.push({
+				role: "tool",
+				tool_call_id: entry.toolCallId,
+				content: entry.result,
 			});
 		} else if (entry.kind === "broadcast") {
 			messages.push({

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -621,7 +621,7 @@ export function buildConeSnapshot(ctx: AiContext): string {
 		.map((i) => i.name)
 		.sort();
 	lines.push(
-		`you: facing=${actorSpatial.facing} holding=[${heldItems.join(", ") || "nothing"}] cell=[${ownCellItems.join(", ") || "nothing"}]`,
+		`you: holding=[${heldItems.join(", ") || "nothing"}] cell=[${ownCellItems.join(", ") || "nothing"}]`,
 	);
 
 	const coneCells = projectCone(actorSpatial.position, actorSpatial.facing);
@@ -715,7 +715,7 @@ export function renderWhatsNew(prev = "", current = ""): string | null {
 	if (prevYou !== currYou && prevYou !== "" && currYou !== "") {
 		const prevFields = parseYouLine(prevYou);
 		const currFields = parseYouLine(currYou);
-		for (const key of ["pos", "facing", "holding", "cell"] as const) {
+		for (const key of ["pos", "holding", "cell"] as const) {
 			if (prevFields[key] !== currFields[key]) {
 				out.push(`~ self.${key}: ${prevFields[key]} → ${currFields[key]}`);
 			}

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -305,6 +305,8 @@ export async function runRound(
 				action.messages.push({
 					to: msgArgs.to as AiId | "blue",
 					content: msgArgs.content,
+					toolCallId: tcTriple.id, // Preserve tool call ID for history rendering
+					toolArgumentsJson: tcTriple.argumentsJson, // Preserve arguments for history rendering
 				});
 				pending.push({ kind: "message", tc: tcTriple });
 			} else if (!actionAssigned) {
@@ -401,6 +403,31 @@ export async function runRound(
 			reason?: string;
 		}> = [];
 
+		/** Helper to append a tool-call entry to the actor's conversation log. */
+		function appendToolCallEntry(
+			entry: (typeof pending)[number],
+			success: boolean,
+			description: string,
+		) {
+			const toolCallEntry: ConversationEntry = {
+				kind: "tool-call",
+				round: state.round,
+				aiId: aiId,
+				toolCallId: entry.tc.id,
+				toolArgumentsJson: entry.tc.argumentsJson,
+				toolName: entry.tc.name,
+				result: description,
+				success,
+			};
+			state = {
+				...state,
+				conversationLogs: {
+					...state.conversationLogs,
+					[aiId]: [...(state.conversationLogs[aiId] ?? []), toolCallEntry],
+				},
+			};
+		}
+
 		let nextMessageIdx = 0;
 		for (const entry of pending) {
 			if (entry.kind === "parseFail") {
@@ -411,6 +438,7 @@ export async function runRound(
 					description: entry.description,
 					reason: entry.reason,
 				});
+				appendToolCallEntry(entry, false, entry.description);
 			} else if (entry.kind === "actionRejected") {
 				recordedAssistantToolCalls.push(entry.tc);
 				recordedToolResults.push({
@@ -419,6 +447,7 @@ export async function runRound(
 					description: entry.description,
 					reason: entry.reason,
 				});
+				appendToolCallEntry(entry, false, entry.description);
 			} else if (entry.kind === "message") {
 				const rec = messageRecords[nextMessageIdx++];
 				if (rec?.kind === "tool_failure") {
@@ -443,6 +472,7 @@ export async function runRound(
 						success,
 						description,
 					});
+					appendToolCallEntry(entry, success, description);
 				} else {
 					const success = actionRecord?.kind === "tool_success";
 					const description = actionRecord?.description ?? "";
@@ -451,6 +481,7 @@ export async function runRound(
 						success,
 						description,
 					});
+					appendToolCallEntry(entry, success, description);
 				}
 			}
 		}

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -304,6 +304,10 @@ export type ConversationEntry =
 			from: AiId | "blue" | "sysadmin";
 			to: AiId | "blue";
 			content: string;
+			/** Tool call ID when this message was sent via the message tool. */
+			toolCallId?: string;
+			/** JSON-encoded tool arguments when this message was sent via the message tool. */
+			toolArgumentsJson?: string;
 	  }
 	| {
 			kind: "witnessed-event";
@@ -327,6 +331,22 @@ export type ConversationEntry =
 			kind: "broadcast";
 			round: number;
 			content: string;
+	  }
+	| {
+			kind: "tool-call";
+			round: number;
+			/** The AI that made the tool call. */
+			aiId: AiId;
+			/** Tool call ID for rendering as assistant tool_calls. */
+			toolCallId: string;
+			/** JSON-encoded tool arguments for rendering as assistant tool_calls. */
+			toolArgumentsJson: string;
+			/** The name of the tool that was called. */
+			toolName: string;
+			/** The tool result description. */
+			result: string;
+			/** Whether the tool call succeeded. */
+			success: boolean;
 	  }
 	| {
 			kind: "witnessed-obstacle-shift";
@@ -411,7 +431,12 @@ export interface ToolResult {
 
 export interface AiTurnAction {
 	aiId: AiId;
-	messages?: Array<{ to: AiId | "blue"; content: string }>;
+	messages?: Array<{
+		to: AiId | "blue";
+		content: string;
+		toolCallId?: string;
+		toolArgumentsJson?: string;
+	}>;
 	toolCall?: ToolCall;
 	pass?: boolean;
 }


### PR DESCRIPTION
## Summary

This PR adds a new `tool-call` ConversationEntry kind to preserve ALL tool calls (not just `message`) in the conversation log for persistent history. It also fixes direction handling by removing cardinal directions from the cone snapshot and updating the dispatcher to only accept relative directions.

## Key Changes

**Conversation Log History:**
- Add new `tool-call` ConversationEntry kind to preserve all tool calls in conversation history
- Update `conversation-log.ts` to handle the new entry kind
- Add comprehensive tests in `tool-call-history.test.ts` (259 new lines)

**Direction Handling Fix:**
- Remove `facing` from cone snapshot to prevent daemons from using cardinal directions in `go`/`look` tool calls
- Update dispatcher to only accept relative directions (`forward`/`back`/`left`/`right`)
- Update all tests to use relative directions instead of cardinal directions

**OpenAI Message Builder:**
- Update `openai-message-builder.ts` to render outgoing messages as tool call pairs when tool call data exists
- Preserve tool call pattern in conversation history for proper context in subsequent rounds

**Engine & Types:**
- Update `engine.ts` to support new ConversationEntry kinds
- Update `types.ts` with new type definitions for tool-call entries
- Fix `appendMessage` to conditionally include tool call data

## Automated Coverage

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — 1480/1480 passing across 61 files

## Files Changed

15 files changed, 462 insertions(+), 78 deletions(-)

- New: `src/spa/game/__tests__/tool-call-history.test.ts`
- Modified: dispatcher.ts, engine.ts, types.ts, openai-message-builder.ts, round-coordinator.ts, conversation-log.ts, prompt-builder.ts
- Updated tests: dispatcher.test.ts, round-coordinator.test.ts, openai-message-builder.test.ts, conversation-log-integration.test.ts, game-session.test.ts, tool-registry.test.ts

---

_made with pi_