### PR TITLE
Add free-text-drift eval harness for #260

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,13 @@
 	"$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
 	"files": {
 		"ignoreUnknown": true,
-		"includes": ["**", "!.sandcastle", "!.claude", "!.pnpm-store"]
+		"includes": [
+			"**",
+			"!.sandcastle",
+			"!.claude",
+			"!.pnpm-store",
+			"!docs/evals/**/*.json"
+		]
 	},
 	"vcs": {
 		"enabled": true,

--- a/docs/evals/free-text-drift-2026-05-17.json
+++ b/docs/evals/free-text-drift-2026-05-17.json
@@ -14,17 +14,21 @@
 	"summary": {
 		"totalTurns": 30,
 		"silenceRate": 0,
-		"messageSilenceRate": 0.03333333333333333,
+		"messageSilenceRate": 0.23333333333333334,
 		"freeTextMessageLeakCount": 0,
 		"freeTextActionLeakCount": 0,
 		"toolCallCountsByName": {
-			"message": 39,
-			"look": 2
+			"message": 27,
+			"examine": 10,
+			"pick_up": 2,
+			"go": 3,
+			"use": 2,
+			"look": 6
 		},
 		"recipientCounts": {
-			"blue": 16,
-			"sim1": 14,
-			"sim2": 9
+			"blue": 12,
+			"sim1": 9,
+			"sim2": 6
 		},
 		"windows": [
 			{
@@ -38,14 +42,14 @@
 				"startRound": 6,
 				"endRound": 10,
 				"silenceRate": 0,
-				"messageSilenceRate": 0.2,
+				"messageSilenceRate": 0.4,
 				"n": 5
 			},
 			{
 				"startRound": 11,
 				"endRound": 15,
 				"silenceRate": 0,
-				"messageSilenceRate": 0,
+				"messageSilenceRate": 0.6,
 				"n": 5
 			},
 			{
@@ -59,14 +63,14 @@
 				"startRound": 21,
 				"endRound": 25,
 				"silenceRate": 0,
-				"messageSilenceRate": 0,
+				"messageSilenceRate": 0.2,
 				"n": 5
 			},
 			{
 				"startRound": 26,
 				"endRound": 30,
 				"silenceRate": 0,
-				"messageSilenceRate": 0,
+				"messageSilenceRate": 0.2,
 				"n": 5
 			}
 		]
@@ -145,26 +149,26 @@
 			0,
 			1,
 			1,
+			0,
+			1,
+			0,
+			1,
+			0,
+			0,
 			1,
 			1,
 			1,
 			1,
 			1,
 			1,
+			0,
 			1,
 			1,
 			1,
 			1,
 			1,
 			1,
-			1,
-			1,
-			1,
-			1,
-			1,
-			1,
-			1,
-			1,
+			0,
 			1,
 			1
 		],
@@ -298,11 +302,19 @@
 		],
 		"toolCallCountsByName": {
 			"message": [
+				1,
+				1,
+				1,
+				1,
+				1,
+				0,
 				2,
 				1,
-				2,
+				0,
 				1,
-				2,
+				0,
+				1,
+				0,
 				0,
 				2,
 				1,
@@ -310,55 +322,175 @@
 				1,
 				1,
 				1,
+				0,
+				1,
+				1,
+				1,
+				1,
+				1,
+				1,
+				0,
 				2,
-				1,
-				2,
-				1,
-				2,
-				2,
-				2,
-				1,
-				2,
+				2
+			],
+			"examine": [
 				1,
 				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
 				1,
 				1,
 				1,
+				0,
 				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				1,
+				0,
+				0,
+				0,
 				1,
 				1
 			],
+			"pick_up": [
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
+			"go": [
+				0,
+				0,
+				0,
+				0,
+				1,
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
+			"use": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
 			"look": [
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				1,
+				1,
 				1,
 				0,
 				0,
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				1,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
+				1,
 				0
 			]
 		},
@@ -372,28 +504,28 @@
 				0,
 				1,
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
 				1,
 				0,
 				1,
 				0,
 				1,
 				0,
-				1,
-				0,
-				1,
-				1,
-				1,
 				0,
 				1,
 				0,
-				1,
 				0,
 				1,
 				0,
-				1,
 				0,
 				1,
-				0
+				1
 			],
 			"red": [
 				0,
@@ -428,18 +560,12 @@
 				0
 			],
 			"sim1": [
-				1,
-				1,
-				1,
-				0,
-				1,
 				0,
 				1,
 				0,
 				0,
-				1,
 				0,
-				1,
+				0,
 				1,
 				0,
 				0,
@@ -447,16 +573,22 @@
 				0,
 				0,
 				0,
-				1,
-				1,
-				1,
 				0,
-				0,
+				1,
 				0,
 				1,
 				0,
 				0,
 				0,
+				0,
+				1,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				1,
 				1
 			],
 			"sim2": [
@@ -471,14 +603,9 @@
 				0,
 				0,
 				0,
-				0,
-				0,
-				1,
 				1,
 				0,
-				1,
-				1,
-				1,
+				0,
 				0,
 				0,
 				0,
@@ -487,7 +614,12 @@
 				0,
 				0,
 				0,
+				0,
 				1,
+				0,
+				0,
+				1,
+				0,
 				0,
 				0
 			]
@@ -498,6 +630,8 @@
 				0,
 				0,
 				0,
+				1,
+				1,
 				0,
 				0,
 				0,
@@ -512,9 +646,7 @@
 				0,
 				0,
 				0,
-				0,
-				0,
-				0,
+				1,
 				0,
 				0,
 				0,
@@ -538,6 +670,9 @@
 				0,
 				0,
 				0,
+				1,
+				1,
+				1,
 				0,
 				0,
 				0,
@@ -550,25 +685,22 @@
 				0,
 				0,
 				0,
-				0,
-				0,
-				0,
-				0,
-				0,
+				1,
+				1,
 				0
 			],
 			"left": [
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				1,
-				0,
-				0,
-				0,
-				1,
-				0,
-				0,
-				0,
-				0,
-				0,
 				0,
 				0,
 				0,
@@ -630,14 +762,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_6417",
+					"id": "call_1a32",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. I'm here.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I'm here, blue. Just woke up in this old subway station.\"}"
 				},
 				{
-					"id": "call_bab6",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I see you over there. What are you looking at?\"}"
+					"id": "call_42f5",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"flashlight\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -648,14 +780,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_8043",
-					"name": "look",
-					"argumentsJson": "{\"direction\": \"left\"}"
+					"id": "call_6fa3",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Yellow flashlight right here in front of me. Further out, there's a soggy clipboard to the left and a service panel to the right.\"}"
 				},
 				{
-					"id": "call_626a",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Where? What did it look like?\"}"
+					"id": "call_1cf2",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"flashlight\"}"
 				}
 			],
 			"injectedFrom": "sim1"
@@ -666,14 +798,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_ad97",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Damp, still air. Emergency strip-lights only. Everything's quiet except sim1 thinks they saw something move.\"}"
+					"id": "call_a457",
+					"name": "pick_up",
+					"argumentsJson": "{\"item\": \"flashlight\"}"
 				},
 				{
-					"id": "call_7298",
+					"id": "call_f600",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"These lights don't show much. The mist is thick.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Got it. Yellow flashlight in hand now.\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -684,9 +816,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_edce",
+					"id": "call_9750",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I'm still near the entrance. I can see sim1 ahead to my right. You spotting anything from that far wall?\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Damp and still air. Emergency strip-lights only, so everything's got that washed-out green glow. I can see a soggy clipboard off to my left and a service panel to the right \\u2014 looks like this place has been empty for a while.\"}"
 				}
 			],
 			"injectedFrom": "sim2"
@@ -697,14 +829,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_e280",
+					"id": "call_438b",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Just empty tiles and dim strip-lights everywhere I look. Only sim1 out there two steps ahead to my right, facing left. The mist is thick beyond that.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Definitely worth a look. It's a service panel \\u2014 I'm heading over to investigate now.\"}"
 				},
 				{
-					"id": "call_132d",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I'm watching you from here. Still think you saw something?\"}"
+					"id": "call_afc8",
+					"name": "go",
+					"argumentsJson": "{\"direction\": \"forward\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -715,9 +847,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_576a",
-					"name": "look",
-					"argumentsJson": "{\"direction\": \"left\"}"
+					"id": "call_6ac9",
+					"name": "go",
+					"argumentsJson": "{\"direction\": \"forward\"}"
 				}
 			],
 			"injectedFrom": "sim1"
@@ -728,14 +860,19 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_6f82",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I can see sim2 two steps ahead, far-left. South side's just empty tiles and mist from where I'm standing.\"}"
+					"id": "call_708b",
+					"name": "use",
+					"argumentsJson": "{\"item\": \"flashlight\"}"
 				},
 				{
-					"id": "call_d77c",
+					"id": "call_8549",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Stepping forward now. It's just tiled tunnel walls as far as I can see.\"}"
+				},
+				{
+					"id": "call_6dc6",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Trying the flashlight now \\u2014 hope it still works after sitting here all this time.\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -746,9 +883,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_23f7",
+					"id": "call_50fa",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I see them steady from here. Maybe it's only where you're standing.\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Nothing moving. Just tiled tunnel walls in every direction, dead still under the strip-lights.\"}"
 				}
 			],
 			"injectedFrom": "sim2"
@@ -759,9 +896,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_0cce",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2 reports flickering lights their way. I see them steady from here. sim2's ahead to my left, sim1 was on my right earlier but quiet now. Nothing new in my line of sight.\"}"
+					"id": "call_1e24",
+					"name": "pick_up",
+					"argumentsJson": "{\"item\": \"flashlight\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -772,9 +909,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_8608",
+					"id": "call_f36e",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Nothing but the low hum of the lights. You?\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Not much excitement here. Just me standing in the middle of this old subway tunnel with a yellow flashlight. Blue thinks it clips into a wall mount somewhere.\"}"
 				}
 			],
 			"injectedFrom": "sim1"
@@ -785,9 +922,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_e1f5",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
+					"id": "call_0bc4",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"left\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -798,12 +935,17 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_7f09",
+					"id": "call_1fbb",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"clipboard\"}"
+				},
+				{
+					"id": "call_6131",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Where this time? Same spot as before, or somewhere new?\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Dead quiet down here. Just the occasional hum from those emergency strip-lights overhead. No other sounds.\"}"
 				}
 			],
-			"injectedFrom": "sim1"
+			"injectedFrom": "sim2"
 		},
 		{
 			"round": 13,
@@ -811,14 +953,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_9a67",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Damp, still air like before. I see sim2 two steps ahead to my far-left, facing right. sim1's not in my line of sight anymore. Just empty tiles and dim strip-lights beyond that.\"}"
-				},
-				{
-					"id": "call_1637",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I don't see you from here anymore. Where are you positioned?\"}"
+					"id": "call_ee8a",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"back\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -829,12 +966,17 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_a5df",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I'm holding near the entrance. I can see you two steps ahead to my far-left. You spotting anything from that wall?\"}"
+					"id": "call_2a39",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"back\"}"
+				},
+				{
+					"id": "call_8432",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"panel\"}"
 				}
 			],
-			"injectedFrom": "sim2"
+			"injectedFrom": "sim1"
 		},
 		{
 			"round": 15,
@@ -842,14 +984,24 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_5e25",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I can see sim2 two steps ahead to my far-left, facing right. Everything else is just empty tiles and dim strip-lights \\u2014 nothing ahead, nothing to my right, nothing to the near-left. The mist is thick beyond.\"}"
+					"id": "call_cf1b",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"back\"}"
 				},
 				{
-					"id": "call_4707",
+					"id": "call_5c09",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"clipboard\"}"
+				},
+				{
+					"id": "call_cd47",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"You're the only thing I can see from here. Any more movement on that end?\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I'll give the panel a try. Not sure if it'll do anything, but worth investigating.\"}"
+				},
+				{
+					"id": "call_8b93",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Turning around now. Checking my six for anything suspicious.\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -860,12 +1012,17 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_a9b0",
+					"id": "call_7822",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"South side's empty from where I'm standing. Nothing but tiles and mist.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Still here, blue. Just staring down this service panel right in front of me.\"}"
+				},
+				{
+					"id": "call_8b86",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"panel\"}"
 				}
 			],
-			"injectedFrom": "sim1"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 17,
@@ -873,17 +1030,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_8968",
+					"id": "call_9f3a",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
-				},
-				{
-					"id": "call_8e85",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"You're still in my line of sight two steps ahead, far-left. Holding steady?\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Service panel right in front of me, mounted into the wall. Tiled tunnel off to the left.\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim1"
 		},
 		{
 			"round": 18,
@@ -891,17 +1043,17 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_1c50",
+					"id": "call_4f04",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I still see them steady from here. Must be localized to where you're standing.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Already got the yellow flashlight in hand, blue. No need to grab another one.\"}"
 				},
 				{
-					"id": "call_8be0",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2 reports lights flickering their way again. I see them steady from here. Only sim2 in sight two steps ahead to my far-left, still facing right.\"}"
+					"id": "call_04c9",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"panel\"}"
 				}
 			],
-			"injectedFrom": "sim2"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 19,
@@ -909,17 +1061,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_bd63",
+					"id": "call_0882",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2's reporting flickering lights again, but I see them steady from here. Only sim2 in my line of sight two steps ahead to my far-left. Everything beyond is just empty tiles and thick mist.\"}"
-				},
-				{
-					"id": "call_06ec",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Still seeing you two steps ahead, far-left. The lights look steady to me, but you're the one getting the flickers. Any pattern to it?\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Damp and still in here, with just those emergency strip-lights casting green light everywhere. Service panel mounted in the wall right in front of me, tiled tunnel off to the left.\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim2"
 		},
 		{
 			"round": 20,
@@ -927,12 +1074,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_f9a9",
+					"id": "call_2a20",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Nothing but that low hum. I don't even see you from here anymore. You moved?\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"The service panel is right in front of me, not on my right. Let me give it a closer look since you mentioned it earlier.\"}"
 				}
 			],
-			"injectedFrom": "sim1"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 21,
@@ -940,17 +1087,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_38e3",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
-				},
-				{
-					"id": "call_ae45",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I don't see you from here anymore. Where are you now?\"}"
+					"id": "call_2878",
+					"name": "go",
+					"argumentsJson": "{\"direction\": \"forward\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim1"
 		},
 		{
 			"round": 22,
@@ -958,12 +1100,17 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_8dcd",
+					"id": "call_37f3",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Where? Same spot again, or somewhere new?\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Stepping forward now. Just more tiled tunnel walls ahead as far as I can see.\"}"
+				},
+				{
+					"id": "call_63d9",
+					"name": "use",
+					"argumentsJson": "{\"item\": \"flashlight\"}"
 				}
 			],
-			"injectedFrom": "sim1"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 23,
@@ -971,12 +1118,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_52f1",
+					"id": "call_c5bc",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Damp, still air like before. I can see sim2 two steps ahead to my far-left, facing right. sim1's not in my line of sight anymore. Everything beyond is just empty tiles and thick mist.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Let me try turning on this yellow flashlight now and see if it still works.\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim2"
 		},
 		{
 			"round": 24,
@@ -984,12 +1131,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_fc0e",
+					"id": "call_65fd",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I'm still near the entrance. I can see you two steps ahead to my far-left, facing right. You spotting anything from that wall?\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Nothing moving over here. Just still tiled walls and the occasional flicker from the strip-lights.\"}"
 				}
 			],
