### PR TITLE
Replace transcript polling with deterministic DOM signal for round completion

### DIFF
--- a/.claude/skills/playtest/02-explore.md
+++ b/.claude/skills/playtest/02-explore.md
@@ -43,8 +43,9 @@ someone else's writeup.
 - **`src/content/{persona-generator.ts, temperament-pool.ts,
   persona-goal-pool.ts, sysadmin-directive-pool.ts, setting-pool.ts,
   weather-pool.ts}`** — the content pools synthesis draws from.
-  `src/content/phases.ts` is still present but its `PHASE_*_CONFIG`
-  exports are deprecated; the live config is `SINGLE_GAME_CONFIG`.
+  `src/content/phases.ts` now exports only `SINGLE_GAME_CONFIG`
+  (`kRange`, `nRange`, `mRange`, `budgetPerAi`); the legacy
+  `PHASE_*_CONFIG` constants have been removed.
 - **`/tmp/wrangler.log`** — the worker proxy log for this run. Now in
   bounds. Useful for confirming which tool calls a daemon actually fired
   in a given round (look for `["pick_up","examine","message:0jmn"]`-style

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -103,8 +103,8 @@ scripts/playtest/cmd.sh '{"op":"view"}'
 scripts/playtest/cmd.sh '{"op":"view","full":true}'
 
 # Type a message into the composer and press send. The daemon waits for the
-# round to go quiet (up to 90 s) before returning a delta snapshot, so you
-# do NOT need a separate "wait" after most sends.
+# round-in-flight DOM signal to clear (up to 90 s) before returning a delta
+# snapshot, so you do NOT need a separate "wait" after most sends.
 scripts/playtest/cmd.sh '{"op":"send","text":"*v86p hi! im blue. what do you see?"}'
 
 # Send with full transcript in the response (for context refresh):

--- a/scripts/playtest/daemon.mjs
+++ b/scripts/playtest/daemon.mjs
@@ -226,23 +226,25 @@ async function send(text) {
 	await page.locator("#send").click();
 }
 
-async function waitForRoundQuiet(maxMs = 60_000) {
-	// A round is "quiet" when no panel transcript has changed in ~3s.
-	const deadline = Date.now() + maxMs;
-	let last = JSON.stringify((await snapshot()).panels.map((p) => p.transcript));
-	let lastChangeAt = Date.now();
-	while (Date.now() < deadline) {
-		await page.waitForTimeout(500);
-		const cur = JSON.stringify(
-			(await snapshot()).panels.map((p) => p.transcript),
-		);
-		if (cur !== last) {
-			last = cur;
-			lastChangeAt = Date.now();
-		} else if (Date.now() - lastChangeAt > 3000) {
-			return;
-		}
+async function waitForRoundEnd(maxMs = 90_000) {
+	// The round handler in routes/game.ts flips `data-round-in-flight` on
+	// `#stage` to "true" synchronously at submit-time, then removes it in the
+	// finally block after the events loop has painted every transcript update.
+	// Waiting on that attribute is deterministic: it fires whether daemons
+	// respond or not (locked-out and silent turns still complete the round)
+	// and only clears once the round's UI updates are fully applied.
+	const inFlight = page.locator("#stage[data-round-in-flight]");
+	try {
+		// Confirm the round actually started. The attribute is set in the
+		// synchronous portion of the click handler, so this should resolve
+		// immediately; a longer wait covers slow-to-handler edge cases.
+		await inFlight.waitFor({ state: "attached", timeout: 5_000 });
+	} catch {
+		// No round started — most likely the message was rejected client-side
+		// (empty / invalid mention). Nothing to wait for.
+		return;
 	}
+	await inFlight.waitFor({ state: "detached", timeout: maxMs });
 }
 
 // Apply delta logic to a snapshot in place. When full=true (or on the first
@@ -269,7 +271,7 @@ async function handle(cmd) {
 		}
 		case "send": {
 			await send(cmd.text);
-			await waitForRoundQuiet(cmd.maxMs ?? 90_000);
+			await waitForRoundEnd(cmd.maxMs ?? 90_000);
 			const snap = await snapshot();
 			applyDelta(snap, cmd.full);
 			return { ok: true, snapshot: snap };

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1134,6 +1134,13 @@ export function renderGame(
 		const addressed = addressee;
 		roundInFlight = true;
 		sendBtn.disabled = true;
+		// Expose round-in-flight as a DOM attribute on #stage so external
+		// drivers (the playtest daemon, e2e tests) can wait on a deterministic
+		// signal instead of polling transcript text. Cleared in the finally
+		// block below — after the events loop has painted the round's output.
+		doc
+			.querySelector<HTMLElement>("#stage")
+			?.setAttribute("data-round-in-flight", "true");
 
 		// Clear any prior round-level error UI before starting the new round.
 		// If this round also fails, the catch block re-shows it; if it
@@ -1608,6 +1615,9 @@ export function renderGame(
 		} finally {
 			stripAllSpinners();
 			roundInFlight = false;
+			doc
+				.querySelector<HTMLElement>("#stage")
+				?.removeAttribute("data-round-in-flight");
 			if (!roundGameEnded) {
 				refreshComposerState();
 				refreshTopInfo();


### PR DESCRIPTION
## Summary
Replaced the heuristic-based `waitForRoundQuiet()` function with a deterministic `waitForRoundEnd()` function that waits on a DOM attribute signal instead of polling transcript text. This improves test reliability and reduces flakiness in the playtest daemon.

## Key Changes

- **Playtest daemon (`scripts/playtest/daemon.mjs`)**: 
  - Replaced `waitForRoundQuiet()` with `waitForRoundEnd()` that waits for the `data-round-in-flight` attribute on `#stage` to be set and then removed
  - The new approach is deterministic: it waits for the attribute to attach (confirming round started) then detach (confirming round completed and UI painted)
  - Handles edge cases where no round starts (client-side validation failures) by catching the initial attachment timeout

- **Game renderer (`src/spa/routes/game.ts`)**:
  - Added `data-round-in-flight="true"` attribute to `#stage` synchronously when a round begins (in the click handler)
  - Removed the attribute in the finally block after the events loop has painted all transcript updates
  - This provides an external signal that external drivers (playtest daemon, e2e tests) can reliably wait on

- **Documentation (`src/content/phases.ts` and skill docs)**:
  - Updated documentation to reflect that `PHASE_*_CONFIG` constants have been removed and only `SINGLE_GAME_CONFIG` remains
  - Updated playtest skill documentation to describe the new round-in-flight DOM signal instead of the transcript polling approach

## Implementation Details

The new approach is more reliable because:
- The attribute is set synchronously at submit-time, so the daemon can confirm a round actually started
- The attribute is only removed after the finally block executes, ensuring all UI updates are painted
- It works regardless of daemon responses (locked-out and silent turns still complete the round)
- It eliminates the 3-second quiet period heuristic that could be unreliable under load

https://claude.ai/code/session_01GnPdHSCYRVLtEr1BejhHd5