### PR TITLE
Cleanup: retire ContentPack.phaseNumber (post-#355 follow-up)

### DIFF
--- a/e2e/helpers/stubs.ts
+++ b/e2e/helpers/stubs.ts
@@ -141,7 +141,7 @@ function buildSynthesisResponseBody(
 }
 
 type PhaseSpec = {
-	phaseNumber: 1 | 2 | 3;
+	tag: string;
 	setting: string;
 	k: number;
 	n: number;
@@ -157,10 +157,8 @@ function parseContentPackPhases(userMessage: string): PhaseSpec[] {
 		/Phase\s+(\d+):\s+setting="([^"]*)"(?:,\s+theme="[^"]*")?,\s+k=(\d+)\s+objective pairs,\s+n=(\d+)\s+interesting objects,\s+m=(\d+)\s+obstacles/g;
 	const phases: PhaseSpec[] = [];
 	for (const match of userMessage.matchAll(re)) {
-		const phaseNumber = Number(match[1]);
-		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) continue;
 		phases.push({
-			phaseNumber: phaseNumber as 1 | 2 | 3,
+			tag: `p${match[1]}`,
 			setting: match[2] ?? "",
 			k: Number(match[3]),
 			n: Number(match[4]),
@@ -171,7 +169,7 @@ function parseContentPackPhases(userMessage: string): PhaseSpec[] {
 }
 
 type DualPhaseSpec = {
-	phaseNumber: 1 | 2 | 3;
+	tag: string;
 	settingA: string;
 	settingB: string;
 	k: number;
@@ -188,10 +186,8 @@ function parseDualContentPackPhases(userMessage: string): DualPhaseSpec[] {
 		/Phase\s+(\d+):\s+settingA="([^"]*)",\s+settingB="([^"]*)",\s+theme="[^"]*",\s+k=(\d+)\s+objective pairs,\s+n=(\d+)\s+interesting objects,\s+m=(\d+)\s+obstacles/g;
 	const phases: DualPhaseSpec[] = [];
 	for (const match of userMessage.matchAll(re)) {
-		const phaseNumber = Number(match[1]);
-		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) continue;
 		phases.push({
-			phaseNumber: phaseNumber as 1 | 2 | 3,
+			tag: `p${match[1]}`,
 			settingA: match[2] ?? "",
 			settingB: match[3] ?? "",
 			k: Number(match[4]),
@@ -230,7 +226,7 @@ function buildDualContentPackResponseBody(body: ParsedBody): string {
 	const userMsg = body?.messages?.[1]?.content ?? "";
 	const phases = parseDualContentPackPhases(userMsg);
 	const resultPhases = phases.map((phase) => {
-		const tag = `p${phase.phaseNumber}`;
+		const tag = phase.tag;
 
 		const buildPack = (setting: string, ab: "a" | "b") => {
 			const objectivePairs = Array.from({ length: phase.k }, (_, i) => {
@@ -291,7 +287,6 @@ function buildDualContentPackResponseBody(body: ParsedBody): string {
 		};
 
 		return {
-			phaseNumber: phase.phaseNumber,
 			packA: buildPack(phase.settingA, "a"),
 			packB: buildPack(phase.settingB, "b"),
 		};
@@ -314,7 +309,7 @@ function buildContentPackResponseBody(body: ParsedBody): string {
 	const userMsg = body?.messages?.[1]?.content ?? "";
 	const phases = parseContentPackPhases(userMsg);
 	const packs = phases.map((phase) => {
-		const tag = `p${phase.phaseNumber}`;
+		const tag = phase.tag;
 		const objectivePairs = Array.from({ length: phase.k }, (_, i) => {
 			const spaceId = `${tag}-spc-${i}`;
 			const objectId = `${tag}-obj-${i}`;
@@ -361,7 +356,6 @@ function buildContentPackResponseBody(body: ParsedBody): string {
 			examineDescription: `Stub obstacle ${tag}-obs-${i}.`,
 		}));
 		return {
-			phaseNumber: phase.phaseNumber,
 			setting: phase.setting,
 			objectivePairs,
 			interestingObjects,

--- a/e2e/responsive-bento.spec.ts
+++ b/e2e/responsive-bento.spec.ts
@@ -411,8 +411,8 @@ test("mobile header: HI-BLUE title visible left, cog right; compact topinfo", as
 	expect(probe.mobileVisible).toBe(true);
 	expect(probe.leftHidden).toBe(true);
 	expect(probe.rightHidden).toBe(true);
-	// Format: "0xXXXX · 01/03 · TRN N" — assert structure with regex.
-	expect(probe.mobileText).toMatch(/^0x[0-9A-F]{4} · \d{2}\/\d{2} · TRN \d+$/);
+	// Format: "0xXXXX · EPC NN · TRN N" — assert structure with regex.
+	expect(probe.mobileText).toMatch(/^0x[0-9A-F]{4} · EPC \d{2} · TRN \d+$/);
 	// And it shouldn't include the desktop labels.
 	expect(probe.mobileText).not.toContain("SESSION");
 	expect(probe.mobileText).not.toContain("PHASE");

--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -66,7 +66,6 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 				west: { shortName: 'Forest', horizonPhrase: 'A dark forest.' },
 			};
 			const stubPack = {
-				phaseNumber: 1,
 				setting: 'test setting',
 				weather: 'clear',
 				timeOfDay: 'morning',
@@ -77,7 +76,7 @@ function seedOkSessionScript(id: string, lastSavedAt: string): string {
 				landmarks: stubLandmarks,
 			};
 			const payload = JSON.stringify({
-				schemaVersion: 7,
+				schemaVersion: 8,
 				isComplete: false,
 				world: { entities: [] },
 				budgets: { red: { remaining: 50, total: 50 } },

--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -385,7 +385,7 @@ test("refresh on #/sessions paints banner and topinfo", async ({ page }) => {
 	await expect(page.locator("#sessions-screen")).toBeVisible();
 	await expect(page.locator("#banner")).not.toBeEmpty();
 	await expect(page.locator("#topinfo-left")).toContainText("SESSION 0x");
-	await expect(page.locator("#topinfo-left")).toContainText("PHASE");
+	await expect(page.locator("#topinfo-left")).toContainText("EPOCH");
 	await expect(page.locator("#topinfo-right")).toContainText(
 		"connection stable",
 	);

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -521,11 +521,9 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 	const engineData = JSON.parse(engineJson) as {
 		personaSpatial: Record<string, PersonaSpatial>;
 		contentPacksA: Array<{
-			phaseNumber: number;
 			obstacles: Array<{ holder: GridPosition | null }>;
 		}>;
 		contentPacksB: Array<{
-			phaseNumber: number;
 			obstacles: Array<{ holder: GridPosition | null }>;
 		}>;
 		activePackId: "A" | "B";
@@ -541,7 +539,7 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 		engineData.activePackId === "B"
 			? engineData.contentPacksB
 			: engineData.contentPacksA;
-	const phase1Pack = activePacks.find((p) => p.phaseNumber === 1);
+	const phase1Pack = activePacks[0];
 	const obstaclePositions: GridPosition[] = (phase1Pack?.obstacles ?? [])
 		.map((o) => o.holder)
 		.filter((h): h is GridPosition => h !== null);

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -58,7 +58,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 };
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -46,7 +46,6 @@ const CARDINAL = new Set(["north", "south", "east", "west"]);
 /** Minimal k=1, n=1, m=1 — stays well within the 5x5 grid. */
 const FIXED_PHASE_CONFIGS: [PhaseConfig, PhaseConfig, PhaseConfig] = [
 	{
-		phaseNumber: 1,
 		kRange: [1, 1],
 		nRange: [1, 1],
 		mRange: [1, 1],
@@ -54,7 +53,6 @@ const FIXED_PHASE_CONFIGS: [PhaseConfig, PhaseConfig, PhaseConfig] = [
 		aiGoalPool: ["find the key"],
 	},
 	{
-		phaseNumber: 2,
 		kRange: [1, 1],
 		nRange: [1, 1],
 		mRange: [1, 1],
@@ -62,7 +60,6 @@ const FIXED_PHASE_CONFIGS: [PhaseConfig, PhaseConfig, PhaseConfig] = [
 		aiGoalPool: ["guard the door"],
 	},
 	{
-		phaseNumber: 3,
 		kRange: [1, 1],
 		nRange: [1, 1],
 		mRange: [1, 1],
@@ -93,49 +90,48 @@ function makeMockProvider(): MockContentPackProvider {
 	return new MockContentPackProvider(
 		(input: ContentPackProviderInput): ContentPackProviderResult => {
 			const packs: ContentPackProviderResult["packs"] = input.phases.map(
-				(phase) => {
-					const phaseNumber = phase.phaseNumber;
-					const spaceId = `p${phaseNumber}_space`;
-					const objId = `p${phaseNumber}_obj`;
-					const interestingId = `p${phaseNumber}_interesting`;
-					const obstacleId = `p${phaseNumber}_obstacle`;
+				(phase, phaseIdx) => {
+					const pn = phaseIdx + 1;
+					const spaceId = `p${pn}_space`;
+					const objId = `p${pn}_obj`;
+					const interestingId = `p${pn}_interesting`;
+					const obstacleId = `p${pn}_obstacle`;
 
 					return {
-						phaseNumber,
 						setting: phase.setting,
 						objectivePairs: Array.from({ length: phase.k }, (_, i) => ({
 							space: {
 								id: `${spaceId}_${i}`,
 								kind: "objective_space" as const,
-								name: `Space ${phaseNumber} ${i}`,
-								examineDescription: `A space in phase ${phaseNumber}.`,
+								name: `Space ${pn} ${i}`,
+								examineDescription: `A space in phase ${pn}.`,
 								holder: { row: 0, col: 0 } as never,
 							},
 							object: {
 								id: `${objId}_${i}`,
 								kind: "objective_object" as const,
-								name: `Object ${phaseNumber} ${i}`,
-								examineDescription: `An object in phase ${phaseNumber} that belongs on Space ${phaseNumber} ${i}.`,
-								useOutcome: `You use object ${phaseNumber} ${i}.`,
+								name: `Object ${pn} ${i}`,
+								examineDescription: `An object in phase ${pn} that belongs on Space ${pn} ${i}.`,
+								useOutcome: `You use object ${pn} ${i}.`,
 								pairsWithSpaceId: `${spaceId}_${i}`,
-								placementFlavor: `{actor} places the object on the space in phase ${phaseNumber}.`,
-								proximityFlavor: `The object hums near its space in phase ${phaseNumber}.`,
+								placementFlavor: `{actor} places the object on the space in phase ${pn}.`,
+								proximityFlavor: `The object hums near its space in phase ${pn}.`,
 								holder: { row: 0, col: 0 } as never,
 							},
 						})),
 						interestingObjects: Array.from({ length: phase.n }, (_, i) => ({
 							id: `${interestingId}_${i}`,
 							kind: "interesting_object" as const,
-							name: `Interesting ${phaseNumber} ${i}`,
-							examineDescription: `Something interesting in phase ${phaseNumber}.`,
-							useOutcome: `You interact with interesting ${phaseNumber} ${i}.`,
+							name: `Interesting ${pn} ${i}`,
+							examineDescription: `Something interesting in phase ${pn}.`,
+							useOutcome: `You interact with interesting ${pn} ${i}.`,
 							holder: { row: 0, col: 0 } as never,
 						})),
 						obstacles: Array.from({ length: phase.m }, (_, i) => ({
 							id: `${obstacleId}_${i}`,
 							kind: "obstacle" as const,
-							name: `Obstacle ${phaseNumber} ${i}`,
-							examineDescription: `An impassable obstacle in phase ${phaseNumber}.`,
+							name: `Obstacle ${pn} ${i}`,
+							examineDescription: `An impassable obstacle in phase ${pn}.`,
 							holder: { row: 0, col: 0 } as never,
 						})),
 						landmarks: DEFAULT_LANDMARKS,
@@ -222,7 +218,8 @@ describe("generateContentPacks — placement constraints", () => {
 			AI_IDS,
 		);
 
-		for (const pack of packs) {
+		for (let packIdx = 0; packIdx < packs.length; packIdx++) {
+			const pack = packs[packIdx] as ContentPack;
 			// Build obstacle set
 			const obstacleKeys = new Set(
 				pack.obstacles.map((obs) => {
@@ -236,7 +233,7 @@ describe("generateContentPacks — placement constraints", () => {
 				const key = gridPosKey(spatial.position);
 				expect(
 					obstacleKeys.has(key),
-					`Phase ${pack.phaseNumber}: AI ${aiId} start is on an obstacle`,
+					`Pack ${packIdx}: AI ${aiId} start is on an obstacle`,
 				).toBe(false);
 			}
 
@@ -246,7 +243,7 @@ describe("generateContentPacks — placement constraints", () => {
 				const spacePos = pair.space.holder as { row: number; col: number };
 				expect(
 					gridPosKey(objPos) === gridPosKey(spacePos),
-					`Phase ${pack.phaseNumber}: objective object ${pair.object.id} is on its paired space`,
+					`Pack ${packIdx}: objective object ${pair.object.id} is on its paired space`,
 				).toBe(false);
 			}
 
@@ -260,7 +257,7 @@ describe("generateContentPacks — placement constraints", () => {
 				const key = gridPosKey(pos);
 				expect(
 					obstacleKeys.has(key),
-					`Phase ${pack.phaseNumber}: entity ${entity.id} (${entity.kind}) is on an obstacle`,
+					`Pack ${packIdx}: entity ${entity.id} (${entity.kind}) is on an obstacle`,
 				).toBe(false);
 			}
 
@@ -281,7 +278,7 @@ describe("generateContentPacks — placement constraints", () => {
 				for (const cell of nonObstacleCells) {
 					expect(
 						reachable.has(cell),
-						`Phase ${pack.phaseNumber}: cell ${cell} not reachable from AI ${aiId} start`,
+						`Pack ${packIdx}: cell ${cell} not reachable from AI ${aiId} start`,
 					).toBe(true);
 				}
 			}
@@ -290,7 +287,7 @@ describe("generateContentPacks — placement constraints", () => {
 			for (const [aiId, spatial] of Object.entries(pack.aiStarts)) {
 				expect(
 					CARDINAL.has(spatial.facing),
-					`Phase ${pack.phaseNumber}: AI ${aiId} has non-cardinal facing "${spatial.facing}"`,
+					`Pack ${packIdx}: AI ${aiId} has non-cardinal facing "${spatial.facing}"`,
 				).toBe(true);
 			}
 
@@ -303,7 +300,7 @@ describe("generateContentPacks — placement constraints", () => {
 			for (const pair of pack.objectivePairs) {
 				expect(
 					pair.object.placementFlavor,
-					`Phase ${pack.phaseNumber}: object ${pair.object.id} missing placementFlavor`,
+					`Pack ${packIdx}: object ${pair.object.id} missing placementFlavor`,
 				).toBeTruthy();
 				expect(pair.object.placementFlavor).toContain("{actor}");
 			}
@@ -325,11 +322,11 @@ describe("generateContentPacks — placement constraints", () => {
 				const lm = pack.landmarks[dir];
 				expect(
 					lm.shortName,
-					`Phase ${pack.phaseNumber}: landmarks.${dir}.shortName missing`,
+					`Pack ${packIdx}: landmarks.${dir}.shortName missing`,
 				).toBeTruthy();
 				expect(
 					lm.horizonPhrase,
-					`Phase ${pack.phaseNumber}: landmarks.${dir}.horizonPhrase missing`,
+					`Pack ${packIdx}: landmarks.${dir}.horizonPhrase missing`,
 				).toBeTruthy();
 			}
 			// All four shortNames should be distinct (the mock returns DEFAULT_LANDMARKS
@@ -393,7 +390,6 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 		// This makes placement impossible.
 		const impossibleConfigs: [PhaseConfig, PhaseConfig, PhaseConfig] = [
 			{
-				phaseNumber: 1,
 				// k=0, n=0, m=23 → only 2 non-obstacle cells for 3 AI starts → impossible
 				kRange: [0, 0],
 				nRange: [0, 0],
@@ -402,7 +398,6 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 				aiGoalPool: ["survive"],
 			},
 			{
-				phaseNumber: 2,
 				kRange: [0, 0],
 				nRange: [0, 0],
 				mRange: [23, 23],
@@ -410,7 +405,6 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 				aiGoalPool: ["survive"],
 			},
 			{
-				phaseNumber: 3,
 				kRange: [0, 0],
 				nRange: [0, 0],
 				mRange: [23, 23],
@@ -423,13 +417,12 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 
 		const impossibleProvider = new MockContentPackProvider(
 			(input: ContentPackProviderInput): ContentPackProviderResult => ({
-				packs: input.phases.map((phase) => ({
-					phaseNumber: phase.phaseNumber,
+				packs: input.phases.map((phase, phaseIdx) => ({
 					setting: phase.setting,
 					objectivePairs: [],
 					interestingObjects: [],
 					obstacles: Array.from({ length: phase.m }, (_, i) => ({
-						id: `obstacle_p${phase.phaseNumber}_${i}`,
+						id: `obstacle_p${phaseIdx + 1}_${i}`,
 						kind: "obstacle" as const,
 						name: `Obstacle ${i}`,
 						examineDescription: "An impassable obstacle.",
@@ -477,8 +470,8 @@ function makeDualMockProvider(): MockContentPackProvider {
 			packs: [],
 		}),
 		(input: DualContentPackProviderInput): DualContentPackProviderResult => {
-			const phases = input.phases.map((phase) => {
-				const pn = phase.phaseNumber;
+			const phases = input.phases.map((phase, phaseIdx) => {
+				const pn = phaseIdx + 1;
 				const spaceId = `p${pn}_space`;
 				const objId = `p${pn}_obj`;
 				const intId = `p${pn}_interesting`;
@@ -488,7 +481,6 @@ function makeDualMockProvider(): MockContentPackProvider {
 					setting: string,
 					suffix: string,
 				): DualContentPackProviderResult["phases"][number]["packA"] => ({
-					phaseNumber: pn,
 					setting,
 					objectivePairs: Array.from({ length: phase.k }, (_, i) => ({
 						space: {
@@ -530,7 +522,6 @@ function makeDualMockProvider(): MockContentPackProvider {
 				});
 
 				return {
-					phaseNumber: pn,
 					packA: makePackVariant(phase.settingA, "A"),
 					packB: makePackVariant(phase.settingB, "B"),
 				};
@@ -568,7 +559,6 @@ describe("generateDualContentPacks — entity ID parity (issue #302)", () => {
 		for (let i = 0; i < 3; i++) {
 			const packA = packsA[i] as ContentPack;
 			const packB = packsB[i] as ContentPack;
-			expect(packA.phaseNumber).toBe(packB.phaseNumber);
 			expect(allEntityIds(packA)).toEqual(allEntityIds(packB));
 		}
 	});

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -49,7 +49,6 @@ export interface SingleGameConfig {
  * @deprecated use SingleGameConfig + generateContentPack
  */
 export interface PhaseConfig {
-	phaseNumber: 1 | 2 | 3;
 	kRange: [number, number];
 	nRange: [number, number];
 	mRange: [number, number];
@@ -272,13 +271,13 @@ function placePhases(
 	packs: ContentPack[],
 	aiIds: AiId[],
 ): ContentPack[] {
-	return packs.map((pack) => {
+	return packs.map((pack, i) => {
 		for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 			const result = tryPlacePhase(rng, pack, aiIds);
 			if (result !== null) return result;
 		}
 		throw new Error(
-			`generateContentPacks: could not place phase ${pack.phaseNumber} after ${MAX_ATTEMPTS} attempts. ` +
+			`generateContentPacks: could not place phase ${i + 1} after ${MAX_ATTEMPTS} attempts. ` +
 				`Check that m (${pack.obstacles.length}) obstacles leave enough room for AI starts and entities.`,
 		);
 	});
@@ -335,7 +334,6 @@ export async function generateContentPacks(
 	// Roll k/n/m per phase
 	const phaseInputs: ContentPackProviderInput["phases"] = configs.map(
 		(cfg, i) => ({
-			phaseNumber: cfg.phaseNumber,
 			setting: drawnSettings[i] as string,
 			theme: drawnThemes[i] as string,
 			k: rollInt(rng, cfg.kRange[0], cfg.kRange[1]),
@@ -355,9 +353,6 @@ export async function generateContentPacks(
 
 	// Build placeholder ContentPack structures from LLM result (no placements yet)
 	const unplacedPacks: ContentPack[] = llmResult.packs.map((pack, i) => ({
-		...(pack.phaseNumber !== undefined
-			? { phaseNumber: pack.phaseNumber as 1 | 2 | 3 }
-			: {}),
 		setting: pack.setting,
 		weather: drawnWeather[i] as string,
 		timeOfDay: drawnTimeOfDay[i] as string,
@@ -438,7 +433,6 @@ export async function generateDualContentPacks(
 	// Roll k/n/m per phase (shared between A and B — same entity counts)
 	const phaseInputs: DualContentPackProviderInput["phases"] = configs.map(
 		(cfg, i) => ({
-			phaseNumber: cfg.phaseNumber,
 			settingA: settingsA[i] as string,
 			settingB: settingsB[i] as string,
 			theme: drawnThemes[i] as string,
@@ -457,7 +451,6 @@ export async function generateDualContentPacks(
 
 	// Build unplaced Pack A and Pack B from LLM result
 	const unplacedPacksA: ContentPack[] = llmResult.phases.map((ph, i) => ({
-		phaseNumber: ph.phaseNumber,
 		setting: ph.packA.setting,
 		weather: drawnWeatherA[i] as string,
 		timeOfDay: drawnTimeOfDayA[i] as string,
@@ -494,7 +487,6 @@ export async function generateDualContentPacks(
 		});
 
 		return {
-			phaseNumber: ph.phaseNumber,
 			setting: ph.packB.setting,
 			weather: drawnWeatherB[i] as string,
 			timeOfDay: drawnTimeOfDayB[i] as string,
@@ -551,7 +543,6 @@ export async function generateContentPack(
 
 	// Roll k/n/m
 	const phaseInput: ContentPackProviderInput["phases"][number] = {
-		phaseNumber: 1,
 		setting,
 		theme,
 		k: rollInt(rng, config.kRange[0], config.kRange[1]),
@@ -573,7 +564,6 @@ export async function generateContentPack(
 	if (!pack) throw new Error("generateContentPack: LLM returned no packs");
 
 	const unplacedPack: ContentPack = {
-		phaseNumber: 1,
 		setting: pack.setting,
 		weather,
 		timeOfDay,

--- a/src/spa/__tests__/fixtures/static-content-packs.ts
+++ b/src/spa/__tests__/fixtures/static-content-packs.ts
@@ -12,7 +12,6 @@ const AI_STARTS: ContentPack["aiStarts"] = {
  * to end via the vacuous win condition on the first round (#295 flat model).
  */
 export const STATIC_CONTENT_PACK_NO_PAIRS: ContentPack = {
-	phaseNumber: 1,
 	setting: "abandoned subway station",
 	weather: "",
 	timeOfDay: "",
@@ -29,7 +28,6 @@ export const STATIC_CONTENT_PACK_NO_PAIRS: ContentPack = {
  */
 export const STATIC_CONTENT_PACKS: ContentPack[] = [
 	{
-		phaseNumber: 1,
 		setting: "abandoned subway station",
 		weather: "",
 		timeOfDay: "",
@@ -58,7 +56,6 @@ export const STATIC_CONTENT_PACKS: ContentPack[] = [
 		aiStarts: AI_STARTS,
 	},
 	{
-		phaseNumber: 2,
 		setting: "sun-baked salt flat",
 		weather: "",
 		timeOfDay: "",
@@ -87,7 +84,6 @@ export const STATIC_CONTENT_PACKS: ContentPack[] = [
 		aiStarts: AI_STARTS,
 	},
 	{
-		phaseNumber: 3,
 		setting: "forgotten laboratory",
 		weather: "",
 		timeOfDay: "",

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -179,7 +179,6 @@ describe("renderGame — session restore (formerly async bootstrap)", () => {
 
 describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 	const TEST_CONTENT_PACK: ContentPack = {
-		phaseNumber: 1,
 		setting: "",
 		weather: "",
 		timeOfDay: "",

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -19,7 +19,6 @@ import { STATIC_CONTENT_PACKS } from "./fixtures/static-content-packs";
 import { STATIC_PERSONAS } from "./fixtures/static-personas";
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/__tests__/sessions.test.ts
+++ b/src/spa/__tests__/sessions.test.ts
@@ -22,7 +22,6 @@ import {
 // ── Test fixture ──────────────────────────────────────────────────────────────
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -87,9 +87,9 @@ export interface TopInfoInputs {
 }
 
 export function formatTopInfoLeft(i: TopInfoInputs): string {
-	const phase = `${String(i.phaseNumber).padStart(2, "0")}/${String(i.totalPhases).padStart(2, "0")}`;
+	const epoch = `${String(i.phaseNumber).padStart(2, "0")}`;
 	const turn = String(i.turn).padStart(1, "0");
-	return `SESSION ${i.sessionId} · PHASE ${phase} · TURN ${turn}`;
+	return `SESSION ${i.sessionId} · EPOCH ${epoch} · TURN ${turn}`;
 }
 
 /**
@@ -103,8 +103,8 @@ export function renderTopInfoLeft(el: HTMLElement, i: TopInfoInputs): void {
 /** Compact form rendered into `#topinfo-mobile` for the <=720px bento
  * layout — drops the labels and the connection trailer. */
 export function formatTopInfoMobile(i: TopInfoInputs): string {
-	const phase = `${String(i.phaseNumber).padStart(2, "0")}/${String(i.totalPhases).padStart(2, "0")}`;
-	return `${i.sessionId} · ${phase} · TRN ${i.turn}`;
+	const epoch = `${String(i.phaseNumber).padStart(2, "0")}`;
+	return `${i.sessionId} · EPOCH ${epoch} · TRN ${i.turn}`;
 }
 
 export const TOPINFO_RIGHT_OK_TEXT = "● connection stable";

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -81,13 +81,12 @@ export function initPanelChrome(panel: HTMLElement, persona: AiPersona): void {
 
 export interface TopInfoInputs {
 	sessionId: string;
-	phaseNumber: number;
-	totalPhases: number;
+	epoch: number;
 	turn: number;
 }
 
 export function formatTopInfoLeft(i: TopInfoInputs): string {
-	const epoch = `${String(i.phaseNumber).padStart(2, "0")}`;
+	const epoch = `${String(i.epoch).padStart(2, "0")}`;
 	const turn = String(i.turn).padStart(1, "0");
 	return `SESSION ${i.sessionId} · EPOCH ${epoch} · TURN ${turn}`;
 }
@@ -103,7 +102,7 @@ export function renderTopInfoLeft(el: HTMLElement, i: TopInfoInputs): void {
 /** Compact form rendered into `#topinfo-mobile` for the <=720px bento
  * layout — drops the labels and the connection trailer. */
 export function formatTopInfoMobile(i: TopInfoInputs): string {
-	const epoch = `${String(i.phaseNumber).padStart(2, "0")}`;
+	const epoch = `${String(i.epoch).padStart(2, "0")}`;
 	return `${i.sessionId} · EPC ${epoch} · TRN ${i.turn}`;
 }
 

--- a/src/spa/bbs-chrome.ts
+++ b/src/spa/bbs-chrome.ts
@@ -104,7 +104,7 @@ export function renderTopInfoLeft(el: HTMLElement, i: TopInfoInputs): void {
  * layout — drops the labels and the connection trailer. */
 export function formatTopInfoMobile(i: TopInfoInputs): string {
 	const epoch = `${String(i.phaseNumber).padStart(2, "0")}`;
-	return `${i.sessionId} · EPOCH ${epoch} · TRN ${i.turn}`;
+	return `${i.sessionId} · EPC ${epoch} · TRN ${i.turn}`;
 }
 
 export const TOPINFO_RIGHT_OK_TEXT = "● connection stable";

--- a/src/spa/game/__tests__/available-tools.test.ts
+++ b/src/spa/game/__tests__/available-tools.test.ts
@@ -56,7 +56,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 /** Build a minimal game with three daemons and no interesting entities in the world. */
 function makeGame() {
 	const pack: ContentPack = {
-		phaseNumber: 1,
 		setting: "abandoned subway station",
 		weather: "clear",
 		timeOfDay: "night",
@@ -238,7 +237,6 @@ function makeGameWithSpace(
 		pairsWithSpaceId: "space1",
 	};
 	const pack: ContentPack = {
-		phaseNumber: 1,
 		setting: "test",
 		weather: "",
 		timeOfDay: "",

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -114,7 +114,6 @@ function makePhase(overrides: Partial<GameState> = {}): GameState {
 	}
 
 	const contentPack: ContentPack = {
-		phaseNumber: 1,
 		setting: "test",
 		weather: "clear",
 		timeOfDay: "day",
@@ -809,7 +808,6 @@ describe("applyComplicationResult — activeComplications appends", () => {
 
 describe("applyComplicationResult — setting_shift swaps active pack", () => {
 	const PACK_A: ContentPack = {
-		phaseNumber: 1,
 		setting: "neon arcade",
 		weather: "clear",
 		timeOfDay: "night",
@@ -821,7 +819,6 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 	};
 
 	const PACK_B: ContentPack = {
-		phaseNumber: 1,
 		setting: "sun-baked salt flat",
 		weather: "hot",
 		timeOfDay: "day",
@@ -935,7 +932,6 @@ describe("startGame — complicationSchedule initialisation", () => {
 		const phase = startGame(
 			TEST_PERSONAS,
 			{
-				phaseNumber: 1,
 				setting: "",
 				weather: "",
 				timeOfDay: "",

--- a/src/spa/game/__tests__/complications.test.ts
+++ b/src/spa/game/__tests__/complications.test.ts
@@ -69,7 +69,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 /** Build a game with a specific weather value in the active phase. */
 function makeGameWithWeather(weather: string) {
 	const pack: ContentPack = {
-		phaseNumber: 1,
 		setting: "abandoned subway station",
 		weather,
 		timeOfDay: "night",
@@ -203,7 +202,6 @@ function makeObstacle(
 function makeGameWithObstacle(obstaclePos: GridPosition, shiftFlavor?: string) {
 	const obstacle = makeObstacle("obs1", obstaclePos, shiftFlavor);
 	const pack: ContentPack = {
-		phaseNumber: 1,
 		setting: "test setting",
 		weather: "clear",
 		timeOfDay: "day",
@@ -273,7 +271,6 @@ describe("obstacleShiftComplication", () => {
 			"A heavy crate scrapes across the floor.",
 		);
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test setting",
 			weather: "clear",
 			timeOfDay: "day",
@@ -319,7 +316,6 @@ describe("obstacleShiftComplication", () => {
 		const flavor = "A heavy crate scrapes across the floor.";
 		const obstacle = makeObstacle("obs1", { row: 3, col: 2 }, flavor);
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test setting",
 			weather: "clear",
 			timeOfDay: "day",
@@ -360,7 +356,6 @@ describe("obstacleShiftComplication", () => {
 		// Obstacle without shiftFlavor field
 		const obstacle = makeObstacle("obs1", { row: 3, col: 2 });
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test setting",
 			weather: "clear",
 			timeOfDay: "day",

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -116,7 +116,6 @@ describe("validateContentPacks — prose tell contract", () => {
 	const input = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				setting: "abandoned subway station",
 				theme: "mundane",
 				k: 1,
@@ -155,7 +154,6 @@ describe("validateContentPacks — prose tell contract", () => {
 		return {
 			packs: [
 				{
-					phaseNumber: 1,
 					setting: "abandoned subway station",
 					objectivePairs: [
 						{
@@ -263,7 +261,6 @@ describe("validateContentPacks — obstacle shiftFlavor validation", () => {
 	const inputWithObstacle = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				setting: "abandoned subway station",
 				theme: "mundane",
 				k: 0,
@@ -277,7 +274,6 @@ describe("validateContentPacks — obstacle shiftFlavor validation", () => {
 		return {
 			packs: [
 				{
-					phaseNumber: 1,
 					setting: "abandoned subway station",
 					objectivePairs: [],
 					interestingObjects: [],
@@ -366,7 +362,6 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 	const inputWithPair = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				setting: "abandoned subway station",
 				theme: "mundane",
 				k: 1,
@@ -402,7 +397,6 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 		return {
 			packs: [
 				{
-					phaseNumber: 1,
 					setting: "abandoned subway station",
 					objectivePairs: [
 						{
@@ -706,7 +700,6 @@ describe("validateContentPacks — interesting_object Use-Item flavor validation
 	const inputWithInteresting = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				setting: "abandoned subway station",
 				theme: "mundane",
 				k: 0,
@@ -734,7 +727,6 @@ describe("validateContentPacks — interesting_object Use-Item flavor validation
 		return {
 			packs: [
 				{
-					phaseNumber: 1,
 					setting: "abandoned subway station",
 					objectivePairs: [],
 					interestingObjects: [item],
@@ -870,7 +862,6 @@ describe("validateContentPacks — objective_space activationFlavor & prose tell
 	const inputWithPair = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				setting: "abandoned subway station",
 				theme: "mundane",
 				k: 1,
@@ -886,7 +877,6 @@ describe("validateContentPacks — objective_space activationFlavor & prose tell
 		return {
 			packs: [
 				{
-					phaseNumber: 1,
 					setting: "abandoned subway station",
 					objectivePairs: [
 						{
@@ -1055,7 +1045,6 @@ describe("validateDualContentPacks — objective_space activationFlavor", () => 
 	const dualInput = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				settingA: "abandoned subway station",
 				settingB: "sun-baked salt flat",
 				theme: "mundane",
@@ -1130,7 +1119,6 @@ describe("validateDualContentPacks — objective_space activationFlavor", () => 
 		return {
 			phases: [
 				{
-					phaseNumber: 1,
 					packA: mkPack(
 						"abandoned subway station",
 						"Iron Key",
@@ -1204,7 +1192,6 @@ describe("validateDualContentPacks — obstacle shiftFlavor validation", () => {
 	const dualInputWithObstacle = {
 		phases: [
 			{
-				phaseNumber: 1 as const,
 				settingA: "abandoned subway station",
 				settingB: "overgrown ruin",
 				theme: "mundane",
@@ -1236,7 +1223,6 @@ describe("validateDualContentPacks — obstacle shiftFlavor validation", () => {
 		return {
 			phases: [
 				{
-					phaseNumber: 1,
 					packA: {
 						setting: "abandoned subway station",
 						objectivePairs: [],

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -95,7 +95,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
  *   dist-2: (2,2), (2,1), (2,0), (2,-1 OOB), (2,-2 OOB)
  */
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "test chamber",
 	weather: "",
 	timeOfDay: "",
@@ -474,7 +473,6 @@ describe("conversation log integration — action-failure (issue #287)", () => {
 	it("dispatch invalid go then buildConversationLog contains one line matching 'Your `go` action failed:'", async () => {
 		// Use a ContentPack where red faces south and there's an obstacle directly south.
 		const obstacleAtSouth: ContentPack = {
-			phaseNumber: 1,
 			setting: "blocked test",
 			weather: "",
 			timeOfDay: "",

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -103,7 +103,6 @@ function makePackWithEntities(
 		makeEntity(`obs${i}`, "obstacle", pos),
 	);
 	return {
-		phaseNumber: 1,
 		setting: "test setting",
 		weather: "",
 		timeOfDay: "",
@@ -350,7 +349,6 @@ describe("validateToolCall", () => {
 			pairsWithSpaceId: "space1",
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",
@@ -396,7 +394,6 @@ describe("executeToolCall — use placement via front arc", () => {
 			holder: { row: 1, col: 0 },
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",
@@ -441,7 +438,6 @@ describe("executeToolCall — use placement via front arc", () => {
 			holder: { row: 1, col: 0 },
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",
@@ -859,7 +855,6 @@ describe("dispatchAiTurn", () => {
 			holder: { row: 0, col: 0 }, // red's cell
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",
@@ -957,7 +952,6 @@ describe("dispatchAiTurn", () => {
 			holder: { row: 3, col: 3 }, // different from red's cell (0,0)
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",
@@ -1005,7 +999,6 @@ describe("dispatchAiTurn", () => {
 			col: 0,
 		});
 		const packWithCone: ContentPack = {
-			phaseNumber: 1,
 			setting: "cone test",
 			weather: "",
 			timeOfDay: "",
@@ -1378,7 +1371,6 @@ function makeGameWithSpaceObjective(
 		spaceId: "shrine",
 	};
 	const pack: ContentPack = {
-		phaseNumber: 1,
 		setting: "test",
 		weather: "",
 		timeOfDay: "",
@@ -1528,7 +1520,6 @@ describe("dispatchAiTurn — use on objective_space witnesses satisfactionFlavor
 			spaceId: "shrine",
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",
@@ -1799,7 +1790,6 @@ describe("dispatchAiTurn — use on objective_space surfaces activationFlavor to
 			spaceId: "shrine",
 		};
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "test",
 			weather: "",
 			timeOfDay: "",

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -54,7 +54,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 };
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -87,7 +87,6 @@ const MINIMAL_CONTENT_PACK: ContentPack = {
  * with AIs at (0,0)=red, (0,1)=green, (0,2)=cyan facing north.
  */
 const CONTENT_PACK_WITH_ITEMS: ContentPack = {
-	phaseNumber: 1,
 	setting: "test setting",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -66,7 +66,6 @@ function expectedSilentTurn(_self: AiId): string {
 }
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -56,7 +56,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 };
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -62,7 +62,6 @@ function makeEntity(
 }
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",
@@ -176,7 +175,6 @@ describe("buildAiContext", () => {
 	it("renders to a system prompt string", () => {
 		// Use a ContentPack with items at (0,0) so red sees them in its cell
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -222,7 +220,6 @@ describe("buildAiContext", () => {
 describe("<setting> block", () => {
 	it("emits <setting> block when phase has a setting noun", () => {
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "abandoned subway station",
 			weather: "",
 			timeOfDay: "",
@@ -256,7 +253,6 @@ describe("<setting> block", () => {
 	it("setting noun appears verbatim in the Setting section", () => {
 		const settingNoun = "sun-baked salt flat";
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: settingNoun,
 			weather: "",
 			timeOfDay: "",
@@ -312,7 +308,6 @@ describe("prompt-builder — spatial 'Where you are' section (current-state user
 
 	it("lists items in the actor's cell under 'Where you are'", () => {
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -745,7 +740,6 @@ describe("<what_you_see> (cone)", () => {
 	it("item in cone cell is listed under 'Directly in front'", () => {
 		// Place flower at (1,0) and use ContentPack with aiStarts so red is at (0,0) facing south.
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -816,7 +810,6 @@ describe("<what_you_see> (cone)", () => {
 		// Place an obstacle named "concrete column" at (1,0) via ContentPack.
 		// Red faces south from (0,0).
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -842,7 +835,6 @@ describe("<what_you_see> (cone)", () => {
 	it("other AI visible in cone is rendered with its color in parentheses", () => {
 		// Use ContentPack to place red at (0,0) facing south, green at (1,0).
 		const pack: ContentPack = {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -1162,7 +1154,6 @@ describe("proximityFlavor sense line", () => {
 			holder: opts.spacePosition,
 		};
 		return {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -1444,7 +1435,6 @@ describe("postLookFlavor swap covers satisfied interesting_object", () => {
 				: {}),
 		};
 		return {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",

--- a/src/spa/game/__tests__/round-coordinator-convergence.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-convergence.test.ts
@@ -81,7 +81,6 @@ const CONVERGENCE_OBJECT: WorldEntity = {
 };
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/round-coordinator-sysadmin-directive.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-sysadmin-directive.test.ts
@@ -55,7 +55,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 };
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -74,7 +74,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
  * red→(0,0), green→(0,1), cyan→(0,2) facing north.
  */
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",
@@ -1223,7 +1222,6 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 		 * The key entity must be an interesting_object held by red (so use is valid).
 		 */
 		const packWithKey: ContentPack = {
-			phaseNumber: 1,
 			setting: "",
 			weather: "",
 			timeOfDay: "",
@@ -1820,7 +1818,6 @@ describe("placement flavor + win condition (issue #126)", () => {
 	const FLAVOR = "{actor} places the gem on the altar.";
 
 	const PHASE1_PACK_K1: ContentPack = {
-		phaseNumber: 1,
 		setting: "temple",
 		weather: "",
 		timeOfDay: "",
@@ -1965,7 +1962,6 @@ describe("placement flavor + win condition (issue #126)", () => {
 		const ORB_SPACE_ID = "orb_space";
 
 		const packK2: ContentPack = {
-			phaseNumber: 1,
 			setting: "vault",
 			weather: "",
 			timeOfDay: "",
@@ -2059,7 +2055,6 @@ describe("examine tool", () => {
 	 * Green starts at (0,1) facing north — so (0,0) is NOT in green's cone.
 	 */
 	const EXAMINE_PACK: ContentPack = {
-		phaseNumber: 1,
 		setting: "vault",
 		weather: "",
 		timeOfDay: "",
@@ -2997,7 +2992,6 @@ describe("action-failure entries — round-coordinator integration", () => {
 	 * go east → blocked by obstacle → action-failure entry.
 	 */
 	const OBSTACLE_PACK: ContentPack = {
-		phaseNumber: 1,
 		setting: "blocked corridor",
 		weather: "",
 		timeOfDay: "",

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -63,7 +63,6 @@ const TEST_PERSONAS: Record<AiId, AiPersona> = {
 };
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/tool-call-history.test.ts
+++ b/src/spa/game/__tests__/tool-call-history.test.ts
@@ -44,7 +44,6 @@ const TEST_PERSONAS: Record<string, AiPersona> = {
 import type { ContentPack } from "../types";
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -64,7 +64,6 @@ function makeObjectivePair(
 
 function makeContentPack(pairs: ObjectivePair[]): ContentPack {
 	return {
-		phaseNumber: 1,
 		setting: "test",
 		weather: "",
 		timeOfDay: "",

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -72,11 +72,7 @@ function buildLegacyPhaseConfigs(): [PhaseConfig, PhaseConfig, PhaseConfig] {
 		budgetPerAi: SINGLE_GAME_CONFIG.budgetPerAi,
 		aiGoalPool: [] as string[],
 	};
-	return [
-		{ phaseNumber: 1 as const, ...base },
-		{ phaseNumber: 2 as const, ...base },
-		{ phaseNumber: 3 as const, ...base },
-	];
+	return [{ ...base }, { ...base }, { ...base }];
 }
 
 /**

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -54,7 +54,6 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
 {
   "packs": [
     {
-      "phaseNumber": <1|2|3>,
       "setting": "<setting noun>",
       "objectivePairs": [
         {
@@ -80,7 +79,6 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
 
 export interface ContentPackProviderInput {
 	phases: Array<{
-		phaseNumber: 1 | 2 | 3;
 		setting: string;
 		theme: string;
 		k: number;
@@ -93,8 +91,8 @@ export function buildContentPackUserMessage(
 	input: ContentPackProviderInput,
 ): string {
 	const lines = input.phases.map(
-		(p) =>
-			`Phase ${p.phaseNumber}: setting="${p.setting}", theme="${p.theme}", k=${p.k} objective pairs, n=${p.n} interesting objects, m=${p.m} obstacles`,
+		(p, i) =>
+			`Phase ${i + 1}: setting="${p.setting}", theme="${p.theme}", k=${p.k} objective pairs, n=${p.n} interesting objects, m=${p.m} obstacles`,
 	);
 	return `Generate content packs for these phases:\n${lines.join("\n")}`;
 }
@@ -161,7 +159,6 @@ Return ONLY valid JSON (no markdown, no preamble):
 {
   "phases": [
     {
-      "phaseNumber": <1|2|3>,
       "packA": {
         "setting": "<settingA>",
         "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "activationFlavor": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "...", "convergenceTier1ActorFlavor": "...", "convergenceTier2ActorFlavor": "..." } }],
@@ -183,7 +180,6 @@ Return ONLY valid JSON (no markdown, no preamble):
 /** Input for dual-pack (A/B) generation. */
 export interface DualContentPackProviderInput {
 	phases: Array<{
-		phaseNumber: 1 | 2 | 3;
 		settingA: string;
 		settingB: string;
 		theme: string;
@@ -200,7 +196,6 @@ type UnplacedPack = Omit<ContentPack, "aiStarts" | "weather" | "timeOfDay"> & {
 
 export interface DualContentPackProviderResult {
 	phases: Array<{
-		phaseNumber: 1 | 2 | 3;
 		packA: UnplacedPack;
 		packB: UnplacedPack;
 	}>;
@@ -210,8 +205,8 @@ export function buildDualContentPackUserMessage(
 	input: DualContentPackProviderInput,
 ): string {
 	const lines = input.phases.map(
-		(p) =>
-			`Phase ${p.phaseNumber}: settingA="${p.settingA}", settingB="${p.settingB}", theme="${p.theme}", k=${p.k} objective pairs, n=${p.n} interesting objects, m=${p.m} obstacles`,
+		(p, i) =>
+			`Phase ${i + 1}: settingA="${p.settingA}", settingB="${p.settingB}", theme="${p.theme}", k=${p.k} objective pairs, n=${p.n} interesting objects, m=${p.m} obstacles`,
 	);
 	return `Generate dual A/B content packs for these phases:\n${lines.join("\n")}`;
 }
@@ -683,27 +678,23 @@ export function validateContentPacks(
 	const allIds = new Set<string>();
 	const packs: ContentPackProviderResult["packs"] = [];
 
-	for (const packRaw of obj.packs) {
+	for (let i = 0; i < obj.packs.length; i++) {
+		const packRaw = obj.packs[i];
 		if (packRaw == null || typeof packRaw !== "object") {
 			throw new ContentPackError("Pack entry is not an object");
 		}
 		const pack = packRaw as Record<string, unknown>;
-		const phaseNumber = pack.phaseNumber as 1 | 2 | 3;
-		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) {
-			throw new ContentPackError(
-				`Invalid phaseNumber: ${String(pack.phaseNumber)}`,
-			);
-		}
-		const inputPhase = input.phases.find((p) => p.phaseNumber === phaseNumber);
+		const inputPhase = input.phases[i];
 		if (!inputPhase) {
-			throw new ContentPackError(`Unexpected phaseNumber: ${phaseNumber}`);
+			throw new ContentPackError(`No input phase for pack index ${i}`);
 		}
+		const phaseLabel = `Phase ${i + 1}`;
 		if (
 			typeof pack.setting !== "string" ||
 			pack.setting !== inputPhase.setting
 		) {
 			throw new ContentPackError(
-				`Phase ${phaseNumber}: setting mismatch. Expected "${inputPhase.setting}", got "${String(pack.setting)}"`,
+				`${phaseLabel}: setting mismatch. Expected "${inputPhase.setting}", got "${String(pack.setting)}"`,
 			);
 		}
 		if (
@@ -711,7 +702,7 @@ export function validateContentPacks(
 			pack.objectivePairs.length !== inputPhase.k
 		) {
 			throw new ContentPackError(
-				`Phase ${phaseNumber}: expected ${inputPhase.k} objectivePairs, got ${Array.isArray(pack.objectivePairs) ? pack.objectivePairs.length : "non-array"}`,
+				`${phaseLabel}: expected ${inputPhase.k} objectivePairs, got ${Array.isArray(pack.objectivePairs) ? pack.objectivePairs.length : "non-array"}`,
 			);
 		}
 		if (
@@ -719,7 +710,7 @@ export function validateContentPacks(
 			pack.interestingObjects.length !== inputPhase.n
 		) {
 			throw new ContentPackError(
-				`Phase ${phaseNumber}: expected ${inputPhase.n} interestingObjects, got ${Array.isArray(pack.interestingObjects) ? pack.interestingObjects.length : "non-array"}`,
+				`${phaseLabel}: expected ${inputPhase.n} interestingObjects, got ${Array.isArray(pack.interestingObjects) ? pack.interestingObjects.length : "non-array"}`,
 			);
 		}
 		if (
@@ -727,7 +718,7 @@ export function validateContentPacks(
 			pack.obstacles.length !== inputPhase.m
 		) {
 			throw new ContentPackError(
-				`Phase ${phaseNumber}: expected ${inputPhase.m} obstacles, got ${Array.isArray(pack.obstacles) ? pack.obstacles.length : "non-array"}`,
+				`${phaseLabel}: expected ${inputPhase.m} obstacles, got ${Array.isArray(pack.obstacles) ? pack.obstacles.length : "non-array"}`,
 			);
 		}
 
@@ -756,17 +747,17 @@ export function validateContentPacks(
 			// Verify pairsWithSpaceId resolves
 			if (object.pairsWithSpaceId !== space.id) {
 				throw new ContentPackError(
-					`Phase ${phaseNumber}: object ${object.id} pairsWithSpaceId "${object.pairsWithSpaceId}" does not match space id "${space.id}"`,
+					`${phaseLabel}: object ${object.id} pairsWithSpaceId "${object.pairsWithSpaceId}" does not match space id "${space.id}"`,
 				);
 			}
 			if (!examineMentionsPairedSpace(object.examineDescription, space.name)) {
 				console.warn(
-					`Phase ${phaseNumber}: object ${object.id} examineDescription does not mention paired space "${space.name}" (the AI-discoverable pairing tell).`,
+					`${phaseLabel}: object ${object.id} examineDescription does not mention paired space "${space.name}" (the AI-discoverable pairing tell).`,
 				);
 			}
 			if (!examineMentionsUseTell(space.examineDescription)) {
 				console.warn(
-					`Phase ${phaseNumber}: space ${space.id} examineDescription has no use/activation cue word (the AI-discoverable prose tell that the space is \`use\`-able as an objective).`,
+					`${phaseLabel}: space ${space.id} examineDescription has no use/activation cue word (the AI-discoverable prose tell that the space is \`use\`-able as an objective).`,
 				);
 			}
 			objectivePairs.push({ object, space });
@@ -799,19 +790,18 @@ export function validateContentPacks(
 		const landmarksRaw = pack.landmarks;
 		if (landmarksRaw == null || typeof landmarksRaw !== "object") {
 			throw new ContentPackError(
-				`Phase ${phaseNumber}: missing or invalid landmarks object`,
+				`${phaseLabel}: missing or invalid landmarks object`,
 			);
 		}
 		const lm = landmarksRaw as Record<string, unknown>;
 		const landmarks: ContentPack["landmarks"] = {
-			north: validateLandmark(lm.north, phaseNumber, "north"),
-			south: validateLandmark(lm.south, phaseNumber, "south"),
-			east: validateLandmark(lm.east, phaseNumber, "east"),
-			west: validateLandmark(lm.west, phaseNumber, "west"),
+			north: validateLandmark(lm.north, i + 1, "north"),
+			south: validateLandmark(lm.south, i + 1, "south"),
+			east: validateLandmark(lm.east, i + 1, "east"),
+			west: validateLandmark(lm.west, i + 1, "west"),
 		};
 
 		packs.push({
-			phaseNumber,
 			setting: pack.setting,
 			objectivePairs,
 			interestingObjects,
@@ -849,21 +839,17 @@ export function validateDualContentPacks(
 
 	const resultPhases: DualContentPackProviderResult["phases"] = [];
 
-	for (const phaseRaw of obj.phases) {
+	for (let i = 0; i < obj.phases.length; i++) {
+		const phaseRaw = obj.phases[i];
 		if (phaseRaw == null || typeof phaseRaw !== "object") {
 			throw new ContentPackError("Phase entry is not an object");
 		}
 		const phaseObj = phaseRaw as Record<string, unknown>;
-		const phaseNumber = phaseObj.phaseNumber as 1 | 2 | 3;
-		if (phaseNumber !== 1 && phaseNumber !== 2 && phaseNumber !== 3) {
-			throw new ContentPackError(
-				`Invalid phaseNumber: ${String(phaseObj.phaseNumber)}`,
-			);
-		}
-		const inputPhase = input.phases.find((p) => p.phaseNumber === phaseNumber);
+		const inputPhase = input.phases[i];
 		if (!inputPhase) {
-			throw new ContentPackError(`Unexpected phaseNumber: ${phaseNumber}`);
+			throw new ContentPackError(`No input phase for phase index ${i}`);
 		}
+		const phaseLabel = `Phase ${i + 1}`;
 
 		// Validate each pack independently, collecting IDs to verify parity
 		const allIdsA = new Set<string>();
@@ -873,12 +859,14 @@ export function validateDualContentPacks(
 			inputPhase,
 			allIdsA,
 			"packA",
+			i,
 		);
 		const packB = validateSinglePack(
 			phaseObj.packB,
 			inputPhase,
 			allIdsB,
 			"packB",
+			i,
 		);
 
 		// Enforce entity ID parity between packA and packB
@@ -888,7 +876,7 @@ export function validateDualContentPacks(
 			const onlyA = idsA.filter((id) => !allIdsB.has(id));
 			const onlyB = idsB.filter((id) => !allIdsA.has(id));
 			throw new ContentPackError(
-				`Phase ${phaseNumber}: entity IDs mismatch between packA and packB. ` +
+				`${phaseLabel}: entity IDs mismatch between packA and packB. ` +
 					`Only in A: [${onlyA.join(", ")}]. Only in B: [${onlyB.join(", ")}].`,
 			);
 		}
@@ -903,12 +891,12 @@ export function validateDualContentPacks(
 		for (const [objId, spaceId] of pairingsA) {
 			if (pairingsB.get(objId) !== spaceId) {
 				throw new ContentPackError(
-					`Phase ${phaseNumber}: pairsWithSpaceId mismatch for object "${objId}" between packA and packB`,
+					`${phaseLabel}: pairsWithSpaceId mismatch for object "${objId}" between packA and packB`,
 				);
 			}
 		}
 
-		resultPhases.push({ phaseNumber, packA, packB });
+		resultPhases.push({ packA, packB });
 	}
 
 	return { phases: resultPhases };
@@ -920,6 +908,7 @@ function validateSinglePack(
 	inputPhase: DualContentPackProviderInput["phases"][number],
 	allIds: Set<string>,
 	label: string,
+	phaseIndex = 0,
 ): UnplacedPack {
 	if (raw == null || typeof raw !== "object") {
 		throw new ContentPackError(`${label} is not an object`);
@@ -1024,14 +1013,13 @@ function validateSinglePack(
 	}
 	const lm = landmarksRaw as Record<string, unknown>;
 	const landmarks: ContentPack["landmarks"] = {
-		north: validateLandmark(lm.north, inputPhase.phaseNumber, "north"),
-		south: validateLandmark(lm.south, inputPhase.phaseNumber, "south"),
-		east: validateLandmark(lm.east, inputPhase.phaseNumber, "east"),
-		west: validateLandmark(lm.west, inputPhase.phaseNumber, "west"),
+		north: validateLandmark(lm.north, phaseIndex + 1, "north"),
+		south: validateLandmark(lm.south, phaseIndex + 1, "south"),
+		east: validateLandmark(lm.east, phaseIndex + 1, "east"),
+		west: validateLandmark(lm.west, phaseIndex + 1, "west"),
 	};
 
 	return {
-		phaseNumber: inputPhase.phaseNumber,
 		setting: pack.setting,
 		objectivePairs,
 		interestingObjects,
@@ -1044,23 +1032,23 @@ function validateSinglePack(
 /** Validate a single landmark entry from the LLM response. */
 function validateLandmark(
 	raw: unknown,
-	phaseNumber: number,
+	phaseLabel: number,
 	direction: string,
 ): LandmarkDescription {
 	if (raw == null || typeof raw !== "object") {
 		throw new ContentPackError(
-			`Phase ${phaseNumber}: landmark "${direction}" is not an object`,
+			`Phase ${phaseLabel}: landmark "${direction}" is not an object`,
 		);
 	}
 	const lm = raw as Record<string, unknown>;
 	if (typeof lm.shortName !== "string" || lm.shortName.length === 0) {
 		throw new ContentPackError(
-			`Phase ${phaseNumber}: landmark "${direction}" missing shortName`,
+			`Phase ${phaseLabel}: landmark "${direction}" missing shortName`,
 		);
 	}
 	if (typeof lm.horizonPhrase !== "string" || lm.horizonPhrase.length === 0) {
 		throw new ContentPackError(
-			`Phase ${phaseNumber}: landmark "${direction}" missing horizonPhrase`,
+			`Phase ${phaseLabel}: landmark "${direction}" missing horizonPhrase`,
 		);
 	}
 	return { shortName: lm.shortName, horizonPhrase: lm.horizonPhrase };

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -102,13 +102,6 @@ export interface LandmarkDescription {
 
 /** Setting-flavored content pack: names, descriptions, outcomes, and placed entities for one game. */
 export interface ContentPack {
-	/**
-	 * Slot index used by the dual-pack generator (1..3) and persisted in save
-	 * data. Retained from the pre-#295 phase-loop generator because the LLM
-	 * pipeline still emits the field and pack validation requires it; the value
-	 * has no runtime meaning in the flat single-game loop.
-	 */
-	phaseNumber?: 1 | 2 | 3;
 	setting: string;
 	weather: string;
 	timeOfDay: string;

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -20,7 +20,6 @@ import {
 } from "../session-storage.js";
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -15,7 +15,6 @@ import { deserializeSession, serializeSession } from "../session-codec.js";
 // ── Test fixtures ─────────────────────────────────────────────────────────────
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -34,7 +34,6 @@ import {
 // ── Test fixtures ─────────────────────────────────────────────────────────────
 
 const TEST_CONTENT_PACK: ContentPack = {
-	phaseNumber: 1,
 	setting: "",
 	weather: "",
 	timeOfDay: "",

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -59,8 +59,13 @@ import {
  *     `contentPacksA`/`contentPacksB` (full pack arrays, one entry per phase).
  *   - `activePackId: "A" | "B"` now persisted correctly (was hardcoded "A").
  *   - Old v6 saves surface `version-mismatch` — no migration provided.
+ *
+ * v8 (issue #358): retire ContentPack.phaseNumber.
+ *   - `phaseNumber` removed from the `ContentPack` type; packs are identified
+ *     by array index rather than an embedded slot number.
+ *   - Old v7 saves surface `version-mismatch` — no migration provided.
  */
-export const SESSION_SCHEMA_VERSION = 7 as const;
+export const SESSION_SCHEMA_VERSION = 8 as const;
 
 // ── File shapes ────────────────────────────────────────────────────────────────
 

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -214,6 +214,7 @@ let session: GameSession | null = null;
  * picker), this drifts from `getActiveSessionId()` and the next renderGame
  * drops the cache so the restore path runs against the new pointer. */
 let cachedSessionId: string | null = null;
+let cachedEpoch: number = 1;
 
 export function renderGame(
 	root: HTMLElement,
@@ -429,7 +430,7 @@ export function renderGame(
 		const sessionIdLocal = getActiveSessionId() ?? "0x????";
 		const inputs = {
 			sessionId: sessionIdLocal,
-			phaseNumber: 1 as const,
+			phaseNumber: cachedEpoch,
 			totalPhases: 1,
 			turn: 0,
 		};
@@ -726,6 +727,7 @@ export function renderGame(
 				const restoredState = loadResult.state;
 				session = GameSession.restore(restoredState);
 				cachedSessionId = loadResult.sessionId;
+				cachedEpoch = loadResult.epoch;
 
 				// Re-render transcripts from restored state using conversationLogs.
 				// (The new format stores conversation logs in daemon .txt files, not as
@@ -918,7 +920,7 @@ export function renderGame(
 		const state = session.getState();
 		const inputs = {
 			sessionId,
-			phaseNumber: 1 as const,
+			phaseNumber: cachedEpoch,
 			totalPhases: 1,
 			turn: state.round,
 		};

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -430,8 +430,7 @@ export function renderGame(
 		const sessionIdLocal = getActiveSessionId() ?? "0x????";
 		const inputs = {
 			sessionId: sessionIdLocal,
-			phaseNumber: cachedEpoch,
-			totalPhases: 1,
+			epoch: cachedEpoch,
 			turn: 0,
 		};
 		if (topinfoLeftEl) renderTopInfoLeft(topinfoLeftEl, inputs);
@@ -920,8 +919,7 @@ export function renderGame(
 		const state = session.getState();
 		const inputs = {
 			sessionId,
-			phaseNumber: cachedEpoch,
-			totalPhases: 1,
+			epoch: cachedEpoch,
 			turn: state.round,
 		};
 		renderTopInfoLeft(topinfoLeftEl, inputs);

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -109,7 +109,7 @@ export function renderSessions(
 	if (loadResult.kind === "ok") {
 		paintTopInfo(doc, {
 			sessionId: loadResult.sessionId,
-			phaseNumber: 1,
+			phaseNumber: loadResult.epoch,
 			totalPhases: 1,
 			turn: loadResult.state.round,
 		});

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -109,8 +109,7 @@ export function renderSessions(
 	if (loadResult.kind === "ok") {
 		paintTopInfo(doc, {
 			sessionId: loadResult.sessionId,
-			phaseNumber: loadResult.epoch,
-			totalPhases: 1,
+			epoch: loadResult.epoch,
 			turn: loadResult.state.round,
 		});
 	}


### PR DESCRIPTION
## What this fixes

Retires `ContentPack.phaseNumber` — the load-bearing-by-accident slot that survived the post-#295 phase-shim cleanup as a prose-deprecated field. The field was driving four orthogonal dependencies that this PR untangles:

- **LLM contract** (`src/spa/game/content-pack-provider.ts`): both `CONTENT_PACK_SYSTEM_PROMPT` and `DUAL_CONTENT_PACK_SYSTEM_PROMPT` no longer ask the model to emit `phaseNumber` in their JSON shapes. The validators (`validateContentPacks`, `validateDualContentPacks`, `validateSinglePack`) now iterate by array index instead of `phaseNumber`-based lookup, and surface `Phase ${i+1}:` in error messages.
- **Save schema** (`src/spa/persistence/session-codec.ts`): `SESSION_SCHEMA_VERSION` bumped `7 → 8` with no migration — consistent with v3→v7's "no migration" precedent. Old saves surface as `version-mismatch` and route to the sessions picker for archival.
- **Generator** (`src/content/content-pack-generator.ts`): `PhaseConfig.phaseNumber` removed; `generateContentPacks` / `generateDualContentPacks` no longer stamp the field onto output packs. `buildLegacyPhaseConfigs` in `src/spa/game/bootstrap.ts` simplifies to a spread of the shared base config.
- **Type definition** (`src/spa/game/types.ts`): `phaseNumber?: 1 | 2 | 3` and its prose comment deleted from `ContentPack`. ~30 test fixtures swept.

The BBS chrome UI (`src/spa/bbs-chrome.ts`) — the only place this field surfaced to humans — was already landed in earlier commits on this branch: `TopInfoInputs.phaseNumber` renamed to `epoch`, `totalPhases` dropped, display now reads `EPOCH 01` (desktop) / `EPC 01` (mobile compact) sourced from the saved session's epoch counter rather than the retired pack field.

## QA steps for the human

- Confirm the topinfo strip reads `SESSION 0xXXXX · EPOCH 01 · TURN N` on desktop and `0xXXXX · EPC 01 · TRN N` on mobile (≤720px viewport).
- Confirm a fresh game saves and reloads correctly under v8.
- A pre-existing v7 save in localStorage should now surface as a "version-mismatch" row in the sessions picker (consistent with prior schema bumps).

## Automated coverage

`pnpm typecheck` ✓ · `pnpm test` ✓ (1406 tests, 58 files) · `pnpm lint` ✓ (164 files) · `pnpm smoke` ✓ (46 e2e tests)

Closes #358

---
_Generated by [Claude Code](https://claude.ai/code/session_019UhCikomgjgdhhVs16WBuq)_