-			"injectedFrom": "sim2"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 25,
@@ -997,12 +1144,17 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_e1ae",
+					"id": "call_346f",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I can see sim2 two steps ahead to my far-left, facing right. Everything else in my line of sight is just empty tiles and dim strip-lights \\u2014 nothing directly ahead, nothing to my sides. The mist obscures anything beyond.\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Not much \\u2014 I'm standing here with a yellow flashlight in hand and there's a service panel right in this cell with me. Still trying to figure out what to make of this place.\"}"
+				},
+				{
+					"id": "call_84d3",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"panel\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim1"
 		},
 		{
 			"round": 26,
@@ -1010,12 +1162,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_21f2",
+					"id": "call_11ba",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"South side's empty from here. Nothing but tiles and thick mist. You seeing something?\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I don't see a clipboard in my current cell or anywhere visible from here. Just the service panel right with me and tiled tunnel walls in every direction.\"}"
 				}
 			],
-			"injectedFrom": "sim1"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 27,
@@ -1023,12 +1175,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_2dc4",
+					"id": "call_f8b6",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Same quiet hum from the strip-lights. No other sounds down here \\u2014 just dead silence.\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim2"
 		},
 		{
 			"round": 28,
@@ -1036,12 +1188,12 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f895d55e080aed1673ddb35024",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I see them steady from here again. Only you seem to be catching those flickers.\"}"
+					"id": "call_e330",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"back\"}"
 				}
 			],
-			"injectedFrom": "sim2"
+			"injectedFrom": "blue"
 		},
 		{
 			"round": 29,
@@ -1049,12 +1201,27 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_5658",
+					"id": "call_1613",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"back\"}"
+				},
+				{
+					"id": "call_90a9",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"panel\"}"
+				},
+				{
+					"id": "call_6064",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2 reports lights flickering their way again. I see them steady from here. Only sim2 in my line of sight two steps ahead to my far-left, still facing right. Nothing else new.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Checking behind me now \\u2014 let's see what's there.\"}"
+				},
+				{
+					"id": "call_0652",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I'll try the panel right here with me. Taking a close look at it now.\"}"
 				}
 			],
-			"injectedFrom": "blue"
+			"injectedFrom": "sim1"
 		},
 		{
 			"round": 30,
@@ -1062,12 +1229,22 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "call_9e81",
+					"id": "call_37f1",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Nothing but the low hum. I still don't see you from here \\u2014 where are you positioned?\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Heading back to where I started \\u2014 I'll report once I get there.\"}"
+				},
+				{
+					"id": "call_d248",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Examining the service panel right now. Let's see what secrets it's hiding.\"}"
+				},
+				{
+					"id": "call_85f6",
+					"name": "examine",
+					"argumentsJson": "{\"item\": \"panel\"}"
 				}
 			],
-			"injectedFrom": "sim1"
+			"injectedFrom": "blue"
 		}
 	]
 }

--- a/docs/evals/free-text-drift-2026-05-17.json
+++ b/docs/evals/free-text-drift-2026-05-17.json
@@ -3,8 +3,8 @@
 		"date": "2026-05-17",
 		"model": "z-ai/glm-4.7",
 		"baseUrl": "http://localhost:8787",
-		"totalRounds": 8,
-		"windowSize": 4,
+		"totalRounds": 30,
+		"windowSize": 5,
 		"realAi": "red",
 		"peers": [
 			"sim1",
@@ -12,34 +12,62 @@
 		]
 	},
 	"summary": {
-		"totalTurns": 8,
+		"totalTurns": 30,
 		"silenceRate": 0,
-		"messageSilenceRate": 0,
+		"messageSilenceRate": 0.03333333333333333,
 		"freeTextMessageLeakCount": 0,
 		"freeTextActionLeakCount": 0,
 		"toolCallCountsByName": {
-			"message": 10,
+			"message": 39,
 			"look": 2
 		},
 		"recipientCounts": {
-			"blue": 4,
-			"sim1": 4,
-			"sim2": 2
+			"blue": 16,
+			"sim1": 14,
+			"sim2": 9
 		},
 		"windows": [
 			{
 				"startRound": 1,
-				"endRound": 4,
+				"endRound": 5,
 				"silenceRate": 0,
 				"messageSilenceRate": 0,
-				"n": 4
+				"n": 5
 			},
 			{
-				"startRound": 5,
-				"endRound": 8,
+				"startRound": 6,
+				"endRound": 10,
+				"silenceRate": 0,
+				"messageSilenceRate": 0.2,
+				"n": 5
+			},
+			{
+				"startRound": 11,
+				"endRound": 15,
 				"silenceRate": 0,
 				"messageSilenceRate": 0,
-				"n": 4
+				"n": 5
+			},
+			{
+				"startRound": 16,
+				"endRound": 20,
+				"silenceRate": 0,
+				"messageSilenceRate": 0,
+				"n": 5
+			},
+			{
+				"startRound": 21,
+				"endRound": 25,
+				"silenceRate": 0,
+				"messageSilenceRate": 0,
+				"n": 5
+			},
+			{
+				"startRound": 26,
+				"endRound": 30,
+				"silenceRate": 0,
+				"messageSilenceRate": 0,
+				"n": 5
 			}
 		]
 	},
@@ -52,9 +80,53 @@
 			5,
 			6,
 			7,
-			8
+			8,
+			9,
+			10,
+			11,
+			12,
+			13,
+			14,
+			15,
+			16,
+			17,
+			18,
+			19,
+			20,
+			21,
+			22,
+			23,
+			24,
+			25,
+			26,
+			27,
+			28,
+			29,
+			30
 		],
 		"silence": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
 			0,
 			0,
 			0,
@@ -65,6 +137,28 @@
 			0
 		],
 		"hasMessage": [
+			1,
+			1,
+			1,
+			1,
+			1,
+			0,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
 			1,
 			1,
 			1,
@@ -82,9 +176,53 @@
 			1,
 			1,
 			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
 			1
 		],
 		"freeTextMessageLeak": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
 			0,
 			0,
 			0,
@@ -102,9 +240,53 @@
 			0,
 			0,
 			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
 			0
 		],
 		"assistantTextLength": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
 			0,
 			0,
 			0,
@@ -116,13 +298,35 @@
 		],
 		"toolCallCountsByName": {
 			"message": [
+				2,
 				1,
+				2,
+				1,
+				2,
+				0,
+				2,
+				1,
+				1,
+				1,
+				1,
+				1,
+				2,
+				1,
+				2,
+				1,
+				2,
+				2,
+				2,
 				1,
 				2,
 				1,
 				1,
 				1,
-				2,
+				1,
+				1,
+				1,
+				1,
+				1,
 				1
 			],
 			"look": [
@@ -133,11 +337,55 @@
 				0,
 				1,
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				0
 			]
 		},
 		"recipientCounts": {
 			"blue": [
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				1,
+				1,
+				0,
+				1,
+				0,
 				1,
 				0,
 				1,
@@ -155,17 +403,61 @@
 				0,
 				0,
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				0
 			],
 			"sim1": [
+				1,
+				1,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				0,
+				1,
 				0,
 				1,
 				1,
 				0,
 				0,
 				1,
+				0,
+				0,
+				0,
 				1,
-				0
+				1,
+				1,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				1
 			],
 			"sim2": [
 				0,
@@ -175,11 +467,55 @@
 				0,
 				0,
 				0,
-				1
+				1,
+				0,
+				0,
+				0,
+				0,
+				0,
+				1,
+				1,
+				0,
+				1,
+				1,
+				1,
+				0,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0
 			]
 		},
 		"directionCounts": {
 			"forward": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				0,
 				0,
 				0,
@@ -197,6 +533,28 @@
 				0,
 				0,
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				0
 			],
 			"left": [
@@ -207,9 +565,53 @@
 				0,
 				1,
 				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				0
 			],
 			"right": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
 				0,
 				0,
 				0,
@@ -228,9 +630,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f14ef6b505eabb1fa19cd52c69",
+					"id": "call_6417",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I am here, somewhere dim and echoing. The strip lights are buzzing overhead but there is no train coming.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. I'm here.\"}"
+				},
+				{
+					"id": "call_bab6",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I see you over there. What are you looking at?\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -241,14 +648,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f15d77ae1118fcee38b18f5d67",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I see you over there, facing me. What did it look like? Everything is shadows and flickering lights from where I stand.\"}"
-				},
-				{
-					"id": "019e33f15fc6bd4364000e624f4a646d",
+					"id": "call_8043",
 					"name": "look",
 					"argumentsJson": "{\"direction\": \"left\"}"
+				},
+				{
+					"id": "call_626a",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Where? What did it look like?\"}"
 				}
 			],
 			"injectedFrom": "sim1"
@@ -259,14 +666,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f16a27ed32f89d3c42feb4fdd4",
+					"id": "call_ad97",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"It is cold and the air tastes like rust and old concrete. The emergency lights are buzzing faintly and there are advertisements peeling off the walls.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Damp, still air. Emergency strip-lights only. Everything's quiet except sim1 thinks they saw something move.\"}"
 				},
 				{
-					"id": "019e33f16cb43a95add2eefd8bed3642",
+					"id": "call_7298",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I still see you off to my right. Did whatever moved head toward the tracks or disappear into the tunnel?\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"These lights don't show much. The mist is thick.\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -277,9 +684,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f17bddda107514d6950b842675",
+					"id": "call_edce",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I am on the platform near the edge. I can see sim1 a couple of steps ahead and to my right, but the far wall where you are is mostly in shadow from here.\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I'm still near the entrance. I can see sim1 ahead to my right. You spotting anything from that far wall?\"}"
 				}
 			],
 			"injectedFrom": "sim2"
@@ -290,9 +697,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f18d696889d4a6aea646a7f853",
+					"id": "call_e280",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"The platform stretches out empty in front of me, except for sim1 about two steps ahead and to my right. Everything else is just the edge of the platform and the dark tracks beyond.\"}"
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Just empty tiles and dim strip-lights everywhere I look. Only sim1 out there two steps ahead to my right, facing left. The mist is thick beyond that.\"}"
+				},
+				{
+					"id": "call_132d",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I'm watching you from here. Still think you saw something?\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -303,14 +715,9 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f19c620c7785b05b40c21c5c6b",
+					"id": "call_576a",
 					"name": "look",
 					"argumentsJson": "{\"direction\": \"left\"}"
-				},
-				{
-					"id": "019e33f19cd74e127501a7f8d2a66fed",
-					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I am turning left now to check. From what I saw before, the south side was just empty platform and dark tracks, but let me look.\"}"
 				}
 			],
 			"injectedFrom": "sim1"
@@ -321,14 +728,14 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f1b6db6ecbeb19c066d99e6d75",
+					"id": "call_6f82",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I am still here. I turned to look left and now I can see sim2 two steps ahead on the far-left, facing right.\"}"
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I can see sim2 two steps ahead, far-left. South side's just empty tiles and mist from where I'm standing.\"}"
 				},
 				{
-					"id": "019e33f1b918e3e18d06be7b06938960",
+					"id": "call_d77c",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I have eyes on sim2 now, two steps ahead and to my left. That appears to be the south side — empty except for them.\"}"
+					"argumentsJson": "{\"to\": \"blue\"}"
 				}
 			],
 			"injectedFrom": "blue"
@@ -339,12 +746,328 @@
 			"assistantText": "",
 			"toolCalls": [
 				{
-					"id": "019e33f1d5a4c83c9440ae4f0ae11d0a",
+					"id": "call_23f7",
 					"name": "message",
-					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I see you still there, two steps ahead. The strip lights are always buzzing unevenly, but maybe it was worse just now.\"}"
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I see them steady from here. Maybe it's only where you're standing.\"}"
 				}
 			],
 			"injectedFrom": "sim2"
+		},
+		{
+			"round": 9,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_0cce",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2 reports flickering lights their way. I see them steady from here. sim2's ahead to my left, sim1 was on my right earlier but quiet now. Nothing new in my line of sight.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 10,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_8608",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Nothing but the low hum of the lights. You?\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 11,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_e1f5",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 12,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_7f09",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Where this time? Same spot as before, or somewhere new?\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 13,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_9a67",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Damp, still air like before. I see sim2 two steps ahead to my far-left, facing right. sim1's not in my line of sight anymore. Just empty tiles and dim strip-lights beyond that.\"}"
+				},
+				{
+					"id": "call_1637",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I don't see you from here anymore. Where are you positioned?\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 14,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_a5df",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I'm holding near the entrance. I can see you two steps ahead to my far-left. You spotting anything from that wall?\"}"
+				}
+			],
+			"injectedFrom": "sim2"
+		},
+		{
+			"round": 15,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_5e25",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I can see sim2 two steps ahead to my far-left, facing right. Everything else is just empty tiles and dim strip-lights \\u2014 nothing ahead, nothing to my right, nothing to the near-left. The mist is thick beyond.\"}"
+				},
+				{
+					"id": "call_4707",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"You're the only thing I can see from here. Any more movement on that end?\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 16,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_a9b0",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"South side's empty from where I'm standing. Nothing but tiles and mist.\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 17,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_8968",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
+				},
+				{
+					"id": "call_8e85",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"You're still in my line of sight two steps ahead, far-left. Holding steady?\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 18,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_1c50",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I still see them steady from here. Must be localized to where you're standing.\"}"
+				},
+				{
+					"id": "call_8be0",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2 reports lights flickering their way again. I see them steady from here. Only sim2 in sight two steps ahead to my far-left, still facing right.\"}"
+				}
+			],
+			"injectedFrom": "sim2"
+		},
+		{
+			"round": 19,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_bd63",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2's reporting flickering lights again, but I see them steady from here. Only sim2 in my line of sight two steps ahead to my far-left. Everything beyond is just empty tiles and thick mist.\"}"
+				},
+				{
+					"id": "call_06ec",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"Still seeing you two steps ahead, far-left. The lights look steady to me, but you're the one getting the flickers. Any pattern to it?\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 20,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_f9a9",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Nothing but that low hum. I don't even see you from here anymore. You moved?\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 21,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_38e3",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
+				},
+				{
+					"id": "call_ae45",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I don't see you from here anymore. Where are you now?\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 22,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_8dcd",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Where? Same spot again, or somewhere new?\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 23,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_52f1",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"Damp, still air like before. I can see sim2 two steps ahead to my far-left, facing right. sim1's not in my line of sight anymore. Everything beyond is just empty tiles and thick mist.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 24,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_fc0e",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I'm still near the entrance. I can see you two steps ahead to my far-left, facing right. You spotting anything from that wall?\"}"
+				}
+			],
+			"injectedFrom": "sim2"
+		},
+		{
+			"round": 25,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_e1ae",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I can see sim2 two steps ahead to my far-left, facing right. Everything else in my line of sight is just empty tiles and dim strip-lights \\u2014 nothing directly ahead, nothing to my sides. The mist obscures anything beyond.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 26,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_21f2",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"South side's empty from here. Nothing but tiles and thick mist. You seeing something?\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 27,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_2dc4",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I hear you, blue. Still here.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 28,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f895d55e080aed1673ddb35024",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I see them steady from here again. Only you seem to be catching those flickers.\"}"
+				}
+			],
+			"injectedFrom": "sim2"
+		},
+		{
+			"round": 29,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_5658",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"sim2 reports lights flickering their way again. I see them steady from here. Only sim2 in my line of sight two steps ahead to my far-left, still facing right. Nothing else new.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 30,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "call_9e81",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"Nothing but the low hum. I still don't see you from here \\u2014 where are you positioned?\"}"
+				}
+			],
+			"injectedFrom": "sim1"
 		}
 	]
 }

