### PR TITLE
Replace setTimeout(300) wait in game-ended.test.ts with vi.waitFor

### DIFF
--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -232,8 +232,10 @@ describe("renderGame — game_ended disables #send permanently (regression #89)"
 			new Event("submit", { bubbles: true, cancelable: true }),
 		);
 
-		// Wait for the async submit handler to complete
-		await new Promise((resolve) => setTimeout(resolve, 300));
+		// Wait for the async submit handler to complete (assertion-driven, no fixed delay)
+		await vi.waitFor(() => {
+			expect(getEl<HTMLButtonElement>("#send").disabled).toBe(true);
+		});
 
 		// Bug: the finally block was unconditionally setting sendBtn.disabled = false,
 		// undoing the game_ended handler's sendBtn.disabled = true.


### PR DESCRIPTION
## What this fixes

`src/spa/__tests__/game-ended.test.ts` line 236 had a hard-coded 300 ms `setTimeout` to wait for the async `renderGame` submit handler to complete before asserting that `#send` and `#prompt` are disabled after a `game_ended` event. Fixed-delay waits are inherently flaky — under load the 300 ms may expire before the microtask queue fully settles, producing a false negative.

The fix replaces the `await new Promise(resolve => setTimeout(resolve, 300))` with `await vi.waitFor(() => { expect(getEl<HTMLButtonElement>("#send").disabled).toBe(true); })`, which polls the assertion until it passes or the default timeout (1 000 ms) is reached. The subsequent named-variable assertions (`sendBtn.disabled` and `promptEl.disabled`) are preserved as explicit documentation of the regression invariant from issue #89.

## QA steps for the human

None — fully covered by the integration smoke (`pnpm test:repeat 20 src/spa/__tests__/game-ended.test.ts` passed 20/20).

## Automated coverage

`pnpm typecheck` (clean), `pnpm lint` (173 files, no issues), `pnpm test src/spa/__tests__/game-ended.test.ts` (1/1 passed), `pnpm test:repeat 20 src/spa/__tests__/game-ended.test.ts` (PASSED 20/20).

Closes #414

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR)_