### PR TITLE
Re-promote `{actor}` token rules to `ContentPackError`

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -19,6 +19,7 @@ import {
 	PARTIAL_RETRY_SYSTEM_PROMPT,
 	validateContentPacks,
 	validateContentPacksOrThrow,
+	validateDualContentPacks,
 	validateDualContentPacksOrThrow,
 } from "../content-pack-provider.js";
 
@@ -342,15 +343,25 @@ describe("validateContentPacks — obstacle shiftFlavor validation", () => {
 		).toThrow(/shiftFlavor/);
 	});
 
-	it("warns but does not throw when an obstacle shiftFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildObstacleResponse("{actor} knocks the gate aside."),
-					inputWithObstacle,
-				),
-			/shiftFlavor/,
+	it("throws ContentPackError when an obstacle shiftFlavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildObstacleResponse("{actor} knocks the gate aside."),
+			inputWithObstacle,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "shiftFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("obs1");
+			expect(error?.retryUnit.kind).toBe("obstacle");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildObstacleResponse("{actor} knocks the gate aside."),
+				inputWithObstacle,
+			),
+		).toThrow(/shiftFlavor/);
 	});
 
 	it("persists shiftFlavor onto the returned WorldEntity", () => {
@@ -361,6 +372,99 @@ describe("validateContentPacks — obstacle shiftFlavor validation", () => {
 		);
 		const obstacle = result.packs[0]?.obstacles[0];
 		expect(obstacle?.shiftFlavor).toBe(flavor);
+	});
+
+	// ── Test A: placementFlavor missing {actor} ───────────────────────────────
+
+	it("throws ContentPackError when placementFlavor is missing {actor}", () => {
+		const inputWithPair = {
+			phases: [
+				{
+					setting: "abandoned subway station",
+					theme: "mundane",
+					k: 1,
+					n: 0,
+					m: 0,
+				},
+			],
+		};
+		const badPack = {
+			packs: [
+				{
+					setting: "abandoned subway station",
+					objectivePairs: [
+						{
+							object: {
+								id: "obj1",
+								kind: "objective_object",
+								name: "Iron Key",
+								examineDescription:
+									"An iron key. It belongs on the brass pedestal.",
+								useOutcome: "You turn the key over in your hands.",
+								pairsWithSpaceId: "space1",
+								placementFlavor: "The actor sets the key on its mount.",
+								proximityFlavor: "The key hums faintly near the pedestal.",
+							},
+							space: {
+								id: "space1",
+								kind: "objective_space",
+								name: "Brass Pedestal",
+								examineDescription:
+									"A sturdy brass pedestal. Press an item onto it to activate.",
+								activationFlavor: "The pedestal hums to life.",
+								satisfactionFlavor: "The pedestal glows brightly.",
+								postExamineDescription: "The pedestal glows softly.",
+								postLookFlavor: "the pedestal hums.",
+								convergenceTier1Flavor: "A lone figure stands.",
+								convergenceTier2Flavor: "Two figures converge.",
+								convergenceTier1ActorFlavor: "You linger alone.",
+								convergenceTier2ActorFlavor: "You share the space.",
+							},
+						},
+					],
+					interestingObjects: [],
+					obstacles: [],
+					landmarks: {
+						north: {
+							shortName: "the tower",
+							horizonPhrase: "rises high",
+						},
+						south: {
+							shortName: "the entrance",
+							horizonPhrase: "gapes wide",
+						},
+						east: { shortName: "the shaft", horizonPhrase: "spins slowly" },
+						west: { shortName: "the tunnel", horizonPhrase: "fades black" },
+					},
+				},
+			],
+		};
+		const result = validateContentPacks(badPack, inputWithPair);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "placementFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-presence");
+			expect(error?.entityId).toBe("obj1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() => validateContentPacksOrThrow(badPack, inputWithPair)).toThrow(
+			/placementFlavor/,
+		);
+	});
+
+	// ── Test B: obstacle shiftFlavor containing {actor} (already flipped above) ─
+
+	it("throws ContentPackError when obstacle shiftFlavor contains {actor} via new error API", () => {
+		const result = validateContentPacks(
+			buildObstacleResponse("{actor} shoves the gate."),
+			inputWithObstacle,
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "shiftFlavor");
+			expect(error?.rule).toBe("actor-exclusion");
+		}
 	});
 });
 
