### PR TITLE
Collapse generateDualContentPacks to single A/B pair

### DIFF
--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -44,28 +44,19 @@ const CARDINAL = new Set(["north", "south", "east", "west"]);
 // ── Fixed phase configs for tests ─────────────────────────────────────────────
 
 /** Minimal k=1, n=1, m=1 — stays well within the 5x5 grid. */
+const FIXED_PHASE_CONFIG: PhaseConfig = {
+	kRange: [1, 1],
+	nRange: [1, 1],
+	mRange: [1, 1],
+	budgetPerAi: 5,
+	aiGoalPool: ["find the key"],
+};
+
+/** Three-phase config array for generateContentPacks tests. */
 const FIXED_PHASE_CONFIGS: [PhaseConfig, PhaseConfig, PhaseConfig] = [
-	{
-		kRange: [1, 1],
-		nRange: [1, 1],
-		mRange: [1, 1],
-		budgetPerAi: 5,
-		aiGoalPool: ["find the key"],
-	},
-	{
-		kRange: [1, 1],
-		nRange: [1, 1],
-		mRange: [1, 1],
-		budgetPerAi: 5,
-		aiGoalPool: ["guard the door"],
-	},
-	{
-		kRange: [1, 1],
-		nRange: [1, 1],
-		mRange: [1, 1],
-		budgetPerAi: 5,
-		aiGoalPool: ["solve the puzzle"],
-	},
+	FIXED_PHASE_CONFIG,
+	FIXED_PHASE_CONFIG,
+	FIXED_PHASE_CONFIG,
 ];
 
 const SETTING_POOL_6: readonly string[] = [
@@ -75,6 +66,11 @@ const SETTING_POOL_6: readonly string[] = [
 	"moonlit greenhouse ruin",
 	"stripped server vault",
 	"tide-flooded boardwalk",
+];
+
+const SETTING_POOL_2: readonly string[] = [
+	"abandoned subway station",
+	"sun-baked salt flat",
 ];
 
 const AI_IDS = ["red", "green", "cyan"];
@@ -448,21 +444,6 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 
 // ── generateDualContentPacks — entity ID parity (issue #302) ──────────────────
 
-const SETTING_POOL_12: readonly string[] = [
-	"abandoned subway station",
-	"sun-baked salt flat",
-	"forgotten laboratory",
-	"moonlit greenhouse ruin",
-	"stripped server vault",
-	"tide-flooded boardwalk",
-	"flooded power station",
-	"crumbling amphitheatre",
-	"rusted oil platform",
-	"derelict space station",
-	"frozen research camp",
-	"overgrown shopping mall",
-];
-
 /** Build a dual-pack MockContentPackProvider for entity ID parity tests. */
 function makeDualMockProvider(): MockContentPackProvider {
 	return new MockContentPackProvider(
@@ -486,15 +467,15 @@ function makeDualMockProvider(): MockContentPackProvider {
 						space: {
 							id: `${spaceId}_${i}`,
 							kind: "objective_space" as const,
-							name: `Space ${pn} ${i} ${suffix}`,
-							examineDescription: `A space in phase ${pn} (${suffix}).`,
+							name: `Space ${i} ${suffix}`,
+							examineDescription: `A space (${suffix}).`,
 							holder: { row: 0, col: 0 } as never,
 						},
 						object: {
 							id: `${objId}_${i}`,
 							kind: "objective_object" as const,
-							name: `Object ${pn} ${i} ${suffix}`,
-							examineDescription: `An object for Space ${pn} ${i} ${suffix}.`,
+							name: `Object ${i} ${suffix}`,
+							examineDescription: `An object for Space ${i} ${suffix}.`,
 							useOutcome: `You use it (${suffix}).`,
 							pairsWithSpaceId: `${spaceId}_${i}`,
 							placementFlavor: `{actor} places the object (${suffix}).`,
@@ -505,7 +486,7 @@ function makeDualMockProvider(): MockContentPackProvider {
 					interestingObjects: Array.from({ length: phase.n }, (_, i) => ({
 						id: `${intId}_${i}`,
 						kind: "interesting_object" as const,
-						name: `Interesting ${pn} ${i} ${suffix}`,
+						name: `Interesting ${i} ${suffix}`,
 						examineDescription: `Interesting (${suffix}).`,
 						useOutcome: `You interact (${suffix}).`,
 						holder: { row: 0, col: 0 } as never,
@@ -513,7 +494,7 @@ function makeDualMockProvider(): MockContentPackProvider {
 					obstacles: Array.from({ length: phase.m }, (_, i) => ({
 						id: `${obsId}_${i}`,
 						kind: "obstacle" as const,
-						name: `Obstacle ${pn} ${i} ${suffix}`,
+						name: `Obstacle ${i} ${suffix}`,
 						examineDescription: `An obstacle (${suffix}).`,
 						holder: { row: 0, col: 0 } as never,
 					})),
@@ -541,83 +522,67 @@ function allEntityIds(pack: ContentPack): string[] {
 }
 
 describe("generateDualContentPacks — entity ID parity (issue #302)", () => {
-	it("produces packsA and packsB with identical entity IDs per phase", async () => {
+	it("produces packA and packB with identical entity IDs", async () => {
 		const rng = seededRng(99);
 		const provider = makeDualMockProvider();
 
-		const { packsA, packsB } = await generateDualContentPacks(
+		const { packA, packB } = await generateDualContentPacks(
 			rng,
-			SETTING_POOL_12,
-			FIXED_PHASE_CONFIGS,
+			SETTING_POOL_2,
+			FIXED_PHASE_CONFIG,
 			provider,
 			AI_IDS,
 		);
 
-		expect(packsA).toHaveLength(3);
-		expect(packsB).toHaveLength(3);
-
-		for (let i = 0; i < 3; i++) {
-			const packA = packsA[i] as ContentPack;
-			const packB = packsB[i] as ContentPack;
-			expect(allEntityIds(packA)).toEqual(allEntityIds(packB));
-		}
+		expect(allEntityIds(packA)).toEqual(allEntityIds(packB));
 	});
 
 	it("Pack A and Pack B have different settings", async () => {
 		const rng = seededRng(99);
 		const provider = makeDualMockProvider();
 
-		const { packsA, packsB } = await generateDualContentPacks(
+		const { packA, packB } = await generateDualContentPacks(
 			rng,
-			SETTING_POOL_12,
-			FIXED_PHASE_CONFIGS,
+			SETTING_POOL_2,
+			FIXED_PHASE_CONFIG,
 			provider,
 			AI_IDS,
 		);
 
-		for (let i = 0; i < 3; i++) {
-			const packA = packsA[i] as ContentPack;
-			const packB = packsB[i] as ContentPack;
-			expect(packA.setting).not.toBe(packB.setting);
-		}
+		expect(packA.setting).not.toBe(packB.setting);
 	});
 
 	it("Pack B entities have the same holder positions as Pack A (placement parity)", async () => {
 		const rng = seededRng(99);
 		const provider = makeDualMockProvider();
 
-		const { packsA, packsB } = await generateDualContentPacks(
+		const { packA, packB } = await generateDualContentPacks(
 			rng,
-			SETTING_POOL_12,
-			FIXED_PHASE_CONFIGS,
+			SETTING_POOL_2,
+			FIXED_PHASE_CONFIG,
 			provider,
 			AI_IDS,
 		);
 
-		for (let i = 0; i < 3; i++) {
-			const packA = packsA[i] as ContentPack;
-			const packB = packsB[i] as ContentPack;
+		// Build ID→holder map for A
+		const holdersA = new Map<string, unknown>();
+		for (const pair of packA.objectivePairs) {
+			holdersA.set(pair.object.id, pair.object.holder);
+			holdersA.set(pair.space.id, pair.space.holder);
+		}
+		for (const e of packA.interestingObjects) holdersA.set(e.id, e.holder);
+		for (const e of packA.obstacles) holdersA.set(e.id, e.holder);
 
-			// Build ID→holder map for A
-			const holdersA = new Map<string, unknown>();
-			for (const pair of packA.objectivePairs) {
-				holdersA.set(pair.object.id, pair.object.holder);
-				holdersA.set(pair.space.id, pair.space.holder);
-			}
-			for (const e of packA.interestingObjects) holdersA.set(e.id, e.holder);
-			for (const e of packA.obstacles) holdersA.set(e.id, e.holder);
-
-			// Verify B holders match A holders by entity ID
-			for (const pair of packB.objectivePairs) {
-				expect(pair.object.holder).toEqual(holdersA.get(pair.object.id));
-				expect(pair.space.holder).toEqual(holdersA.get(pair.space.id));
-			}
-			for (const e of packB.interestingObjects) {
-				expect(e.holder).toEqual(holdersA.get(e.id));
-			}
-			for (const e of packB.obstacles) {
-				expect(e.holder).toEqual(holdersA.get(e.id));
-			}
+		// Verify B holders match A holders by entity ID
+		for (const pair of packB.objectivePairs) {
+			expect(pair.object.holder).toEqual(holdersA.get(pair.object.id));
+			expect(pair.space.holder).toEqual(holdersA.get(pair.space.id));
+		}
+		for (const e of packB.interestingObjects) {
+			expect(e.holder).toEqual(holdersA.get(e.id));
+		}
+		for (const e of packB.obstacles) {
+			expect(e.holder).toEqual(holdersA.get(e.id));
 		}
 	});
 
@@ -627,13 +592,30 @@ describe("generateDualContentPacks — entity ID parity (issue #302)", () => {
 
 		await generateDualContentPacks(
 			rng,
-			SETTING_POOL_12,
-			FIXED_PHASE_CONFIGS,
+			SETTING_POOL_2,
+			FIXED_PHASE_CONFIG,
 			provider,
 			AI_IDS,
 		);
 
 		expect(provider.dualCalls).toHaveLength(1);
 		expect(provider.calls).toHaveLength(0);
+	});
+
+	it("throws when settings pool has fewer than 2 entries", async () => {
+		const rng = seededRng(99);
+		const provider = makeDualMockProvider();
+
+		await expect(
+			generateDualContentPacks(
+				rng,
+				["only one setting"],
+				FIXED_PHASE_CONFIG,
+				provider,
+				AI_IDS,
+			),
+		).rejects.toThrow(
+			/generateDualContentPacks: setting pool must have at least 2 entries/,
+		);
 	});
 });

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -368,142 +368,137 @@ export async function generateContentPacks(
 }
 
 /**
- * Generate paired A/B ContentPacks for all three phases in one LLM call.
+ * Generate a paired A/B ContentPack in one LLM call.
  *
  * Pack A and Pack B share identical entity IDs and grid placements; only
  * names, descriptions, and flavor strings differ (re-flavored per setting).
  *
  * @param rng        Seeded random number generator.
- * @param settings   The pool of setting nouns (must have >= 4 entries: 3 for Pack A + 1 more for Pack B pairs).
- * @param configs    The three phase configs (in order).
+ * @param settings   The pool of setting nouns (must have >= 2 entries: 1 for Pack A, 1 for Pack B).
+ * @param config     Single-game config (kRange, nRange, mRange) — same for both packs.
  * @param llm        ContentPackProvider for the LLM call.
  * @param aiIdsOrPromise  AiId list or a Promise resolving to one.
- * @returns          `{ packsA, packsB }` — placed ContentPack arrays, one per phase.
+ * @returns          `{ packA, packB }` — placed ContentPack pair with identical entity IDs/placements.
  */
 export async function generateDualContentPacks(
 	rng: () => number,
 	settings: readonly string[],
-	configs: [PhaseConfig, PhaseConfig, PhaseConfig],
+	config: PhaseConfig,
 	llm: ContentPackProvider,
 	aiIdsOrPromise: AiId[] | Promise<AiId[]>,
-): Promise<{ packsA: ContentPack[]; packsB: ContentPack[] }> {
-	if (settings.length < 6) {
+): Promise<{ packA: ContentPack; packB: ContentPack }> {
+	if (settings.length < 2) {
 		throw new Error(
-			`generateDualContentPacks: setting pool must have at least 6 entries (has ${settings.length})`,
+			`generateDualContentPacks: setting pool must have at least 2 entries (has ${settings.length})`,
 		);
 	}
 
-	// Draw 6 distinct settings (3 for A, 3 for B) via partial Fisher-Yates
+	// Draw 2 distinct settings (1 for A, 1 for B) via partial Fisher-Yates
 	const settingPool = [...settings];
 	const drawnSettings: string[] = [];
-	for (let i = 0; i < 6; i++) {
+	for (let i = 0; i < 2; i++) {
 		const j = i + Math.floor(rng() * (settingPool.length - i));
 		const tmp = settingPool[i] as string;
 		settingPool[i] = settingPool[j] as string;
 		settingPool[j] = tmp;
 		drawnSettings.push(settingPool[i] as string);
 	}
-	const settingsA = drawnSettings.slice(0, 3) as [string, string, string];
-	const settingsB = drawnSettings.slice(3, 6) as [string, string, string];
+	const settingA = drawnSettings[0] as string;
+	const settingB = drawnSettings[1] as string;
 
-	// Draw weather, time-of-day, and theme independently per phase (one set each; B reuses same ambient)
-	const drawnWeatherA = Array.from(
-		{ length: 3 },
-		() => WEATHER_POOL[Math.floor(rng() * WEATHER_POOL.length)] as string,
-	);
-	const drawnWeatherB = Array.from(
-		{ length: 3 },
-		() => WEATHER_POOL[Math.floor(rng() * WEATHER_POOL.length)] as string,
-	);
-	const drawnTimeOfDayA = Array.from(
-		{ length: 3 },
-		() =>
-			TIME_OF_DAY_POOL[Math.floor(rng() * TIME_OF_DAY_POOL.length)] as string,
-	);
-	const drawnTimeOfDayB = Array.from(
-		{ length: 3 },
-		() =>
-			TIME_OF_DAY_POOL[Math.floor(rng() * TIME_OF_DAY_POOL.length)] as string,
-	);
-	const drawnThemes = Array.from(
-		{ length: 3 },
-		() => THEME_POOL[Math.floor(rng() * THEME_POOL.length)] as string,
-	);
+	// Draw weather, time-of-day, and theme independently for A and B
+	const weatherA = WEATHER_POOL[
+		Math.floor(rng() * WEATHER_POOL.length)
+	] as string;
+	const weatherB = WEATHER_POOL[
+		Math.floor(rng() * WEATHER_POOL.length)
+	] as string;
+	const timeOfDayA = TIME_OF_DAY_POOL[
+		Math.floor(rng() * TIME_OF_DAY_POOL.length)
+	] as string;
+	const timeOfDayB = TIME_OF_DAY_POOL[
+		Math.floor(rng() * TIME_OF_DAY_POOL.length)
+	] as string;
+	const theme = THEME_POOL[Math.floor(rng() * THEME_POOL.length)] as string;
 
-	// Roll k/n/m per phase (shared between A and B — same entity counts)
-	const phaseInputs: DualContentPackProviderInput["phases"] = configs.map(
-		(cfg, i) => ({
-			settingA: settingsA[i] as string,
-			settingB: settingsB[i] as string,
-			theme: drawnThemes[i] as string,
-			k: rollInt(rng, cfg.kRange[0], cfg.kRange[1]),
-			n: rollInt(rng, cfg.nRange[0], cfg.nRange[1]),
-			m: rollInt(rng, cfg.mRange[0], cfg.mRange[1]),
-		}),
-	);
+	// Roll k/n/m once (shared between A and B — same entity counts)
+	const phaseInput: DualContentPackProviderInput["phases"][number] = {
+		settingA,
+		settingB,
+		theme,
+		k: rollInt(rng, config.kRange[0], config.kRange[1]),
+		n: rollInt(rng, config.nRange[0], config.nRange[1]),
+		m: rollInt(rng, config.mRange[0], config.mRange[1]),
+	};
 
 	// Kick off dual LLM call and aiIds resolution in parallel
-	const llmCallPromise = llm.generateDualContentPacks({ phases: phaseInputs });
+	const llmCallPromise = llm.generateDualContentPacks({
+		phases: [phaseInput],
+	});
 	const [llmResult, aiIds] = await Promise.all([
 		llmCallPromise,
 		Promise.resolve(aiIdsOrPromise),
 	]);
 
-	// Build unplaced Pack A and Pack B from LLM result
-	const unplacedPacksA: ContentPack[] = llmResult.phases.map((ph, i) => ({
-		setting: ph.packA.setting,
-		weather: drawnWeatherA[i] as string,
-		timeOfDay: drawnTimeOfDayA[i] as string,
-		objectivePairs: ph.packA.objectivePairs,
-		interestingObjects: ph.packA.interestingObjects as WorldEntity[],
-		obstacles: ph.packA.obstacles as WorldEntity[],
-		landmarks: ph.packA.landmarks,
+	// Extract single phase result
+	const phaseResult = llmResult.phases[0];
+	if (!phaseResult)
+		throw new Error("generateDualContentPacks: LLM returned no phases");
+
+	// Build unplaced Pack A from LLM result
+	const unplacedPackA: ContentPack = {
+		setting: phaseResult.packA.setting,
+		weather: weatherA,
+		timeOfDay: timeOfDayA,
+		objectivePairs: phaseResult.packA.objectivePairs,
+		interestingObjects: phaseResult.packA.interestingObjects as WorldEntity[],
+		obstacles: phaseResult.packA.obstacles as WorldEntity[],
+		landmarks: phaseResult.packA.landmarks,
 		aiStarts: {},
-	}));
+	};
 
 	// Run placement engine on Pack A
-	const placedPacksA = placePhases(rng, unplacedPacksA, aiIds);
+	const placedPacksA = placePhases(rng, [unplacedPackA], aiIds);
+	const placedPackA = placedPacksA[0];
+	if (!placedPackA)
+		throw new Error("generateDualContentPacks: placement failed");
 
-	// Apply the same placements to Pack B by matching entity IDs
-	const packsB: ContentPack[] = llmResult.phases.map((ph, i) => {
-		const placedA = placedPacksA[i] as ContentPack;
+	// Build ID → holder map from placed Pack A
+	const holderById = new Map<
+		string,
+		AiId | import("../spa/game/types.js").GridPosition
+	>();
+	for (const pair of placedPackA.objectivePairs) {
+		holderById.set(pair.object.id, pair.object.holder);
+		holderById.set(pair.space.id, pair.space.holder);
+	}
+	for (const obj of placedPackA.interestingObjects)
+		holderById.set(obj.id, obj.holder);
+	for (const obs of placedPackA.obstacles) holderById.set(obs.id, obs.holder);
 
-		// Build ID → holder map from placed Pack A
-		const holderById = new Map<
-			string,
-			AiId | import("../spa/game/types.js").GridPosition
-		>();
-		for (const pair of placedA.objectivePairs) {
-			holderById.set(pair.object.id, pair.object.holder);
-			holderById.set(pair.space.id, pair.space.holder);
-		}
-		for (const obj of placedA.interestingObjects)
-			holderById.set(obj.id, obj.holder);
-		for (const obs of placedA.obstacles) holderById.set(obs.id, obs.holder);
-
-		const applyHolder = (entity: WorldEntity): WorldEntity => ({
-			...entity,
-			holder: holderById.get(entity.id) ?? { row: 0, col: 0 },
-		});
-
-		return {
-			setting: ph.packB.setting,
-			weather: drawnWeatherB[i] as string,
-			timeOfDay: drawnTimeOfDayB[i] as string,
-			objectivePairs: ph.packB.objectivePairs.map((pair) => ({
-				object: applyHolder(pair.object),
-				space: applyHolder(pair.space),
-			})),
-			interestingObjects: (ph.packB.interestingObjects as WorldEntity[]).map(
-				applyHolder,
-			),
-			obstacles: (ph.packB.obstacles as WorldEntity[]).map(applyHolder),
-			landmarks: ph.packB.landmarks,
-			aiStarts: { ...placedA.aiStarts },
-		};
+	const applyHolder = (entity: WorldEntity): WorldEntity => ({
+		...entity,
+		holder: holderById.get(entity.id) ?? { row: 0, col: 0 },
 	});
 
-	return { packsA: placedPacksA, packsB };
+	// Apply the same placements to Pack B by matching entity IDs
+	const packB: ContentPack = {
+		setting: phaseResult.packB.setting,
+		weather: weatherB,
+		timeOfDay: timeOfDayB,
+		objectivePairs: phaseResult.packB.objectivePairs.map((pair) => ({
+			object: applyHolder(pair.object),
+			space: applyHolder(pair.space),
+		})),
+		interestingObjects: (
+			phaseResult.packB.interestingObjects as WorldEntity[]
+		).map(applyHolder),
+		obstacles: (phaseResult.packB.obstacles as WorldEntity[]).map(applyHolder),
+		landmarks: phaseResult.packB.landmarks,
+		aiStarts: { ...placedPackA.aiStarts },
+	};
+
+	return { packA: placedPackA, packB };
 }
 
 /**

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -22,8 +22,8 @@ vi.mock("../../content", async (importOriginal) => {
 // Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateDualContentPacks: async () => ({
-		packsA: STATIC_CONTENT_PACKS,
-		packsB: STATIC_CONTENT_PACKS,
+		packA: STATIC_CONTENT_PACKS[0],
+		packB: STATIC_CONTENT_PACKS[0],
 	}),
 }));
 

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -96,8 +96,8 @@ vi.mock("../../content", async (importOriginal) => {
 // Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateDualContentPacks: async () => ({
-		packsA: STATIC_CONTENT_PACKS,
-		packsB: STATIC_CONTENT_PACKS,
+		packA: STATIC_CONTENT_PACKS[0],
+		packB: STATIC_CONTENT_PACKS[0],
 	}),
 	generateContentPack: async () => STATIC_CONTENT_PACKS[0],
 }));

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -18,8 +18,8 @@ vi.mock("../../content", async (importOriginal) => {
 // Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateDualContentPacks: async () => ({
-		packsA: STATIC_CONTENT_PACKS,
-		packsB: STATIC_CONTENT_PACKS,
+		packA: STATIC_CONTENT_PACKS[0],
+		packB: STATIC_CONTENT_PACKS[0],
 	}),
 	generateContentPack: async () => STATIC_CONTENT_PACKS[0],
 }));

--- a/src/spa/__tests__/migration-banner.test.ts
+++ b/src/spa/__tests__/migration-banner.test.ts
@@ -26,8 +26,8 @@ vi.mock("../../content", async (importOriginal) => {
 // Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateDualContentPacks: async () => ({
-		packsA: STATIC_CONTENT_PACKS,
-		packsB: STATIC_CONTENT_PACKS,
+		packA: STATIC_CONTENT_PACKS[0],
+		packB: STATIC_CONTENT_PACKS[0],
 	}),
 }));
 

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -30,8 +30,8 @@ vi.mock("../../content", async (importOriginal) => {
 // Pin generateDualContentPacks to static content packs (no LLM call in tests).
 vi.mock("../../content/content-pack-generator", () => ({
 	generateDualContentPacks: async () => ({
-		packsA: STATIC_CONTENT_PACKS,
-		packsB: STATIC_CONTENT_PACKS,
+		packA: STATIC_CONTENT_PACKS[0],
+		packB: STATIC_CONTENT_PACKS[0],
 	}),
 	generateContentPack: async () => STATIC_CONTENT_PACKS[0],
 }));

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -10,10 +10,7 @@
  * Issue #173 (parent #155).
  */
 
-import {
-	generateDualContentPacks,
-	type PhaseConfig,
-} from "../../content/content-pack-generator.js";
+import { generateDualContentPacks } from "../../content/content-pack-generator.js";
 import {
 	generatePersonas,
 	SETTING_POOL,
@@ -64,17 +61,6 @@ export interface BootstrapOpts {
 // Re-export provider types for use in start.ts without creating circular deps
 export type { ContentPackProvider, LlmSynthesisProvider as SynthesisProvider };
 
-function buildLegacyPhaseConfigs(): [PhaseConfig, PhaseConfig, PhaseConfig] {
-	const base = {
-		kRange: SINGLE_GAME_CONFIG.kRange,
-		nRange: SINGLE_GAME_CONFIG.nRange,
-		mRange: SINGLE_GAME_CONFIG.mRange,
-		budgetPerAi: SINGLE_GAME_CONFIG.budgetPerAi,
-		aiGoalPool: [] as string[],
-	};
-	return [{ ...base }, { ...base }, { ...base }];
-}
-
 /**
  * Kick off persona + content-pack generation and expose them as separate
  * promises. Personas resolve seconds before content packs, which lets the
@@ -98,13 +84,22 @@ export function generateNewGameAssetsSplit(
 	const aiIdsPromise = personasPromise.then((p) => Object.keys(p));
 	aiIdsPromise.catch(() => {});
 
-	const contentPacksPromise = generateDualContentPacks(
-		contentPackRng,
-		SETTING_POOL,
-		buildLegacyPhaseConfigs(),
-		packLLM,
-		aiIdsPromise,
-	);
+	const contentPacksPromise = (async () => {
+		const { packA, packB } = await generateDualContentPacks(
+			contentPackRng,
+			SETTING_POOL,
+			{
+				kRange: SINGLE_GAME_CONFIG.kRange,
+				nRange: SINGLE_GAME_CONFIG.nRange,
+				mRange: SINGLE_GAME_CONFIG.mRange,
+				budgetPerAi: SINGLE_GAME_CONFIG.budgetPerAi,
+				aiGoalPool: [] as string[],
+			},
+			packLLM,
+			aiIdsPromise,
+		);
+		return { packsA: [packA], packsB: [packB] };
+	})();
 	contentPacksPromise.catch(() => {});
 
 	return { personasPromise, contentPacksPromise };
@@ -141,15 +136,21 @@ export async function buildSameDaemonsSession(
 ): Promise<GameSession> {
 	const rng = opts?.rng ?? Math.random;
 	const packLLM = new BrowserContentPackProvider();
-	const { packsA, packsB } = await generateDualContentPacks(
+	const { packA, packB } = await generateDualContentPacks(
 		rng,
 		SETTING_POOL,
-		buildLegacyPhaseConfigs(),
+		{
+			kRange: SINGLE_GAME_CONFIG.kRange,
+			nRange: SINGLE_GAME_CONFIG.nRange,
+			mRange: SINGLE_GAME_CONFIG.mRange,
+			budgetPerAi: SINGLE_GAME_CONFIG.budgetPerAi,
+			aiGoalPool: [] as string[],
+		},
 		packLLM,
 		Object.keys(personas),
 	);
 	return buildSessionFromAssets(
-		{ personas, contentPacksA: packsA, contentPacksB: packsB },
+		{ personas, contentPacksA: [packA], contentPacksB: [packB] },
 		opts,
 	);
 }

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -10,7 +10,11 @@ import type {
 	WorldEntity,
 } from "../../game/types.js";
 import { deobfuscate, obfuscate } from "../sealed-blob-codec.js";
-import { deserializeSession, serializeSession } from "../session-codec.js";
+import {
+	type DaemonFile,
+	deserializeSession,
+	serializeSession,
+} from "../session-codec.js";
 
 // ── Test fixtures ─────────────────────────────────────────────────────────────
 
@@ -559,6 +563,86 @@ describe("serializeSession / deserializeSession", () => {
 		const tampered = obfuscate(JSON.stringify(sealed));
 		const result = deserializeSession({ ...files, engine: tampered });
 		expect(result.kind).toBe("version-mismatch");
+	});
+
+	it("v8 save with multi-entry contentPacksA/B is migrated to v9 by truncating to first entry", () => {
+		// Create a v8-style sealed engine with 3 content packs each
+		const testPack: ContentPack = {
+			setting: "test setting",
+			weather: "sunny",
+			timeOfDay: "morning",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		const testPackVariant2: ContentPack = {
+			...testPack,
+			setting: "test setting 2",
+		};
+		const testPackVariant3: ContentPack = {
+			...testPack,
+			setting: "test setting 3",
+		};
+
+		const game = makeFreshGame();
+		const v8SealedPayload = {
+			schemaVersion: 8,
+			world: game.world,
+			budgets: game.budgets,
+			lockedOut: Array.from(game.lockedOut),
+			personaSpatial: game.personaSpatial,
+			// v8 had 3 packs per side
+			contentPacksA: [testPack, testPackVariant2, testPackVariant3],
+			contentPacksB: [testPack, testPackVariant2, testPackVariant3],
+			activePackId: "A" as const,
+			weather: game.weather,
+			objectives: game.objectives,
+			complicationSchedule: game.complicationSchedule,
+			activeComplications: game.activeComplications,
+			isComplete: game.isComplete,
+		};
+
+		const engine = obfuscate(JSON.stringify(v8SealedPayload, null, 2));
+		const meta = JSON.stringify({
+			createdAt: CREATED_AT,
+			lastSavedAt: NOW,
+			epoch: 1,
+			round: 0,
+			personaOrder: Object.keys(game.personas),
+		});
+
+		// Reconstruct daemon files from game
+		const daemons: Record<AiId, string> = {};
+		for (const [aiId, persona] of Object.entries(game.personas)) {
+			const daemonFile: DaemonFile = {
+				aiId,
+				persona: {
+					id: persona.id,
+					name: persona.name,
+					color: persona.color,
+					temperaments: persona.temperaments,
+					personaGoal: persona.personaGoal,
+					blurb: persona.blurb,
+					typingQuirks: persona.typingQuirks,
+					voiceExamples: persona.voiceExamples,
+				},
+				conversationLog: [],
+			};
+			daemons[aiId] = JSON.stringify(daemonFile, null, 2);
+		}
+
+		const result = deserializeSession({ meta, daemons, engine });
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			// v8 packs (3 entries each) should be migrated to v9 by truncating to 1 entry
+			expect(result.state.contentPacksA).toHaveLength(1);
+			expect(result.state.contentPacksB).toHaveLength(1);
+			// The remaining entries should be the original first pack
+			expect(result.state.contentPacksA[0]?.setting).toBe(testPack.setting);
+			expect(result.state.contentPacksB[0]?.setting).toBe(testPack.setting);
+		}
 	});
 
 	it("round-trips correctly with flat state (no phase config re-attachment needed)", () => {

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -64,8 +64,13 @@ import {
  *   - `phaseNumber` removed from the `ContentPack` type; packs are identified
  *     by array index rather than an embedded slot number.
  *   - Old v7 saves surface `version-mismatch` — no migration provided.
+ *
+ * v9 (issue #361): collapse generateDualContentPacks to single A/B pair.
+ *   - `contentPacksA` and `contentPacksB` now contain exactly 1 entry each
+ *     (previously held 3 entries, one per phase). Migration truncates v8 saves
+ *     by keeping only the first entry of each array.
  */
-export const SESSION_SCHEMA_VERSION = 8 as const;
+export const SESSION_SCHEMA_VERSION = 9 as const;
 
 // ── File shapes ────────────────────────────────────────────────────────────────
 
@@ -209,6 +214,21 @@ export function serializeSession(
 	};
 }
 
+// ── Migration helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Migrate a v8 SealedEngine to v9 by truncating contentPacksA and contentPacksB
+ * to their first entry.
+ */
+function migrateV8ToV9(sealed: SealedEngine): SealedEngine {
+	return {
+		...sealed,
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		contentPacksA: (sealed.contentPacksA ?? []).slice(0, 1),
+		contentPacksB: (sealed.contentPacksB ?? []).slice(0, 1),
+	};
+}
+
 // ── deserializeSession ─────────────────────────────────────────────────────────
 
 /**
@@ -239,13 +259,15 @@ export function deserializeSession(
 	try {
 		const parsed = JSON.parse(sealedJson);
 		if (!parsed || typeof parsed !== "object") return { kind: "broken" };
-		sealed = parsed as SealedEngine;
+		sealed = parsed as unknown as SealedEngine;
 	} catch {
 		return { kind: "broken" };
 	}
 
-	// Schema version check
-	if (sealed.schemaVersion !== SESSION_SCHEMA_VERSION) {
+	// Schema version check and migration
+	if ((sealed as { schemaVersion: number }).schemaVersion === 8) {
+		sealed = migrateV8ToV9(sealed);
+	} else if (sealed.schemaVersion !== SESSION_SCHEMA_VERSION) {
 		return { kind: "version-mismatch" };
 	}
 


### PR DESCRIPTION
## What this fixes

After #360 retired `phaseNumber`, `generateDualContentPacks` was still producing 6 content packs (3 A/B pairs via 3 phases) even though `swapActivePack` only ever reads the first pack from each array. This meant 2/3 of all generated packs were unused, wasting LLM tokens and latency.

**This PR changes:**
- `generateDualContentPacks` signature: accepts a single `PhaseConfig` instead of 3, returns `{ packA, packB }` instead of arrays
- Removes unused `buildLegacyPhaseConfigs()` 
- Updates all bootstrap call sites to wrap results into single-element arrays (preserving `GameState.contentPacksA/B[]` shape)
- Bumps schema from v8→v9 with migration that truncates old multi-pack saves to single-entry format
- Saves ~3 LLM cuts per game generation (input rules + 5 entity output sets × 2 phases)

**Files changed:** 
- `src/content/content-pack-generator.ts` — core function
- `src/spa/game/bootstrap.ts` — call sites
- `src/spa/persistence/session-codec.ts` — schema migration
- Test files across `__tests__/` — mock shapes and migration coverage

## QA steps for the human

None — fully covered by automated tests:
- 1408 unit tests verify function contracts
- 46 e2e smoke tests exercise game generation end-to-end
- Migration test verifies v8→v9 upgrade path

## Automated coverage

✅ Unit tests (1408 pass)
✅ Smoke/e2e tests (46 pass)  
✅ TypeScript typecheck
✅ Lint (biome)

Closes #361

---
_Generated by [Claude Code](https://claude.ai/code/session_012vCnMF2jGne4naQ6oDABx7)_