### PR TITLE
Re-promote paired-space prose-tell rule to ContentPackError

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -258,17 +258,29 @@ describe("validateContentPacks — prose tell contract", () => {
 		).toBe(true);
 	});
 
-	it("warns but does not throw when objective_object examine does not mention the paired space", () => {
-		expectWarnNotThrow(
-			() =>
-				validateContentPacksOrThrow(
-					buildResponse(
-						"rusted iron key, heavily corroded but still intact. The teeth are worn smooth from use",
-					),
-					input,
-				),
-			/examineDescription does not mention paired space/,
+	it("throws ContentPackError when objective_object examine does not mention the paired space", () => {
+		const result = validateContentPacks(
+			buildResponse(
+				"rusted iron key, heavily corroded but still intact. The teeth are worn smooth from use",
+			),
+			input,
 		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			const error = result.errors.find((e) => e.field === "examineDescription");
+			expect(error).toBeDefined();
+			expect(error?.rule).toBe("paired-space-tell");
+			expect(error?.entityId).toBe("obj1");
+			expect(error?.retryUnit.kind).toBe("objective-pair");
+		}
+		expect(() =>
+			validateContentPacksOrThrow(
+				buildResponse(
+					"rusted iron key, heavily corroded but still intact. The teeth are worn smooth from use",
+				),
+				input,
+			),
+		).toThrow(/examineDescription does not mention paired space/);
 	});
 
 	it("rejects a content pack whose objective_object is missing proximityFlavor", () => {
@@ -2385,5 +2397,86 @@ describe("BrowserContentPackProvider — partial-retry layer", () => {
 		expect(
 			result.packs[0]?.interestingObjects[0]?.examineDescription,
 		).not.toMatch(/porcelain figurine/);
+	});
+
+	it("Test 8 — paired-space tell missing in objective_object examineDescription → repaired in round 1 (2 chatFn calls)", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: broken pack (no paired-space mention in examineDescription)
+		const brokenPack = buildValidPack();
+		const brokenPackPacks = (brokenPack as Record<string, unknown>).packs as
+			| Record<string, unknown>[]
+			| undefined;
+		if (brokenPackPacks?.[0]) {
+			const pair = (
+				(brokenPackPacks[0] as Record<string, unknown>)
+					.objectivePairs as Record<string, unknown>[]
+			)[0];
+			if (pair) {
+				const obj = pair.object as Record<string, unknown>;
+				obj.examineDescription =
+					"rusted iron key, heavily corroded but still intact. The teeth are worn smooth from use";
+			}
+		}
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(brokenPack),
+			reasoning: null,
+		});
+
+		// Call 2: repair response with valid examineDescription (has paired-space mention)
+		const repair: ContentPackRepair = {
+			unitKind: "objective-pair",
+			phaseIndex: 0,
+			object: {
+				id: "obj1",
+				kind: "objective_object",
+				name: "Iron Key",
+				examineDescription:
+					"An iron key. It looks like it belongs on the brass pedestal across the room.",
+				useOutcome: "You turn the key over in your hands.",
+				pairsWithSpaceId: "space1",
+				placementFlavor: "{actor} sets the key on its mount.",
+				proximityFlavor: "The key hums faintly near the pedestal.",
+			},
+			space: {
+				id: "space1",
+				kind: "objective_space",
+				name: "Brass Pedestal",
+				examineDescription:
+					"A sturdy brass mount. Press an item onto it to activate the mechanism; the space awaits a shared presence.",
+				activationFlavor:
+					"The pedestal hums to life and its surface flushes with warmth.",
+				satisfactionFlavor:
+					"The pedestal glows brightly as the objective completes.",
+				postExamineDescription: "The pedestal glows softly after activation.",
+				postLookFlavor: "the pedestal hums with residual warmth.",
+				convergenceTier1Flavor: "A lone figure stands at the pedestal.",
+				convergenceTier2Flavor: "Two figures converge at the pedestal.",
+				convergenceTier1ActorFlavor:
+					"You linger at the pedestal; the place feels poised for company.",
+				convergenceTier2ActorFlavor:
+					"You share the pedestal with another presence; the runes thrum.",
+			},
+		};
+		mockChatFn.mockResolvedValueOnce({
+			content: buildBatchedRepair([repair]),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		const result = await provider.generateContentPacks(baseInput);
+
+		expect(mockChatFn).toHaveBeenCalledTimes(2);
+		expect(result.packs[0]?.objectivePairs[0]?.object.examineDescription).toBe(
+			"An iron key. It looks like it belongs on the brass pedestal across the room.",
+		);
+		expect(
+			result.packs[0]?.objectivePairs[0]?.object.examineDescription.toLowerCase(),
+		).toContain("brass pedestal");
+
+		const call2Messages = mockChatFn.mock.calls[1]?.[0]?.messages as
+			| Array<{ role: string; content: string }>
+			| undefined;
+		expect(call2Messages?.[1]?.content).toContain("Brass Pedestal");
 	});
 });

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -1439,9 +1439,13 @@ export function validateContentPacks(
 				if (
 					!examineMentionsPairedSpace(object.examineDescription, space.name)
 				) {
-					console.warn(
-						`${phaseLabel}: object ${object.id} examineDescription does not mention paired space "${space.name}" (the AI-discoverable pairing tell).`,
-					);
+					errors.push({
+						entityId: object.id,
+						field: "examineDescription",
+						rule: "paired-space-tell",
+						message: `${phaseLabel}: object ${object.id} examineDescription does not mention paired space "${space.name}" (the AI-discoverable pairing tell). Reference the space's name or a clear noun-phrase synonym.`,
+						retryUnit,
+					});
 				}
 				if (!examineMentionsUseTell(space.examineDescription)) {
 					console.warn(
@@ -1830,9 +1834,13 @@ function validateSinglePack(
 				continue;
 			}
 			if (!examineMentionsPairedSpace(object.examineDescription, space.name)) {
-				console.warn(
-					`${label}: object ${object.id} examineDescription does not mention paired space "${space.name}" (the AI-discoverable pairing tell).`,
-				);
+				errors.push({
+					entityId: object.id,
+					field: "examineDescription",
+					rule: "paired-space-tell",
+					message: `${label}: object ${object.id} examineDescription does not mention paired space "${space.name}" (the AI-discoverable pairing tell). Reference the space's name or a clear noun-phrase synonym.`,
+					retryUnit,
+				});
 			}
 			if (!examineMentionsUseTell(space.examineDescription)) {
 				console.warn(


### PR DESCRIPTION
## What this fixes

PR #345 softened the `examineMentionsPairedSpace` validator on `objective_object.examineDescription` from `ContentPackError` to `console.warn` because two cold-start playtests against `z-ai/glm-4.7` produced 0/10 prose-tells and crashed bootstrap. With the partial-retry layer from #387 now able to absorb the cost of cosmetic drift on a single entity (without throwing away the whole pack), this re-promotion brings the AI-discoverability tell back under hard validator protection — the final re-promotion of the four rules softened in PR #345.

The diff flips both warn sites in `src/spa/game/content-pack-provider.ts`:

- `validateContentPacks` — single-pack path.
- `validateSinglePack` — used by `validateDualContentPacks` for dual packs.

Each site now pushes a `ValidationError` with `rule: "paired-space-tell"`, `field: "examineDescription"`, and the already-in-scope `retryUnit = { kind: "objective-pair", phaseIndex, pairId }`, so the partial-retry layer batches both halves of the pair when issuing the repair call. `buildPartialRetryUserMessage` already surfaces the partner space's `name` for `objective-pair` units (`Note: The paired space is named "${space?.name}".`), so no plumbing change was needed.

The adjacent `examineMentionsUseTell` warn on `objective_space.examineDescription` is a different rule (use/activation cue on a space, not paired-space tell on an object) and was intentionally left untouched.

## QA steps for the human

None — fully covered by the automated coverage. The converted unit test asserts both the result-shape API surfaces the error with the right `rule`, `entityId`, and `retryUnit.kind`, and that the throwing wrapper still throws with the original message. The new partial-retry integration test (Test 8) drives the full bootstrap path end-to-end with a stubbed `chatFn` that returns a drifted pack on call 1 and a batched repair on call 2, then asserts the partner space's name appears in the partial-retry user message.

## Automated coverage

`pnpm typecheck && pnpm test && pnpm lint && pnpm smoke` all green (1466 unit tests, 48 smoke specs).

Closes #390

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYfC763XPFUbwsXHJT3bja)_