### PR TITLE
Daemons cannot perceive grid edges — add setting-flavored wall markers to cone rendering

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,10 @@ A non-win item present on the grid for flavor and negotiation currency. Has a `u
 **Obstacle**:
 A static, impassable cell occupant, named to match the Setting (e.g. "moss-covered concrete column"). Cannot share a cell with anything else.
 
+**Wall**:
+The impassable boundary surrounding the 5×5 grid, perceived by a Daemon as a setting-flavored noun phrase (e.g. "crumbling tile wall") when an out-of-bounds cell falls inside the Daemon's **Cone**. Authored on the **Content Pack** (paired across Pack A / Pack B for Setting Shift) as `wallName`. Rendered alongside obstacles in `<what_you_see>` and `<whats_new>`. Not a `WorldEntity`, not a separate cell occupant — purely a perception sentinel for OOB cone cells.
+_Avoid_: Edge (positional, not lexical), barrier (less setting-natural).
+
 **Cone**:
 The wedge-shaped region of cells an AI can see each turn: 1 cell directly in front + 3 cells two steps ahead (front-left, front, front-right), plus the AI's own cell. Projects from the AI's **Facing**. Obstacles do not occlude — the cone is a fixed-shape mask, not a raycast.
 

--- a/src/__tests__/save-serializer.test.ts
+++ b/src/__tests__/save-serializer.test.ts
@@ -65,6 +65,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/content/__tests__/content-pack-generator.test.ts
+++ b/src/content/__tests__/content-pack-generator.test.ts
@@ -131,6 +131,7 @@ function makeMockProvider(): MockContentPackProvider {
 							holder: { row: 0, col: 0 } as never,
 						})),
 						landmarks: DEFAULT_LANDMARKS,
+						wallName: "wall",
 						aiStarts: {} as Record<string, never>,
 					};
 				},
@@ -425,6 +426,7 @@ describe("generateContentPacks — degenerate config throws after MAX_ATTEMPTS",
 						holder: { row: 0, col: 0 } as never,
 					})),
 					landmarks: DEFAULT_LANDMARKS,
+					wallName: "wall",
 					aiStarts: {} as Record<string, never>,
 				})),
 			}),
@@ -499,6 +501,7 @@ function makeDualMockProvider(): MockContentPackProvider {
 						holder: { row: 0, col: 0 } as never,
 					})),
 					landmarks: DEFAULT_LANDMARKS,
+					wallName: `wall ${suffix}`,
 					aiStarts: {} as never,
 				});
 

--- a/src/content/content-pack-generator.ts
+++ b/src/content/content-pack-generator.ts
@@ -360,6 +360,7 @@ export async function generateContentPacks(
 		interestingObjects: pack.interestingObjects as WorldEntity[],
 		obstacles: pack.obstacles as WorldEntity[],
 		landmarks: pack.landmarks,
+		wallName: pack.wallName,
 		aiStarts: {},
 	}));
 
@@ -454,6 +455,7 @@ export async function generateDualContentPacks(
 		interestingObjects: phaseResult.packA.interestingObjects as WorldEntity[],
 		obstacles: phaseResult.packA.obstacles as WorldEntity[],
 		landmarks: phaseResult.packA.landmarks,
+		wallName: phaseResult.packA.wallName,
 		aiStarts: {},
 	};
 
@@ -495,6 +497,7 @@ export async function generateDualContentPacks(
 		).map(applyHolder),
 		obstacles: (phaseResult.packB.obstacles as WorldEntity[]).map(applyHolder),
 		landmarks: phaseResult.packB.landmarks,
+		wallName: phaseResult.packB.wallName,
 		aiStarts: { ...placedPackA.aiStarts },
 	};
 
@@ -566,6 +569,7 @@ export async function generateContentPack(
 		interestingObjects: pack.interestingObjects as WorldEntity[],
 		obstacles: pack.obstacles as WorldEntity[],
 		landmarks: pack.landmarks,
+		wallName: pack.wallName,
 		aiStarts: {},
 	};
 

--- a/src/spa/__tests__/fixtures/static-content-packs.ts
+++ b/src/spa/__tests__/fixtures/static-content-packs.ts
@@ -19,6 +19,7 @@ export const STATIC_CONTENT_PACK_NO_PAIRS: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "tunnel wall",
 	aiStarts: AI_STARTS,
 };
 
@@ -53,6 +54,7 @@ export const STATIC_CONTENT_PACKS: ContentPack[] = [
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "tunnel wall",
 		aiStarts: AI_STARTS,
 	},
 	{
@@ -81,6 +83,7 @@ export const STATIC_CONTENT_PACKS: ContentPack[] = [
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "salt flat boundary",
 		aiStarts: AI_STARTS,
 	},
 	{
@@ -109,6 +112,7 @@ export const STATIC_CONTENT_PACKS: ContentPack[] = [
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "laboratory bulkhead",
 		aiStarts: AI_STARTS,
 	},
 ];

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -186,6 +186,7 @@ describe("persistence — LLM-shaped blurb round-trips verbatim", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {},
 	};
 

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -26,6 +26,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/__tests__/sessions.test.ts
+++ b/src/spa/__tests__/sessions.test.ts
@@ -29,6 +29,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/__tests__/test-affordances.test.ts
+++ b/src/spa/__tests__/test-affordances.test.ts
@@ -81,6 +81,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: AI_STARTS,
 };
 

--- a/src/spa/game/__tests__/available-tools.test.ts
+++ b/src/spa/game/__tests__/available-tools.test.ts
@@ -63,6 +63,7 @@ function makeGame() {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 2, col: 2 }, facing: "north" },
 			green: { position: { row: 0, col: 0 }, facing: "north" },
@@ -244,6 +245,7 @@ function makeGameWithSpace(
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 2, col: 2 }, facing: actorFacing },
 			green: { position: { row: 0, col: 0 }, facing: "north" },

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -121,6 +121,7 @@ function makePhase(overrides: Partial<GameState> = {}): GameState {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: personaSpatial,
 	};
 
@@ -815,6 +816,7 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: makePersonaSpatial(),
 	};
 
@@ -826,6 +828,7 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: makePersonaSpatial(),
 	};
 
@@ -1032,6 +1035,7 @@ describe("applyComplicationResult — setting_shift reprojects world entities", 
 		interestingObjects: [A_ITEM],
 		obstacles: [A_OBSTACLE],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: makePersonaSpatial(),
 	};
 
@@ -1043,6 +1047,7 @@ describe("applyComplicationResult — setting_shift reprojects world entities", 
 		interestingObjects: [B_ITEM],
 		obstacles: [B_OBSTACLE],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: makePersonaSpatial(),
 	};
 
@@ -1160,6 +1165,7 @@ describe("startGame — complicationSchedule initialisation", () => {
 				interestingObjects: [],
 				obstacles: [],
 				landmarks: DEFAULT_LANDMARKS,
+				wallName: "wall",
 				aiStarts: {},
 			},
 			{ budgetPerAi: 0.5 },

--- a/src/spa/game/__tests__/complications.test.ts
+++ b/src/spa/game/__tests__/complications.test.ts
@@ -76,6 +76,7 @@ function makeGameWithWeather(weather: string) {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -209,6 +210,7 @@ function makeGameWithObstacle(obstaclePos: GridPosition, shiftFlavor?: string) {
 		interestingObjects: [],
 		obstacles: [obstacle],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -278,6 +280,7 @@ describe("obstacleShiftComplication", () => {
 			interestingObjects: [],
 			obstacles: [obstacle],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 2, col: 2 }, facing: "south" }, // cone covers (3,2)
 				green: { position: { row: 0, col: 0 }, facing: "north" }, // cone does not cover (3,2)
@@ -323,6 +326,7 @@ describe("obstacleShiftComplication", () => {
 			interestingObjects: [],
 			obstacles: [obstacle],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 2, col: 2 }, facing: "south" }, // cone covers (3,2)
 				green: { position: { row: 0, col: 0 }, facing: "north" },
@@ -363,6 +367,7 @@ describe("obstacleShiftComplication", () => {
 			interestingObjects: [],
 			obstacles: [obstacle],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 2, col: 2 }, facing: "south" },
 				green: { position: { row: 0, col: 0 }, facing: "north" },

--- a/src/spa/game/__tests__/cone-projector.test.ts
+++ b/src/spa/game/__tests__/cone-projector.test.ts
@@ -141,24 +141,65 @@ describe("projectCone — facing west from (2,2)", () => {
 	});
 });
 
-describe("projectCone — edge cases: out-of-bounds filtering", () => {
-	it("facing north from (0,0) returns only own cell (all cone cells OOB)", () => {
+describe("projectCone — edge cases: wall sentinels for OOB cells", () => {
+	it("facing north from (0,0) returns exactly 9 cells — 8 non-own cells are walls", () => {
 		const cells = projectCone({ row: 0, col: 0 }, "north");
-		// Own cell is always included; all distance-1 and distance-2 cells are OOB
-		expect(cells).toHaveLength(1);
+		// Always 9 cells now — OOB cells are wall sentinels
+		expect(cells).toHaveLength(9);
 		expect(cells[0]?.phrasing).toBe("your cell");
 		expect(cells[0]?.position).toEqual({ row: 0, col: 0 });
+		// All 8 non-own cells must be walls (all cone cells are OOB from (0,0) facing north)
+		const nonOwn = cells.filter((c) => !c.isOwnCell);
+		expect(nonOwn).toHaveLength(8);
+		for (const c of nonOwn) {
+			expect(c.isWall).toBe(true);
+		}
 	});
 
-	it("facing north from (1,0) returns own cell plus the two in-bounds front-arc cells", () => {
-		// front-left (0,-1) OOB; front (0,0) in; front-right (0,1) in; all dist-2 OOB
+	it("facing north from (1,0) — only OOB cells have isWall: true", () => {
+		// front-left (0,-1) OOB → wall; front (0,0) in; front-right (0,1) in; all dist-2 OOB
 		const cells = projectCone({ row: 1, col: 0 }, "north");
-		expect(cells).toHaveLength(3);
-		expect(cells[0]?.phrasing).toBe("your cell");
-		expect(cells[1]?.phrasing).toBe("directly in front");
-		expect(cells[1]?.position).toEqual({ row: 0, col: 0 });
-		expect(cells[2]?.phrasing).toBe("directly in front, right");
-		expect(cells[2]?.position).toEqual({ row: 0, col: 1 });
+		expect(cells).toHaveLength(9);
+		// Own cell: not a wall
+		expect(cells[0]?.isWall).toBe(false);
+		// directly in front, left (0,-1): OOB → wall
+		expect(cells[1]?.phrasing).toBe("directly in front, left");
+		expect(cells[1]?.isWall).toBe(true);
+		// directly in front (0,0): in-bounds → not wall
+		expect(cells[2]?.phrasing).toBe("directly in front");
+		expect(cells[2]?.position).toEqual({ row: 0, col: 0 });
+		expect(cells[2]?.isWall).toBe(false);
+		// directly in front, right (0,1): in-bounds → not wall
+		expect(cells[3]?.phrasing).toBe("directly in front, right");
+		expect(cells[3]?.position).toEqual({ row: 0, col: 1 });
+		expect(cells[3]?.isWall).toBe(false);
+		// All dist-2 cells from (1,0) facing north are OOB → walls
+		for (const c of cells.slice(4)) {
+			expect(c.isWall).toBe(true);
+		}
+	});
+
+	it("center cone (2,2) facing north has all 9 cells with isWall: false", () => {
+		const cells = projectCone({ row: 2, col: 2 }, "north");
+		expect(cells).toHaveLength(9);
+		for (const c of cells) {
+			expect(c.isWall).toBe(false);
+		}
+	});
+
+	it("own cell is never a wall", () => {
+		// Test several positions including corners
+		for (const pos of [
+			{ row: 0, col: 0 },
+			{ row: 4, col: 4 },
+			{ row: 2, col: 2 },
+		]) {
+			for (const facing of ["north", "south", "east", "west"] as const) {
+				const cells = projectCone(pos, facing);
+				expect(cells[0]?.isOwnCell).toBe(true);
+				expect(cells[0]?.isWall).toBe(false);
+			}
+		}
 	});
 
 	it("own cell is always first in the returned array", () => {

--- a/src/spa/game/__tests__/conversation-log-integration.test.ts
+++ b/src/spa/game/__tests__/conversation-log-integration.test.ts
@@ -130,6 +130,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {
 		red: { position: { row: 2, col: 0 }, facing: "south" },
 		green: { position: { row: 0, col: 0 }, facing: "south" },
@@ -488,6 +489,7 @@ describe("conversation log integration — action-failure (issue #287)", () => {
 				},
 			],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 2, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 0 }, facing: "south" },

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -110,6 +110,7 @@ function makePackWithEntities(
 		interestingObjects: [flower, key],
 		obstacles,
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -356,6 +357,7 @@ describe("validateToolCall", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -401,6 +403,7 @@ describe("executeToolCall — use placement via front arc", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -445,6 +448,7 @@ describe("executeToolCall — use placement via front arc", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -862,6 +866,7 @@ describe("dispatchAiTurn", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -959,6 +964,7 @@ describe("dispatchAiTurn", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -1006,6 +1012,7 @@ describe("dispatchAiTurn", () => {
 			interestingObjects: [flower],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 2, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 0 }, facing: "south" },
@@ -1378,6 +1385,7 @@ function makeGameWithSpaceObjective(
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: actorPos, facing: actorFacing },
 			green: { position: { row: 0, col: 0 }, facing: "north" },
@@ -1527,6 +1535,7 @@ describe("dispatchAiTurn — use on objective_space witnesses satisfactionFlavor
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				// red at (2,2) facing south
 				red: { position: { row: 2, col: 2 }, facing: "south" },
@@ -1797,6 +1806,7 @@ describe("dispatchAiTurn — use on objective_space surfaces activationFlavor to
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 2, col: 2 }, facing: "south" },
 				green: { position: { row: 2, col: 0 }, facing: "east" },

--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -62,6 +62,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 
@@ -305,6 +306,7 @@ describe("shiftToBPack", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {},
 	};
 
@@ -316,6 +318,7 @@ describe("shiftToBPack", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {},
 	};
 

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -75,6 +75,7 @@ const MINIMAL_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -120,6 +121,7 @@ const CONTENT_PACK_WITH_ITEMS: ContentPack = {
 	],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },

--- a/src/spa/game/__tests__/non-addressed-anchor.test.ts
+++ b/src/spa/game/__tests__/non-addressed-anchor.test.ts
@@ -99,6 +99,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },

--- a/src/spa/game/__tests__/objective-pool.test.ts
+++ b/src/spa/game/__tests__/objective-pool.test.ts
@@ -87,6 +87,7 @@ function makePack(
 		interestingObjects: interestingObjectIds.map(makeInterestingObject),
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {},
 	};
 }
@@ -291,6 +292,7 @@ describe("drawObjectives — convergence objectives", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {},
 		};
 		// pool: [carry(relic), convergence(relic)] — rng=last → index 1 → convergence
@@ -312,6 +314,7 @@ describe("drawObjectives — convergence objectives", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {},
 		};
 		// Pool is [carry(gem)] only — no convergence
@@ -328,6 +331,7 @@ describe("drawObjectives — convergence objectives", () => {
 			interestingObjects: [makeInterestingObject("torch")],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {},
 		};
 		// Pool: [carry(altar), use_space(altar), use_item(torch), convergence(altar)] — 4 candidates
@@ -370,6 +374,7 @@ describe("drawObjectives — convergence inclusion guard requires all four flavo
 				interestingObjects: [],
 				obstacles: [],
 				landmarks: DEFAULT_LANDMARKS,
+				wallName: "wall",
 				aiStarts: {},
 			};
 			// Pool should be [carry(gem), use_space(gem)] — size 2, no convergence.
@@ -393,6 +398,7 @@ describe("drawObjectives — convergence inclusion guard requires all four flavo
 				interestingObjects: [],
 				obstacles: [],
 				landmarks: DEFAULT_LANDMARKS,
+				wallName: "wall",
 				aiStarts: {},
 			};
 			const drawn = drawObjectives(pack, rngZero, 10);
@@ -409,6 +415,7 @@ describe("drawObjectives — convergence inclusion guard requires all four flavo
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {},
 		};
 		// Draw enough to cycle through all pool indices.

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -63,6 +63,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -7,7 +7,11 @@ import {
 	startGame,
 } from "../engine";
 import { buildOpenAiMessages } from "../openai-message-builder";
-import { buildAiContext, buildConeSnapshot } from "../prompt-builder";
+import {
+	buildAiContext,
+	buildConeSnapshot,
+	renderWhatsNew,
+} from "../prompt-builder";
 import type { AiPersona, ContentPack, WorldEntity } from "../types";
 
 const TEST_PERSONAS: Record<string, AiPersona> = {
@@ -69,6 +73,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 
@@ -185,6 +190,7 @@ describe("buildAiContext", () => {
 			],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -227,6 +233,7 @@ describe("<setting> block", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -260,6 +267,7 @@ describe("<setting> block", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -318,6 +326,7 @@ describe("prompt-builder — spatial 'Where you are' section (current-state user
 			],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -749,6 +758,7 @@ describe("<what_you_see> (cone)", () => {
 			],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -791,19 +801,64 @@ describe("<what_you_see> (cone)", () => {
 		expect(stateMsg).not.toContain("the player");
 	});
 
-	it("out-of-bounds cone cells are omitted from <what_you_see>", () => {
-		// rng=()=>0: red→(0,0) facing north → all cone cells OOB
-		const game = startGame(TEST_PERSONAS, TEST_CONTENT_PACK, {
+	it("out-of-bounds cone cells render as wall markers in <what_you_see>", () => {
+		// rng=()=>0: red→(0,0) facing north → all 8 non-own cone cells are OOB
+		const wallPack: ContentPack = {
+			...TEST_CONTENT_PACK,
+			wallName: "concrete platform wall",
+			aiStarts: {
+				red: { position: { row: 0, col: 0 }, facing: "north" },
+				green: { position: { row: 0, col: 1 }, facing: "north" },
+				cyan: { position: { row: 0, col: 2 }, facing: "north" },
+			},
+		};
+		const game = startGame(TEST_PERSONAS, wallPack, {
 			budgetPerAi: 5,
-			rng: () => 0,
 		});
 		const ctx = buildAiContext(game, "red");
 		const stateMsg = ctx.toCurrentStateUserMessage();
 		const start = stateMsg.indexOf("<what_you_see>");
 		const end = stateMsg.indexOf("</what_you_see>", start);
 		const sectionContent = stateMsg.slice(start, end);
-		// All cone cells from (0,0) facing north are OOB → no bullet entries.
-		expect(sectionContent).not.toMatch(/- Directly in front/);
+		// All 8 OOB cells render as wall markers — wallName from ContentPack
+		expect(sectionContent).toContain(
+			"- Directly in front, left: concrete platform wall",
+		);
+		expect(sectionContent).toContain(
+			"- Directly in front: concrete platform wall",
+		);
+		expect(sectionContent).toContain(
+			"- Directly in front, right: concrete platform wall",
+		);
+		// wallName comes from ContentPack, not hardcoded
+		expect(sectionContent).toContain("concrete platform wall");
+	});
+
+	it("partial edge: only OOB cells render as walls — in-bounds cells render normally", () => {
+		// red at (1,0) facing north: directly-in-front-left (0,-1) is OOB; front (0,0) and front-right (0,1) are in-bounds
+		const wallPack: ContentPack = {
+			...TEST_CONTENT_PACK,
+			wallName: "concrete platform wall",
+			aiStarts: {
+				red: { position: { row: 1, col: 0 }, facing: "north" },
+				green: { position: { row: 4, col: 4 }, facing: "north" },
+				cyan: { position: { row: 4, col: 3 }, facing: "north" },
+			},
+		};
+		const game = startGame(TEST_PERSONAS, wallPack, { budgetPerAi: 5 });
+		const ctx = buildAiContext(game, "red");
+		const stateMsg = ctx.toCurrentStateUserMessage();
+		const start = stateMsg.indexOf("<what_you_see>");
+		const end = stateMsg.indexOf("</what_you_see>", start);
+		const sectionContent = stateMsg.slice(start, end);
+		// OOB cell: directly in front, left → wall
+		expect(sectionContent).toContain(
+			"- Directly in front, left: concrete platform wall",
+		);
+		// In-bounds cell: directly in front (0,0) → "nothing" (no entities there)
+		expect(sectionContent).toContain("- Directly in front: nothing");
+		// In-bounds cell: directly in front, right (0,1) → "nothing"
+		expect(sectionContent).toContain("- Directly in front, right: nothing");
 	});
 
 	it("obstacles in the cone are listed by their name", () => {
@@ -817,6 +872,7 @@ describe("<what_you_see> (cone)", () => {
 			interestingObjects: [],
 			obstacles: [makeEntity("col1", "obstacle", { row: 1, col: 0 })],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -842,6 +898,7 @@ describe("<what_you_see> (cone)", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 1, col: 0 }, facing: "north" },
@@ -1161,6 +1218,7 @@ describe("proximityFlavor sense line", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: opts.actorPosition, facing: opts.actorFacing },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -1442,6 +1500,7 @@ describe("postLookFlavor swap covers satisfied interesting_object", () => {
 			interestingObjects: [item],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "south" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -1478,5 +1537,111 @@ describe("postLookFlavor swap covers satisfied interesting_object", () => {
 		const ctx = buildAiContext(game, "red");
 		const snapshot = buildConeSnapshot(ctx);
 		expect(snapshot).toContain("a steady amber glow lingers near the switch");
+	});
+});
+
+// ----------------------------------------------------------------------------
+// <whats_new> wall diff (issue #374)
+// When a daemon turns toward or away from a wall, the wall entry appears as
+// a + / - diff line in <whats_new>. Uses buildConeSnapshot + renderWhatsNew.
+// ----------------------------------------------------------------------------
+describe("<whats_new> wall diff (issue #374)", () => {
+	/** Build a game with red at the given position and facing. */
+	function makeWallGame(opts: {
+		position: { row: number; col: number };
+		facing: "north" | "south" | "east" | "west";
+		wallName?: string;
+	}) {
+		const wallName = opts.wallName ?? "concrete platform wall";
+		const pack: ContentPack = {
+			setting: "",
+			weather: "",
+			timeOfDay: "",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			wallName,
+			aiStarts: {
+				red: { position: opts.position, facing: opts.facing },
+				green: { position: { row: 4, col: 4 }, facing: "north" },
+				cyan: { position: { row: 4, col: 3 }, facing: "north" },
+			},
+		};
+		return startGame(TEST_PERSONAS, pack, { budgetPerAi: 5 });
+	}
+
+	it("turning toward a wall produces + lines in <whats_new>", () => {
+		// prev: red at (0,0) facing east (cone goes right — hits east wall, no north wall)
+		// curr: red at (0,0) facing north (cone goes up — all OOB)
+		const prevGame = makeWallGame({
+			position: { row: 0, col: 0 },
+			facing: "east",
+		});
+		const currGame = makeWallGame({
+			position: { row: 0, col: 0 },
+			facing: "north",
+		});
+
+		const prevCtx = buildAiContext(prevGame, "red");
+		const currCtx = buildAiContext(currGame, "red");
+
+		const prev = buildConeSnapshot(prevCtx);
+		const curr = buildConeSnapshot(currCtx);
+
+		// The snapshots must differ (east vs north cone)
+		expect(prev).not.toBe(curr);
+
+		const diff = renderWhatsNew(prev, curr);
+		expect(diff).not.toBeNull();
+		// North cone from (0,0) has all walls — "directly in front" line should appear as added
+		expect(diff).toContain("+ at directly in front: concrete platform wall");
+	});
+
+	it("turning away from a wall produces - lines in <whats_new>", () => {
+		// prev: red at (0,0) facing north (all walls)
+		// curr: red at (0,0) facing south (cone goes down — in-bounds)
+		const prevGame = makeWallGame({
+			position: { row: 0, col: 0 },
+			facing: "north",
+		});
+		const currGame = makeWallGame({
+			position: { row: 0, col: 0 },
+			facing: "south",
+		});
+
+		const prevCtx = buildAiContext(prevGame, "red");
+		const currCtx = buildAiContext(currGame, "red");
+
+		const prev = buildConeSnapshot(prevCtx);
+		const curr = buildConeSnapshot(currCtx);
+
+		const diff = renderWhatsNew(prev, curr);
+		expect(diff).not.toBeNull();
+		// "directly in front" was a wall in north cone, now it's in-bounds in south cone → removed
+		expect(diff).toContain("- at directly in front: concrete platform wall");
+	});
+
+	it("identical snapshots at the wall → renderWhatsNew returns null", () => {
+		// Same position and facing → cone snapshot is byte-identical
+		const game = makeWallGame({
+			position: { row: 0, col: 0 },
+			facing: "north",
+		});
+		const ctx = buildAiContext(game, "red");
+		const snap = buildConeSnapshot(ctx);
+		expect(renderWhatsNew(snap, snap)).toBeNull();
+	});
+
+	it("wallName comes from ContentPack.wallName, not hardcoded", () => {
+		const game = makeWallGame({
+			position: { row: 0, col: 0 },
+			facing: "north",
+			wallName: "laboratory bulkhead",
+		});
+		const ctx = buildAiContext(game, "red");
+		const snap = buildConeSnapshot(ctx);
+		expect(snap).toContain("laboratory bulkhead");
+		expect(snap).not.toContain("concrete platform wall");
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator-convergence.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-convergence.test.ts
@@ -88,6 +88,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	// red at (4,4), green at (0,0), cyan at (0,2)
 	// cyan faces south so (4,4) is not in its cone.
 	aiStarts: {

--- a/src/spa/game/__tests__/round-coordinator-sysadmin-directive.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-sysadmin-directive.test.ts
@@ -62,6 +62,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -107,6 +107,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {
 		red: { position: { row: 0, col: 0 }, facing: "north" },
 		green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -1143,6 +1144,7 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -1238,6 +1240,7 @@ describe("game-end conditions — checkWinCondition / checkLoseCondition", () =>
 			],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -1844,6 +1847,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -2006,6 +2010,7 @@ describe("placement flavor + win condition (issue #126)", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {
 				red: { position: { row: 0, col: 0 }, facing: "north" },
 				green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -2082,6 +2087,7 @@ describe("examine tool", () => {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 0, col: 1 }, facing: "north" },
@@ -3007,6 +3013,7 @@ describe("action-failure entries — round-coordinator integration", () => {
 			},
 		],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {
 			red: { position: { row: 0, col: 0 }, facing: "north" },
 			green: { position: { row: 2, col: 2 }, facing: "north" },

--- a/src/spa/game/__tests__/round-result-encoder.test.ts
+++ b/src/spa/game/__tests__/round-result-encoder.test.ts
@@ -70,6 +70,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/game/__tests__/tool-call-history.test.ts
+++ b/src/spa/game/__tests__/tool-call-history.test.ts
@@ -51,6 +51,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -71,6 +71,7 @@ function makeContentPack(pairs: ObjectivePair[]): ContentPack {
 		interestingObjects: [],
 		obstacles: [],
 		landmarks: DEFAULT_LANDMARKS,
+		wallName: "wall",
 		aiStarts: {},
 	};
 }

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -183,6 +183,7 @@ export function buildSessionFromAssets(
 					east: { shortName: "", horizonPhrase: "" },
 					west: { shortName: "", horizonPhrase: "" },
 				},
+				wallName: "",
 				aiStarts: {},
 			},
 		assets.personas,

--- a/src/spa/game/cone-projector.ts
+++ b/src/spa/game/cone-projector.ts
@@ -13,7 +13,9 @@
  *   - Two steps ahead, front-right
  *   - Two steps ahead, far-right
  *
- * Out-of-bounds cells are omitted from the result.
+ * Out-of-bounds cells are returned as wall sentinels (isWall: true) rather than
+ * being omitted, so callers can render setting-flavored wall markers. The result
+ * is always a deterministic 9-cell array for every (position, facing).
  */
 
 import {
@@ -38,6 +40,8 @@ export interface ConeCell {
 	position: GridPosition;
 	phrasing: ConePhrasing;
 	isOwnCell: boolean;
+	/** True when this cell is out-of-bounds — represents the impassable grid-edge wall. */
+	isWall: boolean;
 }
 
 /**
@@ -54,7 +58,8 @@ export interface ConeCell {
  *   8. two steps ahead, front-right
  *   9. two steps ahead, far-right
  *
- * Out-of-bounds cells are omitted. Own cell is always included.
+ * Out-of-bounds cells are included as wall sentinels (isWall: true). Own cell is
+ * always isWall: false. The result is always exactly 9 cells in canonical order.
  */
 export function projectCone(
 	position: GridPosition,
@@ -130,13 +135,13 @@ export function projectCone(
 	const result: ConeCell[] = [];
 	for (const c of candidates) {
 		const pos: GridPosition = { row: c.row, col: c.col };
-		if (c.isOwnCell || inBounds(pos)) {
-			result.push({
-				position: pos,
-				phrasing: c.phrasing,
-				isOwnCell: c.isOwnCell,
-			});
-		}
+		const isWall = !c.isOwnCell && !inBounds(pos);
+		result.push({
+			position: pos,
+			phrasing: c.phrasing,
+			isOwnCell: c.isOwnCell,
+			isWall,
+		});
 	}
 	return result;
 }

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -34,6 +34,7 @@ For each phase:
 - Generate exactly n INTERESTING OBJECTS with: id (unique string), name (2-4 words, thematic to setting and theme), examineDescription (1-2 sentences; MUST hint that the item is meant to be used or activated — include a verb-of-activation cue such as "use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger", or a clear noun-phrase tell like "control", "switch", "lever", "trigger", "button"; the prose tell is the only AI-discoverable channel that distinguishes a Use-Item target from a plain decorative item, so it cannot be omitted; MUST NOT contain "{actor}" and MUST NOT say the item is already used or that an objective is complete), useOutcome (1 sentence: the actor performs a stateless action with the item — nothing about the item, the actor, or the world changes; returned post-satisfaction; MUST NOT say the objective is complete), activationFlavor (1 sentence; world-meaningful third-person description of what happens at the moment the item is activated for the first time — same string returned to actor and to witnesses; MUST NOT contain "{actor}"; MUST NOT say the objective is complete; MUST NOT reference placing or coupling the item with anything else), postExamineDescription (1-2 sentences shown by examine after the item has been activated; describes the post-activation state of the item itself; MUST NOT contain "{actor}"; MUST NOT reference the actor; MUST NOT say the objective is complete), postLookFlavor (1 sentence appended to look output after the item has been activated; in-fiction sensory line a witness perceives; MUST NOT contain "{actor}"). interesting_objects MUST be portable physical items a single person can pick up and carry — never furniture, architecture, or fixed structures.
 - Generate exactly m OBSTACLES with: id (unique string), name (2-4 words, thematic to setting), examineDescription (1 sentence describing the impassable object), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Obstacles are fixed and impassable — never portable items. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS — one anchoring each cardinal direction (north, south, east, west). Each landmark is distant, unreachable, distinctive, mutually visually distinguishable, and consistent with the setting, atmosphere, and weather. Each landmark has: shortName (2-5 words, e.g. "the rusted radio tower"), horizonPhrase (a short evocative clause describing what the landmark itself looks like — its form, condition, materials — NOT where it sits relative to any viewer. The phrase is slotted into "On the horizon ahead: <shortName> — <horizonPhrase>." so it must read coherently as a continuation. Good: "rises above the platform, antenna bent toward the dark". Bad: "looms behind you in the dark" (implies position) or "stands to your left" (implies relative direction).
+- Generate a WALL NAME: a setting-flavored 2-4 word noun phrase for the impassable boundary surrounding the grid (e.g. "subway tunnel wall", "salt-encrusted edge", "laboratory bulkhead"). This is rendered when a Daemon's cone reaches outside the grid.
 
 The theme governs the style of objective_objects, objective_spaces, and interesting_objects only:
 - "mundane" — ordinary, everyday physical items and surfaces.
@@ -72,7 +73,8 @@ Return ONLY valid JSON with this exact shape (no markdown, no preamble):
         "south": { "shortName": "...", "horizonPhrase": "..." },
         "east":  { "shortName": "...", "horizonPhrase": "..." },
         "west":  { "shortName": "...", "horizonPhrase": "..." }
-      }
+      },
+      "wallName": "..."
     }
   ]
 }`;
