### PR TITLE
Playtest skill: track state-driven view, surface bootstrap recovery

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -74,7 +74,7 @@ scripts/playtest/start.sh
 ```
 
 This builds the SPA, launches `wrangler dev` and a headless Chromium playtest
-driver in the background, and waits until the game route is ready. When it
+driver in the background, and waits until the game view is ready. When it
 prints `READY` on stdout, the playtest is live and you can start sending
 commands. The boot can take 2–5 minutes; persona synthesis and the two
 content packs (A + B, batched in one LLM call) are the slow part — the
@@ -82,7 +82,15 @@ daemon will not announce `READY` until the composer is actually enabled, so
 your first `send` will land on a real game instead of a still-loading screen.
 
 If `start.sh` fails, fix the underlying issue rather than retrying blindly. It
-prints a `FAILED: <reason>` line plus the relevant log to stderr.
+prints a `FAILED: <reason>` line plus the relevant log to stderr. Two common
+failure modes worth knowing:
+
+- **Bootstrap recovery UI** — world generation timed out (the SPA's 120 s
+  bootstrap limit) or produced a malformed pack. The daemon detects the
+  `#bootstrap-recovery` section and exits non-zero rather than waiting out
+  its 5-minute stable-state poll; re-run `start.sh` to try again.
+- **Cap hit at startup** — an API budget cap fired before generation
+  finished. Same fail-fast behaviour.
 
 ---
 
@@ -123,6 +131,11 @@ scripts/playtest/cmd.sh '{"op":"snap","path":"/tmp/playtest-turn-7.png"}'
 
 A `snapshot` is an object with these fields:
 
+- `view` — which top-level view the SPA is rendering: `"game"` in the normal
+  case, `"start"` or `"sessions"` if something kicked you out of the game
+  (e.g. the active session was discarded as broken or version-mismatched).
+  The SPA is state-driven, not URL-routed (ADR 0011) — `data-view="game"` on
+  `<main>` is the load-bearing signal that you're in the game.
 - `topinfoLeft`, `topinfoRight` — the top status bar. One of these contains a
   4-hex token like `0x478F`. **That token is your session id.** Record it
   before your second command.
@@ -136,6 +149,11 @@ A `snapshot` is an object with these fields:
   key is configured) `[ continue ]` — but you can't click them from the
   command surface; finishing the game is the goal, not picking a follow-up.
 - `capHit` — non-empty when an API budget cap has been hit.
+- `recovery` — non-empty when the bootstrap-recovery UI has surfaced (world
+  generation failed or timed out). The regenerate / abandon buttons are not
+  reachable from `cmd.sh`, so if this appears mid-playtest the run is stuck
+  — record the text and shut down. (At startup this is caught earlier:
+  `start.sh` exits with `FAILED:` rather than printing `READY`.)
 - `panels` — array of three objects, each `{ name, budget, transcript }`. The
   `name` is the `*xxxx` handle of that daemon. The `budget` is that daemon's
   remaining dollars for the *whole game* (no per-phase reset). The

