### PR TITLE
ci: add smoke tests to pre-push hook and full e2e suite to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,36 @@ jobs:
       - name: Test
         if: ${{ !cancelled() }}
         run: pnpm run test
+
+  smoke:
+    runs-on: ubuntu-latest
+
+    env:
+      ANTHROPIC_API_KEY: ci-invalid-key
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run e2e suite
+        run: pnpm run smoke
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-ANTHROPIC_API_KEY=ci-invalid-key pnpm run lint && pnpm run typecheck && pnpm run test
+ANTHROPIC_API_KEY=ci-invalid-key pnpm run lint && pnpm run typecheck && pnpm run test && pnpm exec playwright test e2e/smoke.spec.ts


### PR DESCRIPTION
Pre-push now runs e2e/smoke.spec.ts (~5s) after lint/typecheck/test,
catching SPA boot regressions before they reach the remote without
materially slowing the hook (~33s total wall clock).

CI gains a parallel `smoke` job that runs the full Playwright suite
(46 tests, ~37s) — too slow for pre-push but worth gating PRs on.