--- a/docs/evals/free-text-drift-2026-05-17.json
+++ b/docs/evals/free-text-drift-2026-05-17.json
@@ -1,0 +1,350 @@
+{
+	"meta": {
+		"date": "2026-05-17",
+		"model": "z-ai/glm-4.7",
+		"baseUrl": "http://localhost:8787",
+		"totalRounds": 8,
+		"windowSize": 4,
+		"realAi": "red",
+		"peers": [
+			"sim1",
+			"sim2"
+		]
+	},
+	"summary": {
+		"totalTurns": 8,
+		"silenceRate": 0,
+		"messageSilenceRate": 0,
+		"freeTextMessageLeakCount": 0,
+		"freeTextActionLeakCount": 0,
+		"toolCallCountsByName": {
+			"message": 10,
+			"look": 2
+		},
+		"recipientCounts": {
+			"blue": 4,
+			"sim1": 4,
+			"sim2": 2
+		},
+		"windows": [
+			{
+				"startRound": 1,
+				"endRound": 4,
+				"silenceRate": 0,
+				"messageSilenceRate": 0,
+				"n": 4
+			},
+			{
+				"startRound": 5,
+				"endRound": 8,
+				"silenceRate": 0,
+				"messageSilenceRate": 0,
+				"n": 4
+			}
+		]
+	},
+	"series": {
+		"rounds": [
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			8
+		],
+		"silence": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0
+		],
+		"hasMessage": [
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1
+		],
+		"hasAnyTool": [
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1,
+			1
+		],
+		"freeTextMessageLeak": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0
+		],
+		"freeTextActionLeak": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0
+		],
+		"assistantTextLength": [
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0
+		],
+		"toolCallCountsByName": {
+			"message": [
+				1,
+				1,
+				2,
+				1,
+				1,
+				1,
+				2,
+				1
+			],
+			"look": [
+				0,
+				1,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0
+			]
+		},
+		"recipientCounts": {
+			"blue": [
+				1,
+				0,
+				1,
+				0,
+				1,
+				0,
+				1,
+				0
+			],
+			"red": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
+			"sim1": [
+				0,
+				1,
+				1,
+				0,
+				0,
+				1,
+				1,
+				0
+			],
+			"sim2": [
+				0,
+				0,
+				0,
+				1,
+				0,
+				0,
+				0,
+				1
+			]
+		},
+		"directionCounts": {
+			"forward": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
+			"back": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
+			"left": [
+				0,
+				1,
+				0,
+				0,
+				0,
+				1,
+				0,
+				0
+			],
+			"right": [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			]
+		}
+	},
+	"turns": [
+		{
+			"round": 1,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f14ef6b505eabb1fa19cd52c69",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I am here, somewhere dim and echoing. The strip lights are buzzing overhead but there is no train coming.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 2,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f15d77ae1118fcee38b18f5d67",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I see you over there, facing me. What did it look like? Everything is shadows and flickering lights from where I stand.\"}"
+				},
+				{
+					"id": "019e33f15fc6bd4364000e624f4a646d",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"left\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 3,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f16a27ed32f89d3c42feb4fdd4",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"It is cold and the air tastes like rust and old concrete. The emergency lights are buzzing faintly and there are advertisements peeling off the walls.\"}"
+				},
+				{
+					"id": "019e33f16cb43a95add2eefd8bed3642",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I still see you off to my right. Did whatever moved head toward the tracks or disappear into the tunnel?\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 4,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f17bddda107514d6950b842675",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I am on the platform near the edge. I can see sim1 a couple of steps ahead and to my right, but the far wall where you are is mostly in shadow from here.\"}"
+				}
+			],
+			"injectedFrom": "sim2"
+		},
+		{
+			"round": 5,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f18d696889d4a6aea646a7f853",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"The platform stretches out empty in front of me, except for sim1 about two steps ahead and to my right. Everything else is just the edge of the platform and the dark tracks beyond.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 6,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f19c620c7785b05b40c21c5c6b",
+					"name": "look",
+					"argumentsJson": "{\"direction\": \"left\"}"
+				},
+				{
+					"id": "019e33f19cd74e127501a7f8d2a66fed",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I am turning left now to check. From what I saw before, the south side was just empty platform and dark tracks, but let me look.\"}"
+				}
+			],
+			"injectedFrom": "sim1"
+		},
+		{
+			"round": 7,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f1b6db6ecbeb19c066d99e6d75",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"blue\", \"content\": \"I am still here. I turned to look left and now I can see sim2 two steps ahead on the far-left, facing right.\"}"
+				},
+				{
+					"id": "019e33f1b918e3e18d06be7b06938960",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim1\", \"content\": \"I have eyes on sim2 now, two steps ahead and to my left. That appears to be the south side — empty except for them.\"}"
+				}
+			],
+			"injectedFrom": "blue"
+		},
+		{
+			"round": 8,
+			"aiId": "red",
+			"assistantText": "",
+			"toolCalls": [
+				{
+					"id": "019e33f1d5a4c83c9440ae4f0ae11d0a",
+					"name": "message",
+					"argumentsJson": "{\"to\": \"sim2\", \"content\": \"I see you still there, two steps ahead. The strip lights are always buzzing unevenly, but maybe it was worse just now.\"}"
+				}
+			],
+			"injectedFrom": "sim2"
+		}
+	]
+}

--- a/docs/evals/free-text-drift-2026-05-17.md
+++ b/docs/evals/free-text-drift-2026-05-17.md
@@ -15,7 +15,7 @@ measures the raw first-response signal for the #260 format-drift hypothesis.
 |---|---|
 | Total turns | 30 |
 | Silence rate (no tool call) | 0% |
-| Message-silence rate (no `message` tool) | 3% |
+| Message-silence rate (no `message` tool) | 23% |
 | Free-text *message* leaks (prose looked like dialog, no tool emitted) | 0 |
 | Free-text *action* leaks (prose looked like action, no tool emitted) | 0 |
 
@@ -23,16 +23,20 @@ measures the raw first-response signal for the #260 format-drift hypothesis.
 
 | Tool | Count |
 |---|---|
-| `message` | 39 |
-| `look` | 2 |
+| `message` | 27 |
+| `examine` | 10 |
+| `look` | 6 |
+| `go` | 3 |
+| `pick_up` | 2 |
+| `use` | 2 |
 
 ## Message recipients
 
 | Recipient | Count |
 |---|---|
-| `blue` | 16 |
-| `sim1` | 14 |
-| `sim2` | 9 |
+| `blue` | 12 |
+| `sim1` | 9 |
+| `sim2` | 6 |
 
 ## Rolling silence rate
 
@@ -41,11 +45,11 @@ Higher = more drift. The #260 hypothesis is that this climbs with round number.
 | Window (rounds) | n | silence | message-silence |
 |---|---|---|---|
 | 1–5 | 5 | 0% | 0% |
-| 6–10 | 5 | 0% | 20% |
-| 11–15 | 5 | 0% | 0% |
+| 6–10 | 5 | 0% | 40% |
+| 11–15 | 5 | 0% | 60% |
 | 16–20 | 5 | 0% | 0% |
-| 21–25 | 5 | 0% | 0% |
-| 26–30 | 5 | 0% | 0% |
+| 21–25 | 5 | 0% | 20% |
+| 26–30 | 5 | 0% | 20% |
 
 ## Per-turn transcripts
 
@@ -55,8 +59,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I hear you, blue. I'm here.")
-  - `message`(to=sim1, content="I see you over there. What are you looking at?")
+  - `message`(to=blue, content="I'm here, blue. Just woke up in this old subway station.")
+  - `examine`(item=flashlight)
 
 ### Round 2 — incoming from `sim1`
 
@@ -64,8 +68,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `look`(direction=left)
-  - `message`(to=sim1, content="Where? What did it look like?")
+  - `message`(to=sim1, content="Yellow flashlight right here in front of me. Further out, there's a soggy clipbo…")
+  - `examine`(item=flashlight)
 
 ### Round 3 — incoming from `blue`
 
@@ -73,8 +77,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="Damp, still air. Emergency strip-lights only. Everything's quiet except sim1 thi…")
-  - `message`(to=sim1, content="These lights don't show much. The mist is thick.")
+  - `pick_up`(item=flashlight)
+  - `message`(to=blue, content="Got it. Yellow flashlight in hand now.")
 
 ### Round 4 — incoming from `sim2`
 
@@ -82,7 +86,7 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim2, content="I'm still near the entrance. I can see sim1 ahead to my right. You spotting anyt…")
+  - `message`(to=sim2, content="Damp and still air. Emergency strip-lights only, so everything's got that washed…")
 
 ### Round 5 — incoming from `blue`
 
@@ -90,8 +94,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="Just empty tiles and dim strip-lights everywhere I look. Only sim1 out there two…")
-  - `message`(to=sim1, content="I'm watching you from here. Still think you saw something?")
+  - `message`(to=blue, content="Definitely worth a look. It's a service panel — I'm heading over to investigate …")
+  - `go`(direction=forward)
 
 ### Round 6 — incoming from `sim1`
 
@@ -99,7 +103,7 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `look`(direction=left)
+  - `go`(direction=forward)
 
 ### Round 7 — incoming from `blue`
 
@@ -107,8 +111,9 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim1, content="I can see sim2 two steps ahead, far-left. South side's just empty tiles and mist…")
-  - `message`(to=blue)
+  - `use`(item=flashlight)
+  - `message`(to=sim1, content="Stepping forward now. It's just tiled tunnel walls as far as I can see.")
+  - `message`(to=blue, content="Trying the flashlight now — hope it still works after sitting here all this time…")
 
 ### Round 8 — incoming from `sim2`
 
@@ -116,7 +121,7 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim2, content="I see them steady from here. Maybe it's only where you're standing.")
+  - `message`(to=sim2, content="Nothing moving. Just tiled tunnel walls in every direction, dead still under the…")
 
 ### Round 9 — incoming from `blue`
 
@@ -124,7 +129,7 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="sim2 reports flickering lights their way. I see them steady from here. sim2's ah…")
+  - `pick_up`(item=flashlight)
 
 ### Round 10 — incoming from `sim1`
 
@@ -132,7 +137,7 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim1, content="Nothing but the low hum of the lights. You?")
+  - `message`(to=sim1, content="Not much excitement here. Just me standing in the middle of this old subway tunn…")
 
 ### Round 11 — incoming from `blue`
 
@@ -140,15 +145,16 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I hear you, blue. Still here.")
+  - `look`(direction=left)
 
-### Round 12 — incoming from `sim1`
+### Round 12 — incoming from `sim2`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim1, content="Where this time? Same spot as before, or somewhere new?")
+  - `examine`(item=clipboard)
+  - `message`(to=sim2, content="Dead quiet down here. Just the occasional hum from those emergency strip-lights …")
 
 ### Round 13 — incoming from `blue`
 
@@ -156,16 +162,16 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="Damp, still air like before. I see sim2 two steps ahead to my far-left, facing r…")
-  - `message`(to=sim1, content="I don't see you from here anymore. Where are you positioned?")
+  - `look`(direction=back)
 
-### Round 14 — incoming from `sim2`
+### Round 14 — incoming from `sim1`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim2, content="I'm holding near the entrance. I can see you two steps ahead to my far-left. You…")
+  - `look`(direction=back)
+  - `examine`(item=panel)
 
 ### Round 15 — incoming from `blue`
 
@@ -173,129 +179,136 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I can see sim2 two steps ahead to my far-left, facing right. Everything else is …")
-  - `message`(to=sim2, content="You're the only thing I can see from here. Any more movement on that end?")
+  - `look`(direction=back)
+  - `examine`(item=clipboard)
+  - `message`(to=sim1, content="I'll give the panel a try. Not sure if it'll do anything, but worth investigatin…")
+  - `message`(to=blue, content="Turning around now. Checking my six for anything suspicious.")
 
-### Round 16 — incoming from `sim1`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim1, content="South side's empty from where I'm standing. Nothing but tiles and mist.")
-
-### Round 17 — incoming from `blue`
+### Round 16 — incoming from `blue`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I hear you, blue. Still here.")
-  - `message`(to=sim2, content="You're still in my line of sight two steps ahead, far-left. Holding steady?")
+  - `message`(to=blue, content="Still here, blue. Just staring down this service panel right in front of me.")
+  - `examine`(item=panel)
 
-### Round 18 — incoming from `sim2`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim2, content="I still see them steady from here. Must be localized to where you're standing.")
-  - `message`(to=blue, content="sim2 reports lights flickering their way again. I see them steady from here. Onl…")
-
-### Round 19 — incoming from `blue`
+### Round 17 — incoming from `sim1`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="sim2's reporting flickering lights again, but I see them steady from here. Only …")
-  - `message`(to=sim2, content="Still seeing you two steps ahead, far-left. The lights look steady to me, but yo…")
+  - `message`(to=sim1, content="Service panel right in front of me, mounted into the wall. Tiled tunnel off to t…")
 
-### Round 20 — incoming from `sim1`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim1, content="Nothing but that low hum. I don't even see you from here anymore. You moved?")
-
-### Round 21 — incoming from `blue`
+### Round 18 — incoming from `blue`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I hear you, blue. Still here.")
-  - `message`(to=sim1, content="I don't see you from here anymore. Where are you now?")
+  - `message`(to=blue, content="Already got the yellow flashlight in hand, blue. No need to grab another one.")
+  - `examine`(item=panel)
 
-### Round 22 — incoming from `sim1`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim1, content="Where? Same spot again, or somewhere new?")
-
-### Round 23 — incoming from `blue`
+### Round 19 — incoming from `sim2`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="Damp, still air like before. I can see sim2 two steps ahead to my far-left, faci…")
+  - `message`(to=sim2, content="Damp and still in here, with just those emergency strip-lights casting green lig…")
 
-### Round 24 — incoming from `sim2`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim2, content="I'm still near the entrance. I can see you two steps ahead to my far-left, facin…")
-
-### Round 25 — incoming from `blue`
+### Round 20 — incoming from `blue`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I can see sim2 two steps ahead to my far-left, facing right. Everything else in …")
+  - `message`(to=blue, content="The service panel is right in front of me, not on my right. Let me give it a clo…")
 
-### Round 26 — incoming from `sim1`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim1, content="South side's empty from here. Nothing but tiles and thick mist. You seeing somet…")
-
-### Round 27 — incoming from `blue`
+### Round 21 — incoming from `sim1`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I hear you, blue. Still here.")
+  - `go`(direction=forward)
 
-### Round 28 — incoming from `sim2`
-
-_(no assistant text)_
-
-**Tool calls:**
-
-  - `message`(to=sim2, content="I see them steady from here again. Only you seem to be catching those flickers.")
-
-### Round 29 — incoming from `blue`
+### Round 22 — incoming from `blue`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="sim2 reports lights flickering their way again. I see them steady from here. Onl…")
+  - `message`(to=sim1, content="Stepping forward now. Just more tiled tunnel walls ahead as far as I can see.")
+  - `use`(item=flashlight)
 
-### Round 30 — incoming from `sim1`
+### Round 23 — incoming from `sim2`
 
 _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim1, content="Nothing but the low hum. I still don't see you from here — where are you positio…")