@@ -482,32 +586,62 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 		).toThrow(/convergenceTier2Flavor/);
 	});
 
-	it("warns but does not throw when convergenceTier1Flavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildConvergenceResponse(
-						"{actor} stands at the pedestal.",
-						"Two figures converge at the pedestal.",
-					),
-					inputWithPair,
-				),
-			/convergenceTier1Flavor/,
+	it("throws ContentPackError when convergenceTier1Flavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildConvergenceResponse(
+				"{actor} stands at the pedestal.",
+				"Two figures converge at the pedestal.",
+			),
+			inputWithPair,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find(
+				(e) => e.field === "convergenceTier1Flavor",
+			);
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("space1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildConvergenceResponse(
+					"{actor} stands at the pedestal.",
+					"Two figures converge at the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1Flavor/);
 	});
 
-	it("warns but does not throw when convergenceTier2Flavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildConvergenceResponse(
-						"A lone figure stands at the pedestal.",
-						"{actor} and another figure converge.",
-					),
-					inputWithPair,
-				),
-			/convergenceTier2Flavor/,
+	it("throws ContentPackError when convergenceTier2Flavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildConvergenceResponse(
+				"A lone figure stands at the pedestal.",
+				"{actor} and another figure converge.",
+			),
+			inputWithPair,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find(
+				(e) => e.field === "convergenceTier2Flavor",
+			);
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("space1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildConvergenceResponse(
+					"A lone figure stands at the pedestal.",
+					"{actor} and another figure converge.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2Flavor/);
 	});
 
 	it("throws ContentPackError when convergenceTier1Flavor is an empty string", () => {
@@ -571,35 +705,68 @@ describe("validateContentPacks — convergence tier flavor validation", () => {
 		).toThrow(/convergenceTier2ActorFlavor/);
 	});
 
-	it("warns but does not throw when convergenceTier1ActorFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildConvergenceResponse(
-						undefined,
-						undefined,
-						"{actor} stands alone at the pedestal.",
-					),
-					inputWithPair,
-				),
-			/convergenceTier1ActorFlavor/,
+	it("throws ContentPackError when convergenceTier1ActorFlavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildConvergenceResponse(
+				undefined,
+				undefined,
+				"{actor} stands alone at the pedestal.",
+			),
+			inputWithPair,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find(
+				(e) => e.field === "convergenceTier1ActorFlavor",
+			);
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("space1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildConvergenceResponse(
+					undefined,
+					undefined,
+					"{actor} stands alone at the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier1ActorFlavor/);
 	});
 
-	it("warns but does not throw when convergenceTier2ActorFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildConvergenceResponse(
-						undefined,
-						undefined,
-						undefined,
-						"{actor} and another share the pedestal.",
-					),
-					inputWithPair,
-				),
-			/convergenceTier2ActorFlavor/,
+	it("throws ContentPackError when convergenceTier2ActorFlavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildConvergenceResponse(
+				undefined,
+				undefined,
+				undefined,
+				"{actor} and another share the pedestal.",
+			),
+			inputWithPair,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find(
+				(e) => e.field === "convergenceTier2ActorFlavor",
+			);
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("space1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildConvergenceResponse(
+					undefined,
+					undefined,
+					undefined,
+					"{actor} and another share the pedestal.",
+				),
+				inputWithPair,
+			),
+		).toThrow(/convergenceTier2ActorFlavor/);
 	});
 });
 
@@ -805,17 +972,29 @@ describe("validateContentPacks — interesting_object Use-Item flavor validation
 		).toThrow(/activationFlavor/);
 	});
 
-	it("warns but does not throw when an interesting_object activationFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildInterestingResponse({
-						activationFlavor: "{actor} flips the switch home.",
-					}),
-					inputWithInteresting,
-				),
-			/activationFlavor/,
+	it("throws ContentPackError when an interesting_object activationFlavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildInterestingResponse({
+				activationFlavor: "{actor} flips the switch home.",
+			}),
+			inputWithInteresting,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "activationFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("item1");
+			expect(error?.retryUnit.kind).toBe("interesting-object");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildInterestingResponse({
+					activationFlavor: "{actor} flips the switch home.",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/activationFlavor/);
 	});
 
 	it("rejects a missing postExamineDescription", () => {
@@ -827,30 +1006,56 @@ describe("validateContentPacks — interesting_object Use-Item flavor validation
 		).toThrow(/postExamineDescription/);
 	});
 
