### PR TITLE
playtest skill: remove ambiguous "most" from send wait note

### DIFF
--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -112,7 +112,9 @@ scripts/playtest/cmd.sh '{"op":"view","full":true}'
 
 # Type a message into the composer and press send. The daemon waits for the
 # round-in-flight DOM signal to clear (up to 90 s) before returning a delta
-# snapshot, so you do NOT need a separate "wait" after send — ever.
+# snapshot. Do NOT add a separate "wait" after send — if the round didn't
+# start (rejected message), waiting won't help; if it did start, send already
+# waited for it.
 scripts/playtest/cmd.sh '{"op":"send","text":"*v86p hi! im blue. what do you see?"}'
 
 # Send with full transcript in the response (for context refresh):

--- a/.claude/skills/playtest/SKILL.md
+++ b/.claude/skills/playtest/SKILL.md
@@ -112,7 +112,7 @@ scripts/playtest/cmd.sh '{"op":"view","full":true}'
 
 # Type a message into the composer and press send. The daemon waits for the
 # round-in-flight DOM signal to clear (up to 90 s) before returning a delta
-# snapshot, so you do NOT need a separate "wait" after most sends.
+# snapshot, so you do NOT need a separate "wait" after send — ever.
 scripts/playtest/cmd.sh '{"op":"send","text":"*v86p hi! im blue. what do you see?"}'
 
 # Send with full transcript in the response (for context refresh):


### PR DESCRIPTION
"you do NOT need a separate wait after most sends" was causing agents to
add defensive wait calls after every send anyway. Changed to "ever" since
the daemon unconditionally calls waitForRoundEnd() on every send op.

https://claude.ai/code/session_01Xq2LUV2YaRZWEiemPsah5A