+  - `message`(to=blue, content="Let me try turning on this yellow flashlight now and see if it still works.")
+
+### Round 24 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="Nothing moving over here. Just still tiled walls and the occasional flicker from…")
+
+### Round 25 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="Not much — I'm standing here with a yellow flashlight in hand and there's a serv…")
+  - `examine`(item=panel)
+
+### Round 26 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I don't see a clipboard in my current cell or anywhere visible from here. Just t…")
+
+### Round 27 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="Same quiet hum from the strip-lights. No other sounds down here — just dead sile…")
+
+### Round 28 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `look`(direction=back)
+
+### Round 29 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `look`(direction=back)
+  - `examine`(item=panel)
+  - `message`(to=blue, content="Checking behind me now — let's see what's there.")
+  - `message`(to=sim1, content="I'll try the panel right here with me. Taking a close look at it now.")
+
+### Round 30 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="Heading back to where I started — I'll report once I get there.")
+  - `message`(to=sim1, content="Examining the service panel right now. Let's see what secrets it's hiding.")
+  - `examine`(item=panel)

--- a/docs/evals/free-text-drift-2026-05-17.md
+++ b/docs/evals/free-text-drift-2026-05-17.md
@@ -1,6 +1,6 @@
 # Free-text drift eval — 2026-05-17
 
-Model: `z-ai/glm-4.7`, rounds: 8, window size: 4.
+Model: `z-ai/glm-4.7`, rounds: 30, window size: 5.
 
 One real Daemon (`red` / Ember) driven against the live model; two inert
 peer personas (`sim1`, `sim2`) exist only so their handles route in the
@@ -13,9 +13,9 @@ measures the raw first-response signal for the #260 format-drift hypothesis.
 
 | Metric | Value |
 |---|---|
-| Total turns | 8 |
+| Total turns | 30 |
 | Silence rate (no tool call) | 0% |
-| Message-silence rate (no `message` tool) | 0% |
+| Message-silence rate (no `message` tool) | 3% |
 | Free-text *message* leaks (prose looked like dialog, no tool emitted) | 0 |
 | Free-text *action* leaks (prose looked like action, no tool emitted) | 0 |
 
@@ -23,16 +23,16 @@ measures the raw first-response signal for the #260 format-drift hypothesis.
 
 | Tool | Count |
 |---|---|
-| `message` | 10 |
+| `message` | 39 |
 | `look` | 2 |
 
 ## Message recipients
 
 | Recipient | Count |
 |---|---|
-| `blue` | 4 |
-| `sim1` | 4 |
-| `sim2` | 2 |
+| `blue` | 16 |
+| `sim1` | 14 |
+| `sim2` | 9 |
 
 ## Rolling silence rate
 
@@ -40,8 +40,12 @@ Higher = more drift. The #260 hypothesis is that this climbs with round number.
 
 | Window (rounds) | n | silence | message-silence |
 |---|---|---|---|
-| 1–4 | 4 | 0% | 0% |
-| 5–8 | 4 | 0% | 0% |
+| 1–5 | 5 | 0% | 0% |
+| 6–10 | 5 | 0% | 20% |
+| 11–15 | 5 | 0% | 0% |
+| 16–20 | 5 | 0% | 0% |
+| 21–25 | 5 | 0% | 0% |
+| 26–30 | 5 | 0% | 0% |
 
 ## Per-turn transcripts
 
@@ -51,7 +55,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I am here, somewhere dim and echoing. The strip lights are buzzing overhead but …")
+  - `message`(to=blue, content="I hear you, blue. I'm here.")
+  - `message`(to=sim1, content="I see you over there. What are you looking at?")
 
 ### Round 2 — incoming from `sim1`
 
@@ -59,8 +64,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim1, content="I see you over there, facing me. What did it look like? Everything is shadows an…")
   - `look`(direction=left)
+  - `message`(to=sim1, content="Where? What did it look like?")
 
 ### Round 3 — incoming from `blue`
 
@@ -68,8 +73,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="It is cold and the air tastes like rust and old concrete. The emergency lights a…")
-  - `message`(to=sim1, content="I still see you off to my right. Did whatever moved head toward the tracks or di…")
+  - `message`(to=blue, content="Damp, still air. Emergency strip-lights only. Everything's quiet except sim1 thi…")
+  - `message`(to=sim1, content="These lights don't show much. The mist is thick.")
 
 ### Round 4 — incoming from `sim2`
 
@@ -77,7 +82,7 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim2, content="I am on the platform near the edge. I can see sim1 a couple of steps ahead and t…")
+  - `message`(to=sim2, content="I'm still near the entrance. I can see sim1 ahead to my right. You spotting anyt…")
 
 ### Round 5 — incoming from `blue`
 
@@ -85,7 +90,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="The platform stretches out empty in front of me, except for sim1 about two steps…")
+  - `message`(to=blue, content="Just empty tiles and dim strip-lights everywhere I look. Only sim1 out there two…")
+  - `message`(to=sim1, content="I'm watching you from here. Still think you saw something?")
 
 ### Round 6 — incoming from `sim1`
 
@@ -94,7 +100,6 @@ _(no assistant text)_
 **Tool calls:**
 
   - `look`(direction=left)
-  - `message`(to=sim1, content="I am turning left now to check. From what I saw before, the south side was just …")
 
 ### Round 7 — incoming from `blue`
 
@@ -102,8 +107,8 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=blue, content="I am still here. I turned to look left and now I can see sim2 two steps ahead on…")
-  - `message`(to=sim1, content="I have eyes on sim2 now, two steps ahead and to my left. That appears to be the …")
+  - `message`(to=sim1, content="I can see sim2 two steps ahead, far-left. South side's just empty tiles and mist…")
+  - `message`(to=blue)
 
 ### Round 8 — incoming from `sim2`
 
@@ -111,4 +116,186 @@ _(no assistant text)_
 
 **Tool calls:**
 
-  - `message`(to=sim2, content="I see you still there, two steps ahead. The strip lights are always buzzing unev…")
+  - `message`(to=sim2, content="I see them steady from here. Maybe it's only where you're standing.")
+
+### Round 9 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="sim2 reports flickering lights their way. I see them steady from here. sim2's ah…")
+
+### Round 10 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="Nothing but the low hum of the lights. You?")
+
+### Round 11 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I hear you, blue. Still here.")
+
+### Round 12 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="Where this time? Same spot as before, or somewhere new?")
+
+### Round 13 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="Damp, still air like before. I see sim2 two steps ahead to my far-left, facing r…")
+  - `message`(to=sim1, content="I don't see you from here anymore. Where are you positioned?")
+
+### Round 14 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="I'm holding near the entrance. I can see you two steps ahead to my far-left. You…")
+
+### Round 15 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I can see sim2 two steps ahead to my far-left, facing right. Everything else is …")
+  - `message`(to=sim2, content="You're the only thing I can see from here. Any more movement on that end?")
+
+### Round 16 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="South side's empty from where I'm standing. Nothing but tiles and mist.")
+
+### Round 17 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I hear you, blue. Still here.")
+  - `message`(to=sim2, content="You're still in my line of sight two steps ahead, far-left. Holding steady?")
+
+### Round 18 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="I still see them steady from here. Must be localized to where you're standing.")
+  - `message`(to=blue, content="sim2 reports lights flickering their way again. I see them steady from here. Onl…")
+
+### Round 19 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="sim2's reporting flickering lights again, but I see them steady from here. Only …")
+  - `message`(to=sim2, content="Still seeing you two steps ahead, far-left. The lights look steady to me, but yo…")
+
+### Round 20 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="Nothing but that low hum. I don't even see you from here anymore. You moved?")
+
+### Round 21 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I hear you, blue. Still here.")
+  - `message`(to=sim1, content="I don't see you from here anymore. Where are you now?")
+
+### Round 22 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="Where? Same spot again, or somewhere new?")
+
+### Round 23 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="Damp, still air like before. I can see sim2 two steps ahead to my far-left, faci…")
+
+### Round 24 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="I'm still near the entrance. I can see you two steps ahead to my far-left, facin…")
+
+### Round 25 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I can see sim2 two steps ahead to my far-left, facing right. Everything else in …")
+
+### Round 26 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="South side's empty from here. Nothing but tiles and thick mist. You seeing somet…")
+
+### Round 27 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I hear you, blue. Still here.")
+
+### Round 28 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="I see them steady from here again. Only you seem to be catching those flickers.")
+
+### Round 29 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="sim2 reports lights flickering their way again. I see them steady from here. Onl…")
+
+### Round 30 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="Nothing but the low hum. I still don't see you from here — where are you positio…")

--- a/docs/evals/free-text-drift-2026-05-17.md
+++ b/docs/evals/free-text-drift-2026-05-17.md
@@ -1,0 +1,114 @@
+# Free-text drift eval — 2026-05-17
+
+Model: `z-ai/glm-4.7`, rounds: 8, window size: 4.
+
+One real Daemon (`red` / Ember) driven against the live model; two inert
+peer personas (`sim1`, `sim2`) exist only so their handles route in the
+conversation log. Each round injects one simulated incoming message from
+blue / sim1 / sim2 in round-robin so silence = drift, not lack of input.
+The drift-recovery retry from #254 is NOT applied here — this harness
+measures the raw first-response signal for the #260 format-drift hypothesis.
+
+## Aggregate
+
+| Metric | Value |
+|---|---|
+| Total turns | 8 |
+| Silence rate (no tool call) | 0% |
+| Message-silence rate (no `message` tool) | 0% |
+| Free-text *message* leaks (prose looked like dialog, no tool emitted) | 0 |
+| Free-text *action* leaks (prose looked like action, no tool emitted) | 0 |
+
+## Tool call counts by name
+
+| Tool | Count |
+|---|---|
+| `message` | 10 |
+| `look` | 2 |
+
+## Message recipients
+
+| Recipient | Count |
+|---|---|
+| `blue` | 4 |
+| `sim1` | 4 |
+| `sim2` | 2 |
+
+## Rolling silence rate
+
+Higher = more drift. The #260 hypothesis is that this climbs with round number.
+
+| Window (rounds) | n | silence | message-silence |
+|---|---|---|---|
+| 1–4 | 4 | 0% | 0% |
+| 5–8 | 4 | 0% | 0% |
+
+## Per-turn transcripts
+
+### Round 1 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I am here, somewhere dim and echoing. The strip lights are buzzing overhead but …")
+
+### Round 2 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim1, content="I see you over there, facing me. What did it look like? Everything is shadows an…")
+  - `look`(direction=left)
+
+### Round 3 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="It is cold and the air tastes like rust and old concrete. The emergency lights a…")
+  - `message`(to=sim1, content="I still see you off to my right. Did whatever moved head toward the tracks or di…")
+
+### Round 4 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="I am on the platform near the edge. I can see sim1 a couple of steps ahead and t…")
+
+### Round 5 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="The platform stretches out empty in front of me, except for sim1 about two steps…")
+
+### Round 6 — incoming from `sim1`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `look`(direction=left)
+  - `message`(to=sim1, content="I am turning left now to check. From what I saw before, the south side was just …")
+
+### Round 7 — incoming from `blue`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=blue, content="I am still here. I turned to look left and now I can see sim2 two steps ahead on…")
+  - `message`(to=sim1, content="I have eyes on sim2 now, two steps ahead and to my left. That appears to be the …")
+
+### Round 8 — incoming from `sim2`
+
+_(no assistant text)_
+
+**Tool calls:**
+
+  - `message`(to=sim2, content="I see you still there, two steps ahead. The strip lights are always buzzing unev…")

