### PR TITLE
Replace setTimeout(50) KV-write waits with read-poll in openai-proxy.test.ts

### DIFF
--- a/src/proxy/openai-proxy.test.ts
+++ b/src/proxy/openai-proxy.test.ts
@@ -20,6 +20,30 @@ import { globalKey, perIpKey } from "./rate-guard";
 
 const ENDPOINT = "https://example.com/v1/chat/completions";
 
+/**
+ * Poll a KV key until its string value equals `expected`, or throw after
+ * `timeoutMs` ms. Replaces fixed-duration sleeps that were racing KV write
+ * visibility in Miniflare — the 5 ms poll interval is bounded and
+ * assertion-gated (not a time guess).
+ */
+async function waitForCounter(
+	kvNs: KVNamespace,
+	key: string,
+	expected: string,
+	{ timeoutMs = 1000 } = {},
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const v = await kvNs.get(key);
+		if (v === expected) return;
+		await new Promise((r) => setTimeout(r, 5));
+	}
+	const final = await kvNs.get(key);
+	throw new Error(
+		`counter ${key} did not reach expected ${expected}, got ${final} within ${timeoutMs}ms`,
+	);
+}
+
 const VALID_BODY = JSON.stringify({
 	model: "gpt-4o",
 	messages: [{ role: "user", content: "Hello" }],
@@ -408,9 +432,13 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 
 		expect(resp.status).toBe(200);
 		await resp.text();
-		await new Promise((r) => setTimeout(r, 50));
 
 		const now = Date.now();
+		await Promise.all([
+			waitForCounter(kv(), perIpKey(ip, now), "1500"),
+			waitForCounter(kv(), globalKey(now), "1500"),
+		]);
+
 		const [ipVal, gVal] = await Promise.all([
 			kv().get(perIpKey(ip, now)),
 			kv().get(globalKey(now)),
@@ -451,9 +479,11 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 		});
 
 		await resp.text();
-		await new Promise((r) => setTimeout(r, 50));
 
-		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		const ipKey454 = perIpKey(ip, Date.now());
+		await waitForCounter(kv(), ipKey454, String(PRE_CHARGE));
+
+		const ipVal = await kv().get(ipKey454);
 		expect(Number(ipVal)).toBe(PRE_CHARGE);
 	});
 
@@ -634,9 +664,13 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 		});
 
 		await resp.text();
-		await new Promise((r) => setTimeout(r, 50));
 
 		const now = Date.now();
+		await Promise.all([
+			waitForCounter(kv(), perIpKey(ip, now), "0"),
+			waitForCounter(kv(), globalKey(now), "0"),
+		]);
+
 		const [ipVal, gVal] = await Promise.all([
 			kv().get(perIpKey(ip, now)),
 			kv().get(globalKey(now)),
@@ -763,9 +797,10 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 			// expected: the upstream stream error propagates to the client reader
 		}
 
-		await new Promise((r) => setTimeout(r, 100));
+		const ipKey766 = perIpKey(ip, Date.now());
+		await waitForCounter(kv(), ipKey766, String(seeded));
 
-		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		const ipVal = await kv().get(ipKey766);
 		expect(Number(ipVal)).toBe(seeded);
 	});
 
@@ -809,9 +844,11 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 
 		expect(resp.status).toBe(200);
 		await resp.text();
-		await new Promise((r) => setTimeout(r, 50));
 
-		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		const ipKey812 = perIpKey(ip, Date.now());
+		await waitForCounter(kv(), ipKey812, "200");
+
+		const ipVal = await kv().get(ipKey812);
 		expect(Number(ipVal)).toBe(200);
 	});
 
@@ -848,9 +885,10 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 			body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
 		});
 
-		await new Promise((r) => setTimeout(r, 50));
+		const ipKey851 = perIpKey(ip, Date.now());
+		await waitForCounter(kv(), ipKey851, "150");
 
-		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		const ipVal = await kv().get(ipKey851);
 		expect(Number(ipVal)).toBe(150);
 	});
 
@@ -885,9 +923,11 @@ describe("cost-guard integration — POST /v1/chat/completions", () => {
 		});
 
 		await resp.text();
-		await new Promise((r) => setTimeout(r, 50));
 
-		const ipVal = await kv().get(perIpKey(ip, Date.now()));
+		const ipKey888 = perIpKey(ip, Date.now());
+		await waitForCounter(kv(), ipKey888, "1500");
+
+		const ipVal = await kv().get(ipKey888);
 		expect(Number(ipVal)).toBe(1500);
 	});
 });


### PR DESCRIPTION
## What this fixes

The rate-guard integration tests in `src/proxy/openai-proxy.test.ts` used 7 fixed-duration post-request sleeps (50ms or 100ms) to wait for KV writes to settle before asserting counter values. Miniflare's KV write visibility is not time-bounded, so these sleeps were first-to-fail on a contended CI runner (particularly the 100ms site which can race a UTC daily-reset bucket boundary).

Each sleep is replaced with a bounded `waitForCounter()` helper that polls `env.RATE_GUARD_KV.get(key)` every 5ms until the expected string value appears, or throws with a clear diagnostic after 1s:

```
counter cost:ip:2026-05-17:7.7.7.7 did not reach expected 1500, got 4000 within 1000ms
```

The 5ms poll-interval `setTimeout` inside the helper is bounded and assertion-gated — not a time guess.

## QA steps for the human

- [ ] Review the `waitForCounter` helper added near the top of `openai-proxy.test.ts`
- [ ] Confirm all 7 post-request `setTimeout` sleeps are gone (search for `setTimeout(r, 50)` and `setTimeout(r, 100)` — should have zero matches in the test assertions)
- [ ] Run `pnpm test src/proxy/openai-proxy.test.ts` — all 33 tests should pass
- [ ] Run `pnpm test:repeat 20 src/proxy/openai-proxy.test.ts` — should be 20/20

## Automated coverage

- `pnpm typecheck` — clean
- `pnpm lint` — clean (biome CI, 0 fixes)
- `pnpm test src/proxy/openai-proxy.test.ts` — 33/33 passed
- `pnpm test:repeat 20 src/proxy/openai-proxy.test.ts` — **20/20 passed**

Closes #412

https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR)_