### PR TITLE
e2e: witnessed-event-reload renders relative direction with inverted rotation (expected `right`, got `left`)

### DIFF
--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -841,9 +841,20 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 	// Compute the relative direction from the plan's absolute cardinal.
 	const CARDINALS = ["north", "east", "south", "west"];
 	const RELATIVES = ["forward", "right", "back", "left"];
-	const witnessFacing =
-		(phase1Spatial?.[witnessId] as PersonaSpatial | undefined)?.facing ??
-		"north";
+
+	// Determine the witness's effective facing after any plan-driven mutations.
+	let witnessFacing: CardinalDirection;
+	if (plan.kind === "setup") {
+		witnessFacing = plan.witnessLookDir;
+	} else if (plan.kind === "patch") {
+		witnessFacing = plan.witnessNewFacing;
+	} else {
+		// "direct": no mutation, use phase1 snapshot
+		witnessFacing =
+			(phase1Spatial?.[witnessId] as PersonaSpatial | undefined)?.facing ??
+			"north";
+	}
+
 	const facingIdx = CARDINALS.indexOf(witnessFacing);
 	const dirIdx = CARDINALS.indexOf(direction);
 	const relativeDirection =


### PR DESCRIPTION
## What this fixes

`e2e/witnessed-event-reload.spec.ts:496` was failing intermittently because the spec was reading a **stale, pre-setup** witness facing from the `phase1Spatial` snapshot it captured before any rounds ran, and computing the expected relative direction against that. The engine, on the other hand, renders the witnessed-event line in `src/spa/game/conversation-log.ts` against the witness's facing **at render time** — i.e. after any plan-driven mutations (setup-round `look_around` dispatch, or patch-round spatial mutation).

Diagnosis: both rendering paths use the same convention. The spec's helper `cardinalToRelative` (e2e/witnessed-event-reload.spec.ts:139) and the engine's `cardinalToRelative` (src/spa/game/direction.ts:63) both compute `(absIdx - facingIdx + 4) % 4` against `RELATIVES = [forward, right, back, left]`. The disagreement was only about *which facing* to compute against — the snapshot vs. the effective facing after setup. Engine is correct; spec was wrong.

Fix in `e2e/witnessed-event-reload.spec.ts` (assertion block ~lines 844-855): derive `witnessFacing` by branching on `plan.kind`:

- `kind === "setup"` → `plan.witnessLookDir` (post-look-dispatch facing)
- `kind === "patch"` → `plan.witnessNewFacing` (post-patch facing)
- `kind === "direct"` → `phase1Spatial[witnessId].facing ?? "north"` (unchanged — no mutation)

No engine code changed; AC #3's maintainer pause was not triggered, and AC #5's engine-side regression test does not apply.

## QA steps for the human

None — fully covered by the integration smoke. The previously failing spec now passes, and the full e2e suite is green.

## Automated coverage

`pnpm typecheck`, `pnpm test` (1450 unit tests across 58 files), `pnpm lint`, and `pnpm exec playwright test` (48/48 specs) all pass on this branch.

Closes #379

---
_Generated by [Claude Code](https://claude.ai/code/session_01UceWVgTGXSNS6jcFX3Yz6g)_