### PR TITLE
Fix dial coloring loss when reduce-motion skips the animation

### DIFF
--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -169,6 +169,27 @@ describe("renderStart — screen visibility", () => {
 		expect(panelsEl?.hasAttribute("hidden")).toBe(true);
 		expect(composerEl?.hasAttribute("hidden")).toBe(true);
 	});
+
+	it("renders dial with colored status spans when animation is skipped", async () => {
+		// shouldSkipAnimation() short-circuits the typed animation and paints
+		// the full transcript synchronously. The DIAL_LINES status strings
+		// embed `<span class="ok">` / `<span class="hot">` HTML; assigning
+		// them via `textContent` would escape the tags and lose the coloring.
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+		vi.resetModules();
+		const { renderStart } = await import("../routes/start.js");
+
+		setSearch("skipDialup=1");
+		try {
+			await renderStart(getMain());
+		} catch {
+			// generation may reject in test environment — ok
+		}
+
+		const dialEl = document.querySelector<HTMLElement>("#dial");
+		expect(dialEl?.querySelectorAll(".ok").length ?? 0).toBeGreaterThan(0);
+		expect(dialEl?.querySelectorAll(".hot").length ?? 0).toBeGreaterThan(0);
+	});
 });
 
 describe("renderStart — BEGIN button state", () => {

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -382,7 +382,10 @@ export function renderStart(
 	};
 
 	if (skipAnimation) {
-		if (dialEl) dialEl.textContent = renderDialFinalText();
+		// renderDialFinalText() embeds the .ok / .hot status spans as HTML
+		// markup — assign via innerHTML so they parse, otherwise the tags
+		// render as literal text and the dial loses its coloring.
+		if (dialEl) dialEl.innerHTML = renderDialFinalText();
 		revealLogin();
 	} else if (dialEl) {
 		typeDialUp(dialEl, () => setTimeout(revealLogin, 220));


### PR DESCRIPTION
renderDialFinalText() returns a string with embedded `<span class="ok">` /
`<span class="hot">` markup. The skip-animation branch assigned it via
`textContent`, which escapes the tags and renders them as literal text —
so users with `prefers-reduced-motion: reduce` saw the dialup transcript
appear instantly but with all the green/amber status spans gone.

Switch to `innerHTML` so the spans parse, matching the animated path
(lines 126, 133) which already uses innerHTML for the same reason.

https://claude.ai/code/session_01Mpfk9AfBpG2mbv5uPqaqoo