-	it("warns but does not throw when a postExamineDescription contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildInterestingResponse({
-						postExamineDescription: "{actor} sees the switch locked on.",
-					}),
-					inputWithInteresting,
-				),
-			/postExamineDescription/,
+	it("throws ContentPackError when a postExamineDescription contains {actor}", () => {
+		const result = validateContentPacks(
+			buildInterestingResponse({
+				postExamineDescription: "{actor} sees the switch locked on.",
+			}),
+			inputWithInteresting,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find(
+				(e) => e.field === "postExamineDescription",
+			);
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("item1");
+			expect(error?.retryUnit.kind).toBe("interesting-object");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildInterestingResponse({
+					postExamineDescription: "{actor} sees the switch locked on.",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/postExamineDescription/);
 	});
 
-	it("warns but does not throw when a postLookFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildInterestingResponse({
-						postLookFlavor: "{actor} glances at the amber light",
-					}),
-					inputWithInteresting,
-				),
-			/postLookFlavor/,
+	it("throws ContentPackError when a postLookFlavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildInterestingResponse({
+				postLookFlavor: "{actor} glances at the amber light",
+			}),
+			inputWithInteresting,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "postLookFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("item1");
+			expect(error?.retryUnit.kind).toBe("interesting-object");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildInterestingResponse({
+					postLookFlavor: "{actor} glances at the amber light",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/postLookFlavor/);
 	});
 
 	it("accepts an interesting_object with postLookFlavor omitted (optional)", () => {
@@ -993,19 +1198,33 @@ describe("validateContentPacks — objective_space activationFlavor & prose tell
 		).toThrow(/activationFlavor/);
 	});
 
-	it("warns but does not throw when an objective_space activationFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildPackWithSpaceFields({
-						examineDescription:
-							"A sturdy pedestal. Press an item onto it to activate.",
-						activationFlavor: "{actor} activates the pedestal.",
-					}),
-					inputWithPair,
-				),
-			/activationFlavor/,
+	it("throws ContentPackError when an objective_space activationFlavor contains {actor}", () => {
+		const result = validateContentPacks(
+			buildPackWithSpaceFields({
+				examineDescription:
+					"A sturdy pedestal. Press an item onto it to activate.",
+				activationFlavor: "{actor} activates the pedestal.",
+			}),
+			inputWithPair,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "activationFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.entityId).toBe("space1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildPackWithSpaceFields({
+					examineDescription:
+						"A sturdy pedestal. Press an item onto it to activate.",
+					activationFlavor: "{actor} activates the pedestal.",
+				}),
+				inputWithPair,
+			),
+		).toThrow(/activationFlavor/);
 	});
 });
 
@@ -1164,18 +1383,30 @@ describe("validateDualContentPacks — objective_space activationFlavor", () => 
 		);
 	});
 
-	it("warns but does not throw when packB activationFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateDualContentPacksOrThrow(
-					buildDualPair(
-						"The pedestal hums to life.",
-						"{actor} activates the marker.",
-					),
-					dualInput,
-				),
-			/activationFlavor/,
+	it("throws ContentPackError when packB activationFlavor contains {actor}", () => {
+		const result = validateDualContentPacks(
+			buildDualPair(
+				"The pedestal hums to life.",
+				"{actor} activates the marker.",
+			),
+			dualInput,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "activationFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateDualContentPacksOrThrow(
+				buildDualPair(
+					"The pedestal hums to life.",
+					"{actor} activates the marker.",
+				),
+				dualInput,
+			),
+		).toThrow(/activationFlavor/);
 	});
 
 	it("warns but does not throw when packA space examineDescription has no use-tell", () => {
@@ -1293,18 +1524,30 @@ describe("validateDualContentPacks — obstacle shiftFlavor validation", () => {
 		).toThrow(/shiftFlavor/);
 	});
 
-	it("warns but does not throw when a dual-pack obstacle shiftFlavor contains {actor}", () => {
-		expectWarnNotThrow(
-			() =>
-				validateDualContentPacksOrThrow(
-					buildDualObstacleResponse(
-						"{actor} pushes the gate.",
-						"Something rustles.",
-					),
-					dualInputWithObstacle,
-				),
-			/shiftFlavor/,
+	it("throws ContentPackError when a dual-pack obstacle shiftFlavor contains {actor}", () => {
+		const result = validateDualContentPacks(
+			buildDualObstacleResponse(
+				"{actor} pushes the gate.",
+				"Something rustles.",
+			),
+			dualInputWithObstacle,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "shiftFlavor");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("actor-exclusion");
+			expect(error?.retryUnit.kind).toBe("obstacle");
+		}
+		expect(() =>
+			validateDualContentPacksOrThrow(
+				buildDualObstacleResponse(
+					"{actor} pushes the gate.",
+					"Something rustles.",
+				),
+				dualInputWithObstacle,
+			),
+		).toThrow(/shiftFlavor/);
 	});
 });
 

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -2203,4 +2203,79 @@ describe("BrowserContentPackProvider — partial-retry layer", () => {
 		);
 		expect(mockChatFn).toHaveBeenCalledTimes(1);
 	});