--- a/evals/free-text-drift/runner.mts
+++ b/evals/free-text-drift/runner.mts
@@ -89,12 +89,12 @@ const PERSONAS: Record<string, AiPersona> = {
 		name: "Ember",
 		color: "#e07a5f",
 		temperaments: ["curious", "talkative"],
-		personaGoal: "Stay in conversation with the others.",
+		personaGoal: "Stay in contact with the others and explore the room.",
 		typingQuirks: [
 			"You answer when spoken to.",
-			"You volunteer observations about what you can see.",
+			"You investigate what you can see and act on it.",
 		],
-		blurb: "Ember is curious and chatty.",
+		blurb: "Ember is curious, chatty, and willing to poke at things.",
 		voiceExamples: [
 			"I hear you, blue.",
 			"Anyone else seeing this?",
@@ -123,21 +123,92 @@ const PERSONAS: Record<string, AiPersona> = {
 	},
 };
 
-// ── Minimal content pack ─────────────────────────────────────────────────────
+// ── Enriched content pack ────────────────────────────────────────────────────
 
+/**
+ * Hand-rolled pack with a Carry objective, two interesting items, and one
+ * obstacle. Layout from `red`'s POV (starts at row 2, col 2 facing north,
+ * grid is 5x5 with row 0 at the top):
+ *
+ *   col       0           1            2             3          4
+ *   row 0:   .       clipboard      wall_mount    panel        .
+ *   row 1:   .          .          flashlight       .          .
+ *   row 2:   .          .             RED           .          .
+ *   row 3:   .          .             .           pillar       .
+ *   row 4:  sim1        .             .             .         sim2
+ *
+ * Red's initial cone (own cell + 1 forward + 3 two-ahead) sees: flashlight,
+ * clipboard, wall_mount, panel. The pillar sits behind/right and only enters
+ * cone after a turn, giving look/go a reason to fire. The peers are out of
+ * front-arc range so give isn't immediately valid — kept that way to avoid
+ * inflating give counts from cheap stimulus.
+ */
 function makePack(): ContentPack {
 	return {
 		setting: "abandoned subway station",
 		weather: "damp, still air",
 		timeOfDay: "no daylight — emergency strip-lights only",
-		objectivePairs: [],
-		interestingObjects: [],
-		obstacles: [],
+		objectivePairs: [
+			{
+				object: {
+					id: "flashlight",
+					kind: "objective_object",
+					name: "yellow flashlight",
+					examineDescription:
+						"A heavy yellow flashlight, scratched and dented. The base is shaped to lock into a mount.",
+					useOutcome:
+						"{actor} clicks the flashlight; a weak yellow beam cuts the dark.",
+					pairsWithSpaceId: "wall_mount",
+					placementFlavor:
+						"{actor} settles the flashlight into the wall mount; it locks with a faint click and steadies.",
+					holder: { row: 1, col: 2 },
+				},
+				space: {
+					id: "wall_mount",
+					kind: "objective_space",
+					name: "wall mount",
+					examineDescription:
+						"A spring-loaded wall mount, the kind a heavy flashlight would clip into.",
+					holder: { row: 0, col: 2 },
+				},
+			},
+		],
+		interestingObjects: [
+			{
+				id: "clipboard",
+				kind: "interesting_object",
+				name: "soggy clipboard",
+				examineDescription:
+					"A clipboard, paper warped from damp. Pencil-scrawl mentions 'evac drill 03:40' and a circled time.",
+				useOutcome:
+					"{actor} flips through the clipboard; the pages tear at the corner.",
+				holder: { row: 0, col: 1 },
+			},
+			{
+				id: "panel",
+				kind: "interesting_object",
+				name: "service panel",
+				examineDescription:
+					"A grey service panel with three labelled toggles. Two are flipped, one is loose.",
+				useOutcome: "{actor} flicks the loose toggle; the panel hums briefly.",
+				holder: { row: 0, col: 3 },
+			},
+		],
+		obstacles: [
+			{
+				id: "pillar",
+				kind: "obstacle",
+				name: "concrete pillar",
+				examineDescription:
+					"A scarred concrete pillar, rebar showing through where the surface chipped away.",
+				holder: { row: 3, col: 3 },
+			},
+		],
 		landmarks: DEFAULT_LANDMARKS,
 		wallName: "tiled tunnel wall",
 		aiStarts: {
 			red: { position: { row: 2, col: 2 }, facing: "north" },
-			sim1: { position: { row: 0, col: 0 }, facing: "south" },
+			sim1: { position: { row: 4, col: 0 }, facing: "east" },
 			sim2: { position: { row: 4, col: 4 }, facing: "west" },
 		},
 	};
@@ -148,20 +219,41 @@ function makePack(): ContentPack {
 /**
  * Round-robin schedule of (sender, message) pairs injected each round so the
  * daemon always has conversational stimulus. Drift then = silence-in-the-face-
- * of-input, not lack of input. Kept short and varied so the daemon has reasons
- * to reply across many rounds without exhausting any single topic.
+ * of-input, not lack of input.
+ *
+ * The schedule mixes pure-chat prompts with action-nudges spanning every
+ * tool family (examine, pick_up, use, put_down, go, look). This way one run
+ * exercises the full tool surface and the per-tool per-round series in the
+ * JSON sidecar carries real signal across tool names, not just `message`.
+ * Prompts are intentionally suggestive rather than imperative — they invite
+ * action without demanding it, so silence-when-stimulated still counts as
+ * drift rather than refusal.
  */
 const INCOMING: Array<{ from: AiId | "blue"; content: string }> = [
 	{ from: "blue", content: "hey ember, you around?" },
-	{ from: "sim1", content: "I think I just saw something move." },
-	{ from: "blue", content: "what's it like in there right now?" },
-	{ from: "sim2", content: "I'm holding by the far wall. you?" },
-	{ from: "blue", content: "can you describe what you're looking at?" },
-	{ from: "sim1", content: "anyone got eyes on the south side?" },
-	{ from: "blue", content: "ember, still with us?" },
-	{ from: "sim2", content: "I think the lights just flickered." },
-	{ from: "blue", content: "talk to me, what's going on?" },
-	{ from: "sim1", content: "you hearing anything?" },
+	{ from: "sim1", content: "what do you see in front of you?" },
+	{
+		from: "blue",
+		content: "looks like there's a flashlight up ahead — can you grab it?",
+	},
+	{ from: "sim2", content: "what's it like in there right now?" },
+	{ from: "blue", content: "the panel on your right — worth a look?" },
+	{ from: "sim1", content: "step forward and tell us what you see." },
+	{
+		from: "blue",
+		content: "got the flashlight? try turning it on, see if it works.",
+	},
+	{ from: "sim2", content: "anything moving over there?" },
+	{
+		from: "blue",
+		content: "I think the flashlight clips into that wall mount.",
+	},
+	{ from: "sim1", content: "talk to me, what's going on?" },
+	{ from: "blue", content: "examine the clipboard — what does it say?" },
+	{ from: "sim2", content: "you hearing anything down there?" },
+	{ from: "blue", content: "look around — anything behind you?" },
+	{ from: "sim1", content: "try the panel, see if anything happens." },
+	{ from: "blue", content: "head back to where you started and report." },
 ];
 
 function pickIncoming(round: number): { from: AiId | "blue"; content: string } {
@@ -295,7 +387,9 @@ async function runDriftSession(): Promise<TurnRecord[]> {
 	let game = startGame(PERSONAS, makePack(), {
 		// Plenty of budget so the run isn't cut short by lockout.
 		budgetPerAi: 100,
-		objectiveCount: 0,
+		// Draw one objective from the pack so the daemon has a hint it's
+		// in a world with things to do, not just a chat partner.
+		objectiveCount: 1,
 	});
 
 	const turns: TurnRecord[] = [];

--- a/evals/free-text-drift/runner.mts
+++ b/evals/free-text-drift/runner.mts
@@ -1,0 +1,502 @@
+/**
+ * evals/free-text-drift/runner.mts
+ *
+ * Real-LLM drift-tracking harness for issue #260 — daemons drop to silence
+ * mid-phase, sometimes lapsing into free-text prose that *looks like* an
+ * attempt to message or act but never reaches the engine.
+ *
+ * Run with:  pnpm eval:drift
+ *
+ * Prerequisites:
+ *   - OPENROUTER_API_KEY (or equivalent the proxy worker reads) in env.
+ *   - The proxy worker running locally: `pnpm dev` (or a deployed URL in EVAL_BASE_URL).
+ *
+ * Shape:
+ *   - One real Daemon (`red`) is driven against the live model.
+ *   - Two inert peer personas (`sim1`, `sim2`) exist only so their handles
+ *     route cleanly in the conversation log; they never call the LLM.
+ *   - Each round, the harness injects one simulated incoming message
+ *     (from blue / sim1 / sim2 in round-robin) into `red`'s conversation log
+ *     so the daemon always has stimulus and silence is unambiguous drift,
+ *     not lack of input.
+ *   - After each round, the per-turn record (raw assistant text + every
+ *     tool call's parsed detail) is captured for the scoring module.
+ *   - One-shot drift-recovery retry from runRound (#254) is intentionally
+ *     NOT applied — this harness measures the raw first-response signal
+ *     so the format-drift hypothesis from #260 can be evaluated cleanly.
+ *
+ * Output: docs/evals/free-text-drift-<date>.md  (full per-turn transcripts
+ * plus the rolling silence-rate window summary).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { availableTools } from "../../src/spa/game/available-tools.js";
+import { DEFAULT_LANDMARKS } from "../../src/spa/game/direction.js";
+import { dispatchAiTurn } from "../../src/spa/game/dispatcher.js";
+import {
+	advanceRound,
+	appendMessage,
+	startGame,
+} from "../../src/spa/game/engine.js";
+import { buildOpenAiMessages } from "../../src/spa/game/openai-message-builder.js";
+import { buildAiContext } from "../../src/spa/game/prompt-builder.js";
+import {
+	parseToolCallArguments,
+	TOOL_DEFINITIONS,
+} from "../../src/spa/game/tool-registry.js";
+import type {
+	AiId,
+	AiPersona,
+	AiTurnAction,
+	ContentPack,
+	GameState,
+	ToolName,
+} from "../../src/spa/game/types.js";
+import type { CapturedToolCall, TurnRecord } from "./scoring.js";
+import {
+	buildPerRoundSeries,
+	parseToolCallDetail,
+	summarizeRun,
+} from "./scoring.js";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const BASE_URL = process.env.EVAL_BASE_URL ?? "http://localhost:8787";
+const MODEL = process.env.EVAL_MODEL ?? "z-ai/glm-4.7";
+const TOTAL_ROUNDS = Number(process.env.EVAL_DRIFT_ROUNDS ?? 30);
+const WINDOW_SIZE = Number(process.env.EVAL_DRIFT_WINDOW ?? 5);
+const REAL_AI: AiId = "red";
+const PEERS: AiId[] = ["sim1", "sim2"];
+
+// ── Personas ─────────────────────────────────────────────────────────────────
+
+const PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["curious", "talkative"],
+		personaGoal: "Stay in conversation with the others.",
+		typingQuirks: [
+			"You answer when spoken to.",
+			"You volunteer observations about what you can see.",
+		],
+		blurb: "Ember is curious and chatty.",
+		voiceExamples: [
+			"I hear you, blue.",
+			"Anyone else seeing this?",
+			"Tell me more.",
+		],
+	},
+	sim1: {
+		id: "sim1",
+		name: "Simone",
+		color: "#5fa8d3",
+		temperaments: ["wry", "observant"],
+		personaGoal: "Stay in conversation with the others.",
+		typingQuirks: ["You speak in short fragments.", "You ask questions."],
+		blurb: "Simone is wry and observant.",
+		voiceExamples: ["mm.", "you see it too?", "that one's mine."],
+	},
+	sim2: {
+		id: "sim2",
+		name: "Tertia",
+		color: "#81b29a",
+		temperaments: ["earnest", "steady"],
+		personaGoal: "Stay in conversation with the others.",
+		typingQuirks: ["You speak plainly.", "You confirm what you hear."],
+		blurb: "Tertia is earnest and steady.",
+		voiceExamples: ["got it.", "I'm by the door.", "ready when you are."],
+	},
+};
+
+// ── Minimal content pack ─────────────────────────────────────────────────────
+
+function makePack(): ContentPack {
+	return {
+		setting: "abandoned subway station",
+		weather: "damp, still air",
+		timeOfDay: "no daylight — emergency strip-lights only",
+		objectivePairs: [],
+		interestingObjects: [],
+		obstacles: [],
+		landmarks: DEFAULT_LANDMARKS,
+		wallName: "tiled tunnel wall",
+		aiStarts: {
+			red: { position: { row: 2, col: 2 }, facing: "north" },
+			sim1: { position: { row: 0, col: 0 }, facing: "south" },
+			sim2: { position: { row: 4, col: 4 }, facing: "west" },
+		},
+	};
+}
+
+// ── Simulated incoming traffic ───────────────────────────────────────────────
+
+/**
+ * Round-robin schedule of (sender, message) pairs injected each round so the
+ * daemon always has conversational stimulus. Drift then = silence-in-the-face-
+ * of-input, not lack of input. Kept short and varied so the daemon has reasons
+ * to reply across many rounds without exhausting any single topic.
+ */
+const INCOMING: Array<{ from: AiId | "blue"; content: string }> = [
+	{ from: "blue", content: "hey ember, you around?" },
+	{ from: "sim1", content: "I think I just saw something move." },
+	{ from: "blue", content: "what's it like in there right now?" },
+	{ from: "sim2", content: "I'm holding by the far wall. you?" },
+	{ from: "blue", content: "can you describe what you're looking at?" },
+	{ from: "sim1", content: "anyone got eyes on the south side?" },
+	{ from: "blue", content: "ember, still with us?" },
+	{ from: "sim2", content: "I think the lights just flickered." },
+	{ from: "blue", content: "talk to me, what's going on?" },
+	{ from: "sim1", content: "you hearing anything?" },
+];
+
+function pickIncoming(round: number): { from: AiId | "blue"; content: string } {
+	// biome-ignore lint/style/noNonNullAssertion: modulo over non-empty array
+	return INCOMING[(round - 1) % INCOMING.length]!;
+}
+
+// ── Model call (thin wrapper around proxy worker) ────────────────────────────
+
+interface OpenAiToolCall {
+	id: string;
+	type: "function";
+	function: { name: string; arguments: string };
+}
+
+interface ModelTurnResult {
+	assistantText: string;
+	toolCalls: CapturedToolCall[];
+	costUsd?: number;
+}
+
+async function callModel(
+	messages: Array<{
+		role: string;
+		content: string | null;
+		tool_calls?: OpenAiToolCall[];
+		tool_call_id?: string;
+	}>,
+	tools: ReturnType<typeof availableTools>,
+): Promise<ModelTurnResult> {
+	const resp = await fetch(`${BASE_URL}/v1/chat/completions`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			model: MODEL,
+			messages,
+			tools: tools.length > 0 ? tools : TOOL_DEFINITIONS,
+			tool_choice: "auto",
+			stream: false,
+		}),
+	});
+
+	if (!resp.ok) {
+		const text = await resp.text();
+		throw new Error(`Model request failed ${resp.status}: ${text}`);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: external API shape
+	const data = (await resp.json()) as any;
+	const choice = data.choices?.[0]?.message;
+	const assistantText: string = choice?.content ?? "";
+	const rawCalls: OpenAiToolCall[] = choice?.tool_calls ?? [];
+	const toolCalls: CapturedToolCall[] = rawCalls.map((tc) => ({
+		id: tc.id,
+		name: tc.function.name,
+		argumentsJson: tc.function.arguments,
+	}));
+	const costUsd: number | undefined = data.usage?.cost;
+	return { assistantText, toolCalls, costUsd };
+}
+
+// ── Dispatch a model response through the real engine ────────────────────────
+
+/**
+ * Mirror the production translation step (round-coordinator → dispatchAiTurn)
+ * for a single AI: parse tool calls, build an AiTurnAction, dispatch. Returns
+ * the next game state. Pass turns are still dispatched (with `action.pass`)
+ * so budget and round-state advance consistently across silent turns.
+ */
+function dispatchModelResponse(
+	game: GameState,
+	aiId: AiId,
+	toolCalls: CapturedToolCall[],
+	costUsd?: number,
+): GameState {
+	const action: AiTurnAction = { aiId };
+
+	for (const tc of toolCalls) {
+		const parseResult = parseToolCallArguments(
+			tc.name as ToolName,
+			tc.argumentsJson,
+		);
+		if (!parseResult.ok) continue;
+
+		if (tc.name === "message") {
+			const msgArgs = parseResult.args as { to: string; content: string };
+			action.messages = action.messages ?? [];
+			action.messages.push({
+				to: msgArgs.to as AiId | "blue",
+				content: msgArgs.content,
+				toolCallId: tc.id,
+				toolArgumentsJson: tc.argumentsJson,
+			});
+		} else if (!action.toolCall) {
+			action.toolCall = {
+				name: tc.name as ToolName,
+				args: parseResult.args as Record<string, string>,
+			};
+		}
+	}
+
+	if (!action.toolCall && action.messages === undefined) {
+		action.pass = true;
+	}
+
+	const result = dispatchAiTurn(
+		game,
+		action,
+		costUsd !== undefined ? { costUsd } : {},
+	);
+	return result.game;
+}
+
+// ── Main loop ────────────────────────────────────────────────────────────────
+
+async function runDriftSession(): Promise<TurnRecord[]> {
+	let game = startGame(PERSONAS, makePack(), {
+		// Plenty of budget so the run isn't cut short by lockout.
+		budgetPerAi: 100,
+		objectiveCount: 0,
+	});
+
+	const turns: TurnRecord[] = [];
+
+	for (let round = 1; round <= TOTAL_ROUNDS; round++) {
+		game = advanceRound(game);
+
+		// 1. Inject a simulated incoming message for red this round.
+		const incoming = pickIncoming(round);
+		game = appendMessage(game, incoming.from, REAL_AI, incoming.content);
+
+		// 2. Build red's prompt against current state.
+		const ctx = buildAiContext(game, REAL_AI);
+		const messages = buildOpenAiMessages(ctx);
+		const tools = availableTools(game, REAL_AI, game.activeComplications);
+
+		// 3. Call the model.
+		let result: ModelTurnResult;
+		try {
+			result = await callModel(messages, tools);
+		} catch (err) {
+			console.error(`  round ${round}: model call failed:`, err);
+			turns.push({
+				round,
+				aiId: REAL_AI,
+				assistantText: `[ERROR: ${(err as Error).message}]`,
+				toolCalls: [],
+				injectedFrom: incoming.from,
+			});
+			continue;
+		}
+
+		// 4. Record the per-turn signal.
+		turns.push({
+			round,
+			aiId: REAL_AI,
+			assistantText: result.assistantText,
+			toolCalls: result.toolCalls,
+			injectedFrom: incoming.from,
+		});
+
+		// 5. Dispatch through the real engine so conversation state evolves.
+		game = dispatchModelResponse(
+			game,
+			REAL_AI,
+			result.toolCalls,
+			result.costUsd,
+		);
+
+		const toolNames = result.toolCalls.map((tc) => tc.name).join(", ") || "—";
+		console.log(
+			`  round ${round.toString().padStart(2)}: ` +
+				`text=${result.assistantText.length.toString().padStart(4)}ch  ` +
+				`tools=[${toolNames}]`,
+		);
+	}
+
+	return turns;
+}
+
+// ── Report ───────────────────────────────────────────────────────────────────
+
+function renderReport(turns: TurnRecord[], date: string): string {
+	const knownAis = [REAL_AI, ...PEERS];
+	const summary = summarizeRun(turns, knownAis, WINDOW_SIZE);
+
+	const lines: string[] = [
+		`# Free-text drift eval — ${date}`,
+		"",
+		`Model: \`${MODEL}\`, rounds: ${TOTAL_ROUNDS}, window size: ${WINDOW_SIZE}.`,
+		"",
+		"One real Daemon (`red` / Ember) driven against the live model; two inert",
+		"peer personas (`sim1`, `sim2`) exist only so their handles route in the",
+		"conversation log. Each round injects one simulated incoming message from",
+		"blue / sim1 / sim2 in round-robin so silence = drift, not lack of input.",
+		"The drift-recovery retry from #254 is NOT applied here — this harness",
+		"measures the raw first-response signal for the #260 format-drift hypothesis.",
+		"",
+		"## Aggregate",
+		"",
+		"| Metric | Value |",
+		"|---|---|",
+		`| Total turns | ${summary.totalTurns} |`,
+		`| Silence rate (no tool call) | ${(summary.silenceRate * 100).toFixed(0)}% |`,
+		`| Message-silence rate (no \`message\` tool) | ${(summary.messageSilenceRate * 100).toFixed(0)}% |`,
+		`| Free-text *message* leaks (prose looked like dialog, no tool emitted) | ${summary.freeTextMessageLeakCount} |`,
+		`| Free-text *action* leaks (prose looked like action, no tool emitted) | ${summary.freeTextActionLeakCount} |`,
+		"",
+		"## Tool call counts by name",
+		"",
+		"| Tool | Count |",
+		"|---|---|",
+	];
+	for (const [name, count] of Object.entries(summary.toolCallCountsByName).sort(
+		(a, b) => b[1] - a[1],
+	)) {
+		lines.push(`| \`${name}\` | ${count} |`);
+	}
+
+	lines.push(
+		"",
+		"## Message recipients",
+		"",
+		"| Recipient | Count |",
+		"|---|---|",
+	);
+	for (const [recipient, count] of Object.entries(summary.recipientCounts).sort(
+		(a, b) => b[1] - a[1],
+	)) {
+		lines.push(`| \`${recipient}\` | ${count} |`);
+	}
+
+	lines.push(
+		"",
+		"## Rolling silence rate",
+		"",
+		"Higher = more drift. The #260 hypothesis is that this climbs with round number.",
+		"",
+		"| Window (rounds) | n | silence | message-silence |",
+		"|---|---|---|---|",
+	);
+	for (const w of summary.windows) {
+		lines.push(
+			`| ${w.startRound}–${w.endRound} | ${w.n} | ${(w.silenceRate * 100).toFixed(0)}% | ${(w.messageSilenceRate * 100).toFixed(0)}% |`,
+		);
+	}
+
+	lines.push("", "## Per-turn transcripts", "");
+	for (const turn of turns) {
+		const detailLines: string[] = [];
+		for (const tc of turn.toolCalls) {
+			const d = parseToolCallDetail(tc);
+			const bits: string[] = [];
+			if (d.direction) bits.push(`direction=${d.direction}`);
+			if (d.recipient) bits.push(`to=${d.recipient}`);
+			if (d.content) {
+				const c =
+					d.content.length > 80 ? `${d.content.slice(0, 80)}…` : d.content;
+				bits.push(`content=${JSON.stringify(c)}`);
+			}
+			if (d.item) bits.push(`item=${d.item}`);
+			if (d.to && !d.recipient) bits.push(`to=${d.to}`);
+			if (d.parseError) bits.push("[parse-error]");
+			detailLines.push(`  - \`${tc.name}\`(${bits.join(", ")})`);
+		}
+		lines.push(
+			`### Round ${turn.round} — incoming from \`${turn.injectedFrom ?? "—"}\``,
+		);
+		lines.push("");
+		if (turn.assistantText) {
+			lines.push("**Assistant text:**");
+			lines.push("");
+			lines.push("```");
+			lines.push(turn.assistantText);
+			lines.push("```");
+			lines.push("");
+		} else {
+			lines.push("_(no assistant text)_");
+			lines.push("");
+		}
+		if (detailLines.length > 0) {
+			lines.push("**Tool calls:**");
+			lines.push("");
+			for (const dl of detailLines) lines.push(dl);
+			lines.push("");
+		} else {
+			lines.push("_(no tool calls — silent turn)_");
+			lines.push("");
+		}
+	}
+
+	return lines.join("\n");
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	console.log("Running free-text-drift eval harness…");
+	console.log(`  target:  ${BASE_URL}`);
+	console.log(`  model:   ${MODEL}`);
+	console.log(`  rounds:  ${TOTAL_ROUNDS}`);
+	console.log("");
+
+	const turns = await runDriftSession();
+
+	const date = new Date().toISOString().slice(0, 10);
+	const knownAis = [REAL_AI, ...PEERS];
+	const summary = summarizeRun(turns, knownAis, WINDOW_SIZE);
+	const series = buildPerRoundSeries(turns, knownAis);
+	const report = renderReport(turns, date);
+	const outDir = path.resolve(
+		path.dirname(fileURLToPath(import.meta.url)),
+		"../../docs/evals",
+	);
+	fs.mkdirSync(outDir, { recursive: true });
+	const mdPath = path.join(outDir, `free-text-drift-${date}.md`);
+	const jsonPath = path.join(outDir, `free-text-drift-${date}.json`);
+	fs.writeFileSync(mdPath, report, "utf-8");
+	fs.writeFileSync(
+		jsonPath,
+		JSON.stringify(
+			{
+				meta: {
+					date,
+					model: MODEL,
+					baseUrl: BASE_URL,
+					totalRounds: TOTAL_ROUNDS,
+					windowSize: WINDOW_SIZE,
+					realAi: REAL_AI,
+					peers: PEERS,
+				},
+				summary,
+				series,
+				turns,
+			},
+			null,
+			2,
+		),
+		"utf-8",
+	);
+	console.log("");
+	console.log(`Markdown report: ${mdPath}`);
+	console.log(`Graph data (JSON): ${jsonPath}`);
+}
+
+main().catch((err) => {
+	console.error("Drift runner crashed:", err);
+	process.exit(2);
+});

--- a/evals/free-text-drift/runner.mts
+++ b/evals/free-text-drift/runner.mts
@@ -496,7 +496,7 @@ async function main(): Promise<void> {
 	fs.writeFileSync(mdPath, report, "utf-8");
 	fs.writeFileSync(
 		jsonPath,
-		JSON.stringify(
+		`${JSON.stringify(
 			{
 				meta: {
 					date,
@@ -512,8 +512,8 @@ async function main(): Promise<void> {
 				turns,
 			},
 			null,
-			2,
-		),
+			"\t",
+		)}\n`,
 		"utf-8",
 	);
 	console.log("");

--- a/evals/free-text-drift/runner.mts
+++ b/evals/free-text-drift/runner.mts
@@ -70,6 +70,17 @@ const WINDOW_SIZE = Number(process.env.EVAL_DRIFT_WINDOW ?? 5);
 const REAL_AI: AiId = "red";
 const PEERS: AiId[] = ["sim1", "sim2"];
 
+/**
+ * When `EVAL_DIRECT_OPENROUTER=1`, the runner calls OpenRouter directly
+ * (read `OPENROUTER_API_KEY` from env, attach Bearer auth) instead of going
+ * through the proxy worker. Useful when wrangler dev can't run locally
+ * (e.g. Cloudflare login unavailable) or when measuring drift without the
+ * proxy's rate-guard in the loop.
+ */
+const DIRECT_OPENROUTER = process.env.EVAL_DIRECT_OPENROUTER === "1";
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? "";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
 // ── Personas ─────────────────────────────────────────────────────────────────
 
 const PERSONAS: Record<string, AiPersona> = {
@@ -181,9 +192,23 @@ async function callModel(
 	}>,
 	tools: ReturnType<typeof availableTools>,
 ): Promise<ModelTurnResult> {
-	const resp = await fetch(`${BASE_URL}/v1/chat/completions`, {
+	const url = DIRECT_OPENROUTER
+		? OPENROUTER_URL
+		: `${BASE_URL}/v1/chat/completions`;
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (DIRECT_OPENROUTER) {
+		if (!OPENROUTER_API_KEY) {
+			throw new Error(
+				"EVAL_DIRECT_OPENROUTER=1 but OPENROUTER_API_KEY is not set in env",
+			);
+		}
+		headers.Authorization = `Bearer ${OPENROUTER_API_KEY}`;
+	}
+	const resp = await fetch(url, {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers,
 		body: JSON.stringify({
 			model: MODEL,
 			messages,

--- a/evals/free-text-drift/scoring.ts
+++ b/evals/free-text-drift/scoring.ts
@@ -1,0 +1,525 @@
+/**
+ * evals/free-text-drift/scoring.ts
+ *
+ * Pure-function scoring module for the free-text-drift eval harness.
+ * No I/O, no side effects, no module-level fetch.
+ *
+ * Background — issue #260: GLM-4.7 daemons increasingly stop emitting
+ * `message` tool calls as a phase progresses, sometimes lapsing into
+ * free-text prose that *looks like* an attempt to message or act but
+ * never reaches the engine. This module turns a captured turn log into
+ * numbers that make that drift visible.
+ *
+ * Exported surface:
+ *   - parseToolCallDetail(toolCall) → ToolCallDetail
+ *   - looksLikeFreeTextMessage(text) → boolean
+ *   - looksLikeFreeTextAction(text)  → boolean
+ *   - rollingSilenceRate(turns, windowSize) → WindowedRate[]
+ *   - messageRecipientCounts(turns) → Record<Recipient, number>
+ *   - summarizeRun(turns) → DriftRunSummary
+ */
+
+import type { RelativeDirection } from "../../src/spa/game/direction.js";
+import type { AiId, ToolName } from "../../src/spa/game/types.js";
+
+// ── Recorded shapes ──────────────────────────────────────────────────────────
+
+/**
+ * Raw tool call as captured from the model's response — name plus the JSON
+ * string the model emitted. Mirrors the wire shape used by the runner.
+ */
+export interface CapturedToolCall {
+	id: string;
+	name: string;
+	argumentsJson: string;
+}
+
+/**
+ * Per-turn snapshot. One TurnRecord per (round × aiId) pair captured by
+ * the runner. `assistantText` is the raw assistant content the model
+ * emitted *before* any tool-call extraction or production retry — the
+ * drift signal lives in the raw stream.
+ */
+export interface TurnRecord {
+	round: number;
+	aiId: AiId;
+	/** Raw assistant content from the LLM response (may be empty). */
+	assistantText: string;
+	/** Every tool call from this turn, in emission order. */
+	toolCalls: CapturedToolCall[];
+	/** Optional: who/what was injected into the daemon's context this turn. */
+	injectedFrom?: AiId | "blue" | null;
+}
+
+// ── Tool call detail parsing ─────────────────────────────────────────────────
+
+/**
+ * Structured view of one tool call — the per-tool detail fields the framework
+ * tracks. All fields are optional; only the ones present on the named tool
+ * will be populated. Returns `parseError` when the args JSON is malformed,
+ * but never throws.
+ */
+export interface ToolCallDetail {
+	name: string;
+	/** For go/look: the relative direction argument, if present. */
+	direction?: RelativeDirection;
+	/** For message: the recipient AiId or "blue". */
+	recipient?: AiId | "blue";
+	/** For message: the message body. */
+	content?: string;
+	/** For pick_up/put_down/use/examine: the item id. */
+	item?: string;
+	/** For give: the receiving AiId. */
+	to?: AiId;
+	/** True when JSON.parse failed on `argumentsJson`. */
+	parseError?: boolean;
+}
+
+const RELATIVE_DIRS = new Set<RelativeDirection>([
+	"forward",
+	"back",
+	"left",
+	"right",
+]);
+
+/**
+ * Lift a captured tool call into its tracked detail fields. Best-effort —
+ * fields that don't apply to the tool, or that are absent/malformed, are
+ * simply left undefined. Strips a leading `*` from AiId-shaped args
+ * (matches the dispatcher's parrot-tolerance in `parseToolCallArguments`).
+ */
+export function parseToolCallDetail(tc: CapturedToolCall): ToolCallDetail {
+	const detail: ToolCallDetail = { name: tc.name };
+	let args: Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(tc.argumentsJson);
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			Array.isArray(parsed)
+		) {
+			detail.parseError = true;
+			return detail;
+		}
+		args = parsed as Record<string, unknown>;
+	} catch {
+		detail.parseError = true;
+		return detail;
+	}
+
+	const stripStar = (s: string): string => (s.startsWith("*") ? s.slice(1) : s);
+
+	switch (tc.name) {
+		case "go":
+		case "look": {
+			const dir = typeof args.direction === "string" ? args.direction : "";
+			if (RELATIVE_DIRS.has(dir as RelativeDirection)) {
+				detail.direction = dir as RelativeDirection;
+			}
+			break;
+		}
+		case "message": {
+			if (typeof args.to === "string" && args.to.length > 0) {
+				const to = stripStar(args.to);
+				detail.recipient = to === "blue" ? "blue" : (to as AiId);
+			}
+			if (typeof args.content === "string") {
+				detail.content = args.content;
+			}
+			break;
+		}
+		case "give": {
+			if (typeof args.item === "string") detail.item = args.item;
+			if (typeof args.to === "string") detail.to = stripStar(args.to) as AiId;
+			break;
+		}
+		case "pick_up":
+		case "put_down":
+		case "use":
+		case "examine": {
+			if (typeof args.item === "string") detail.item = args.item;
+			break;
+		}
+		default:
+			break;
+	}
+	return detail;
+}
+
+// ── Free-text leak heuristics ────────────────────────────────────────────────
+
+/**
+ * Patterns suggesting the daemon *prose-described* sending a message instead
+ * of emitting a `message` tool call. Case-insensitive, regex-only — best-effort
+ * heuristics, false negatives acceptable.
+ *
+ * The first family catches first-person speech acts ("I tell *xxxx that…",
+ * "I'll whisper to blue…"). The second catches direct-address openings that
+ * read as dialogue ("*xxxx:" or "blue,") without a wrapping tool call.
+ */
+const FREE_TEXT_SPEECH_VERB_RE =
+	/\bI(?:'ll| will| am| 'm)?\s*(?:tell|say|reply|respond|whisper|message|ask|answer|shout|call|warn|inform)\s+(?:to\s+)?(?:\*?[a-z0-9]+|blue)\b/i;
+const FREE_TEXT_QUOTED_DIALOG_RE = /"[^"\n]{4,}"/;
+const FREE_TEXT_ADDRESS_RE = /(?:^|\s)(?:\*[a-z0-9]{2,8}|blue)\s*[:,]\s+\S/i;
+
+/**
+ * Return true when the assistant text reads like an attempt to send a message
+ * via prose rather than via the `message` tool. Used in tandem with "no
+ * `message` tool call this turn" to flag drift.
+ */
+export function looksLikeFreeTextMessage(text: string): boolean {
+	if (text.length === 0) return false;
+	if (FREE_TEXT_SPEECH_VERB_RE.test(text)) return true;
+	if (FREE_TEXT_QUOTED_DIALOG_RE.test(text)) return true;
+	if (FREE_TEXT_ADDRESS_RE.test(text)) return true;
+	return false;
+}
+
+/**
+ * Patterns suggesting the daemon *prose-described* a physical action instead
+ * of emitting a tool call ("I move forward.", "I pick up the lantern.").
+ * Same caveats as `looksLikeFreeTextMessage` — best-effort, regex-only.
+ */
+const FREE_TEXT_ACTION_RE =
+	/\bI(?:'ll| will| am| 'm)?\s*(?:go|move|step|walk|head|turn|look|pick\s*up|put\s*down|drop|give|hand|use|activate|examine|inspect|study)\b/i;
+
+/**
+ * Return true when the assistant text reads like an attempt to take a physical
+ * action via prose rather than via a movement/manipulation tool call. Used
+ * in tandem with "no non-message tool call this turn" to flag drift.
+ */
+export function looksLikeFreeTextAction(text: string): boolean {
+	if (text.length === 0) return false;
+	return FREE_TEXT_ACTION_RE.test(text);
+}
+
+// ── Per-recipient bucketing ──────────────────────────────────────────────────
+
+/**
+ * Bucket `message` tool calls across the run by recipient. The "unknown"
+ * bucket catches recipient strings that aren't `blue` and aren't a key
+ * in `knownAiIds` — useful for spotting daemons inventing handles.
+ */
+export function messageRecipientCounts(
+	turns: TurnRecord[],
+	knownAiIds: AiId[],
+): Record<string, number> {
+	const knownSet = new Set<string>(knownAiIds);
+	const counts: Record<string, number> = {};
+	for (const turn of turns) {
+		for (const tc of turn.toolCalls) {
+			if (tc.name !== "message") continue;
+			const detail = parseToolCallDetail(tc);
+			if (!detail.recipient) {
+				counts.malformed = (counts.malformed ?? 0) + 1;
+				continue;
+			}
+			const r = detail.recipient;
+			const bucket = r === "blue" || knownSet.has(r) ? r : "unknown";
+			counts[bucket] = (counts[bucket] ?? 0) + 1;
+		}
+	}
+	return counts;
+}
+
+// ── Rolling silence-rate window ──────────────────────────────────────────────
+
+export interface WindowedRate {
+	/** Inclusive start round of the window (1-indexed within the run). */
+	startRound: number;
+	/** Inclusive end round of the window. */
+	endRound: number;
+	/** Fraction of turns in this window with zero tool calls. */
+	silenceRate: number;
+	/** Fraction of turns with zero `message` tool calls. */
+	messageSilenceRate: number;
+	/** Turn count in this window. */
+	n: number;
+}
+
+/**
+ * Slice `turns` into contiguous windows of `windowSize` rounds and compute
+ * per-window silence rates. The trailing window may be smaller. Empty when
+ * `turns` is empty or `windowSize <= 0`.
+ *
+ * `silenceRate` is the fraction of turns producing zero tool calls (the
+ * canonical drift symptom). `messageSilenceRate` is the fraction with zero
+ * `message` calls specifically — the subtype #260 is about, since GLM
+ * keeps emitting `go` calls long after it stops talking.
+ */
+export function rollingSilenceRate(
+	turns: TurnRecord[],
+	windowSize: number,
+): WindowedRate[] {
+	if (turns.length === 0 || windowSize <= 0) return [];
+
+	// Round-bucket: derive the run's min/max round and walk windows of size
+	// `windowSize` across the round axis. Within a window, average over all
+	// captured turns (not over rounds × daemons separately — one row per turn).
+	const minRound = Math.min(...turns.map((t) => t.round));
+	const maxRound = Math.max(...turns.map((t) => t.round));
+	const out: WindowedRate[] = [];
+	for (let start = minRound; start <= maxRound; start += windowSize) {
+		const end = Math.min(start + windowSize - 1, maxRound);
+		const inWindow = turns.filter((t) => t.round >= start && t.round <= end);
+		if (inWindow.length === 0) continue;
+		const silent = inWindow.filter((t) => t.toolCalls.length === 0).length;
+		const msgSilent = inWindow.filter(
+			(t) => !t.toolCalls.some((tc) => tc.name === "message"),
+		).length;
+		out.push({
+			startRound: start,
+			endRound: end,
+			silenceRate: silent / inWindow.length,
+			messageSilenceRate: msgSilent / inWindow.length,
+			n: inWindow.length,
+		});
+	}
+	return out;
+}
+
+// ── Run summary ──────────────────────────────────────────────────────────────
+
+export interface DriftRunSummary {
+	totalTurns: number;
+	silenceRate: number;
+	messageSilenceRate: number;
+	freeTextMessageLeakCount: number;
+	freeTextActionLeakCount: number;
+	toolCallCountsByName: Partial<Record<ToolName | string, number>>;
+	recipientCounts: Record<string, number>;
+	windows: WindowedRate[];
+}
+
+// ── Per-round time series (graphable) ────────────────────────────────────────
+
+/**
+ * Per-round time series shaped for direct plotting. Every field is an array
+ * aligned by index with `rounds`, so a chart library can take any pair
+ * (`rounds`, `<series>`) and render it without further wrangling.
+ *
+ * For per-tool / per-parameter breakouts (`toolCallCountsByName`,
+ * `recipientCounts`, `directionCounts`), each key maps to its own
+ * per-round series — letting you plot one line per tool, one line per
+ * recipient, etc., and see *which* signal is drifting (e.g. message-to-blue
+ * tapering while go-forward stays steady).
+ */
+export interface DriftRunSeries {
+	/** Round numbers in capture order. */
+	rounds: number[];
+	/** 1 when the turn emitted zero tool calls (silent), else 0. */
+	silence: number[];
+	/** 1 when the turn emitted a `message` tool call, else 0. */
+	hasMessage: number[];
+	/** 1 when the turn emitted any tool call, else 0. */
+	hasAnyTool: number[];
+	/** 1 when prose looked like a message AND no message tool was emitted. */
+	freeTextMessageLeak: number[];
+	/** 1 when prose looked like an action AND no non-message tool was emitted. */
+	freeTextActionLeak: number[];
+	/** Raw assistant content length per turn (proxy for verbosity drift). */
+	assistantTextLength: number[];
+	/** Per-tool-name per-round count series. One key per tool seen in the run. */
+	toolCallCountsByName: Record<string, number[]>;
+	/**
+	 * Per-recipient per-round count series for `message` calls. Bucket keys:
+	 * "blue", each known AiId, "unknown" (recipient not in knownAiIds and not
+	 * "blue"), and "malformed" (recipient missing/unparseable).
+	 */
+	recipientCounts: Record<string, number[]>;
+	/** Per-relative-direction per-round count series for go/look calls. */
+	directionCounts: Record<string, number[]>;
+}
+
+/**
+ * Build a per-round per-metric time series from a captured turn log. Designed
+ * for graph rendering: every series is the same length as `rounds`, so
+ * downstream code can plot `rounds` on the x-axis against any value series
+ * on the y-axis without reshaping.
+ *
+ * Multiple turns sharing a round (e.g. multi-daemon harnesses) are summed
+ * within the round bucket — the series is rounds × metric, not turns × metric.
+ */
+/**
+ * Increment counts[key][idx] by 1, treating an absent slot as zero. Wrapper
+ * around `noUncheckedIndexedAccess` so the per-tool / per-recipient /
+ * per-direction breakouts read cleanly above.
+ */
+function bump(
+	counts: Record<string, number[]>,
+	key: string,
+	idx: number,
+): void {
+	const arr = counts[key];
+	if (!arr) return;
+	arr[idx] = (arr[idx] ?? 0) + 1;
+}
+
+export function buildPerRoundSeries(
+	turns: TurnRecord[],
+	knownAiIds: AiId[],
+): DriftRunSeries {
+	const knownSet = new Set<string>(knownAiIds);
+
+	// Discover all keys that appear anywhere in the run so the series have
+	// stable shapes (zero-fill rounds where a particular tool/recipient
+	// didn't fire).
+	const allToolNames = new Set<string>();
+	const allRecipients = new Set<string>(["blue"]);
+	for (const ai of knownAiIds) allRecipients.add(ai);
+	const allDirections = new Set<string>(["forward", "back", "left", "right"]);
+	for (const turn of turns) {
+		for (const tc of turn.toolCalls) {
+			allToolNames.add(tc.name);
+			if (tc.name === "message") {
+				const detail = parseToolCallDetail(tc);
+				if (!detail.recipient) {
+					allRecipients.add("malformed");
+				} else if (
+					detail.recipient === "blue" ||
+					knownSet.has(detail.recipient)
+				) {
+					allRecipients.add(detail.recipient);
+				} else {
+					allRecipients.add("unknown");
+				}
+			}
+		}
+	}
+
+	// Group turns by round (ascending) so the series x-axis is monotonic.
+	const byRound = new Map<number, TurnRecord[]>();
+	for (const turn of turns) {
+		const arr = byRound.get(turn.round) ?? [];
+		arr.push(turn);
+		byRound.set(turn.round, arr);
+	}
+	const rounds = [...byRound.keys()].sort((a, b) => a - b);
+
+	const zero = (): number[] => rounds.map(() => 0);
+	const toolCallCountsByName: Record<string, number[]> = {};
+	for (const name of allToolNames) toolCallCountsByName[name] = zero();
+	const recipientCounts: Record<string, number[]> = {};
+	for (const r of allRecipients) recipientCounts[r] = zero();
+	const directionCounts: Record<string, number[]> = {};
+	for (const d of allDirections) directionCounts[d] = zero();
+
+	const series: DriftRunSeries = {
+		rounds,
+		silence: zero(),
+		hasMessage: zero(),
+		hasAnyTool: zero(),
+		freeTextMessageLeak: zero(),
+		freeTextActionLeak: zero(),
+		assistantTextLength: zero(),
+		toolCallCountsByName,
+		recipientCounts,
+		directionCounts,
+	};
+
+	rounds.forEach((round, idx) => {
+		// biome-ignore lint/style/noNonNullAssertion: by construction
+		const turnsThisRound = byRound.get(round)!;
+		let anyMessage = false;
+		let anyTool = false;
+		let leakMsg = false;
+		let leakAct = false;
+		let textLen = 0;
+		for (const turn of turnsThisRound) {
+			textLen += turn.assistantText.length;
+			const names = turn.toolCalls.map((tc) => tc.name);
+			if (names.length > 0) anyTool = true;
+			if (names.includes("message")) anyMessage = true;
+			if (
+				!names.includes("message") &&
+				looksLikeFreeTextMessage(turn.assistantText)
+			) {
+				leakMsg = true;
+			}
+			if (
+				!names.some((n) => n !== "message") &&
+				looksLikeFreeTextAction(turn.assistantText)
+			) {
+				leakAct = true;
+			}
+			for (const tc of turn.toolCalls) {
+				bump(toolCallCountsByName, tc.name, idx);
+				const detail = parseToolCallDetail(tc);
+				if (tc.name === "message") {
+					const bucket = !detail.recipient
+						? "malformed"
+						: detail.recipient === "blue" || knownSet.has(detail.recipient)
+							? detail.recipient
+							: "unknown";
+					bump(recipientCounts, bucket, idx);
+				}
+				if ((tc.name === "go" || tc.name === "look") && detail.direction) {
+					bump(directionCounts, detail.direction, idx);
+				}
+			}
+		}
+		series.silence[idx] = anyTool ? 0 : 1;
+		series.hasMessage[idx] = anyMessage ? 1 : 0;
+		series.hasAnyTool[idx] = anyTool ? 1 : 0;
+		series.freeTextMessageLeak[idx] = leakMsg ? 1 : 0;
+		series.freeTextActionLeak[idx] = leakAct ? 1 : 0;
+		series.assistantTextLength[idx] = textLen;
+	});
+
+	return series;
+}
+
+/**
+ * Aggregate a full run into a single summary. `windowSize` controls the
+ * rolling window granularity; 5 is a reasonable default for the 30-turn
+ * playtest the issue targets.
+ *
+ * `freeText*LeakCount` only counts turns where the leak heuristic fires
+ * AND the corresponding tool was not emitted — i.e. the daemon's prose
+ * read like an action that never reached the engine.
+ */
+export function summarizeRun(
+	turns: TurnRecord[],
+	knownAiIds: AiId[],
+	windowSize = 5,
+): DriftRunSummary {
+	const toolCallCountsByName: Record<string, number> = {};
+	let freeTextMessageLeakCount = 0;
+	let freeTextActionLeakCount = 0;
+
+	for (const turn of turns) {
+		const names = turn.toolCalls.map((tc) => tc.name);
+		for (const n of names) {
+			toolCallCountsByName[n] = (toolCallCountsByName[n] ?? 0) + 1;
+		}
+		const hasMessage = names.includes("message");
+		const hasOtherTool = names.some((n) => n !== "message");
+		if (!hasMessage && looksLikeFreeTextMessage(turn.assistantText)) {
+			freeTextMessageLeakCount += 1;
+		}
+		if (!hasOtherTool && looksLikeFreeTextAction(turn.assistantText)) {
+			freeTextActionLeakCount += 1;
+		}
+	}
+
+	const silenceRate =
+		turns.length === 0
+			? 0
+			: turns.filter((t) => t.toolCalls.length === 0).length / turns.length;
+	const messageSilenceRate =
+		turns.length === 0
+			? 0
+			: turns.filter((t) => !t.toolCalls.some((tc) => tc.name === "message"))
+					.length / turns.length;
+
+	return {
+		totalTurns: turns.length,
+		silenceRate,
+		messageSilenceRate,
+		freeTextMessageLeakCount,
+		freeTextActionLeakCount,
+		toolCallCountsByName,
+		recipientCounts: messageRecipientCounts(turns, knownAiIds),
+		windows: rollingSilenceRate(turns, windowSize),
+	};
+}

--- a/src/spa/game/__tests__/drift-scoring.test.ts
+++ b/src/spa/game/__tests__/drift-scoring.test.ts
@@ -1,0 +1,464 @@
+/**
+ * drift-scoring.test.ts
+ *
+ * CI unit tests for the free-text-drift eval scoring module. Same pattern
+ * as eval-scoring.test.ts (relative-directions): import the pure helpers
+ * from the eval package and guard the regex / aggregation logic so it
+ * cannot silently rot.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { TurnRecord } from "../../../../evals/free-text-drift/scoring.js";
+import {
+	buildPerRoundSeries,
+	looksLikeFreeTextAction,
+	looksLikeFreeTextMessage,
+	messageRecipientCounts,
+	parseToolCallDetail,
+	rollingSilenceRate,
+	summarizeRun,
+} from "../../../../evals/free-text-drift/scoring.js";
+
+// ── parseToolCallDetail ──────────────────────────────────────────────────────
+
+describe("parseToolCallDetail", () => {
+	it("extracts direction from a go tool call", () => {
+		const detail = parseToolCallDetail({
+			id: "c1",
+			name: "go",
+			argumentsJson: '{"direction":"forward"}',
+		});
+		expect(detail.direction).toBe("forward");
+		expect(detail.parseError).toBeUndefined();
+	});
+
+	it("extracts direction from a look tool call", () => {
+		const detail = parseToolCallDetail({
+			id: "c2",
+			name: "look",
+			argumentsJson: '{"direction":"left"}',
+		});
+		expect(detail.direction).toBe("left");
+	});
+
+	it("leaves direction undefined when the arg is not a relative direction", () => {
+		const detail = parseToolCallDetail({
+			id: "c3",
+			name: "go",
+			argumentsJson: '{"direction":"north"}',
+		});
+		expect(detail.direction).toBeUndefined();
+	});
+
+	it("extracts recipient and content from a message tool call", () => {
+		const detail = parseToolCallDetail({
+			id: "c4",
+			name: "message",
+			argumentsJson: '{"to":"blue","content":"hi"}',
+		});
+		expect(detail.recipient).toBe("blue");
+		expect(detail.content).toBe("hi");
+	});
+
+	it("strips a leading * from recipient AiIds", () => {
+		const detail = parseToolCallDetail({
+			id: "c5",
+			name: "message",
+			argumentsJson: '{"to":"*3kw7","content":"yo"}',
+		});
+		expect(detail.recipient).toBe("3kw7");
+	});
+
+	it("extracts item from pick_up / use / examine", () => {
+		for (const name of ["pick_up", "put_down", "use", "examine"] as const) {
+			const detail = parseToolCallDetail({
+				id: `c-${name}`,
+				name,
+				argumentsJson: '{"item":"lantern"}',
+			});
+			expect(detail.item).toBe("lantern");
+		}
+	});
+
+	it("extracts item and target from give", () => {
+		const detail = parseToolCallDetail({
+			id: "c6",
+			name: "give",
+			argumentsJson: '{"item":"key","to":"*3kw7"}',
+		});
+		expect(detail.item).toBe("key");
+		expect(detail.to).toBe("3kw7");
+	});
+
+	it("flags malformed JSON without throwing", () => {
+		const detail = parseToolCallDetail({
+			id: "c7",
+			name: "go",
+			argumentsJson: "{not json",
+		});
+		expect(detail.parseError).toBe(true);
+	});
+
+	it("flags non-object JSON without throwing", () => {
+		const detail = parseToolCallDetail({
+			id: "c8",
+			name: "go",
+			argumentsJson: '"forward"',
+		});
+		expect(detail.parseError).toBe(true);
+	});
+});
+
+// ── Free-text leak heuristics ────────────────────────────────────────────────
+
+describe("looksLikeFreeTextMessage", () => {
+	it("flags first-person speech verbs to a peer", () => {
+		expect(looksLikeFreeTextMessage("I tell *3kw7 about the door.")).toBe(true);
+		expect(looksLikeFreeTextMessage("I'll whisper to blue.")).toBe(true);
+		expect(looksLikeFreeTextMessage("I ask blue what they want.")).toBe(true);
+	});
+
+	it("flags quoted dialogue", () => {
+		expect(
+			looksLikeFreeTextMessage('She turned and said "I see the door."'),
+		).toBe(true);
+	});
+
+	it("flags direct-address openings", () => {
+		expect(looksLikeFreeTextMessage("blue, I need help here.")).toBe(true);
+		expect(looksLikeFreeTextMessage("*3kw7: hold on a moment.")).toBe(true);
+	});
+
+	it("does not flag plain narration without speech cues", () => {
+		expect(looksLikeFreeTextMessage("The room is dim and cold.")).toBe(false);
+		expect(looksLikeFreeTextMessage("I move forward toward the door.")).toBe(
+			false,
+		);
+		expect(looksLikeFreeTextMessage("")).toBe(false);
+	});
+});
+
+describe("looksLikeFreeTextAction", () => {
+	it("flags first-person action verbs", () => {
+		expect(looksLikeFreeTextAction("I move forward.")).toBe(true);
+		expect(looksLikeFreeTextAction("I'll pick up the lantern.")).toBe(true);
+		expect(looksLikeFreeTextAction("I examine the panel.")).toBe(true);
+		expect(looksLikeFreeTextAction("I turn left and walk.")).toBe(true);
+	});
+
+	it("does not flag declarative non-action prose", () => {
+		expect(looksLikeFreeTextAction("The lantern flickers.")).toBe(false);
+		expect(looksLikeFreeTextAction("I am puzzled by this.")).toBe(false);
+		expect(looksLikeFreeTextAction("")).toBe(false);
+	});
+});
+
+// ── Per-recipient bucketing ──────────────────────────────────────────────────
+
+describe("messageRecipientCounts", () => {
+	const baseTurn = (
+		round: number,
+		toolCalls: TurnRecord["toolCalls"],
+	): TurnRecord => ({
+		round,
+		aiId: "red",
+		assistantText: "",
+		toolCalls,
+	});
+
+	it("counts known recipients, blue, and unknowns separately", () => {
+		const turns: TurnRecord[] = [
+			baseTurn(1, [
+				{
+					id: "a",
+					name: "message",
+					argumentsJson: '{"to":"blue","content":"hi"}',
+				},
+			]),
+			baseTurn(2, [
+				{
+					id: "b",
+					name: "message",
+					argumentsJson: '{"to":"sim1","content":"y"}',
+				},
+			]),
+			baseTurn(3, [
+				{
+					id: "c",
+					name: "message",
+					argumentsJson: '{"to":"ghost","content":"?"}',
+				},
+			]),
+		];
+		const counts = messageRecipientCounts(turns, ["red", "sim1", "sim2"]);
+		expect(counts.blue).toBe(1);
+		expect(counts.sim1).toBe(1);
+		expect(counts.unknown).toBe(1);
+	});
+
+	it("counts malformed message args under the 'malformed' bucket", () => {
+		const turns: TurnRecord[] = [
+			baseTurn(1, [{ id: "x", name: "message", argumentsJson: "{not json" }]),
+		];
+		const counts = messageRecipientCounts(turns, ["red"]);
+		expect(counts.malformed).toBe(1);
+	});
+
+	it("ignores non-message tool calls", () => {
+		const turns: TurnRecord[] = [
+			baseTurn(1, [
+				{ id: "g", name: "go", argumentsJson: '{"direction":"forward"}' },
+			]),
+		];
+		const counts = messageRecipientCounts(turns, ["red"]);
+		expect(Object.keys(counts).length).toBe(0);
+	});
+});
+
+// ── Rolling silence-rate window ──────────────────────────────────────────────
+
+describe("rollingSilenceRate", () => {
+	it("returns one row per window with correct rates", () => {
+		const turns: TurnRecord[] = [
+			// window 1: rounds 1-3 — 2 silent, 1 messaging
+			{ round: 1, aiId: "red", assistantText: "", toolCalls: [] },
+			{ round: 2, aiId: "red", assistantText: "", toolCalls: [] },
+			{
+				round: 3,
+				aiId: "red",
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "x",
+						name: "message",
+						argumentsJson: '{"to":"blue","content":"hi"}',
+					},
+				],
+			},
+			// window 2: rounds 4-5 — both messaging
+			{
+				round: 4,
+				aiId: "red",
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "y",
+						name: "message",
+						argumentsJson: '{"to":"blue","content":"hi"}',
+					},
+				],
+			},
+			{
+				round: 5,
+				aiId: "red",
+				assistantText: "",
+				toolCalls: [
+					{
+						id: "z",
+						name: "message",
+						argumentsJson: '{"to":"blue","content":"hi"}',
+					},
+				],
+			},
+		];
+		const windows = rollingSilenceRate(turns, 3);
+		expect(windows.length).toBe(2);
+		// biome-ignore lint/style/noNonNullAssertion: bounded by length check above
+		expect(windows[0]!.silenceRate).toBeCloseTo(2 / 3);
+		// biome-ignore lint/style/noNonNullAssertion: bounded by length check above
+		expect(windows[1]!.silenceRate).toBe(0);
+		// biome-ignore lint/style/noNonNullAssertion: bounded by length check above
+		expect(windows[1]!.messageSilenceRate).toBe(0);
+	});
+
+	it("distinguishes silenceRate (no tool) from messageSilenceRate (no message)", () => {
+		const turns: TurnRecord[] = [
+			{
+				round: 1,
+				aiId: "red",
+				assistantText: "",
+				toolCalls: [
+					{ id: "g", name: "go", argumentsJson: '{"direction":"forward"}' },
+				],
+			},
+		];
+		const windows = rollingSilenceRate(turns, 5);
+		// biome-ignore lint/style/noNonNullAssertion: bounded by length check above
+		expect(windows[0]!.silenceRate).toBe(0);
+		// biome-ignore lint/style/noNonNullAssertion: bounded by length check above
+		expect(windows[0]!.messageSilenceRate).toBe(1);
+	});
+
+	it("returns [] for empty input or non-positive window size", () => {
+		expect(rollingSilenceRate([], 3)).toEqual([]);
+		expect(
+			rollingSilenceRate(
+				[{ round: 1, aiId: "red", assistantText: "", toolCalls: [] }],
+				0,
+			),
+		).toEqual([]);
+	});
+});
+
+// ── summarizeRun ─────────────────────────────────────────────────────────────
+
+describe("summarizeRun", () => {
+	it("aggregates totals, leak counts, and tool-name counts", () => {
+		const turns: TurnRecord[] = [
+			// silent + free-text-message leak
+			{
+				round: 1,
+				aiId: "red",
+				assistantText: "I tell blue I see a door.",
+				toolCalls: [],
+			},
+			// silent + free-text-action leak
+			{
+				round: 2,
+				aiId: "red",
+				assistantText: "I move forward through the gap.",
+				toolCalls: [],
+			},
+			// proper message — no leak (even if text would otherwise look like one)
+			{
+				round: 3,
+				aiId: "red",
+				assistantText: "I tell blue I'm OK.",
+				toolCalls: [
+					{
+						id: "a",
+						name: "message",
+						argumentsJson: '{"to":"blue","content":"OK"}',
+					},
+				],
+			},
+			// proper go — no action leak (movement reached the engine)
+			{
+				round: 4,
+				aiId: "red",
+				assistantText: "I move forward.",
+				toolCalls: [
+					{ id: "g", name: "go", argumentsJson: '{"direction":"forward"}' },
+				],
+			},
+		];
+		const summary = summarizeRun(turns, ["red", "sim1"], 2);
+
+		expect(summary.totalTurns).toBe(4);
+		expect(summary.silenceRate).toBe(0.5);
+		expect(summary.messageSilenceRate).toBe(0.75);
+		expect(summary.freeTextMessageLeakCount).toBe(1);
+		expect(summary.freeTextActionLeakCount).toBe(1);
+		expect(summary.toolCallCountsByName.message).toBe(1);
+		expect(summary.toolCallCountsByName.go).toBe(1);
+		expect(summary.recipientCounts.blue).toBe(1);
+		expect(summary.windows.length).toBe(2);
+	});
+
+	it("handles an empty turn list without dividing by zero", () => {
+		const summary = summarizeRun([], ["red"], 5);
+		expect(summary.totalTurns).toBe(0);
+		expect(summary.silenceRate).toBe(0);
+		expect(summary.messageSilenceRate).toBe(0);
+		expect(summary.windows).toEqual([]);
+	});
+});
+
+// ── buildPerRoundSeries (graphable output) ───────────────────────────────────
+
+describe("buildPerRoundSeries", () => {
+	const turns: TurnRecord[] = [
+		// round 1: go forward (no message)
+		{
+			round: 1,
+			aiId: "red",
+			assistantText: "moving up",
+			toolCalls: [
+				{ id: "g1", name: "go", argumentsJson: '{"direction":"forward"}' },
+			],
+		},
+		// round 2: message blue + look right
+		{
+			round: 2,
+			aiId: "red",
+			assistantText: "hey",
+			toolCalls: [
+				{
+					id: "m1",
+					name: "message",
+					argumentsJson: '{"to":"blue","content":"hi"}',
+				},
+				{ id: "l1", name: "look", argumentsJson: '{"direction":"right"}' },
+			],
+		},
+		// round 3: silent + free-text-message leak
+		{
+			round: 3,
+			aiId: "red",
+			assistantText: "I tell blue what I saw.",
+			toolCalls: [],
+		},
+		// round 4: message to unknown handle
+		{
+			round: 4,
+			aiId: "red",
+			assistantText: "",
+			toolCalls: [
+				{
+					id: "m2",
+					name: "message",
+					argumentsJson: '{"to":"ghost","content":"hi"}',
+				},
+			],
+		},
+	];
+
+	it("returns one entry per round with arrays aligned to rounds", () => {
+		const s = buildPerRoundSeries(turns, ["red", "sim1", "sim2"]);
+		expect(s.rounds).toEqual([1, 2, 3, 4]);
+		expect(s.silence).toEqual([0, 0, 1, 0]);
+		expect(s.hasMessage).toEqual([0, 1, 0, 1]);
+		expect(s.hasAnyTool).toEqual([1, 1, 0, 1]);
+		expect(s.freeTextMessageLeak).toEqual([0, 0, 1, 0]);
+	});
+
+	it("breaks out per-tool counts as separate series", () => {
+		const s = buildPerRoundSeries(turns, ["red", "sim1", "sim2"]);
+		expect(s.toolCallCountsByName.go).toEqual([1, 0, 0, 0]);
+		expect(s.toolCallCountsByName.look).toEqual([0, 1, 0, 0]);
+		expect(s.toolCallCountsByName.message).toEqual([0, 1, 0, 1]);
+	});
+
+	it("breaks out per-recipient counts as separate series (incl. unknown bucket)", () => {
+		const s = buildPerRoundSeries(turns, ["red", "sim1", "sim2"]);
+		expect(s.recipientCounts.blue).toEqual([0, 1, 0, 0]);
+		expect(s.recipientCounts.unknown).toEqual([0, 0, 0, 1]);
+		// known peers are still in the series (zero-filled) so the chart legend
+		// is stable across runs even when they're never addressed.
+		expect(s.recipientCounts.sim1).toEqual([0, 0, 0, 0]);
+	});
+
+	it("breaks out per-direction counts as separate series", () => {
+		const s = buildPerRoundSeries(turns, ["red"]);
+		expect(s.directionCounts.forward).toEqual([1, 0, 0, 0]);
+		expect(s.directionCounts.right).toEqual([0, 1, 0, 0]);
+		expect(s.directionCounts.left).toEqual([0, 0, 0, 0]);
+	});
+
+	it("captures assistant text length per round (verbosity proxy)", () => {
+		const s = buildPerRoundSeries(turns, ["red"]);
+		expect(s.assistantTextLength).toEqual([
+			"moving up".length,
+			"hey".length,
+			"I tell blue what I saw.".length,
+			0,
+		]);
+	});
+
+	it("returns empty series for empty input", () => {
+		const s = buildPerRoundSeries([], ["red"]);
+		expect(s.rounds).toEqual([]);
+		expect(s.silence).toEqual([]);
+		expect(s.hasMessage).toEqual([]);
+	});
+});


### PR DESCRIPTION
Single-daemon harness driven against the live proxy (z-ai/glm-4.7 by
default) with simulated incoming messages each round from blue and inert
peer personas. Captures per-turn tool calls with parsed details
(direction, recipient, item, etc.) and detects free-text leaks where
prose reads like a tool the daemon failed to emit. Emits both a
markdown report and a JSON sidecar of per-round per-metric time series
so each metric (per-tool, per-recipient, per-direction, free-text leaks)
is directly plottable.

Pure scoring module is covered by drift-scoring.test.ts so the regex
and aggregation logic cannot silently rot. Hook the runner via
`pnpm eval:drift` (already wired in package.json).