### PR TITLE
Switch go/look tool enums from cardinal to relative directions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,7 +82,7 @@ _Avoid_: Edge (positional, not lexical), barrier (less setting-natural).
 The wedge-shaped region of cells an AI can see each turn: 1 cell directly in front + 3 cells two steps ahead (front-left, front, front-right), plus the AI's own cell. Projects from the AI's **Facing**. Obstacles do not occlude — the cone is a fixed-shape mask, not a raycast.
 
 **Facing**:
-The cardinal direction (N/S/E/W) an AI is currently looking. Part of the AI's state alongside `(row, col)`. Updated by `go(direction)` (move and face) and `look(direction)` (face without moving).
+The cardinal direction (N/S/E/W) an AI is currently looking. Stored internally as a cardinal alongside `(row, col)` in the AI's spatial state. Updated by `go(direction)` (move and face) and `look(direction)` (face without moving); both tools take a relative direction argument (`forward | back | left | right`) which the dispatcher translates against the current Facing — daemons never see cardinals (ADR 0008).
 
 **Conversation log**:
 The single chronological per-AI per-phase section of the system prompt that interleaves directional **message**s (incoming and outgoing, with the recipient axis carrying routing) and **Witnessed event**s — all tagged by round. The AI's complete phase memory: nothing the AI has experienced this phase exists outside this log. Now also the per-Daemon storage shape — see **ConversationEntry**. The unified `message` kind replaces the previous chat/whisper split (per ADR 0007 / commit c60e995, schema v4). Replaces both the broadcast action log of an earlier design and the once-considered separate "events in your cone" section.

--- a/docs/adr/0008-relative-directions-and-horizon-landmarks.md
+++ b/docs/adr/0008-relative-directions-and-horizon-landmarks.md
@@ -76,11 +76,12 @@ provided, the cardinal direction in the entry is converted with `cardinalToRelat
 
 **Negative / watch-out:**
 
-- The dispatcher now silently accepts both cardinal and relative tokens for `go`/`look`. This
-  backward-compatibility path exists so that internal engine helpers and existing test fixtures
-  using cardinal strings continue to work without modification. If this creates confusion in
-  the future, the cardinal path should be deprecated and removed once all test fixtures are
-  migrated.
+- ~~The dispatcher now silently accepts both cardinal and relative tokens for `go`/`look`.~~
+  Superseded: the dispatcher's `validate` function now rejects cardinal tokens with an explicit
+  "use relative directions" reason; the execution path only handles `RelativeDirection`. The
+  backward-compat shim turned out to be unnecessary and the dual-acceptance behavior was a
+  liability — `available-tools.ts` was inadvertently still advertising a cardinal enum, which
+  this branch fixed alongside the dead-code removal.
 - Content-pack generation now requires the LLM to produce four horizon landmarks per phase.
   The system prompt includes explicit shape constraints and a "no cardinal language in
   horizonPhrase" rule to prevent leakage. Playtests should monitor whether the LLM reliably

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -12,9 +12,10 @@
 import { projectCone } from "./cone-projector.js";
 import {
 	applyDirection,
-	CARDINAL_DIRECTIONS,
 	frontArc,
 	inBounds,
+	RELATIVE_DIRECTIONS,
+	relativeToCardinal,
 } from "./direction.js";
 import { type OpenAiTool, TOOL_DEFINITIONS } from "./tool-registry.js";
 import type {
@@ -152,14 +153,15 @@ export function availableTools(
 	// 1. look — always present
 	if (!disabledTools.has("look")) {
 		tools.push(
-			cloneToolWithEnums("look", { direction: [...CARDINAL_DIRECTIONS] }),
+			cloneToolWithEnums("look", { direction: [...RELATIVE_DIRECTIONS] }),
 		);
 	}
 
 	// 2. go — restricted to legal directions
 	if (actorSpatial && !disabledTools.has("go")) {
-		const legalDirections = CARDINAL_DIRECTIONS.filter((dir) => {
-			const next = applyDirection(actorSpatial.position, dir);
+		const legalDirections = RELATIVE_DIRECTIONS.filter((relDir) => {
+			const cardinal = relativeToCardinal(actorSpatial.facing, relDir);
+			const next = applyDirection(actorSpatial.position, cardinal);
 			if (!inBounds(next)) return false;
 			if (obstacles.some((o) => positionsEqual(o, next))) return false;
 			return true;

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -100,7 +100,7 @@ function cloneToolWithEnums(
  *
  * Algorithm:
  * 0. `message` — always present; `to` enum = "blue" + live peer daemon ids.
- * 1. `look` — always present, full CARDINAL_DIRECTIONS enum.
+ * 1. `look` — always present, full RELATIVE_DIRECTIONS enum.
  * 2. `go` — included only when at least one direction is in-bounds AND non-obstacle.
  *    Enum restricted to legal directions.
  * 3. `pick_up` — included only when pickable entities are in the actor's own cell

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -17,7 +17,6 @@ import {
 import type {
 	AiId,
 	AiTurnAction,
-	CardinalDirection,
 	GameState,
 	GridPosition,
 	PersonaSpatialState,
@@ -391,13 +390,11 @@ export function executeToolCall(
 			break;
 		case "go": {
 			if (!actorSpatial) break;
-			// Translate relative → cardinal if needed
-			const rawGoDir = call.args.direction;
-			const direction: CardinalDirection = RELATIVE_DIRECTIONS.includes(
-				rawGoDir as RelativeDirection,
-			)
-				? relativeToCardinal(actorSpatial.facing, rawGoDir as RelativeDirection)
-				: (rawGoDir as CardinalDirection);
+			// Validation upstream guarantees direction is a RelativeDirection.
+			const direction = relativeToCardinal(
+				actorSpatial.facing,
+				call.args.direction as RelativeDirection,
+			);
 			const nextPos = applyDirection(actorSpatial.position, direction);
 			return {
 				...game,


### PR DESCRIPTION
ADR 0008 moved the daemon-facing API to relative directions (forward,
back, left, right), updating tool-registry.ts and the dispatcher
accordingly. available-tools.ts was overlooked: its cloneToolWithEnums
calls for `look` and `go` overrode the relative enum back to
CARDINAL_DIRECTIONS, so daemons saw a tool whose description said
"relative direction" but whose enum was ["north","south","east","west"]
— values the dispatcher then rejected.

Replace CARDINAL_DIRECTIONS with RELATIVE_DIRECTIONS for both tools.
For `go`, translate each relative direction through
relativeToCardinal(actorFacing, relDir) before the bounds/obstacle
legality check.

https://claude.ai/code/session_017yqZQECAKhG9deCdTCeJqi