### PR TITLE
Add test coverage for swapActivePack (weather, timeOfDay, idempotency, no-B-pack)

### DIFF
--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -7,9 +7,10 @@ import {
 	appendMessage,
 	deductBudget,
 	isAiLockedOut,
+	shiftToBPack,
 	startGame,
 } from "../engine";
-import type { AiPersona, ContentPack } from "../types";
+import type { AiPersona, ContentPack, GameState } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
 	red: {
@@ -292,5 +293,88 @@ describe("appendActionFailure", () => {
 		expect(redLog).toHaveLength(2);
 		expect(redLog[0]).toEqual(entry1);
 		expect(redLog[1]).toEqual(entry2);
+	});
+});
+
+describe("shiftToBPack", () => {
+	const PACK_A: ContentPack = {
+		setting: "neon arcade",
+		weather: "clear",
+		timeOfDay: "night",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {},
+	};
+
+	const PACK_B: ContentPack = {
+		setting: "sun-baked salt flat",
+		weather: "hot",
+		timeOfDay: "day",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: {},
+	};
+
+	function makeDualPackGame(): GameState {
+		const game = startGame(TEST_PERSONAS, PACK_A, { budgetPerAi: 5 });
+		return {
+			...game,
+			contentPacksA: [PACK_A],
+			contentPacksB: [PACK_B],
+		};
+	}
+
+	it("propagates weather from the B pack into game.weather", () => {
+		const game = makeDualPackGame();
+		const updated = shiftToBPack(game);
+		expect(updated.weather).toBe("hot");
+		expect(game.weather).toBe("clear");
+	});
+
+	it("propagates timeOfDay from the B pack into game.timeOfDay", () => {
+		const game = makeDualPackGame();
+		const updated = shiftToBPack(game);
+		expect(updated.timeOfDay).toBe("day");
+		expect(game.timeOfDay).toBe("night");
+	});
+
+	it("is idempotent when called a second time from B-state", () => {
+		const game = makeDualPackGame();
+		const once = shiftToBPack(game);
+		const twice = shiftToBPack(once);
+		expect(twice.activePackId).toBe("B");
+		expect(twice.setting).toBe("sun-baked salt flat");
+		expect(twice.weather).toBe("hot");
+		expect(twice.timeOfDay).toBe("day");
+		expect(twice.contentPack).toBe(PACK_B);
+		expect({
+			activePackId: twice.activePackId,
+			setting: twice.setting,
+			weather: twice.weather,
+			timeOfDay: twice.timeOfDay,
+		}).toEqual({
+			activePackId: once.activePackId,
+			setting: once.setting,
+			weather: once.weather,
+			timeOfDay: once.timeOfDay,
+		});
+	});
+
+	it("returns the input game unchanged when contentPacksB is empty", () => {
+		const game = {
+			...startGame(TEST_PERSONAS, PACK_A, { budgetPerAi: 5 }),
+			contentPacksA: [PACK_A],
+			contentPacksB: [] as ContentPack[],
+		};
+		const result = shiftToBPack(game);
+		expect(result).toBe(game);
+		expect(result.activePackId).toBe("A");
+		expect(result.setting).toBe("neon arcade");
+		expect(result.weather).toBe("clear");
+		expect(result.timeOfDay).toBe("night");
 	});
 });


### PR DESCRIPTION
## What this fixes

Adds the four missing direct unit tests for `shiftToBPack` (the function the issue still calls by its old name `swapActivePack` — renamed in #367). The existing 11 `setting_shift` tests in `src/spa/game/__tests__/complication-engine.test.ts` already cover the function indirectly through `applyComplicationResult`, and #362 landed the actual `weather` / `timeOfDay` propagation in `engine.ts`. What was missing was a direct contract for `shiftToBPack` itself, locking the function's behaviour in independently of the complication pipeline.

The new `describe("shiftToBPack", ...)` block in `src/spa/game/__tests__/engine.test.ts` declares two local `ContentPack` fixtures with deliberately distinct `weather` / `timeOfDay` / `setting` values (the static fixtures under `src/spa/__tests__/fixtures/` use empty strings and were unusable for assertions), plus a small `makeDualPackGame()` helper, and exercises:

1. **weather propagation** — `shiftToBPack` copies B-pack `weather` onto the game; original game is not mutated.
2. **timeOfDay propagation** — same shape for `timeOfDay`.
3. **idempotency from B-state** — `shiftToBPack(shiftToBPack(game))` produces field-equal `activePackId` / `setting` / `weather` / `timeOfDay` to a single call (the function returns a new spread object each time, so the assertion is field-equality, not reference-equality).
4. **no-B-pack branch** — when `contentPacksB` is empty, `shiftToBPack` returns the input game by reference unchanged (matches the `return game` path in `engine.ts:177`), asserted with `toBe(game)` plus defensive field assertions.

No production code was touched.

## QA steps for the human

None — fully covered by the unit tests and the Playwright smoke that ran clean.

## Automated coverage

`pnpm typecheck` ✅ • `pnpm test` (1414/1414) ✅ • `pnpm smoke` (46/46 Playwright) ✅

Closes #364

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSrJ7VPoHtvEHMSnmyNH5V)_