### PR TITLE
Propagate weather and timeOfDay in swapActivePack

### DIFF
--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -830,7 +830,12 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 	};
 
 	function makeGameWithDualPacks(): GameState {
-		const phase = makePhase({ contentPack: PACK_A, setting: PACK_A.setting });
+		const phase = makePhase({
+			contentPack: PACK_A,
+			setting: PACK_A.setting,
+			weather: PACK_A.weather,
+			timeOfDay: PACK_A.timeOfDay,
+		});
 		return makeGameStateAround({
 			...phase,
 			contentPacksA: [PACK_A],
@@ -860,6 +865,22 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 		const updated = applyComplicationResult(game, result, seededRng([0.5]));
 		const updatedPhase = updated;
 		expect(updatedPhase.setting).toBe("sun-baked salt flat");
+	});
+
+	it("updates phase.weather to the B-side pack's weather string", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = updated;
+		expect(updatedPhase.weather).toBe("hot");
+	});
+
+	it("updates phase.timeOfDay to the B-side pack's timeOfDay string", () => {
+		const game = makeGameWithDualPacks();
+		const result = { fired: { kind: "setting_shift" as const } };
+		const updated = applyComplicationResult(game, result, seededRng([0.5]));
+		const updatedPhase = updated;
+		expect(updatedPhase.timeOfDay).toBe("day");
 	});
 
 	it("leaves world entity positions unchanged after setting_shift", () => {
@@ -906,6 +927,8 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 		const result = { fired: { kind: "weather_change" as const } };
 		const updated = applyComplicationResult(game, result, seededRng([0.5]));
 		expect(updated.activePackId).toBe("A");
+		expect(updated.weather).toBe("clear");
+		expect(updated.timeOfDay).toBe("night");
 	});
 });
 

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -157,8 +157,9 @@ export function getActivePack(game: GameState): ContentPack {
 
 /**
  * One-way activation of the B-side content pack. Sets `activePackId` to "B"
- * and points `contentPack` / `setting` at `contentPacksB[0]` so prompt
- * builders and dispatchers see the new names/descriptions immediately.
+ * and points `contentPack` at `contentPacksB[0]`, and propagates `setting`,
+ * `weather`, and `timeOfDay` from the B pack so prompt builders and
+ * dispatchers see the new names/descriptions and ambient values immediately.
  *
  * Semantics:
  *   - A → B only. There is no reverse path; the `settingShiftFired` flag on
@@ -179,6 +180,8 @@ export function shiftToBPack(game: GameState): GameState {
 		activePackId: "B",
 		contentPack: bPack,
 		setting: bPack.setting,
+		weather: bPack.weather,
+		timeOfDay: bPack.timeOfDay,
 	};
 }
 


### PR DESCRIPTION
## What this fixes

`shiftToBPack` (formerly `swapActivePack`) in `src/spa/game/engine.ts` previously copied only `setting` from the B pack onto the returned `GameState`, leaving `weather` and `timeOfDay` at their pre-shift values. This was asymmetric with `startGame` (engine.ts:90-91), which initializes all three fields from the active content pack, and it meant the prompt builder at `src/spa/game/prompt-builder.ts:107-109` (which reads `game.weather` / `game.timeOfDay`) silently kept describing the A pack's ambient values after a `setting_shift` complication fired.

The fix extends `shiftToBPack`'s return literal to also propagate `weather: bPack.weather` and `timeOfDay: bPack.timeOfDay`, and updates the JSDoc to document the new propagation. Behaviour is now symmetrical with `startGame`: all setting-related fields refresh together when the pack activates.

The only caller is `complication-engine.ts:521` (the `setting_shift` handler); no other code paths needed updating.

## QA steps for the human

None — fully covered by the integration smoke. The two new unit tests in `complication-engine.test.ts` assert that after a `setting_shift`, `weather === "hot"` and `timeOfDay === "day"` (PACK_B values, distinct from PACK_A's `clear` / `night`), and the existing non-shift test now also locks in that those fields are preserved for non-`setting_shift` complications.

## Automated coverage

`pnpm typecheck`, `pnpm test` (1410/1410), and `pnpm smoke` (46/46 Playwright) all pass.

Closes #362

---
_Generated by [Claude Code](https://claude.ai/code/session_017xFBNT9pytomqiukjQdZLw)_