### PR TITLE
fix: replace import.meta.env with __DEV__ build-time global

### DIFF
--- a/scripts/build-spa.mjs
+++ b/scripts/build-spa.mjs
@@ -115,6 +115,7 @@ const ctx = await esbuild.context({
 		__WORKER_BASE_URL__: JSON.stringify(WORKER_BASE_URL),
 		__COMMIT_SHA__: JSON.stringify(COMMIT_SHA),
 		__COMMIT_TIMESTAMP_MS__: JSON.stringify(COMMIT_TIMESTAMP_MS),
+		__DEV__: watchMode ? "true" : "false",
 	},
 	plugins: [templateHtmlPlugin],
 });

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../content/content-pack-generator", () => ({
 }));
 
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+vi.stubGlobal("__DEV__", true);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -92,6 +93,7 @@ function getEl<T extends HTMLElement>(selector: string): T {
 describe("renderGame — session restore (formerly async bootstrap)", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		// Pre-populate a valid session so game.ts takes the restore path.
 		const store: Record<string, string> = {};

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Provide globals before importing the module
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+vi.stubGlobal("__DEV__", true);
 
 import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -346,6 +346,7 @@ describe("renderGame (game route — three-AI)", () => {
 	beforeEach(async () => {
 		// Must be set before each test since vi.unstubAllGlobals() in afterEach removes it
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		// Seed a valid session so game.ts finds an active session on render.
 		_stub = makeLocalStorageStub();
@@ -928,6 +929,7 @@ describe("renderGame — localStorage persistence", () => {
 	beforeEach(() => {
 		// Must be set before each test since vi.unstubAllGlobals() in afterEach removes it
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 	});
 
@@ -1253,6 +1255,7 @@ describe("renderGame — chat_lockout event", () => {
 	beforeEach(async () => {
 		// Must be set before each test since vi.unstubAllGlobals() in afterEach removes it
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -1331,6 +1334,7 @@ describe("renderGame — chat_lockout event", () => {
 describe("renderGame — mention-based addressing", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -1472,6 +1476,7 @@ describe("renderGame — mention-based addressing", () => {
 describe("renderGame — panel-click addressee", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -1623,6 +1628,7 @@ describe("renderGame — panel-click addressee", () => {
 describe("renderGame — URL param sourcing", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -1693,6 +1699,7 @@ describe("renderGame — URL param sourcing", () => {
 describe("renderGame — addressee persistence after send", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -1910,6 +1917,7 @@ describe("renderGame — addressee persistence after send", () => {
 describe("visual feedback for active addressee", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -2160,6 +2168,7 @@ describe("visual feedback for active addressee", () => {
 describe("renderGame — chat lockout visual affordances (panel muting + inline error)", () => {
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		const _stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -2399,6 +2408,7 @@ describe("renderGame — round error surfacing (issue #231)", () => {
 
 	beforeEach(async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		_stub = makeLocalStorageStub();
 		await seedSessionInStub(_stub);
@@ -2495,6 +2505,7 @@ describe("renderGame — version-mismatch session with pending bootstrap (regres
 
 	it("redirects to #/sessions and does not overwrite the old session when a bootstrap is pending", async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 
 		// Build a localStorage stub seeded with a version-mismatch session.
@@ -2586,6 +2597,7 @@ describe("renderGame — version-mismatch session with pending bootstrap (regres
 
 	it("redirects to #/sessions and clears pending bootstrap when session is broken", async () => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 
 		vi.resetModules();

--- a/src/spa/__tests__/home.test.ts
+++ b/src/spa/__tests__/home.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Provide __WORKER_BASE_URL__ global before importing home module
+// Provide build-time globals before importing home module
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+vi.stubGlobal("__DEV__", true);
 
 // Matches the body content of src/spa/index.html
 const INDEX_BODY_HTML = `

--- a/src/spa/__tests__/llm-client.test.ts
+++ b/src/spa/__tests__/llm-client.test.ts
@@ -10,9 +10,11 @@ import {
 	streamCompletion,
 } from "../llm-client.js";
 
-// Provide __WORKER_BASE_URL__ global before importing the module
+// Provide build-time globals before importing the module
 // biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
 (globalThis as any).__WORKER_BASE_URL__ = "http://localhost:8787";
+// biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
+(globalThis as any).__DEV__ = true;
 
 const WORKER_COMPLETIONS_URL = "http://localhost:8787/v1/chat/completions";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";

--- a/src/spa/__tests__/migration-banner.test.ts
+++ b/src/spa/__tests__/migration-banner.test.ts
@@ -127,6 +127,7 @@ function getMain(): HTMLElement {
 describe("renderStart — legacy-save-discarded banner (via reason param)", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 	});
 

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -130,6 +130,7 @@ function getMain(): HTMLElement {
 describe("renderStart — screen visibility", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		vi.stubGlobal("localStorage", makeLocalStorageStub());
 	});
@@ -166,6 +167,7 @@ describe("renderStart — screen visibility", () => {
 describe("renderStart — BEGIN button state", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		vi.stubGlobal("localStorage", makeLocalStorageStub());
 	});
@@ -219,6 +221,7 @@ describe("renderStart — BEGIN button state", () => {
 describe("renderStart — BEGIN click saves session and navigates", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		vi.stubGlobal("localStorage", makeLocalStorageStub());
 	});
@@ -299,6 +302,7 @@ describe("renderStart — BEGIN click saves session and navigates", () => {
 describe("renderStart — CapHitError handling", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		vi.stubGlobal("localStorage", makeLocalStorageStub());
 	});
@@ -360,6 +364,7 @@ describe("renderStart — CapHitError handling", () => {
 describe("renderStart — persistence warning banners", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		document.body.innerHTML = INDEX_BODY_HTML;
 		vi.stubGlobal("localStorage", makeLocalStorageStub());
 	});

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ToolCallResult, UsageInfo } from "../streaming.js";
 import { parseSSEStream } from "../streaming.js";
 
-// __WORKER_BASE_URL__ is a build-time constant; provide a stub for tests
+// Build-time constants; provide stubs for tests
 // biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
 (globalThis as any).__WORKER_BASE_URL__ = "http://localhost:8787";
+// biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
+(globalThis as any).__DEV__ = true;
 
 function makeSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
 	const encoder = new TextEncoder();

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -12,9 +12,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-// Provide __WORKER_BASE_URL__ global before importing the module under test.
-// Tests that exercise the production gate will override this stub locally.
+// Provide build-time globals before importing the module under test.
+// Tests that exercise the production gate will override these stubs locally.
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+vi.stubGlobal("__DEV__", true);
 
 import { DEFAULT_LANDMARKS } from "../game/direction";
 import { GameSession } from "../game/game-session";

--- a/src/spa/env.d.ts
+++ b/src/spa/env.d.ts
@@ -1,9 +1,13 @@
+/**
+ * Type declarations for build-time globals injected by esbuild
+ * (see scripts/build-spa.mjs `define`).
+ */
 declare const __WORKER_BASE_URL__: string;
 declare const __COMMIT_SHA__: string;
 declare const __COMMIT_TIMESTAMP_MS__: number;
+declare const __DEV__: boolean;
 
-// Allow CSS side-effect imports processed by esbuild
-declare module "*.css" {
-	const _: string;
-	export default _;
-}
+/**
+ * Side-effect CSS import type (consumed by esbuild's css loader).
+ */
+declare module "*.css";

--- a/src/spa/game/__tests__/browser-llm-provider.test.ts
+++ b/src/spa/game/__tests__/browser-llm-provider.test.ts
@@ -8,9 +8,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { BrowserLLMProvider } from "../browser-llm-provider";
 
-// Provide __WORKER_BASE_URL__ global before importing the module
-// biome-ignore lint/suspicious/noExplicitAny: stubbing a build-time constant
-(globalThis as any).__WORKER_BASE_URL__ = "http://localhost:8787";
+// Build-time globals are provided by src/spa/test-setup.ts
 
 function makeSseBody(words: string[]): ReadableStream<Uint8Array> {
 	const encoder = new TextEncoder();

--- a/src/spa/game/__tests__/game-loop.test.ts
+++ b/src/spa/game/__tests__/game-loop.test.ts
@@ -4,6 +4,7 @@ import type { AiPersona } from "../types";
 
 // Provide globals before importing the module
 vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+vi.stubGlobal("__DEV__", true);
 vi.stubGlobal("localStorage", { getItem: () => null });
 
 const WORKER_COMPLETIONS_URL = "http://localhost:8787/v1/chat/completions";

--- a/src/spa/game/__tests__/llm-synthesis-provider.test.ts
+++ b/src/spa/game/__tests__/llm-synthesis-provider.test.ts
@@ -206,6 +206,7 @@ describe("buildSynthesisUserMessage", () => {
 describe("BrowserSynthesisProvider", () => {
 	beforeEach(() => {
 		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
 		// Stub localStorage so resolveLLMTarget can read it
 		vi.stubGlobal("localStorage", { getItem: () => null });
 	});

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -74,7 +74,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 				promptTokens > 0
 					? Math.round((cachedPromptTokens / promptTokens) * 100)
 					: 0;
-			if (import.meta.env.DEV) {
+			if (__DEV__) {
 				console.log(
 					`[cache] prompt ${cachedPromptTokens}/${promptTokens} cached (${pct}%)`,
 				);
@@ -86,7 +86,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 		// For `message` calls, append the recipient so per-recipient counts can
 		// be derived (e.g. "message:blue" vs "message:*xqr9"). Devtools-only
 		// signal; not persisted.
-		if (import.meta.env.DEV) {
+		if (__DEV__) {
 			const calls = toolCalls.map((c) => {
 				try {
 					const args = JSON.parse(c.argumentsJson);

--- a/src/spa/test-setup.ts
+++ b/src/spa/test-setup.ts
@@ -1,0 +1,10 @@
+/**
+ * Vitest setup for the browser (jsdom) project.
+ * Provides build-time globals that esbuild would normally inject.
+ */
+import { beforeEach, vi } from "vitest";
+
+beforeEach(() => {
+	vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+	vi.stubGlobal("__DEV__", true);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 					environmentOptions: {
 						jsdom: { url: "http://localhost:8787/" },
 					},
+					setupFiles: ["src/spa/test-setup.ts"],
 				},
 			},
 			{


### PR DESCRIPTION
## Problem

The previous agent used `import.meta.env.DEV` (a Vite API) to guard debug logs in `browser-llm-provider.ts`. Since the SPA is built with esbuild — not Vite — esbuild passes `import.meta.env` through to the browser untouched. In the browser `import.meta.env` is `undefined`, so `undefined.DEV` throws a `TypeError`, which surfaces as the `the daemons stuttered — try again` error.

## Fix

Replace `import.meta.env.DEV` with `__DEV__`, an esbuild `define` global that gets replaced at build time (like the existing `__WORKER_BASE_URL__`).

- Define `__DEV__` in esbuild: `true` in watch/dev, `false` in prod builds
- Add `src/spa/env.d.ts` declaring all esbuild-injected globals
- Add `src/spa/test-setup.ts` for vitest browser project
- Add `__DEV__` stubs to all test files that stub `__WORKER_BASE_URL__`
- Remove `src/vite-env.d.ts` (Vite-specific type stubs)

## Test plan

- [x] All 1470 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` — `__DEV__` fully replaced, zero `import.meta` in output, dead-code branches tree-shaken
- [ ] Manual: run `wrangler dev`, verify \`[cache]\\/[tools]` logs appear; deploy to staging, verify they do not