### PR TITLE
Rename swapActivePack to clarify one-way semantics

### DIFF
--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -13,7 +13,7 @@
  */
 
 import { applyDirection, CARDINAL_DIRECTIONS, inBounds } from "./direction.js";
-import { appendBroadcast, swapActivePack } from "./engine.js";
+import { appendBroadcast, shiftToBPack } from "./engine.js";
 import type {
 	ActiveComplication,
 	AiId,
@@ -516,9 +516,9 @@ export function applyComplicationResult(
 		activeComplications,
 	};
 
-	// setting_shift: swap the active pack and broadcast the change to all Daemons
+	// setting_shift: shift to the B pack and broadcast the change to all Daemons
 	if (fired.kind === "setting_shift") {
-		state = swapActivePack(state);
+		state = shiftToBPack(state);
 		state = appendBroadcast(
 			state,
 			`[SYSTEM] The setting has shifted. You are now in: ${state.setting}.`,

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -156,12 +156,22 @@ export function getActivePack(game: GameState): ContentPack {
 }
 
 /**
- * Swap `activePackId` from "A" to "B". Updates the game's `contentPack`
- * reference to the B-side pack so prompt builders and dispatchers see the new
- * names/descriptions immediately. Entity positions in `world` are
- * unchanged — world state is keyed by entity ID, which is stable across packs.
+ * One-way activation of the B-side content pack. Sets `activePackId` to "B"
+ * and points `contentPack` / `setting` at `contentPacksB[0]` so prompt
+ * builders and dispatchers see the new names/descriptions immediately.
+ *
+ * Semantics:
+ *   - A → B only. There is no reverse path; the `settingShiftFired` flag on
+ *     `complicationSchedule` ensures this fires at most once per game.
+ *   - No-op when no B pack exists (`contentPacksB[0]` undefined): returns the
+ *     input `game` unchanged.
+ *   - Idempotent from B-state: re-applies the same B-pack values; safe but
+ *     should not happen in practice given the fired-once guard.
+ *
+ * Entity positions in `world` are unchanged — world state is keyed by entity
+ * ID, which is stable across packs.
  */
-export function swapActivePack(game: GameState): GameState {
+export function shiftToBPack(game: GameState): GameState {
 	const bPack = game.contentPacksB[0];
 	if (!bPack) return game; // No B pack; no-op
 	return {


### PR DESCRIPTION
### What this fixes

`swapActivePack` in `src/spa/game/engine.ts` only ever flips the active content pack A → B; there is no reverse path, and `complicationSchedule.settingShiftFired` guards it so it fires at most once per game. The verb "swap" implied a toggle, which misled readers about the real semantics. This PR renames the function to `shiftToBPack` (the same vocabulary as the surrounding `setting_shift` complication and the `settingShiftFired` flag), updates the sole caller in `src/spa/game/complication-engine.ts:521` plus its import on line 16, and replaces the doc comment with a longer one that spells out the A → B-only behavior, the no-op path when no B pack exists, and the idempotency note for callers. The function body is byte-for-byte unchanged — pure rename + doc clarification, zero behavior change.

### QA steps for the human

None — fully covered by the integration smoke.

### Automated coverage

`pnpm typecheck`, `pnpm lint`, `pnpm test` (1408/1408), and `pnpm smoke` (46/46 Playwright e2e specs) all green; pre-push hooks re-ran the same suites cleanly on push.

Closes #363

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6BgoXEV1nMdUqgAHz3Nrb)_