@@ -133,7 +135,7 @@ export const DUAL_CONTENT_PACK_SYSTEM_PROMPT = `You generate paired content pack
 For each phase produce packA and packB with the following rules:
 - Entity IDs (id fields) MUST be identical between packA and packB. Choose the ids once and reuse them.
 - Entity structural relationships (pairsWithSpaceId, kind) MUST be identical between packA and packB.
-- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, activationFlavor (for objective_space AND interesting_object), satisfactionFlavor (for objective_space), convergenceTier1Flavor, convergenceTier2Flavor, convergenceTier1ActorFlavor, convergenceTier2ActorFlavor (for objective_space), postExamineDescription, postLookFlavor (for objective_space AND interesting_object), shiftFlavor (for obstacles), landmark shortName, landmark horizonPhrase.
+- These fields MUST differ (re-flavored for each setting): name, examineDescription, useOutcome (for objects), placementFlavor, proximityFlavor, activationFlavor (for objective_space AND interesting_object), satisfactionFlavor (for objective_space), convergenceTier1Flavor, convergenceTier2Flavor, convergenceTier1ActorFlavor, convergenceTier2ActorFlavor (for objective_space), postExamineDescription, postLookFlavor (for objective_space AND interesting_object), shiftFlavor (for obstacles), landmark shortName, landmark horizonPhrase, wallName.
 - The setting field at pack level MUST match settingA for packA and settingB for packB.
 
 Entity rules (same as always):
@@ -143,6 +145,7 @@ Entity rules (same as always):
 - Generate exactly n INTERESTING OBJECTS per pack: id, kind="interesting_object", name (2-4 words), examineDescription (1-2 sentences; MUST contain a verb-of-activation cue ("use", "activate", "press", "pull", "turn", "twist", "flip", "wind", "engage", "trigger") or a clear control noun ("control", "switch", "lever", "trigger", "button", "dial", "handle", "crank") — the only AI-discoverable Use-Item tell; MUST NOT contain "{actor}"; MUST NOT say the item is already used or the objective is complete), useOutcome (1 stateless sentence; returned post-satisfaction; MUST NOT say the objective is complete), activationFlavor (1 sentence; world-meaningful third-person line returned to actor and witnesses on the use call that satisfies the UseItemObjective; MUST NOT contain "{actor}"; MUST NOT say the objective is complete; MUST NOT reference placing or coupling), postExamineDescription (1-2 sentences shown by examine after activation; MUST NOT contain "{actor}"; MUST NOT reference the actor), postLookFlavor (1 sentence appended to look output after activation; MUST NOT contain "{actor}"). Must be portable.
 - Generate exactly m OBSTACLES per pack: id, kind="obstacle", name (2-4 words), examineDescription (1 sentence), shiftFlavor (1 sentence, in-fiction sensory line a witness Daemon perceives when the obstacle moves one cell. Third person from witness POV. Does NOT specify a direction word (north/south/east/west). Does NOT contain {actor}.). Fixed and impassable. Obstacles follow the setting only and are NOT constrained by the item theme.
 - Generate exactly 4 HORIZON LANDMARKS per pack (north/south/east/west): shortName (2-5 words), horizonPhrase (evocative clause; no cardinal direction words; no positional phrases implying viewer relationship).
+- Generate a WALL NAME per pack: a setting-flavored 2-4 word noun phrase for the impassable boundary surrounding the grid (e.g. "subway tunnel wall", "salt-encrusted edge", "laboratory bulkhead"). Must differ between packA and packB (re-flavored for each setting).
 
 Global constraints:
 - All ids must be unique within a pack (across phases within the same call).
@@ -164,14 +167,16 @@ Return ONLY valid JSON (no markdown, no preamble):
         "objectivePairs": [{ "object": { "id": "...", "kind": "objective_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "...", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "...", "kind": "objective_space", "name": "...", "examineDescription": "...", "activationFlavor": "...", "satisfactionFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "...", "convergenceTier2Flavor": "...", "convergenceTier1ActorFlavor": "...", "convergenceTier2ActorFlavor": "..." } }],
         "interestingObjects": [{ "id": "...", "kind": "interesting_object", "name": "...", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "...", "postExamineDescription": "...", "postLookFlavor": "..." }],
         "obstacles": [{ "id": "...", "kind": "obstacle", "name": "...", "examineDescription": "...", "shiftFlavor": "..." }],
-        "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
+        "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } },
+        "wallName": "..."
       },
       "packB": {
         "setting": "<settingB>",
         "objectivePairs": [{ "object": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "pairsWithSpaceId": "SAME_AS_PACK_A", "placementFlavor": "...{actor}...", "proximityFlavor": "..." }, "space": { "id": "SAME_ID_AS_PACK_A", "kind": "objective_space", "name": "DIFFERENT_NAME", "examineDescription": "...", "activationFlavor": "DIFFERENT_FLAVOR", "satisfactionFlavor": "DIFFERENT_FLAVOR", "postExamineDescription": "...", "postLookFlavor": "...", "convergenceTier1Flavor": "DIFFERENT_FLAVOR", "convergenceTier2Flavor": "DIFFERENT_FLAVOR", "convergenceTier1ActorFlavor": "DIFFERENT_FLAVOR", "convergenceTier2ActorFlavor": "DIFFERENT_FLAVOR" } }],
         "interestingObjects": [{ "id": "SAME_ID_AS_PACK_A", "kind": "interesting_object", "name": "DIFFERENT_NAME", "examineDescription": "...", "useOutcome": "...", "activationFlavor": "DIFFERENT_FLAVOR", "postExamineDescription": "DIFFERENT_DESCRIPTION", "postLookFlavor": "DIFFERENT_FLAVOR" }],
         "obstacles": [{ "id": "SAME_ID_AS_PACK_A", "kind": "obstacle", "name": "DIFFERENT_NAME", "examineDescription": "...", "shiftFlavor": "DIFFERENT_FLAVOR" }],
-        "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } }
+        "landmarks": { "north": { "shortName": "...", "horizonPhrase": "..." }, "south": { "shortName": "...", "horizonPhrase": "..." }, "east": { "shortName": "...", "horizonPhrase": "..." }, "west": { "shortName": "...", "horizonPhrase": "..." } },
+        "wallName": "DIFFERENT_WALL_NAME"
       }
     }
   ]
@@ -801,12 +806,18 @@ export function validateContentPacks(
 			west: validateLandmark(lm.west, i + 1, "west"),
 		};
 
+		const wallName =
+			typeof pack.wallName === "string" && pack.wallName.length > 0
+				? pack.wallName
+				: "";
+
 		packs.push({
 			setting: pack.setting,
 			objectivePairs,
 			interestingObjects,
 			obstacles,
 			landmarks,
+			wallName,
 			aiStarts: {} as Record<AiId, never>,
 		});
 	}
@@ -1019,12 +1030,18 @@ function validateSinglePack(
 		west: validateLandmark(lm.west, phaseIndex + 1, "west"),
 	};
 
+	const wallName =
+		typeof pack.wallName === "string" && pack.wallName.length > 0
+			? pack.wallName
+			: "";
+
 	return {
 		setting: pack.setting,
 		objectivePairs,
 		interestingObjects,
 		obstacles,
 		landmarks,
+		wallName,
 		aiStarts: {} as Record<AiId, never>,
 	};
 }

--- a/src/spa/game/prompt-builder.ts
+++ b/src/spa/game/prompt-builder.ts
@@ -40,6 +40,11 @@ export interface AiContext {
 	 */
 	landmarks: ContentPack["landmarks"];
 	/**
+	 * Setting-flavored name for the impassable grid edge (e.g. "subway tunnel wall").
+	 * Rendered in `<what_you_see>` and `<whats_new>` for OOB cone cells.
+	 */
+	wallName: string;
+	/**
 	 * Canonical cone-snapshot string captured at the end of this AI's last turn,
 	 * or undefined on the first turn of a phase. Used by `renderCurrentState`
 	 * to emit a `<whats_new>` diff so the model has a fresh delta to react to
@@ -109,6 +114,7 @@ export function buildAiContext(
 	const timeOfDay = game.timeOfDay ?? "";
 	const personaSpatial = game.personaSpatial;
 	const landmarks = game.contentPack.landmarks;
+	const wallName = game.contentPack.wallName;
 
 	if (!persona) throw new Error(`No persona for aiId: ${aiId}`);
 
@@ -132,6 +138,7 @@ export function buildAiContext(
 		personaSpatial,
 		personaColors,
 		landmarks,
+		wallName,
 		pendingBroadcasts,
 		activeDirectives,
 		...(opts?.prevConeSnapshot !== undefined
@@ -627,6 +634,12 @@ export function buildConeSnapshot(ctx: AiContext): string {
 	const coneCells = projectCone(actorSpatial.position, actorSpatial.facing);
 	const viewCells = coneCells.filter((c) => !c.isOwnCell);
 	for (const cell of viewCells) {
+		// Wall sentinel — OOB cell
+		if (cell.isWall) {
+			lines.push(`at ${cell.phrasing}: ${ctx.wallName}`);
+			continue;
+		}
+
 		const { position } = cell;
 		const contentParts: string[] = [];
 
@@ -838,6 +851,13 @@ function renderCurrentState(ctx: AiContext): string {
 		const viewCells = coneCells.filter((c) => !c.isOwnCell);
 		for (const cell of viewCells) {
 			const { position, phrasing } = cell;
+
+			// Wall sentinel — OOB cell
+			if (cell.isWall) {
+				const label = phrasing.charAt(0).toUpperCase() + phrasing.slice(1);
+				lines.push(`- ${label}: ${ctx.wallName}`);
+				continue;
+			}
 
 			// Build contents of this cell
 			const contentParts: string[] = [];

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -120,6 +120,14 @@ export interface ContentPack {
 		east: LandmarkDescription;
 		west: LandmarkDescription;
 	};
+	/**
+	 * Setting-flavored 2-4 word name for the impassable grid edge
+	 * (e.g. "subway tunnel wall", "salt-encrusted edge", "laboratory bulkhead").
+	 * Rendered in `<what_you_see>` and `<whats_new>` when an out-of-bounds cone
+	 * cell falls inside the Daemon's cone. Paired across Pack A / Pack B for
+	 * Setting Shift.
+	 */
+	wallName: string;
 }
 
 export type ObjectiveKind = "carry" | "use_item" | "use_space" | "convergence";

--- a/src/spa/persistence/__tests__/devtools-edit.test.ts
+++ b/src/spa/persistence/__tests__/devtools-edit.test.ts
@@ -27,6 +27,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -26,6 +26,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 
@@ -575,6 +576,7 @@ describe("serializeSession / deserializeSession", () => {
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "wall",
 			aiStarts: {},
 		};
 		const testPackVariant2: ContentPack = {

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -41,6 +41,7 @@ const TEST_CONTENT_PACK: ContentPack = {
 	interestingObjects: [],
 	obstacles: [],
 	landmarks: DEFAULT_LANDMARKS,
+	wallName: "wall",
 	aiStarts: {},
 };
 

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -69,8 +69,12 @@ import {
  *   - `contentPacksA` and `contentPacksB` now contain exactly 1 entry each
  *     (previously held 3 entries, one per phase). Migration truncates v8 saves
  *     by keeping only the first entry of each array.
+ *
+ * v10 (issue #374): add `wallName` to `ContentPack`.
+ *   - Old v9 saves have no `wallName`; version-mismatch result (consistent
+ *     with v7/v8 policy — no migration provided).
  */
-export const SESSION_SCHEMA_VERSION = 9 as const;
+export const SESSION_SCHEMA_VERSION = 10 as const;
 
 // ── File shapes ────────────────────────────────────────────────────────────────
 
@@ -332,6 +336,7 @@ export function deserializeSession(
 			interestingObjects: [],
 			obstacles: [],
 			landmarks: DEFAULT_LANDMARKS,
+			wallName: "",
 			aiStarts: {},
 		};
 		const setting = contentPack.setting;


### PR DESCRIPTION
## What this fixes

Daemons standing at the edge of the 5×5 grid had no in-prompt signal that a wall existed — `projectCone` silently dropped out-of-bounds (OOB) cells before rendering, so the only signals the model got were "fewer cells than usual in `<what_you_see>`" (inference, not perception) or a failed `go(direction)` (after wasting a turn). Walls were mechanically equivalent to **Obstacles** but invisible.

The change makes the cone always deterministic 9-cell. `projectCone` (`src/spa/game/cone-projector.ts`) now sets `isWall: true` on each OOB cell instead of filtering it. Both rendering paths in `src/spa/game/prompt-builder.ts` branch on `cell.isWall`:

- `renderCurrentState` emits `- <Phrasing>: <wallName>` into `<what_you_see>`, matching the existing obstacle line shape.
- `buildConeSnapshot` emits `at <phrasing>: <wallName>` so `renderWhatsNew` picks up wall enter/exit on facing changes without special-casing (it groups diff buckets by the `at ` prefix already).

`wallName` is a required `string` on `ContentPack` (`src/spa/game/types.ts`), authored by the LLM alongside the rest of the pack — both `CONTENT_PACK_SYSTEM_PROMPT` and `DUAL_CONTENT_PACK_SYSTEM_PROMPT` in `src/spa/game/content-pack-provider.ts` were updated, and `wallName` is in the dual prompt's "MUST differ" list so Setting Shift pairs walls cleanly across Pack A / Pack B. `validateContentPacks` / `validateSinglePack` enforce a non-empty string. The field is propagated through every `ContentPack` construction site in `src/content/content-pack-generator.ts` and given a defensive `""` fallback in `src/spa/game/bootstrap.ts` and `src/spa/persistence/session-codec.ts`. The session schema is bumped to v10 (version-mismatch, consistent with prior bumps — no migration). **Wall** is added to `CONTEXT.md` between **Obstacle** and **Cone**.

## QA steps for the human

None for behaviour correctness — the integration smoke (46 Playwright specs) and the prompt-builder unit tests cover every observable surface (`<what_you_see>` render, `<whats_new>` diff on facing/movement at the edge, content-pack validation, codec version handling).

Worth a glance during review:
- The setting-flavored wall names the LLM produces (look at a live generated pack and confirm the `wallName` reads naturally for each setting — e.g. "moss-covered concrete wall" rather than "wall").
- The Setting Shift pairing: confirm Pack A's and Pack B's `wallName` values differ in feel, like landmarks do.

## Automated coverage

`pnpm typecheck && pnpm test && pnpm lint` (58 test files, 1426 unit tests) — green. `pnpm smoke` (46 Playwright e2e specs) — green.

Closes #374

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY4nGXTVhC33gVytEEqgz9)_