### PR TITLE
Bump SPA bootstrap timeout from 120s to 300s

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -85,7 +85,7 @@ If `start.sh` fails, fix the underlying issue rather than retrying blindly. It
 prints a `FAILED: <reason>` line plus the relevant log to stderr. Two common
 failure modes worth knowing:
 
-- **Bootstrap recovery UI** — world generation timed out (the SPA's 120 s
+- **Bootstrap recovery UI** — world generation timed out (the SPA's 5-minute
   bootstrap limit) or produced a malformed pack. The daemon detects the
   `#bootstrap-recovery` section and exits non-zero rather than waiting out
   its 5-minute stable-state poll; re-run `start.sh` to try again.

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -44,8 +44,11 @@ import {
 import { type RenderOpts, renderApp } from "../render-app.js";
 
 /** Maximum time allowed for bootstrap loading (personas + content packs) before
- * timing out and surfacing the recovery UI. */
-export const BOOTSTRAP_LOADING_TIMEOUT_MS = 120_000;
+ * timing out and surfacing the recovery UI. Sized to absorb a slow first-attempt
+ * persona-synthesis call (~95s observed cold) plus the retry-once-on-fail path
+ * and a parallel content-pack outer retry, matching the daemon harness's
+ * stable-state wait window. */
+export const BOOTSTRAP_LOADING_TIMEOUT_MS = 300_000;
 
 /** Lowercased persona name for transcript prefixes (`> *ember <msg>`). */
 function transcriptName(name: string): string {


### PR DESCRIPTION
Persona synthesis can take ~95s cold on a single first attempt; combined
with parallel content-pack generation and either side's silent
retry-on-fail, the 120s deadline reliably trips before any real failure
mode and the daemon bails to FAILED. 300s aligns the SPA-side cap with
the playtest daemon's 5-minute stable-state poll and the skill's
documented 2-5 minute boot window.