### PR TITLE
Loosen `examineMentionsPairedSpace` matcher to token-overlap

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -97,6 +97,45 @@ describe("examineMentionsPairedSpace", () => {
 	it("returns false for an empty space name", () => {
 		expect(examineMentionsPairedSpace("anything goes here", "")).toBe(false);
 	});
+
+	it("matches via token-overlap when multiple content tokens appear (issue #382 motivating case)", () => {
+		expect(
+			examineMentionsPairedSpace(
+				"A heavy brass ring that once slid along the ropes near the stage pulley.",
+				"Stage Pulley System",
+			),
+		).toBe(true);
+	});
+
+	it("matches when the examine contains the full space name (regression guard for 'Main Console Slot')", () => {
+		expect(
+			examineMentionsPairedSpace(
+				"fits into the main console slot",
+				"Main Console Slot",
+			),
+		).toBe(true);
+	});
+
+	it("matches via token-overlap on a non-head-noun token (telescope vs Telescope Mounting Arm)", () => {
+		expect(
+			examineMentionsPairedSpace(
+				"intended for the telescope mount",
+				"Telescope Mounting Arm",
+			),
+		).toBe(true);
+	});
+
+	it("rejects an examine that shares only the stopword 'for' with the space name", () => {
+		expect(
+			examineMentionsPairedSpace("the cake is for you", "For The Win"),
+		).toBe(false);
+	});
+
+	it("rejects an examine that shares only a 3-letter token with the space name", () => {
+		expect(
+			examineMentionsPairedSpace("the top of the stack", "Top Shelf"),
+		).toBe(false);
+	});
 });
 
 describe("CONTENT_PACK_SYSTEM_PROMPT", () => {

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -363,17 +363,34 @@ export function buildPartialRetryUserMessage(
 	return lines.join("\n");
 }
 
+const STOPWORDS = new Set([
+	"the",
+	"and",
+	"or",
+	"of",
+	"with",
+	"for",
+	"at",
+	"in",
+	"on",
+	"a",
+	"an",
+]);
+
 // ── Prose-tell check ──────────────────────────────────────────────────────────
 
 /**
  * Returns true when an objective_object's examineDescription mentions its paired
  * objective_space's name — either the literal name (case-insensitive substring)
- * or the head noun of the name (last whitespace-separated token, length >= 3).
+ * or any non-stopword token of length >= 4 from the space name.
  *
- * The head-noun fallback admits noun-phrase synonyms like "the pedestal" for a
- * space named "Brass Pedestal". The system prompt MUSTs this property; this
- * helper exists so tests and any future validator-side enforcement (see #248)
- * share one definition.
+ * The token-overlap fallback admits valid tells like "stage pulley" for a
+ * space named "Stage Pulley System" where neither token appears in the literal
+ * name but both are substantial content words. This widens the matcher beyond
+ * the head-noun fallback (see issue #382) to capture more valid adjacencies
+ * while still rejecting the playtest-0007 misses. The system prompt MUSTs
+ * this property; this helper exists so tests and any future validator-side
+ * enforcement (see #346) share one definition.
  */
 export function examineMentionsPairedSpace(
 	examineDescription: string,
@@ -383,9 +400,10 @@ export function examineMentionsPairedSpace(
 	const spaceLc = spaceName.toLowerCase().trim();
 	if (spaceLc.length === 0) return false;
 	if (examineLc.includes(spaceLc)) return true;
-	const tokens = spaceLc.split(/\s+/).filter((t) => t.length >= 3);
-	const headNoun = tokens[tokens.length - 1];
-	return headNoun !== undefined && examineLc.includes(headNoun);
+	const tokens = spaceLc
+		.split(/\s+/)
+		.filter((t) => t.length >= 4 && !STOPWORDS.has(t));
+	return tokens.some((t) => examineLc.includes(t));
 }
 
 /**


### PR DESCRIPTION
### What this fixes

`examineMentionsPairedSpace` in `src/spa/game/content-pack-provider.ts` previously fell back to a *head-noun* substring check (the last whitespace-separated token of the space name, length ≥ 3). That false-negatived valid token-overlap tells whose head noun was a generic word — e.g. an examine mentioning "stage pulley" against the space `"Stage Pulley System"` whose head noun is `"system"`. With #346's validator-side enforcement looming, those false negatives would have triggered spurious LLM retries on legitimately well-formed content packs.

This change replaces the head-noun fallback with **any-content-token overlap**: any non-stopword token of length ≥ 4 from the space name must appear in the examine description. A module-private `STOPWORDS` set (`the, and, or, of, with, for, at, in, on, a, an`) keeps trivial overlaps from registering, and the length-≥-4 threshold keeps short generic tokens like `top` from matching by accident. The case-insensitive full-name substring path is preserved as a fast-positive. Token-overlap is a strict superset of head-noun-overlap for all length-≥-4 head nouns, so existing positive cases (e.g. `"Brass Pedestal"`) keep matching, and the two playtest-0007 negative regression guards (`"Brass Pedestal"` and `"Crystal Altar"`) keep rejecting.

Both call sites of the helper in `content-pack-provider.ts` (around L1422 and L1814) only use the return value to gate a `console.warn` — no caller behavior changes here. The downstream validator wire-up that will treat this as a hard gate stays in parent #346, per the issue's "out of scope" section.

### QA steps for the human

None — fully covered by the unit suite. Five new behavior-anchored tests in `src/spa/game/__tests__/content-pack-provider.test.ts` exercise the motivating case ("stage pulley"), a non-head-noun token-overlap case ("telescope"), the regression guard for full-name match, and two new negatives (stopword-only and 3-letter-token thresholds). The two playtest-0007 verbatim negative quotes remain as-is and still reject.

### Automated coverage

`pnpm typecheck` + `pnpm test` (1465 unit tests across Vitest jsdom and `@cloudflare/vitest-pool-workers`) + `pnpm lint` (biome) + `pnpm smoke` (Playwright e2e, 48/48) all green on the reviewer's machine and via the pre-push hook on this branch.

Closes #382

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrYyiw88YtNV3c92hxfLux)_