--- a/scripts/playtest/daemon.mjs
+++ b/scripts/playtest/daemon.mjs
@@ -104,7 +104,12 @@ while (Date.now() - start < 90_000) {
 log("filling password and clicking CONNECT");
 await page.locator("#password").fill("password");
 await page.locator("#begin").click();
-await page.waitForURL(/#\/game/, { timeout: 30_000 });
+// The SPA no longer uses hash-based routing (ADR 0011). Clicking CONNECT
+// calls renderApp(), which sets `data-view="game"` on the <main> root —
+// that is the load-bearing signal that we've left the start screen.
+await page
+	.locator('main[data-view="game"]')
+	.waitFor({ state: "attached", timeout: 30_000 });
 await page.locator("#composer").waitFor({ state: "visible", timeout: 30_000 });
 
 // The composer is visible during the "loading-daemons" and "generating-room"
@@ -113,6 +118,10 @@ await page.locator("#composer").waitFor({ state: "visible", timeout: 30_000 });
 // enabled, no `data-load-state` on #stage) before announcing READY —
 // otherwise the first `send` would type into a disabled input and the
 // playtest would hang silently.
+//
+// Also watch for #bootstrap-recovery and #cap-hit: if either becomes visible,
+// the run is unrecoverable from this command surface (we can't click the
+// regen / retry buttons through cmd.sh) so we fail fast for start.sh.
 log("waiting for game route to reach stable state (content packs loading)...");
 const stableDeadline = Date.now() + 300_000; // up to 5 min for slow packs
 while (Date.now() < stableDeadline) {
@@ -121,6 +130,31 @@ while (Date.now() < stableDeadline) {
 		.locator("#stage")
 		.getAttribute("data-load-state");
 	if (promptDisabled === null && loadState === null) break;
+
+	const recoveryVisible = await page
+		.locator("#bootstrap-recovery")
+		.isVisible()
+		.catch(() => false);
+	if (recoveryVisible) {
+		const body = await page
+			.locator("#bootstrap-recovery-title, #bootstrap-recovery-body")
+			.allInnerTexts()
+			.catch(() => []);
+		log(`bootstrap recovery UI surfaced: ${body.join(" — ")}`);
+		log("FATAL: bootstrap failed; restart the daemon to try again");
+		await browser.close();
+		process.exit(1);
+	}
+	const capHitVisible = await page
+		.locator("#cap-hit")
+		.isVisible()
+		.catch(() => false);
+	if (capHitVisible) {
+		log("FATAL: API budget cap was hit before the room finished generating");
+		await browser.close();
+		process.exit(1);
+	}
+
 	await page.waitForTimeout(500);
 }
 const finalPromptDisabled = await page
@@ -162,6 +196,15 @@ async function readVisibleText(loc) {
 }
 
 async function snapshot() {
+	// Which top-level view the state-driven renderer (ADR 0011) is showing:
+	// "start" | "game" | "sessions". During a normal playtest this is always
+	// "game"; "start" or "sessions" here means something kicked us out (e.g.
+	// the active session was discarded as broken or version-mismatched).
+	const view =
+		(await page
+			.locator("main")
+			.getAttribute("data-view")
+			.catch(() => null)) ?? "";
 	// #phase-banner is legacy UI from the retired three-phase model. In the
 	// current single-game build it stays hidden, so `phase` is normally "".
 	// Kept in the snapshot shape for backward compat with older playtest logs.
@@ -186,6 +229,16 @@ async function snapshot() {
 	const capHit = capHitVisible
 		? await readVisibleText(page.locator("#cap-hit"))
 		: "";
+	// #bootstrap-recovery surfaces when world generation fails or times out.
+	// Non-empty here means the cmd surface cannot proceed — the regen /
+	// abandon buttons aren't reachable, so the playtest is effectively stuck.
+	const recoveryVisible = await page
+		.locator("#bootstrap-recovery")
+		.isVisible()
+		.catch(() => false);
+	const recovery = recoveryVisible
+		? await readVisibleText(page.locator("#bootstrap-recovery"))
+		: "";
 
 	const panels = await page.locator("article.ai-panel").all();
 	const panelData = [];
@@ -207,6 +260,7 @@ async function snapshot() {
 		panelData.push({ name, budget, transcript });
 	}
 	return {
+		view,
 		topinfoLeft,
 		topinfoRight,
 		phase,
@@ -214,6 +268,7 @@ async function snapshot() {
 		lockoutErr,
 		endgame,
 		capHit,
+		recovery,
 		panels: panelData,
 	};
 }


### PR DESCRIPTION
The Chromium daemon waited on `page.waitForURL(/#\/game/)` to detect the
CONNECT transition, which never fires now that hash routing has been
replaced by `renderApp` writing `data-view` on `<main>` (ADR 0011). Wait
on the attribute instead, and let the snapshot expose `view` so the
agent can see if it ever lands on something other than `game`. Add a
`recovery` field and an early bail-out in the boot poll so a stuck or
failed world generation fails `start.sh` fast instead of running out
the 5-minute timer.