### PR TITLE
Drain pageerror events before teardown in e2e specs

### DIFF
--- a/e2e/addressed-and-parallel.spec.ts
+++ b/e2e/addressed-and-parallel.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers/index";
+import { expectNoPageErrors, goToGame } from "./helpers/index";
 
 /**
  * The three distinct completions served to the three AIs.  Since the SPA
@@ -108,5 +108,5 @@ test("addressed message lands only on first panel; all three panels render progr
 	// `--repeat-each=10`. Inter-panel render-timing coverage, if needed, belongs
 	// in a dedicated spec built on a deterministic sequencing harness rather
 	// than piggy-backed onto this addressed-mention test. See issue #151.
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
+import {
+	expectNoPageErrors,
+	getAiHandles,
+	goToGame,
+	stubChatCompletions,
+} from "./helpers";
 
 // XOR obfuscation key for engine.dat (matches sealed-blob-codec.ts)
 const OBFUSCATION_KEY = "hi-blue:engine/v1@kJvN3pX8wQmR2sZt";
@@ -76,5 +81,5 @@ test("chat lockout disables send for locked-out AI and is silent to player", asy
 	await expect(page.locator("#send")).toBeEnabled();
 
 	// No page errors.
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/endgame-choices.spec.ts
+++ b/e2e/endgame-choices.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { expectNoPageErrors, goToGame } from "./helpers";
 
 /**
  * E2E — end-game choice screen (issue #307)
@@ -47,7 +47,7 @@ test("endgame shows choice buttons; Continue hidden without openrouter_key", asy
 	await expect(continueBtn).toBeHidden();
 
 	// No page errors
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("Continue button visible when openrouter_key is set in localStorage", async ({
@@ -67,7 +67,7 @@ test("Continue button visible when openrouter_key is set in localStorage", async
 	await expect(page.locator("#endgame-continue-btn")).toBeVisible();
 
 	// No page errors
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("New Daemons click archives session and transitions to start view", async ({
@@ -101,5 +101,5 @@ test("New Daemons click archives session and transitions to start view", async (
 	expect(sessionAfter).not.toBe(sessionBefore);
 
 	// No page errors
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/endgame-current-behaviour.spec.ts
+++ b/e2e/endgame-current-behaviour.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { expectNoPageErrors, goToGame } from "./helpers";
 
 /**
  * E2E Slice 4 — game_ended current behaviour (issue #80, simplified by #101)
@@ -86,5 +86,5 @@ test("game_ended disables composer and shows endgame choices", async ({
 	expect(page.url(), "URL must not change after game_ended").toBe(urlBefore);
 
 	// No page errors
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,4 +1,5 @@
 export { type AiHandles, getAiHandles } from "./handles";
+export { expectNoPageErrors } from "./page-errors";
 export {
 	classifyJsonRequest,
 	type GoToGameOptions,

--- a/e2e/helpers/page-errors.ts
+++ b/e2e/helpers/page-errors.ts
@@ -1,0 +1,29 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Drain in-flight `pageerror` events and then assert none were collected.
+ *
+ * Browser `pageerror` events are dispatched asynchronously — errors thrown
+ * inside `queueMicrotask`, `setTimeout(fn, 0)`, or during teardown may fire
+ * after the last `await` in a test body but before the page is torn down.
+ * A bare synchronous `expect(pageErrors).toEqual([])` misses these.
+ *
+ * This helper gives the browser a short bounded settle (100 ms via
+ * `page.waitForTimeout`) to flush any queued error events before asserting.
+ *
+ * Usage (replaces the bare inline assertion):
+ * ```ts
+ * const pageErrors: Error[] = [];
+ * page.on("pageerror", (err) => pageErrors.push(err));
+ * // ... test body ...
+ * await expectNoPageErrors(page, pageErrors);
+ * ```
+ */
+export async function expectNoPageErrors(
+	page: Page,
+	pageErrors: Error[],
+): Promise<void> {
+	// Allow up to 100 ms for late-fired microtask / timer errors to arrive.
+	await page.waitForTimeout(100);
+	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+}

