### PR TITLE
Replace microtask-flush setTimeout sleeps in byok-modal.test.ts

### DIFF
--- a/src/spa/__tests__/byok-modal.test.ts
+++ b/src/spa/__tests__/byok-modal.test.ts
@@ -340,7 +340,7 @@ describe("openByokModal UI", () => {
 		vi.stubGlobal("fetch", mockFetch);
 
 		getEl("byok-validate-save").click();
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await Promise.resolve();
 
 		expect(getEl("byok-status").textContent).toBeTruthy();
 		expect(mockFetch).not.toHaveBeenCalled();
@@ -362,9 +362,10 @@ describe("openByokModal UI", () => {
 		);
 
 		getEl("byok-validate-save").click();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await vi.waitFor(() => {
+			expect(store.openrouter_key).toBe("sk-or-v1-goodkey");
+		});
 
-		expect(store.openrouter_key).toBe("sk-or-v1-goodkey");
 		expect(getEl("byok-status").textContent).toBe("Key validated.");
 	});
 
@@ -378,11 +379,12 @@ describe("openByokModal UI", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 401 }));
 
 		getEl("byok-validate-save").click();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await vi.waitFor(() => {
+			expect(getEl("byok-status").textContent).toContain(
+				"That key didn't authenticate",
+			);
+		});
 
-		expect(getEl("byok-status").textContent).toContain(
-			"That key didn't authenticate",
-		);
 		expect(store.openrouter_key).toBeUndefined();
 	});
 
@@ -396,9 +398,10 @@ describe("openByokModal UI", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 402 }));
 
 		getEl("byok-validate-save").click();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await vi.waitFor(() => {
+			expect(getEl("byok-status").textContent).toContain("out of credit");
+		});
 
-		expect(getEl("byok-status").textContent).toContain("out of credit");
 		expect(store.openrouter_key).toBeUndefined();
 	});
 
@@ -412,11 +415,12 @@ describe("openByokModal UI", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 502 }));
 
 		getEl("byok-validate-save").click();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await vi.waitFor(() => {
+			expect(getEl("byok-status").textContent).toContain(
+				"Couldn't reach OpenRouter",
+			);
+		});
 
-		expect(getEl("byok-status").textContent).toContain(
-			"Couldn't reach OpenRouter",
-		);
 		expect(getEl("byok-save-unverified").hidden).toBe(false);
 	});
 
@@ -430,11 +434,13 @@ describe("openByokModal UI", () => {
 		// Simulate 5xx first to reveal the button
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 502 }));
 		getEl("byok-validate-save").click();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await vi.waitFor(() => {
+			expect(getEl("byok-save-unverified").hidden).toBe(false);
+		});
 
 		// Now click Save unverified
 		getEl("byok-save-unverified").click();
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await Promise.resolve();
 
 		expect(store.openrouter_key).toBe("sk-or-v1-somekey1234");
 		// biome-ignore lint/style/noNonNullAssertion: test assertion
@@ -464,7 +470,9 @@ describe("openByokModal UI", () => {
 		);
 
 		getEl("byok-revalidate").click();
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await vi.waitFor(() => {
+			expect(getEl("byok-status").textContent).toBe("Key validated.");
+		});
 
 		const meta = JSON.parse(store.openrouter_key_meta);
 		expect(meta.status).toBe("validated");
@@ -487,7 +495,7 @@ describe("openByokModal UI", () => {
 		vi.stubGlobal("confirm", confirmSpy);
 
 		getEl("byok-clear").click();
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await Promise.resolve();
 
 		expect(store.openrouter_key).toBeUndefined();
 		expect(store.openrouter_key_meta).toBeUndefined();
@@ -510,7 +518,7 @@ describe("openByokModal UI", () => {
 		expect(keyInput.hasAttribute("readonly")).toBe(true);
 
 		getEl("byok-replace").click();
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await Promise.resolve();
 
 		expect(keyInput.value).toBe("");
 		expect(keyInput.hasAttribute("readonly")).toBe(false);


### PR DESCRIPTION
## What this fixes

`src/spa/__tests__/byok-modal.test.ts` had 10 real-time `setTimeout` sleeps (10–50 ms each) used to wait for async side-effects after button clicks. These were non-deterministic and added ~300 ms of wall-clock delay per run.

The fix applies two replacement idioms based on the handler type:

- **Synchronous handlers** (`byok-replace`, `byok-clear`, `byok-save-unverified`, empty-input validate path): replaced with `await Promise.resolve()` — a single microtask flush is sufficient because the DOM mutation happens synchronously in the event listener with no `await`.
- **Async handlers** (`byok-validate-save`, `byok-revalidate`): replaced with `await vi.waitFor(() => expect(...))` — these handlers `await validateOpenRouterKey()` which itself `await`s the mocked fetch and then `await`s `response.json()`, spanning multiple microtask turns. `vi.waitFor` polls until the assertion passes, making the test correct regardless of how many turns the chain takes.

Files changed: `src/spa/__tests__/byok-modal.test.ts` only (test-only change, no production code modified).

## QA steps for the human

None — fully covered by the automated checks below. The flake gate ran 20/20 clean.

## Automated coverage

- `pnpm typecheck` — passed (tsgo, both tsconfigs)
- `pnpm lint` — passed (biome ci, 173 files, no fixes)
- `pnpm test src/spa/__tests__/byok-modal.test.ts` — 32/32 passed
- `pnpm test:repeat 20 src/spa/__tests__/byok-modal.test.ts` — 20/20 passed

Closes #413

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR)_