### PR TITLE
Reproject world entities when swapping to pack B

### DIFF
--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -960,6 +960,205 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 	});
 });
 
+// ── setting_shift reprojects world entities onto pack B ───────────────────────
+
+describe("applyComplicationResult — setting_shift reprojects world onto pack B", () => {
+	/**
+	 * Pack A / pack B share entity ids (mirroring how
+	 * `generateDualContentPacks` produces them). Pack A is a "neon arcade",
+	 * pack B a "sun-baked salt flat" — entity names and flavor differ.
+	 */
+	const A_OBJECT: WorldEntity = {
+		id: "obj-1",
+		kind: "objective_object",
+		name: "joystick",
+		examineDescription: "A worn arcade joystick.",
+		useOutcome: "It clicks.",
+		pairsWithSpaceId: "space-1",
+		proximityFlavor: "neon hums nearby.",
+		holder: { row: 0, col: 0 },
+	};
+	const A_SPACE: WorldEntity = {
+		id: "space-1",
+		kind: "objective_space",
+		name: "control panel",
+		examineDescription: "A scuffed arcade control panel.",
+		holder: { row: 1, col: 1 },
+	};
+	const A_ITEM: WorldEntity = {
+		id: "item-1",
+		kind: "interesting_object",
+		name: "token",
+		examineDescription: "A brass arcade token.",
+		useOutcome: "It rattles into a slot.",
+		holder: { row: 2, col: 2 },
+	};
+	const A_OBSTACLE: WorldEntity = {
+		id: "obs-1",
+		kind: "obstacle",
+		name: "cabinet",
+		examineDescription: "A hulking cabinet.",
+		holder: { row: 3, col: 3 },
+	};
+
+	const B_OBJECT: WorldEntity = {
+		id: "obj-1",
+		kind: "objective_object",
+		name: "salt-crusted compass",
+		examineDescription: "A compass rimed with salt.",
+		useOutcome: "Its needle drifts lazily.",
+		pairsWithSpaceId: "space-1",
+		proximityFlavor: "the air shimmers.",
+		holder: { row: 0, col: 0 },
+	};
+	const B_SPACE: WorldEntity = {
+		id: "space-1",
+		kind: "objective_space",
+		name: "salt cairn",
+		examineDescription: "A waist-high cairn of crystallised salt.",
+		holder: { row: 1, col: 1 },
+	};
+	const B_ITEM: WorldEntity = {
+		id: "item-1",
+		kind: "interesting_object",
+		name: "sun-bleached shell",
+		examineDescription: "A papery shell, baked white.",
+		useOutcome: "It crumbles to dust.",
+		holder: { row: 2, col: 2 },
+	};
+	const B_OBSTACLE: WorldEntity = {
+		id: "obs-1",
+		kind: "obstacle",
+		name: "wind-scoured boulder",
+		examineDescription: "A boulder grooved by wind.",
+		holder: { row: 3, col: 3 },
+	};
+
+	const PACK_A: ContentPack = {
+		phaseNumber: 1,
+		setting: "neon arcade",
+		weather: "humid",
+		timeOfDay: "night",
+		objectivePairs: [{ object: A_OBJECT, space: A_SPACE }],
+		interestingObjects: [A_ITEM],
+		obstacles: [A_OBSTACLE],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: makePersonaSpatial(),
+	};
+
+	const PACK_B: ContentPack = {
+		phaseNumber: 1,
+		setting: "sun-baked salt flat",
+		weather: "scorching",
+		timeOfDay: "day",
+		objectivePairs: [{ object: B_OBJECT, space: B_SPACE }],
+		interestingObjects: [B_ITEM],
+		obstacles: [B_OBSTACLE],
+		landmarks: DEFAULT_LANDMARKS,
+		aiStarts: makePersonaSpatial(),
+	};
+
+	function makeGameWithLiveWorld(entities: WorldEntity[]): GameState {
+		const phase = makePhase({
+			contentPack: PACK_A,
+			setting: PACK_A.setting,
+			weather: PACK_A.weather,
+			timeOfDay: PACK_A.timeOfDay,
+			world: { entities },
+		});
+		return makeGameStateAround({
+			...phase,
+			contentPacksA: [PACK_A],
+			contentPacksB: [PACK_B],
+			activePackId: "A",
+		});
+	}
+
+	const SHIFT = { fired: { kind: "setting_shift" as const } };
+
+	it("reprojects entity names from pack B by id", () => {
+		const game = makeGameWithLiveWorld([A_OBJECT, A_SPACE, A_ITEM, A_OBSTACLE]);
+		const updated = applyComplicationResult(game, SHIFT, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const byId = new Map(
+			updatedPhase.world.entities.map((e) => [e.id, e.name]),
+		);
+		expect(byId.get("obj-1")).toBe("salt-crusted compass");
+		expect(byId.get("space-1")).toBe("salt cairn");
+		expect(byId.get("item-1")).toBe("sun-bleached shell");
+		expect(byId.get("obs-1")).toBe("wind-scoured boulder");
+	});
+
+	it("reprojects examineDescription and flavor fields from pack B", () => {
+		const game = makeGameWithLiveWorld([A_OBJECT, A_SPACE, A_ITEM, A_OBSTACLE]);
+		const updated = applyComplicationResult(game, SHIFT, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const obj = updatedPhase.world.entities.find((e) => e.id === "obj-1");
+		expect(obj?.examineDescription).toBe("A compass rimed with salt.");
+		expect(obj?.proximityFlavor).toBe("the air shimmers.");
+		expect(obj?.useOutcome).toBe("Its needle drifts lazily.");
+	});
+
+	it("preserves holder when a daemon is carrying an entity across the swap", () => {
+		// Move obj-1 into a daemon's hand before the shift.
+		const held: WorldEntity = { ...A_OBJECT, holder: "red" };
+		const game = makeGameWithLiveWorld([held, A_SPACE, A_ITEM, A_OBSTACLE]);
+		const updated = applyComplicationResult(game, SHIFT, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const obj = updatedPhase.world.entities.find((e) => e.id === "obj-1");
+		expect(obj?.holder).toBe("red");
+		// And the new name comes through even though the daemon is holding it.
+		expect(obj?.name).toBe("salt-crusted compass");
+	});
+
+	it("preserves satisfactionState and useAvailable from the pre-swap world", () => {
+		const satisfiedSpace: WorldEntity = {
+			...A_SPACE,
+			satisfactionState: "satisfied",
+			useAvailable: false,
+		};
+		const game = makeGameWithLiveWorld([
+			A_OBJECT,
+			satisfiedSpace,
+			A_ITEM,
+			A_OBSTACLE,
+		]);
+		const updated = applyComplicationResult(game, SHIFT, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const space = updatedPhase.world.entities.find((e) => e.id === "space-1");
+		expect(space?.satisfactionState).toBe("satisfied");
+		expect(space?.useAvailable).toBe(false);
+		expect(space?.name).toBe("salt cairn");
+	});
+
+	it("reprojects weather and timeOfDay onto pack B values", () => {
+		const game = makeGameWithLiveWorld([A_OBJECT, A_SPACE, A_ITEM, A_OBSTACLE]);
+		const updated = applyComplicationResult(game, SHIFT, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		expect(updatedPhase.weather).toBe("scorching");
+		expect(updatedPhase.timeOfDay).toBe("day");
+	});
+
+	it("leaves entities without a pack-B match unchanged", () => {
+		// An entity in the live world but absent from pack B — a test
+		// fixture or a future kind packs don't yet author.
+		const orphan: WorldEntity = {
+			id: "orphan-1",
+			kind: "obstacle",
+			name: "unpacked boulder",
+			examineDescription: "Not in any pack.",
+			holder: { row: 4, col: 4 },
+		};
+		const game = makeGameWithLiveWorld([A_OBJECT, orphan]);
+		const updated = applyComplicationResult(game, SHIFT, seededRng([0.5]));
+		const updatedPhase = getActivePhase(updated);
+		const orphanAfter = updatedPhase.world.entities.find(
+			(e) => e.id === "orphan-1",
+		);
+		expect(orphanAfter).toEqual(orphan);
+	});
+});
+
 // ── Determinism ───────────────────────────────────────────────────────────────
 
 describe("determinism", () => {

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -18,6 +18,7 @@ import type {
 	GridPosition,
 	PersonaSpatialState,
 	ToolName,
+	WorldEntity,
 } from "./types";
 
 /**
@@ -161,10 +162,55 @@ export function getActivePack(game: GameState): ContentPack {
 }
 
 /**
- * Swap `activePackId` from "A" to "B". Updates the game's `contentPack`
- * reference to the B-side pack so prompt builders and dispatchers see the new
- * names/descriptions immediately. Entity positions in `world` are
- * unchanged — world state is keyed by entity ID, which is stable across packs.
+ * Reproject `world.entities` onto pack B by entity id.
+ *
+ * Pack B is generated mirror-keyed to pack A (`generateDualContentPacks`):
+ * every id in pack A has a counterpart in pack B carrying the new setting's
+ * name, descriptions, and flavor fields. This walks the live world and swaps
+ * each entity's presentation for its pack-B counterpart while preserving the
+ * runtime state that has accumulated through play (`holder`,
+ * `satisfactionState`, `useAvailable`).
+ *
+ * Entities without a pack-B match are left unchanged — defensive for tests
+ * that construct world entities directly without populating pack B.
+ */
+function reprojectEntitiesOnto(
+	entities: WorldEntity[],
+	bPack: ContentPack,
+): WorldEntity[] {
+	const byId = new Map<string, WorldEntity>();
+	for (const pair of bPack.objectivePairs) {
+		byId.set(pair.object.id, pair.object);
+		byId.set(pair.space.id, pair.space);
+	}
+	for (const obj of bPack.interestingObjects) byId.set(obj.id, obj);
+	for (const obs of bPack.obstacles) byId.set(obs.id, obs);
+
+	return entities.map((entity) => {
+		const bEntity = byId.get(entity.id);
+		if (!bEntity) return entity;
+		const reprojected: WorldEntity = {
+			...bEntity,
+			holder: entity.holder,
+		};
+		if (entity.satisfactionState !== undefined) {
+			reprojected.satisfactionState = entity.satisfactionState;
+		}
+		if (entity.useAvailable !== undefined) {
+			reprojected.useAvailable = entity.useAvailable;
+		}
+		return reprojected;
+	});
+}
+
+/**
+ * Swap `activePackId` from "A" to "B" and reproject the live world onto
+ * pack B's presentation. After the swap a Daemon's `<where_you_are>` and
+ * `<what_you_see>` blocks reflect the new setting — held items and visible
+ * cells are described with pack B's names and flavor — while entity
+ * positions, satisfaction state, and `useAvailable` carry over from
+ * pre-swap play. `weather` and `timeOfDay` are also reprojected from pack
+ * B since the dual generator draws them independently per side.
  */
 export function swapActivePack(game: GameState): GameState {
 	const bPack = game.contentPacksB[0];
@@ -174,6 +220,9 @@ export function swapActivePack(game: GameState): GameState {
 		activePackId: "B",
 		contentPack: bPack,
 		setting: bPack.setting,
+		weather: bPack.weather,
+		timeOfDay: bPack.timeOfDay,
+		world: { entities: reprojectEntitiesOnto(game.world.entities, bPack) },
 	};
 }
 


### PR DESCRIPTION
## Summary
When a `setting_shift` complication swaps the active content pack from A to B, the live world's entities are now reprojected onto pack B's presentation. This ensures that after the swap, a Daemon's descriptions and observations reflect the new setting's names, flavor text, and environmental details.

## Key Changes
- **Added `reprojectEntitiesOnto()` function**: Maps live world entities to their pack-B counterparts by ID, preserving runtime state (holder, satisfactionState, useAvailable) while swapping presentation fields (name, examineDescription, proximityFlavor, useOutcome).
- **Enhanced `swapActivePack()` function**: Now reprojected entities onto pack B, and also updates `weather` and `timeOfDay` from pack B since the dual content generator produces these independently per side.
- **Comprehensive test coverage**: Added 6 test cases validating that entity names/descriptions are swapped, runtime state is preserved, orphaned entities (not in pack B) remain unchanged, and environmental attributes are updated.

## Implementation Details
- Pack A and B share entity IDs (by design of `generateDualContentPacks`), enabling ID-based lookup and reprojection
- The reprojection preserves all accumulated runtime state: entity positions (`holder`), objective satisfaction state, and item availability flags
- Entities without a pack-B match are defensively left unchanged to support test fixtures and future entity kinds
- The function copies all presentation fields from pack B while selectively preserving only the runtime state fields that may have been modified during play

https://claude.ai/code/session_013iYDE1Jz1HNFXV4KksuSHD