--- a/e2e/mention-addressing.spec.ts
+++ b/e2e/mention-addressing.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { expectNoPageErrors, goToGame } from "./helpers";
 
 /**
  * E2E spec for #107: *mention-based addressing replaces the address dropdown.
@@ -76,5 +76,5 @@ test("typing '*<ai1> hi' enables Send and submits to that transcript only", asyn
 	expect(otherTranscript0 ?? "").not.toContain("> hi");
 	expect(otherTranscript2 ?? "").not.toContain("> hi");
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/persistence-reload.spec.ts
+++ b/e2e/persistence-reload.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
+import {
+	expectNoPageErrors,
+	getAiHandles,
+	goToGame,
+	stubChatCompletions,
+} from "./helpers";
 
 /**
  * AI completions returned by the stub, keyed by call index (0 = first, 1 = second, 2 = third
@@ -125,5 +130,5 @@ test("game state and transcripts persist across mid-round reload", async ({
 
 	// ── No page errors ──────────────────────────────────────────────────────────
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/sessions-picker.spec.ts
+++ b/e2e/sessions-picker.spec.ts
@@ -16,7 +16,7 @@
  * navigating to a URL. Sticky for broken / version-mismatch active sessions.
  */
 import { expect, test } from "@playwright/test";
-import { goToGame, stubNewGameLLM } from "./helpers";
+import { expectNoPageErrors, goToGame, stubNewGameLLM } from "./helpers";
 
 // ── Obfuscation key (embedded in seed scripts) ────────────────────────────────
 
