### PR TITLE
Re-promote verb-of-activation cue rule to `ContentPackError`

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -940,18 +940,31 @@ describe("validateContentPacks — interesting_object Use-Item flavor validation
 		expect(item?.postLookFlavor).toContain("amber pinpoint");
 	});
 
-	it("warns but does not throw when examineDescription has no verb-of-activation or control-noun cue", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildInterestingResponse({
-						examineDescription:
-							"A small porcelain figurine, chipped along one edge but otherwise intact.",
-					}),
-					inputWithInteresting,
-				),
-			/verb-of-activation cue|control noun/,
+	it("throws ContentPackError when examineDescription has no verb-of-activation or control-noun cue", () => {
+		const result = validateContentPacks(
+			buildInterestingResponse({
+				examineDescription:
+					"A small porcelain figurine, chipped along one edge but otherwise intact.",
+			}),
+			inputWithInteresting,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "examineDescription");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("verb-of-activation");
+			expect(error?.entityId).toBe("item1");
+			expect(error?.retryUnit.kind).toBe("interesting-object");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildInterestingResponse({
+					examineDescription:
+						"A small porcelain figurine, chipped along one edge but otherwise intact.",
+				}),
+				inputWithInteresting,
+			),
+		).toThrow(/verb-of-activation cue|control noun/);
 	});
 
 	it("rejects a missing activationFlavor", () => {
@@ -2277,5 +2290,61 @@ describe("BrowserContentPackProvider — partial-retry layer", () => {
 		expect(
 			result.packs[0]?.objectivePairs[0]?.space.convergenceTier1Flavor,
 		).not.toMatch(/{actor}/);
+	});
+
+	it("Test 7 — verb-of-activation cue missing in interesting_object examineDescription → repaired in round 1 (2 chatFn calls)", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: broken pack (no verb-of-activation cue in examineDescription)
+		const brokenPack = buildValidPack();
+		const brokenPackPacks = (brokenPack as Record<string, unknown>).packs as
+			| Record<string, unknown>[]
+			| undefined;
+		if (brokenPackPacks?.[0]) {
+			const pack = brokenPackPacks[0] as Record<string, unknown>;
+			const items = pack.interestingObjects as
+				| Record<string, unknown>[]
+				| undefined;
+			if (items?.[0]) {
+				(items[0] as Record<string, unknown>).examineDescription =
+					"A small porcelain figurine, chipped along one edge but otherwise intact.";
+			}
+		}
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(brokenPack),
+			reasoning: null,
+		});
+
+		// Call 2: repair response with valid examineDescription (has verb-of-activation cue)
+		const repair: ContentPackRepair = {
+			unitKind: "interesting-object",
+			phaseIndex: 0,
+			entity: {
+				id: "item1",
+				kind: "interesting_object",
+				name: "Brass Switch",
+				examineDescription:
+					"A small brass switch mounted on a panel. It looks like it should be pressed.",
+				useOutcome: "The switch clicks under your finger.",
+				activationFlavor: "The switch snaps loudly into place.",
+				postExamineDescription: "The switch sits locked in its on position.",
+				postLookFlavor: "an amber pinpoint of light glows beside the panel.",
+			},
+		};
+		mockChatFn.mockResolvedValueOnce({
+			content: buildBatchedRepair([repair]),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		const result = await provider.generateContentPacks(baseInput);
+
+		expect(mockChatFn).toHaveBeenCalledTimes(2);
+		expect(result.packs[0]?.interestingObjects[0]?.examineDescription).toBe(
+			"A small brass switch mounted on a panel. It looks like it should be pressed.",
+		);
+		expect(
+			result.packs[0]?.interestingObjects[0]?.examineDescription,
+		).not.toMatch(/porcelain figurine/);
 	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -967,9 +967,13 @@ function validateEntity(
 
 	if (requireUseItemFlavors) {
 		if (!examineMentionsUseTell(e.examineDescription as string)) {
-			console.warn(
-				`Interesting object ${e.id}: examineDescription has no verb-of-activation cue or control noun (e.g. "use", "activate", "press", "pull", "turn", "twist", "switch", "lever", "trigger", "button"). The AI-discoverable Use-Item tell is missing; daemons may not realise the item is usable.`,
-			);
+			errors.push({
+				entityId: e.id,
+				field: "examineDescription",
+				rule: "verb-of-activation",
+				message: `Interesting object ${e.id}: examineDescription has no verb-of-activation cue or control noun (e.g. "use", "activate", "press", "pull", "turn", "twist", "switch", "lever", "trigger", "button"). The AI-discoverable Use-Item tell is missing; daemons may not realise the item is usable.`,
+				retryUnit,
+			});
 		}
 		if (
 			typeof e.activationFlavor !== "string" ||


### PR DESCRIPTION
## What this fixes

PR #345 had softened the verb-of-activation cue check on `interesting_object.examineDescription` from `ContentPackError` to `console.warn` so cosmetic prompt drift wouldn't crash bootstrap. With the partial-retry layer (#387) and the `{actor}` re-promotion (#388) in place, that soft fallback can come back off: a missing verb-cue is now a hard validator error that the partial-retry layer absorbs via a batched repair call.

The change is two-spot:

- `src/spa/game/content-pack-provider.ts` (the `!examineMentionsUseTell(e.examineDescription)` branch inside the `requireUseItemFlavors` block of `validateEntity`): the previous `console.warn` is replaced with `errors.push({ entityId: e.id, field: "examineDescription", rule: "verb-of-activation", message, retryUnit })`. The `retryUnit` is the in-scope parameter — `{ kind: "interesting-object", phaseIndex, entityId }` — already used by the surrounding `errors.push` calls (e.g. the neighbouring `activationFlavor` actor-exclusion check). The original warn message is preserved verbatim inside the error so message-matching tests keep working.
- The keyword-match helper `examineMentionsUseTell` is unchanged. The two `examineMentionsUseTell` call sites on the `objective_space` paired-space path stay `console.warn` — they belong to a different rule and re-promote separately.

This pressure-tests the partial-retry layer on its first **prose-level** rule (the previous re-promotion in #388 was token-level — `{actor}`). The repair prompt now has to convince the LLM to insert one of the listed verb cues into the regenerated `examineDescription` rather than just delete a substring.

## QA steps for the human

None — fully covered by the integration smoke. The new partial-retry integration test drives the broken→repair flow through `BrowserContentPackProvider.generateContentPacks` end-to-end (broken pack on call 1, batched repair with a valid `examineDescription` on call 2, bootstrap succeeds with `chatFn` called twice). The 48-spec Playwright e2e suite exercises the live bootstrap surface against `pnpm build` + `wrangler dev`.

## Automated coverage

`pnpm typecheck` ✓ · `pnpm test` 1460/1460 ✓ · `pnpm lint` ✓ · `pnpm smoke` 48/48 Playwright specs ✓

## Out of scope

The paired-space prose-tell `console.warn` (the last remaining softened rule) stays soft — it re-promotes in its own ticket (#E in the #346 sequence).

Closes #389

---
_Generated by [Claude Code](https://claude.ai/code/session_019PoCTaWFiRDv3YYGQZFZR9)_