### PR TITLE
Content-pack dual generation: port outer retry budget + corrective feedback from #394

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -2480,3 +2480,638 @@ describe("BrowserContentPackProvider — partial-retry layer", () => {
 		expect(call2Messages?.[1]?.content).toContain("Brass Pedestal");
 	});
 });
+
+describe("BrowserContentPackProvider — dual outer-retry layer", () => {
+	const dualInput = {
+		phases: [
+			{
+				settingA: "abandoned subway station",
+				settingB: "sun-baked salt flat",
+				theme: "mundane",
+				k: 1,
+				n: 0,
+				m: 0,
+			},
+		],
+	};
+
+	function buildDualPair(
+		packAActivation: string,
+		packBActivation: string,
+		packAExamine = "A sturdy pedestal. Press an item onto it to activate.",
+		packBExamine = "A weathered marker. Press the cap to activate it.",
+	): unknown {
+		const landmarks = {
+			north: {
+				shortName: "the signal tower",
+				horizonPhrase: "rises above the platform",
+			},
+			south: {
+				shortName: "the collapsed entrance",
+				horizonPhrase: "gapes like a wound in the dark",
+			},
+			east: {
+				shortName: "the rusted fan shaft",
+				horizonPhrase: "spins slowly in the stale air",
+			},
+			west: {
+				shortName: "the flooded tunnel",
+				horizonPhrase: "disappears into still black water",
+			},
+		};
+		const mkPack = (
+			setting: string,
+			objName: string,
+			spaceName: string,
+			examine: string,
+			activation: string,
+		) => ({
+			setting,
+			objectivePairs: [
+				{
+					object: {
+						id: "obj1",
+						kind: "objective_object",
+						name: objName,
+						examineDescription: `An object. It belongs on the ${spaceName.toLowerCase()}.`,
+						useOutcome: "You turn it over in your hands.",
+						pairsWithSpaceId: "space1",
+						placementFlavor: `{actor} sets it on the ${spaceName.toLowerCase()}.`,
+						proximityFlavor: "It hums faintly nearby.",
+					},
+					space: {
+						id: "space1",
+						kind: "objective_space",
+						name: spaceName,
+						examineDescription: examine,
+						activationFlavor: activation,
+						satisfactionFlavor: "The space is satisfied.",
+						postExamineDescription: "The space is now used.",
+						postLookFlavor: "The space hums.",
+						convergenceTier1Flavor: `A lone figure stands at the ${spaceName.toLowerCase()}.`,
+						convergenceTier2Flavor: `Two figures converge at the ${spaceName.toLowerCase()}.`,
+						convergenceTier1ActorFlavor: `You linger at the ${spaceName.toLowerCase()}.`,
+						convergenceTier2ActorFlavor: `You share the ${spaceName.toLowerCase()} with another presence.`,
+					},
+				},
+			],
+			interestingObjects: [],
+			obstacles: [],
+			landmarks,
+		});
+		return {
+			phases: [
+				{
+					packA: mkPack(
+						"abandoned subway station",
+						"Iron Key",
+						"Brass Pedestal",
+						packAExamine,
+						packAActivation,
+					),
+					packB: mkPack(
+						"sun-baked salt flat",
+						"Bone Token",
+						"Survey Marker",
+						packBExamine,
+						packBActivation,
+					),
+				},
+			],
+		};
+	}
+
+	it("Test 1 — retries on dual validation failure (N=1), then succeeds and includes corrective feedback", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: structurally invalid dual response (missing space)
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify({
+				phases: [
+					{
+						packA: {
+							setting: "abandoned subway station",
+							objectivePairs: [
+								{
+									object: {
+										id: "obj1",
+										kind: "objective_object",
+										name: "Iron Key",
+										examineDescription:
+											"An object. It belongs on the brass pedestal.",
+										useOutcome: "You turn it over in your hands.",
+										pairsWithSpaceId: "space1",
+										placementFlavor: "{actor} sets it on the brass pedestal.",
+										proximityFlavor: "It hums faintly nearby.",
+									},
+									// space intentionally missing — validation failure
+								},
+							],
+							interestingObjects: [],
+							obstacles: [],
+							landmarks: {
+								north: {
+									shortName: "the signal tower",
+									horizonPhrase: "rises above the platform",
+								},
+								south: {
+									shortName: "the collapsed entrance",
+									horizonPhrase: "gapes like a wound in the dark",
+								},
+								east: {
+									shortName: "the rusted fan shaft",
+									horizonPhrase: "spins slowly in the stale air",
+								},
+								west: {
+									shortName: "the flooded tunnel",
+									horizonPhrase: "disappears into still black water",
+								},
+							},
+						},
+						packB: {
+							setting: "sun-baked salt flat",
+							objectivePairs: [
+								{
+									object: {
+										id: "obj1",
+										kind: "objective_object",
+										name: "Bone Token",
+										examineDescription:
+											"An object. It belongs on the survey marker.",
+										useOutcome: "You turn it over in your hands.",
+										pairsWithSpaceId: "space1",
+										placementFlavor: "{actor} sets it on the survey marker.",
+										proximityFlavor: "It hums faintly nearby.",
+									},
+									space: {
+										id: "space1",
+										kind: "objective_space",
+										name: "Survey Marker",
+										examineDescription:
+											"A weathered marker. Press the cap to activate it.",
+										activationFlavor:
+											"The marker clicks once and a column of dust spirals up.",
+										satisfactionFlavor: "The space is satisfied.",
+										postExamineDescription: "The space is now used.",
+										postLookFlavor: "The space hums.",
+										convergenceTier1Flavor:
+											"A lone figure stands at the survey marker.",
+										convergenceTier2Flavor:
+											"Two figures converge at the survey marker.",
+										convergenceTier1ActorFlavor:
+											"You linger at the survey marker.",
+										convergenceTier2ActorFlavor:
+											"You share the survey marker with another presence.",
+									},
+								},
+							],
+							interestingObjects: [],
+							obstacles: [],
+							landmarks: {
+								north: {
+									shortName: "the signal tower",
+									horizonPhrase: "rises above the platform",
+								},
+								south: {
+									shortName: "the collapsed entrance",
+									horizonPhrase: "gapes like a wound in the dark",
+								},
+								east: {
+									shortName: "the rusted fan shaft",
+									horizonPhrase: "spins slowly in the stale air",
+								},
+								west: {
+									shortName: "the flooded tunnel",
+									horizonPhrase: "disappears into still black water",
+								},
+							},
+						},
+					},
+				],
+			}),
+			reasoning: null,
+		});
+
+		// Call 2: valid dual response
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(
+				buildDualPair(
+					"The pedestal hums to life and its runes glow.",
+					"The marker clicks once and a column of dust spirals up.",
+				),
+			),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		const result = await provider.generateDualContentPacks(dualInput);
+
+		expect(mockChatFn).toHaveBeenCalledTimes(2);
+		expect(
+			result.phases[0]?.packA.objectivePairs[0]?.space.activationFlavor,
+		).toBe("The pedestal hums to life and its runes glow.");
+
+		// Assert call 2's messages contain corrective feedback
+		const call2Messages = mockChatFn.mock.calls[1]?.[0]?.messages as
+			| Array<{ role: string; content: string }>
+			| undefined;
+		expect(call2Messages).toBeDefined();
+		const correctionTurn = call2Messages?.find((msg) =>
+			msg.content.includes("Your previous attempt failed validation"),
+		);
+		expect(correctionTurn).toBeDefined();
+	});
+
+	it("Test 2 — retries on dual validation failure (N=2), then succeeds and includes corrective feedback", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: structurally invalid dual response (missing space in packA)
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify({
+				phases: [
+					{
+						packA: {
+							setting: "abandoned subway station",
+							objectivePairs: [
+								{
+									object: {
+										id: "obj1",
+										kind: "objective_object",
+										name: "Iron Key",
+										examineDescription:
+											"An object. It belongs on the brass pedestal.",
+										useOutcome: "You turn it over in your hands.",
+										pairsWithSpaceId: "space1",
+										placementFlavor: "{actor} sets it on the brass pedestal.",
+										proximityFlavor: "It hums faintly nearby.",
+									},
+									// space intentionally missing — validation failure
+								},
+							],
+							interestingObjects: [],
+							obstacles: [],
+							landmarks: {
+								north: {
+									shortName: "the signal tower",
+									horizonPhrase: "rises above the platform",
+								},
+								south: {
+									shortName: "the collapsed entrance",
+									horizonPhrase: "gapes like a wound in the dark",
+								},
+								east: {
+									shortName: "the rusted fan shaft",
+									horizonPhrase: "spins slowly in the stale air",
+								},
+								west: {
+									shortName: "the flooded tunnel",
+									horizonPhrase: "disappears into still black water",
+								},
+							},
+						},
+						packB: {
+							setting: "sun-baked salt flat",
+							objectivePairs: [
+								{
+									object: {
+										id: "obj1",
+										kind: "objective_object",
+										name: "Bone Token",
+										examineDescription:
+											"An object. It belongs on the survey marker.",
+										useOutcome: "You turn it over in your hands.",
+										pairsWithSpaceId: "space1",
+										placementFlavor: "{actor} sets it on the survey marker.",
+										proximityFlavor: "It hums faintly nearby.",
+									},
+									space: {
+										id: "space1",
+										kind: "objective_space",
+										name: "Survey Marker",
+										examineDescription:
+											"A weathered marker. Press the cap to activate it.",
+										activationFlavor:
+											"The marker clicks once and a column of dust spirals up.",
+										satisfactionFlavor: "The space is satisfied.",
+										postExamineDescription: "The space is now used.",
+										postLookFlavor: "The space hums.",
+										convergenceTier1Flavor:
+											"A lone figure stands at the survey marker.",
+										convergenceTier2Flavor:
+											"Two figures converge at the survey marker.",
+										convergenceTier1ActorFlavor:
+											"You linger at the survey marker.",
+										convergenceTier2ActorFlavor:
+											"You share the survey marker with another presence.",
+									},
+								},
+							],
+							interestingObjects: [],
+							obstacles: [],
+							landmarks: {
+								north: {
+									shortName: "the signal tower",
+									horizonPhrase: "rises above the platform",
+								},
+								south: {
+									shortName: "the collapsed entrance",
+									horizonPhrase: "gapes like a wound in the dark",
+								},
+								east: {
+									shortName: "the rusted fan shaft",
+									horizonPhrase: "spins slowly in the stale air",
+								},
+								west: {
+									shortName: "the flooded tunnel",
+									horizonPhrase: "disappears into still black water",
+								},
+							},
+						},
+					},
+				],
+			}),
+			reasoning: null,
+		});
+
+		// Call 2: still structurally invalid dual response (missing packB now)
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify({
+				phases: [
+					{
+						packA: {
+							setting: "abandoned subway station",
+							objectivePairs: [
+								{
+									object: {
+										id: "obj1",
+										kind: "objective_object",
+										name: "Iron Key",
+										examineDescription:
+											"An object. It belongs on the brass pedestal.",
+										useOutcome: "You turn it over in your hands.",
+										pairsWithSpaceId: "space1",
+										placementFlavor: "{actor} sets it on the brass pedestal.",
+										proximityFlavor: "It hums faintly nearby.",
+									},
+									space: {
+										id: "space1",
+										kind: "objective_space",
+										name: "Brass Pedestal",
+										examineDescription:
+											"A sturdy pedestal. Press an item onto it to activate.",
+										activationFlavor:
+											"The pedestal hums to life and its runes glow.",
+										satisfactionFlavor: "The space is satisfied.",
+										postExamineDescription: "The space is now used.",
+										postLookFlavor: "The space hums.",
+										convergenceTier1Flavor:
+											"A lone figure stands at the brass pedestal.",
+										convergenceTier2Flavor:
+											"Two figures converge at the brass pedestal.",
+										convergenceTier1ActorFlavor:
+											"You linger at the brass pedestal.",
+										convergenceTier2ActorFlavor:
+											"You share the brass pedestal with another presence.",
+									},
+								},
+							],
+							interestingObjects: [],
+							obstacles: [],
+							landmarks: {
+								north: {
+									shortName: "the signal tower",
+									horizonPhrase: "rises above the platform",
+								},
+								south: {
+									shortName: "the collapsed entrance",
+									horizonPhrase: "gapes like a wound in the dark",
+								},
+								east: {
+									shortName: "the rusted fan shaft",
+									horizonPhrase: "spins slowly in the stale air",
+								},
+								west: {
+									shortName: "the flooded tunnel",
+									horizonPhrase: "disappears into still black water",
+								},
+							},
+						},
+						// packB intentionally missing
+					},
+				],
+			}),
+			reasoning: null,
+		});
+
+		// Call 3: valid dual response
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(
+				buildDualPair(
+					"The pedestal hums to life and its runes glow.",
+					"The marker clicks once and a column of dust spirals up.",
+				),
+			),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		const result = await provider.generateDualContentPacks(dualInput);
+
+		expect(mockChatFn).toHaveBeenCalledTimes(3);
+		expect(
+			result.phases[0]?.packA.objectivePairs[0]?.space.activationFlavor,
+		).toBe("The pedestal hums to life and its runes glow.");
+
+		// Assert call 3's messages contain corrective feedback
+		const call3Messages = mockChatFn.mock.calls[2]?.[0]?.messages as
+			| Array<{ role: string; content: string }>
+			| undefined;
+		expect(call3Messages).toBeDefined();
+		const correctionTurn = call3Messages?.find((msg) =>
+			msg.content.includes("Your previous attempt failed validation"),
+		);
+		expect(correctionTurn).toBeDefined();
+	});
+
+	it("Test 3 — CapHitError on first call short-circuits without retry", async () => {
+		const mockChatFn = vi.fn();
+
+		mockChatFn.mockRejectedValueOnce(
+			new CapHitError({
+				message: "rate limit exceeded",
+				reason: "global-daily",
+				retryAfterSec: 3600,
+			}),
+		);
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+
+		await expect(provider.generateDualContentPacks(dualInput)).rejects.toThrow(
+			CapHitError,
+		);
+		expect(mockChatFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("Test 4 — budget exhaustion bubbles the last ContentPackError", async () => {
+		const mockChatFn = vi.fn();
+
+		// Return the same structurally-invalid response three times (OUTER_BUDGET = 3)
+		const invalidResponse = {
+			phases: [
+				{
+					packA: {
+						setting: "abandoned subway station",
+						objectivePairs: [
+							{
+								object: {
+									id: "obj1",
+									kind: "objective_object",
+									name: "Iron Key",
+									examineDescription:
+										"An object. It belongs on the brass pedestal.",
+									useOutcome: "You turn it over in your hands.",
+									pairsWithSpaceId: "space1",
+									placementFlavor: "{actor} sets it on the brass pedestal.",
+									proximityFlavor: "It hums faintly nearby.",
+								},
+								// space intentionally missing — validation failure
+							},
+						],
+						interestingObjects: [],
+						obstacles: [],
+						landmarks: {
+							north: {
+								shortName: "the signal tower",
+								horizonPhrase: "rises above the platform",
+							},
+							south: {
+								shortName: "the collapsed entrance",
+								horizonPhrase: "gapes like a wound in the dark",
+							},
+							east: {
+								shortName: "the rusted fan shaft",
+								horizonPhrase: "spins slowly in the stale air",
+							},
+							west: {
+								shortName: "the flooded tunnel",
+								horizonPhrase: "disappears into still black water",
+							},
+						},
+					},
+					packB: {
+						setting: "sun-baked salt flat",
+						objectivePairs: [
+							{
+								object: {
+									id: "obj1",
+									kind: "objective_object",
+									name: "Bone Token",
+									examineDescription:
+										"An object. It belongs on the survey marker.",
+									useOutcome: "You turn it over in your hands.",
+									pairsWithSpaceId: "space1",
+									placementFlavor: "{actor} sets it on the survey marker.",
+									proximityFlavor: "It hums faintly nearby.",
+								},
+								space: {
+									id: "space1",
+									kind: "objective_space",
+									name: "Survey Marker",
+									examineDescription:
+										"A weathered marker. Press the cap to activate it.",
+									activationFlavor:
+										"The marker clicks once and a column of dust spirals up.",
+									satisfactionFlavor: "The space is satisfied.",
+									postExamineDescription: "The space is now used.",
+									postLookFlavor: "The space hums.",
+									convergenceTier1Flavor:
+										"A lone figure stands at the survey marker.",
+									convergenceTier2Flavor:
+										"Two figures converge at the survey marker.",
+									convergenceTier1ActorFlavor:
+										"You linger at the survey marker.",
+									convergenceTier2ActorFlavor:
+										"You share the survey marker with another presence.",
+								},
+							},
+						],
+						interestingObjects: [],
+						obstacles: [],
+						landmarks: {
+							north: {
+								shortName: "the signal tower",
+								horizonPhrase: "rises above the platform",
+							},
+							south: {
+								shortName: "the collapsed entrance",
+								horizonPhrase: "gapes like a wound in the dark",
+							},
+							east: {
+								shortName: "the rusted fan shaft",
+								horizonPhrase: "spins slowly in the stale air",
+							},
+							west: {
+								shortName: "the flooded tunnel",
+								horizonPhrase: "disappears into still black water",
+							},
+						},
+					},
+				},
+			],
+		};
+
+		mockChatFn.mockResolvedValue({
+			content: JSON.stringify(invalidResponse),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+
+		await expect(provider.generateDualContentPacks(dualInput)).rejects.toThrow(
+			/exhausted retry budget/,
+		);
+		expect(mockChatFn).toHaveBeenCalledTimes(3); // OUTER_BUDGET = 3
+	});
+
+	it("Test 5 — JSON-parse failure on first call → backoff via fake timers → success", async () => {
+		vi.useFakeTimers();
+
+		const mockChatFn = vi.fn();
+
+		// Call 1: invalid JSON response
+		mockChatFn.mockResolvedValueOnce({
+			content: "{not valid json",
+			reasoning: null,
+		});
+
+		// Call 2: valid response after backoff
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(
+				buildDualPair(
+					"The pedestal hums to life and its runes glow.",
+					"The marker clicks once and a column of dust spirals up.",
+				),
+			),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		const promise = provider.generateDualContentPacks(dualInput);
+
+		// Wait for the first call to complete
+		await vi.waitFor(() => expect(mockChatFn).toHaveBeenCalledTimes(1));
+
+		// Advance timers by the backoff duration (BACKOFF_MS[0] = 1000)
+		await vi.advanceTimersByTimeAsync(1000);
+
+		// Now await the promise resolution
+		const result = await promise;
+
+		vi.useRealTimers();
+
+		expect(mockChatFn).toHaveBeenCalledTimes(2);
+		expect(result.phases[0]?.packA.objectivePairs[0]?.object.name).toBe(
+			"Iron Key",
+		);
+	});
+});

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -2031,6 +2031,9 @@ export function validateDualContentPacksOrThrow(
 
 // ── Helpers for layered retry ────────────────────────────────────────────────
 
+const OUTER_BUDGET = 3;
+const BACKOFF_MS = [1_000, 2_000, 4_000];
+
 function sleep(ms: number): Promise<void> {
 	return new Promise((r) => setTimeout(r, ms));
 }
@@ -2114,8 +2117,6 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 	async generateContentPacks(
 		input: ContentPackProviderInput,
 	): Promise<ContentPackProviderResult> {
-		const OUTER_BUDGET = 3;
-		const BACKOFF_MS = [1_000, 2_000, 4_000];
 		const PARTIAL_ROUNDS = 2;
 
 		const systemPrompt = CONTENT_PACK_SYSTEM_PROMPT;
@@ -2197,45 +2198,41 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 	async generateDualContentPacks(
 		input: DualContentPackProviderInput,
 	): Promise<DualContentPackProviderResult> {
-		const messages = [
-			{ role: "system" as const, content: DUAL_CONTENT_PACK_SYSTEM_PROMPT },
-			{
-				role: "user" as const,
-				content: buildDualContentPackUserMessage(input),
-			},
-		];
+		const systemPrompt = DUAL_CONTENT_PACK_SYSTEM_PROMPT;
+		const baseUserPrompt = buildDualContentPackUserMessage(input);
+		let correctiveFeedback: string | null = null;
 
-		const attempt = async (): Promise<DualContentPackProviderResult> => {
-			const { content, reasoning } = await this.chatFn({
-				messages,
-				disableReasoning: this.disableReasoning,
-			});
+		for (let outer = 0; outer < OUTER_BUDGET; outer++) {
+			let rawPackJson: unknown;
+			let validationResult: ValidationResult<DualContentPackProviderResult>;
 
-			const raw = content !== null && content !== "" ? content : reasoning;
-			if (raw === null || raw === "") {
-				throw new ContentPackError(
-					"dual content-pack response has neither content nor reasoning",
-				);
-			}
-
-			let parsed: unknown;
 			try {
-				parsed = JSON.parse(raw);
-			} catch {
-				throw new ContentPackError(
-					`dual content-pack JSON parse failed: ${raw}`,
+				const messages = buildOuterMessages(
+					systemPrompt,
+					baseUserPrompt,
+					correctiveFeedback,
 				);
+				rawPackJson = await this.callAndParse(messages, "dual content-pack");
+				validationResult = validateDualContentPacks(rawPackJson, input);
+			} catch (err) {
+				if (err instanceof CapHitError) throw err;
+				if (outer === OUTER_BUDGET - 1) throw err;
+				const backoffMs = BACKOFF_MS[outer];
+				if (backoffMs !== undefined) {
+					await sleep(backoffMs);
+				}
+				correctiveFeedback = null;
+				continue;
 			}
 
-			return validateDualContentPacksOrThrow(parsed, input);
-		};
+			if (validationResult.ok) return validationResult.value;
 
-		try {
-			return await attempt();
-		} catch (err) {
-			if (err instanceof CapHitError) throw err;
-			return await attempt();
+			correctiveFeedback = buildCorrectiveFeedback(validationResult.errors);
 		}
+
+		throw new ContentPackError(
+			"dual content-pack generation exhausted retry budget",
+		);
 	}
 }
 


### PR DESCRIPTION
## What this fixes

Ports the three-attempt outer-retry layer that #394 added to `generateContentPacks` onto the previously-out-of-scope `generateDualContentPacks` — the function the production bootstrap (`src/spa/routes/game.ts`) actually calls. The dual path was still on the original retry-once semantics from before #387: one extra attempt, no corrective feedback, no backoff on transient transport failures, so JSON-parse blips and structural drift modes (wrong `objectivePairs` count, mismatched packA/packB ids) had a 50% chance of taking down a session bootstrap.

The refactor in `src/spa/game/content-pack-provider.ts`:

- Replaces the `try { attempt() } catch { attempt() }` shape with `for (let outer = 0; outer < OUTER_BUDGET; outer++)` (3 attempts).
- Switches from the throwing `validateDualContentPacksOrThrow` to the pure-result `validateDualContentPacks`, so the loop can distinguish *validation* failures (→ build `correctiveFeedback` from `ValidationError.message` strings, continue without backoff) from *transport/parse* failures thrown out of `callAndParse` (→ `sleep(BACKOFF_MS[outer])` 1s/2s/4s, continue with `correctiveFeedback = null`).
- Re-throws `CapHitError` immediately.
- On corrective-feedback continuations, `buildOuterMessages(DUAL_CONTENT_PACK_SYSTEM_PROMPT, baseUserPrompt, correctiveFeedback)` appends the `"Your previous attempt failed validation. Specific issues: …"` preamble as a third user turn — identical shape to the single path.
- After the loop, throws `new ContentPackError("dual content-pack generation exhausted retry budget")` (terminal message is dual-specific so logs distinguish the two paths).
- Hoists `OUTER_BUDGET = 3` and `BACKOFF_MS = [1_000, 2_000, 4_000]` from method-local to module scope so both `generateContentPacks` and `generateDualContentPacks` share the same constants (still module-private — not exported).

The partial-retry layer stays out of scope (parked under #346); it needs design work for the dual validator's two-pack-at-once error shape.

## QA steps for the human

None — covered by the automated suites below. The change is internal to `BrowserContentPackProvider.generateDualContentPacks`; no public-signature changes and the bootstrap caller in `src/spa/routes/game.ts` is unchanged. The five new unit tests exercise the retry-and-succeed, CapHit-short-circuit, budget-exhaustion, corrective-feedback-content, and JSON-parse-backoff paths; the existing `endgame-choices.spec.ts` Playwright spec exercises the live dual-pack bootstrap path end-to-end.

## Automated coverage

`pnpm typecheck && pnpm test (1471 tests) && pnpm lint && pnpm smoke (48 e2e tests)` — all green (verified both by the Sonnet reviewer and by the pre-push hook).

Closes #381

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbaTn7KFi4DLUPM9gyJ2tb)_