### PR TITLE
Drift-to-silence: 30–43% of daemon turns drop free-form text instead of emitting a message tool call

### DIFF
--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -202,6 +202,18 @@ function makeAiSseStream(_jsonAction: string): ReadableStream<Uint8Array> {
 }
 
 /**
+ * Creates an SSE response body that yields text-only content (no tool call).
+ * Used for testing drift-to-silence recovery (#254): when a daemon returns
+ * text without a tool call, it triggers a retry.
+ */
+function makeTextOnlySseStream(text: string): ReadableStream<Uint8Array> {
+	const deltaChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`;
+	const usageChunk = `data: ${JSON.stringify({ choices: [], usage: { cost: 0.01, total_tokens: 100 } })}\n\n`;
+	const sseData = `${deltaChunk}${usageChunk}data: [DONE]\n\n`;
+	return makeSSEStream([sseData]);
+}
+
+/**
  * Creates an SSE response body that yields a `message` tool call (AI→blue).
  * This is the v4 way to have an AI "chat back" so the content lands in conversationLogs
  * and is restored on reload.
@@ -2484,6 +2496,133 @@ describe("renderGame — round error surfacing (issue #231)", () => {
 		expect(topinfoRight.textContent).toContain("connection stable");
 		const pipAfter = topinfoRight.querySelector("span");
 		expect(pipAfter?.className).toBe("ok");
+	});
+});
+
+// Regression for #254: when a daemon drifts (produces text without a tool call)
+// and the retry path fires, surface a transient "<daemon> hesitated" indicator
+// in #round-error (reusing #231's element) to signal the player that a drift
+// occurred (whether recovered or not). The indicator clears on the next round.
+describe("renderGame — drift-to-silence indicator (issue #254)", () => {
+	let _stub: ReturnType<typeof makeLocalStorageStub>;
+
+	beforeEach(async () => {
+		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
+		vi.stubGlobal("__DEV__", true);
+		document.body.innerHTML = INDEX_BODY_HTML;
+		_stub = makeLocalStorageStub();
+		await seedSessionInStub(_stub);
+		vi.stubGlobal("localStorage", _stub);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.resetModules();
+		document.body.innerHTML = "";
+	});
+
+	it("surfaces #round-error 'hesitated' after a daemon drifts and recovers; clears on next round", async () => {
+		// Set up a four-call fetch mock:
+		// 1. Red: text-only (drifts), triggers retry
+		// 2. Red: retry with message tool call (recovered)
+		// 3. Green: pass
+		// 4. Cyan: pass
+		// Then for the second round, all daemons return clean (no drift):
+		// 5. Red: message tool call
+		// 6. Green: message tool call
+		// 7. Cyan: message tool call
+		const driftAndRecoverFetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				// Red first attempt: text only (no tool call) — triggers retry
+				body: makeTextOnlySseStream("I'd like to say something"),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				// Red retry: message tool call (recovers)
+				body: makeMessageToolCallSseStream("RED_RECOVERED"),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				// Green: pass
+				body: makeAiSseStream(PASS_ACTION),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				// Cyan: pass
+				body: makeAiSseStream(PASS_ACTION),
+			})
+			// Second round: all clean
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				body: makeMessageToolCallSseStream("RED_SECOND"),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				body: makeMessageToolCallSseStream("GREEN_SECOND"),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				body: makeMessageToolCallSseStream("CYAN_SECOND"),
+			});
+		vi.stubGlobal("fetch", driftAndRecoverFetch);
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+
+		vi.resetModules();
+		const { renderGame } = await import("../routes/game.js");
+		await renderGame(getEl<HTMLElement>("main"));
+
+		const promptInput = getEl<HTMLInputElement>("#prompt");
+		const form = getEl<HTMLFormElement>("#composer");
+		const roundError = getEl<HTMLOutputElement>("#round-error");
+		const topinfoRight = getEl<HTMLElement>("#topinfo-right");
+
+		// First submit: red drifts and recovers
+		promptInput.value = "*Ember hello";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// 1. Inline error visible with hesitated text (from Red's persona name)
+		expect(roundError.hasAttribute("hidden")).toBe(false);
+		expect(roundError.textContent?.trim()).toContain("hesitated");
+		// The persona name "Ember" should be in the message
+		expect(roundError.textContent).toMatch(/ember|Ember/i);
+
+		// 2. Topinfo right cell shows "connection stable" (drift is a successful round, not a wire error)
+		expect(topinfoRight.textContent).toContain("connection stable");
+		const pip = topinfoRight.querySelector("span");
+		expect(pip?.className).toBe("ok");
+
+		// Second submit: all daemons return clean; the indicator should clear
+		promptInput.value = "*Ember retry";
+		promptInput.dispatchEvent(new Event("input"));
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		// The pre-submit clear (around lines 1186-1190 in game.ts) should have hidden it
+		expect(roundError.hasAttribute("hidden")).toBe(true);
+		expect(roundError.textContent ?? "").toBe("");
 	});
 });
 

--- a/src/spa/game/__tests__/round-coordinator.test.ts
+++ b/src/spa/game/__tests__/round-coordinator.test.ts
@@ -518,6 +518,165 @@ describe("drift-to-silence retry (#254)", () => {
 		// first attempt must not slip in either.
 		expect(toolRoundtrip.red).toBeUndefined();
 	});
+
+	it("fires onAiDrift(aiId, recovered=true) when the retry rescues the turn", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			// red: text-only first attempt → triggers retry
+			{ assistantText: "I'd say hello to blue.", toolCalls: [] },
+			// red retry: emits the message
+			{
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "msg_retry",
+						name: "message",
+						argumentsJson: JSON.stringify({
+							to: "blue",
+							content: "Hello blue!",
+						}),
+					},
+				],
+			},
+			// green, cyan: pass
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const driftCalls: Array<{ aiId: AiId; recovered: boolean }> = [];
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId, recovered) => driftCalls.push({ aiId, recovered }),
+		);
+
+		// Callback fires exactly once for red with recovered=true
+		expect(driftCalls).toHaveLength(1);
+		expect(driftCalls[0]).toEqual({ aiId: "red", recovered: true });
+
+		// Message still lands in conversation log
+		const redLog = nextState.conversationLogs.red ?? [];
+		expect(
+			redLog.some(
+				(e) =>
+					e.kind === "message" &&
+					e.from === "red" &&
+					e.content.includes("Hello blue!"),
+			),
+		).toBe(true);
+	});
+
+	it("fires onAiDrift(aiId, recovered=false) when the retry also drops", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "I think I should say something.", toolCalls: [] },
+			// retry also drops
+			{ assistantText: "still no tool call here.", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const driftCalls: Array<{ aiId: AiId; recovered: boolean }> = [];
+		const { nextState } = await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId, recovered) => driftCalls.push({ aiId, recovered }),
+		);
+
+		// Callback fires exactly once for red with recovered=false
+		expect(driftCalls).toHaveLength(1);
+		expect(driftCalls[0]).toEqual({ aiId: "red", recovered: false });
+
+		// Action becomes pass
+		const redLog = nextState.conversationLogs.red ?? [];
+		const redMsgs = redLog.filter(
+			(e) => e.kind === "message" && e.from === "red",
+		);
+		expect(redMsgs).toHaveLength(0);
+	});
+
+	it("does not fire onAiDrift when the first attempt has a tool call", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{
+				assistantText: "I will take the flower",
+				toolCalls: [
+					{
+						id: "call_1",
+						name: "pick_up",
+						argumentsJson: '{"item":"flower"}',
+					},
+				],
+			},
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const driftCalls: Array<{ aiId: AiId; recovered: boolean }> = [];
+		await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId, recovered) => driftCalls.push({ aiId, recovered }),
+		);
+
+		// Callback never fires — no retry happened
+		expect(driftCalls).toHaveLength(0);
+	});
+
+	it("does not fire onAiDrift when the first attempt is a true pass (empty text)", async () => {
+		const game = makeGame();
+		const provider = new MockRoundLLMProvider([
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+			{ assistantText: "", toolCalls: [] },
+		]);
+
+		const driftCalls: Array<{ aiId: AiId; recovered: boolean }> = [];
+		await runRound(
+			game,
+			"red",
+			"hi",
+			provider,
+			undefined,
+			["red", "green", "cyan"] as AiId[],
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			(aiId, recovered) => driftCalls.push({ aiId, recovered }),
+		);
+
+		// Callback never fires — no retry happened
+		expect(driftCalls).toHaveLength(0);
+	});
 });
 
 // ----------------------------------------------------------------------------

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -101,6 +101,8 @@ export class GameSession {
 	 * @param onAiDelta  Optional per-AI live-delta callback. Fires synchronously inside
 	 *   the SSE parser loop for each text chunk arriving from the wire.
 	 *   Never called for locked-out AIs or mock providers that ignore onDelta.
+	 * @param onAiTurnComplete  Optional per-AI "turn finished" callback.
+	 * @param onAiDrift  Optional per-AI drift-to-silence callback.
 	 */
 	async submitMessage(
 		addressed: AiId,
@@ -109,6 +111,7 @@ export class GameSession {
 		initiative?: AiId[],
 		onAiDelta?: (aiId: AiId, text: string) => void,
 		onAiTurnComplete?: (aiId: AiId) => void,
+		onAiDrift?: (aiId: AiId, recovered: boolean) => void,
 	): Promise<SubmitMessageResult> {
 		const turnOrder = initiative ?? Object.keys(this.state.personas);
 
@@ -136,6 +139,7 @@ export class GameSession {
 			onAiDelta,
 			this.coneSnapshots,
 			onAiTurnComplete,
+			onAiDrift,
 		);
 
 		// Fill in empty string for AIs whose completions weren't captured

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -119,6 +119,12 @@ export interface RunRoundResult {
  *   exactly once per AI in initiative order, AFTER any drift-to-silence
  *   retry (#254) has resolved and after dispatch. Fires for locked-out
  *   AIs too (so callers can clear per-AI UI state uniformly).
+ * @param onAiDrift  Optional per-AI drift-to-silence callback. Fires when a
+ *   daemon's turn drifts (produces text without a tool call) and the retry
+ *   resolves. Fires exactly once per drifted AI, after retry completes,
+ *   with a recovered flag indicating whether the retry rescued the turn
+ *   (recovered=true means a tool call landed; recovered=false means it also
+ *   dropped to pass).
  */
 export async function runRound(
 	game: GameState,
@@ -132,6 +138,7 @@ export async function runRound(
 	onAiDelta?: (aiId: AiId, text: string) => void,
 	priorConeSnapshots?: Partial<Record<AiId, string>>,
 	onAiTurnComplete?: (aiId: AiId) => void,
+	onAiDrift?: (aiId: AiId, recovered: boolean) => void,
 ): Promise<RunRoundResult> {
 	const aiOrder = Object.keys(game.personas);
 
@@ -233,6 +240,10 @@ export async function runRound(
 			if (retry.costUsd !== undefined) {
 				costUsd = (costUsd ?? 0) + retry.costUsd;
 			}
+			// Fire drift callback after retry resolves, indicating whether
+			// the retry rescued the turn (tool call landed).
+			const recovered = retry.toolCalls.length > 0;
+			onAiDrift?.(aiId, recovered);
 		}
 
 		// Capture completion text

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1267,6 +1267,9 @@ export function renderGame(
 			const provider = new BrowserLLMProvider({
 				disableReasoning: !enableReasoning,
 			});
+			// Capture current state for use in callbacks (TypeScript doesn't guarantee
+			// module-level `session` won't be reassigned during async operations)
+			const sessionState = session.getState();
 			// Strip each daemon's spinner as the coordinator finishes its
 			// turn (post-retry per #254). Coordinator awaits AIs serially in
 			// initiative order, so this fires staged in real time —
@@ -1279,6 +1282,15 @@ export function renderGame(
 				initiative,
 				undefined,
 				(aiId) => stripSpinner(aiId),
+				(aiId, _recovered) => {
+					const personaName = sessionState.personas[aiId]?.name ?? aiId;
+					const roundErrorEl =
+						doc.querySelector<HTMLOutputElement>("#round-error");
+					if (roundErrorEl) {
+						roundErrorEl.textContent = `${personaName} hesitated`;
+						roundErrorEl.removeAttribute("hidden");
+					}
+				},
 			);
 
 			const events = encodeRoundResult(


### PR DESCRIPTION
Closing — the auto-retry already recovers the dropped turn transparently (the recovered message lands in the transcript), so a player-facing hesitation indicator is unnecessary noise on the common case. See #254 close comment for full rationale.