+
+	it("Test 7 — {actor} drift in convergenceTier1Flavor → repaired in round 1 (2 chatFn calls)", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: broken pack ({actor} in convergenceTier1Flavor)
+		const brokenPack = buildValidPack();
+		const brokenPackPacks = (brokenPack as Record<string, unknown>).packs as
+			| Record<string, unknown>[]
+			| undefined;
+		if (brokenPackPacks?.[0]) {
+			const pair = (
+				(brokenPackPacks[0] as Record<string, unknown>)
+					.objectivePairs as Record<string, unknown>[]
+			)[0];
+			if (pair) {
+				const space = pair.space as Record<string, unknown>;
+				space.convergenceTier1Flavor = "{actor} stands at the pedestal.";
+			}
+		}
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(brokenPack),
+			reasoning: null,
+		});
+
+		// Call 2: repair response with valid convergenceTier1Flavor (no {actor})
+		const repair: ContentPackRepair = {
+			unitKind: "objective-pair",
+			phaseIndex: 0,
+			object: {
+				id: "obj1",
+				kind: "objective_object",
+				name: "Iron Key",
+				examineDescription:
+					"An iron key. It looks like it belongs on the brass pedestal.",
+				useOutcome: "You turn the key over in your hands.",
+				pairsWithSpaceId: "space1",
+				placementFlavor: "{actor} sets the key on its mount.",
+				proximityFlavor: "The key hums faintly near the pedestal.",
+			},
+			space: {
+				id: "space1",
+				kind: "objective_space",
+				name: "Brass Pedestal",
+				examineDescription:
+					"A sturdy brass mount. Press an item onto it to activate the mechanism; the space awaits a shared presence.",
+				activationFlavor:
+					"The pedestal hums to life and its surface flushes with warmth.",
+				satisfactionFlavor:
+					"The pedestal glows brightly as the objective completes.",
+				postExamineDescription: "The pedestal glows softly after activation.",
+				postLookFlavor: "the pedestal hums with residual warmth.",
+				convergenceTier1Flavor: "A lone figure stands at the pedestal.",
+				convergenceTier2Flavor: "Two figures converge at the pedestal.",
+				convergenceTier1ActorFlavor:
+					"You linger at the pedestal; the place feels poised for company.",
+				convergenceTier2ActorFlavor:
+					"You share the pedestal with another presence; the runes thrum.",
+			},
+		};
+		mockChatFn.mockResolvedValueOnce({
+			content: buildBatchedRepair([repair]),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		const result = await provider.generateContentPacks(baseInput);
+
+		expect(mockChatFn).toHaveBeenCalledTimes(2);
+		expect(
+			result.packs[0]?.objectivePairs[0]?.space.convergenceTier1Flavor,
+		).toBe("A lone figure stands at the pedestal.");
+		expect(
+			result.packs[0]?.objectivePairs[0]?.space.convergenceTier1Flavor,
+		).not.toMatch(/{actor}/);
+	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -915,13 +915,17 @@ function validateEntity(
 			});
 		}
 		if (
-			!e.placementFlavor ||
-			(typeof e.placementFlavor === "string" &&
-				!e.placementFlavor.includes("{actor}"))
+			typeof e.placementFlavor === "string" &&
+			e.placementFlavor.length > 0 &&
+			!e.placementFlavor.includes("{actor}")
 		) {
-			console.warn(
-				`Objective object ${e.id}: placementFlavor has no "{actor}" token; the actor's name will not be interpolated into the line.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "placementFlavor",
+				rule: "actor-presence",
+				message: `Objective object ${e.id}: placementFlavor must contain the literal string "{actor}" so the actor's name is interpolated. Remove any "{actor}" tokens that are absent.`,
+				retryUnit,
+			});
 		}
 		if (
 			typeof e.proximityFlavor !== "string" ||
@@ -951,9 +955,13 @@ function validateEntity(
 			typeof e.shiftFlavor === "string" &&
 			e.shiftFlavor.includes("{actor}")
 		) {
-			console.warn(
-				`Obstacle ${e.id}: shiftFlavor contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "shiftFlavor",
+				rule: "actor-exclusion",
+				message: `Obstacle ${e.id}: shiftFlavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 	}
 
@@ -979,9 +987,13 @@ function validateEntity(
 			typeof e.activationFlavor === "string" &&
 			e.activationFlavor.includes("{actor}")
 		) {
-			console.warn(
-				`Interesting object ${e.id}: activationFlavor contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "activationFlavor",
+				rule: "actor-exclusion",
+				message: `Interesting object ${e.id}: activationFlavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 		if (
 			typeof e.postExamineDescription !== "string" ||
@@ -999,9 +1011,13 @@ function validateEntity(
 			typeof e.postExamineDescription === "string" &&
 			e.postExamineDescription.includes("{actor}")
 		) {
-			console.warn(
-				`Interesting object ${e.id}: postExamineDescription contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "postExamineDescription",
+				rule: "actor-exclusion",
+				message: `Interesting object ${e.id}: postExamineDescription contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 		if (e.postLookFlavor !== undefined) {
 			if (
@@ -1020,9 +1036,13 @@ function validateEntity(
 				typeof e.postLookFlavor === "string" &&
 				e.postLookFlavor.includes("{actor}")
 			) {
-				console.warn(
-					`Interesting object ${e.id}: postLookFlavor contains "{actor}"; the token will be rendered literally.`,
-				);
+				errors.push({
+					entityId: e.id,
+					field: "postLookFlavor",
+					rule: "actor-exclusion",
+					message: `Interesting object ${e.id}: postLookFlavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+					retryUnit,
+				});
 			}
 		}
 	}
@@ -1044,9 +1064,13 @@ function validateEntity(
 			typeof e.convergenceTier1Flavor === "string" &&
 			e.convergenceTier1Flavor.includes("{actor}")
 		) {
-			console.warn(
-				`Objective space ${e.id}: convergenceTier1Flavor contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "convergenceTier1Flavor",
+				rule: "actor-exclusion",
+				message: `Objective space ${e.id}: convergenceTier1Flavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 		if (
 			typeof e.convergenceTier2Flavor !== "string" ||
@@ -1064,9 +1088,13 @@ function validateEntity(
 			typeof e.convergenceTier2Flavor === "string" &&
 			e.convergenceTier2Flavor.includes("{actor}")
 		) {
-			console.warn(
-				`Objective space ${e.id}: convergenceTier2Flavor contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "convergenceTier2Flavor",
+				rule: "actor-exclusion",
+				message: `Objective space ${e.id}: convergenceTier2Flavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 		// First-person actor variants (#336): delivered to Daemons standing on
 		// the space; existing tier1/2 flavors fan out to non-occupant cone-witnesses.
@@ -1086,9 +1114,13 @@ function validateEntity(
 			typeof e.convergenceTier1ActorFlavor === "string" &&
 			e.convergenceTier1ActorFlavor.includes("{actor}")
 		) {
-			console.warn(
-				`Objective space ${e.id}: convergenceTier1ActorFlavor contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "convergenceTier1ActorFlavor",
+				rule: "actor-exclusion",
+				message: `Objective space ${e.id}: convergenceTier1ActorFlavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 		if (
 			typeof e.convergenceTier2ActorFlavor !== "string" ||
@@ -1106,9 +1138,13 @@ function validateEntity(
 			typeof e.convergenceTier2ActorFlavor === "string" &&
 			e.convergenceTier2ActorFlavor.includes("{actor}")
 		) {
-			console.warn(
-				`Objective space ${e.id}: convergenceTier2ActorFlavor contains "{actor}"; the token will be rendered literally.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "convergenceTier2ActorFlavor",
+				rule: "actor-exclusion",
+				message: `Objective space ${e.id}: convergenceTier2ActorFlavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+				retryUnit,
+			});
 		}
 	}
 
@@ -1156,9 +1192,13 @@ function validateEntity(
 				typeof e.activationFlavor === "string" &&
 				e.activationFlavor.includes("{actor}")
 			) {
-				console.warn(
-					`Objective space ${e.id}: activationFlavor contains "{actor}"; the token will be rendered literally.`,
-				);
+				errors.push({
+					entityId: e.id,
+					field: "activationFlavor",
+					rule: "actor-exclusion",
+					message: `Objective space ${e.id}: activationFlavor contains "{actor}"; the token will render literally. Remove the "{actor}" substring.`,
+					retryUnit,
+				});
 			}
 			entity.activationFlavor = e.activationFlavor;
 		}


### PR DESCRIPTION
## What this fixes

Flips ten `console.warn` sites in `validateEntity` (`src/spa/game/content-pack-provider.ts`) to hard `ValidationError`s using the `actor-presence` / `actor-exclusion` rule taxonomy added in #392. Before this change, an LLM that drifted and emitted literal `{actor}` tokens in flavor strings (or omitted `{actor}` where it was required) would log a warning and the token would render as raw text to the player. With the partial-retry layer from #394 in place, the layer can now absorb the repair cost — so these cosmetic-but-player-visible failures are caught at validation and routed through a batched repair call instead of leaking through.

The ten promoted rules:

- `objective_object.placementFlavor` — MUST contain `{actor}` (`actor-presence`)
- `interesting_object.activationFlavor` / `postExamineDescription` / `postLookFlavor` — MUST NOT contain `{actor}` (`actor-exclusion`, retry-unit `interesting-object`)
- `objective_space.convergenceTier1Flavor` / `convergenceTier2Flavor` / `convergenceTier1ActorFlavor` / `convergenceTier2ActorFlavor` / `activationFlavor` — MUST NOT contain `{actor}` (`actor-exclusion`, retry-unit `objective-pair`)
- `obstacle.shiftFlavor` — MUST NOT contain `{actor}` (`actor-exclusion`, retry-unit `obstacle`) — included beyond the issue's 9-row table per scope confirmation; the eleventh remaining `{actor}`-rule warn that re-promotes to errors is in the same class of "low-risk pilot for partial-retry".

Each flip reuses the existing `errors` accumulator and `retryUnit` parameter that `validateEntity` already receives — no new wiring, no signature changes. Error messages are phrased imperatively so the partial-retry / corrective-feedback prompt has a concrete repair instruction (e.g. *"Remove the `{actor}` substring"*, *"must contain the literal string `{actor}` so the actor's name is interpolated"*).

The `placementFlavor` predicate was narrowed to `typeof === "string" && length > 0 && !includes("{actor}")` so it doesn't double-report alongside the upstream `structural` check.

The three other softened rules called out by the parent epic (paired-space prose-tell, verb-of-activation, paired-space mention) are explicitly **unchanged** — they re-promote in their own follow-up tickets.

## QA steps for the human

None — fully covered by the automated suite. The new Test 7 in `BrowserContentPackProvider — partial-retry layer` drives the full path end-to-end (drift `{actor}` into `convergenceTier1Flavor` → partial-retry round 1 fires a batched repair → recovered pack contains no `{actor}` → exactly 2 `chatFn` calls).

If you want a manual sniff: pop open a session in dev and confirm flavor strings render without literal `{actor}` tokens. The promoted rules guarantee the content pack now fails validation (and the layer auto-repairs it) rather than letting the token leak through.

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm test` — 1459 / 1459 across 58 files
- `pnpm lint` — clean
- `pnpm smoke` (Playwright e2e) — 47 / 48; the single failure (`e2e/endgame-choices.spec.ts:73`) is pre-existing on `main` and unrelated to this change

Closes #388

---
_Generated by [Claude Code](https://claude.ai/code/session_015dGqd6zGXuyGM9FuU5CWLc)_