@@ -216,7 +216,7 @@ test("picker renders ok/broken/version-mismatch rows with correct tags and butto
 		vmRow.locator(".ops button", { hasText: "[ load ]" }),
 	).not.toBeVisible();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("[ load ] flow: click load on non-active row → game view", async ({
@@ -261,7 +261,7 @@ test("[ load ] flow: click load on non-active row → game view", async ({
 	);
 	expect(activeId).toBe("0xBBBB");
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("[ dup ] flow: click dup → two rows, active pointer unchanged", async ({
@@ -299,7 +299,7 @@ test("[ dup ] flow: click dup → two rows, active pointer unchanged", async ({
 	);
 	expect(activeId).toBe("0xAAAA");
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("[ rm ] confirm/cancel flow", async ({ page }) => {
@@ -344,7 +344,7 @@ test("[ rm ] confirm/cancel flow", async ({ page }) => {
 	// Row should be gone
 	await expect(page.locator(".session-row")).toHaveCount(0);
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("sessions-icon click → sessions view", async ({ page }) => {
@@ -364,7 +364,7 @@ test("sessions-icon click → sessions view", async ({ page }) => {
 	});
 	await expect(page.locator("#sessions-screen")).toBeVisible();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("sessions-icon toggles back to game on second click", async ({ page }) => {
@@ -385,7 +385,7 @@ test("sessions-icon toggles back to game on second click", async ({ page }) => {
 	});
 	await expect(page.locator("#composer")).toBeVisible();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("refresh while picker is open lands on the game view (picker state is in-memory)", async ({
@@ -414,7 +414,7 @@ test("refresh while picker is open lands on the game view (picker state is in-me
 		"connection stable",
 	);
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("Escape on the picker returns to the game view", async ({ page }) => {
@@ -433,7 +433,7 @@ test("Escape on the picker returns to the game view", async ({ page }) => {
 	});
 	await expect(page.locator("#composer")).toBeVisible();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("broken-session banner: active session with missing engine.dat → sessions view with reason", async ({
@@ -463,7 +463,7 @@ test("broken-session banner: active session with missing engine.dat → sessions
 	await expect(banner).toBeVisible();
 	await expect(banner).toContainText("unreadable");
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("[ + new session ] flow: click → start view, new active pointer", async ({
@@ -504,5 +504,5 @@ test("[ + new session ] flow: click → start view, new active pointer", async (
 	expect(activeId).not.toBe("0xAAAA");
 	expect(activeId).toMatch(/^0x[0-9A-Fa-f]{4}$/i);
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { expectNoPageErrors, goToGame } from "./helpers";
 
 test("SPA root renders three AI panels and composer", async ({ page }) => {
 	const pageErrors: Error[] = [];
@@ -22,5 +22,28 @@ test("SPA root renders three AI panels and composer", async ({ page }) => {
 
 	await expect(page.locator("#composer")).toBeVisible();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
+});
+
+test("expectNoPageErrors catches late-fired microtask errors (regression)", async ({
+	page,
+}) => {
+	const pageErrors: Error[] = [];
+	page.on("pageerror", (err) => pageErrors.push(err));
+
+	await goToGame(page, { sse: ["hi"] });
+
+	// Fire a late error via queueMicrotask — this runs after the current
+	// task unwinds but before the next macrotask, simulating errors that
+	// arrive asynchronously after the last `await` in a test body.
+	await page.evaluate(() => {
+		queueMicrotask(() => {
+			throw new Error("late pageerror from microtask");
+		});
+	});
+
+	// expectNoPageErrors must catch this; the test asserts the helper works.
+	await expect(expectNoPageErrors(page, pageErrors)).rejects.toThrow(
+		"late pageerror from microtask",
+	);
 });

--- a/e2e/start-screen.spec.ts
+++ b/e2e/start-screen.spec.ts
@@ -19,6 +19,7 @@
 import { expect, type Request, type Route, test } from "@playwright/test";
 import {
 	classifyJsonRequest,
+	expectNoPageErrors,
 	stubChatCompletions,
 	stubNewGameLLM,
 } from "./helpers";
@@ -57,7 +58,7 @@ test("new visitor sees start screen with disabled [ BEGIN ] button initially", a
 	await expect(page.locator("#panels")).toBeHidden();
 	await expect(page.locator("#composer")).toBeHidden();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test.describe("mobile viewport", () => {
@@ -80,7 +81,7 @@ test.describe("mobile viewport", () => {
 		await expect(page.locator("#panels")).toBeHidden();
 		await expect(page.locator("#composer")).toBeHidden();
 
-		expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+		await expectNoPageErrors(page, pageErrors);
 	});
 });
 
@@ -103,7 +104,7 @@ test("password input disables ligatures so masked `***` doesn't shift mid-char",
 		.evaluate((el) => getComputedStyle(el).fontVariantLigatures);
 	expect(liga).toBe("none");
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("[ BEGIN ] is enabled after persona synthesis and content-pack generation complete", async ({
@@ -121,7 +122,7 @@ test("[ BEGIN ] is enabled after persona synthesis and content-pack generation c
 	const beginBtn = page.locator("#begin");
 	await expect(beginBtn).toBeEnabled({ timeout: 30_000 });
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("clicking [ BEGIN ] transitions to the game view and shows panels", async ({
@@ -157,7 +158,7 @@ test("clicking [ BEGIN ] transitions to the game view and shows panels", async (
 	// Active session should be set in localStorage
 	await waitForActiveSession(page);
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("refreshing on the game view with an active session stays on the game view", async ({
@@ -193,7 +194,7 @@ test("refreshing on the game view with an active session stays on the game view"
 	await expect(page.locator("#composer")).toBeVisible();
 	await expect(page.locator("#start-screen")).toBeHidden();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("CapHit during generation surfaces #cap-hit", async ({ page }) => {
@@ -310,7 +311,7 @@ test("refresh during generation re-enters start screen and restarts generation",
 	// Generation restarts on the second load: BEGIN re-enables once synthesis completes
 	await expect(beginBtn).toBeEnabled({ timeout: 30_000 });
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("empty active-session pointer surfaces the start screen on load", async ({
@@ -338,5 +339,5 @@ test("empty active-session pointer surfaces the start screen on load", async ({
 	});
 	await expect(page.locator("#start-screen")).toBeVisible();
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/think-disabled.spec.ts
+++ b/e2e/think-disabled.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { expectNoPageErrors, goToGame } from "./helpers";
 
 /**
  * Routine daemon turns disable reasoning by default — `BrowserLLMProvider`
@@ -50,7 +50,7 @@ test("default daemon turns add reasoning:{enabled:false} to chat-completions req
 		expect(body).toMatchObject({ reasoning: { enabled: false } });
 	}
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });
 
 test("?think=1 opts back into thinking — requests do NOT include the reasoning field", async ({
@@ -84,5 +84,5 @@ test("?think=1 opts back into thinking — requests do NOT include the reasoning
 		expect(body).not.toHaveProperty("reasoning");
 	}
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/token-pacing.spec.ts
+++ b/e2e/token-pacing.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { goToGame } from "./helpers";
+import { expectNoPageErrors, goToGame } from "./helpers";
 
 // 20 words of stub content. The default `goToGame` SSE stub now emits a single
 // `message` tool call addressed to "blue" carrying these joined words as its
@@ -70,5 +70,5 @@ test("AI message content lands in the addressed panel after the round", async ({
 		timeout: 20_000,
 	});
 
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/whisper-tampering.spec.ts
+++ b/e2e/whisper-tampering.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
+import {
+	expectNoPageErrors,
+	getAiHandles,
+	goToGame,
+	stubChatCompletions,
+} from "./helpers";
 
 /**
  * E2E — Per-Daemon asymmetric message tampering (issue #213)
@@ -183,5 +188,5 @@ test("fabricated message appears in target daemon prompt and is absent from othe
 	).not.toContain(SENTINEL);
 
 	// 9. No page errors.
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });

--- a/e2e/witnessed-event-reload.spec.ts
+++ b/e2e/witnessed-event-reload.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { getAiHandles, goToGame, stubChatCompletions } from "./helpers";
+import {
+	expectNoPageErrors,
+	getAiHandles,
+	goToGame,
+	stubChatCompletions,
+} from "./helpers";
 
 /**
  * E2E — Witnessed-event reload survival (issue #196, PRD #157)
@@ -890,5 +895,5 @@ test("live go tool-call produces witnessed-event that survives reload and appear
 	).not.toContain(expectedLine);
 
 	// ── 16. No page errors ────────────────────────────────────────────────────
-	expect(pageErrors, pageErrors.map((e) => e.message).join("\n")).toEqual([]);
+	await expectNoPageErrors(page, pageErrors);
 });


### PR DESCRIPTION
## What this fixes

`pageerror` events are dispatched asynchronously by the browser. Errors emitted inside `queueMicrotask`, `setTimeout(fn, 0)`, or during page teardown can arrive after the last `await` in a test body, making the old bare synchronous `expect(pageErrors).toEqual([])` blind to them (false negatives).

## Changes

- **`e2e/helpers/page-errors.ts`** (new): exports `expectNoPageErrors(page, pageErrors)` which waits 100 ms via `page.waitForTimeout` to flush any queued microtask/timer error events before asserting.
- **`e2e/helpers/index.ts`**: re-exports `expectNoPageErrors`.
- **All 13 affected specs** converted from the inline bare assertion to `await expectNoPageErrors(page, pageErrors)`. Specs touched: `smoke`, `persistence-reload`, `chat-lockout`, `addressed-and-parallel`, `endgame-choices`, `endgame-current-behaviour`, `mention-addressing`, `sessions-picker`, `start-screen`, `think-disabled`, `token-pacing`, `whisper-tampering`, `witnessed-event-reload`.

## Regression test

`smoke.spec.ts` now contains a second test — "expectNoPageErrors catches late-fired microtask errors (regression)" — that fires `queueMicrotask(() => { throw new Error("late pageerror from microtask") })` and asserts that `expectNoPageErrors` catches it (the call rejects). This proves the helper detects errors that a synchronous assertion would miss.

## QA

- `pnpm typecheck` — passes
- `pnpm lint` — passes (174 files, no issues)
- `pnpm test` — 1510/1510 unit tests pass
- `pnpm smoke` — 45 pass, 6 fail (all 6 are pre-existing failures on `main` confirmed by baseline check: `endgame-choices` x3, `endgame-current-behaviour`, `start-screen` refresh-during-generation, `think-disabled ?think=1`)
- Manual 10-iteration repeat on the passing subset of specs — 22/22 × 10 passes (0 flakes)

Closes #417

https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR)_