### PR TITLE
Remove 60s setTimeout landmine in start-screen.spec.ts

### DIFF
--- a/e2e/start-screen.spec.ts
+++ b/e2e/start-screen.spec.ts
@@ -255,9 +255,9 @@ test("refresh during generation re-enters start screen and restarts generation",
 	const pageErrors: Error[] = [];
 	page.on("pageerror", (err) => pageErrors.push(err));
 
-	// First load: install a stub that delays synthesis so BEGIN stays disabled.
-	// Playwright aborts in-flight requests on navigation, so the 10 s delay
-	// is never reached after the reload — the test does not actually wait 10 s.
+	// First load: install a stub that holds synthesis so BEGIN stays disabled.
+	// The handler blocks on a never-resolving promise; Playwright aborts the
+	// in-flight request when the page reloads, so the test does not stall.
 	const slowSynthesisHandler = async (route: Route, request: Request) => {
 		let body: {
 			stream?: boolean;
@@ -271,9 +271,10 @@ test("refresh during generation re-enters start screen and restarts generation",
 		const isJsonMode =
 			body !== null && (body.stream === false || body.response_format != null);
 		if (isJsonMode) {
-			// Hold synthesis indefinitely — reload will abort this in-flight request
-			await new Promise((r) => setTimeout(r, 60_000));
-			await route.abort();
+			// Hold synthesis indefinitely — Playwright aborts this in-flight request
+			// when the page navigates (reload). Using a never-resolving promise makes
+			// the intent explicit and removes any worst-case wall-clock ceiling.
+			await new Promise<never>(() => {});
 			return;
 		}
 		await route.fallback();


### PR DESCRIPTION
## What this fixes

`e2e/start-screen.spec.ts` line 275 held the synthesis route handler with `await new Promise((r) => setTimeout(r, 60_000))`. The inline comment already said "Hold synthesis indefinitely — reload will abort this in-flight request," so the 60-second ceiling was always load-bearing fiction: if Playwright's abort timing changed even slightly, the suite would stall for a full minute before tripping the timeout. The fix replaces that with `await new Promise<never>(() => {})`, a promise that never resolves. Playwright's route abort on navigation cancels the pending handler immediately, so the worst-case wall-clock cost is zero (the browser aborts it as soon as the reload fires). The now-unreachable `route.abort()` after the promise was also removed, and a stale outer comment that mentioned "10 s delay" (an earlier version's value) was updated to match the new shape.

**Files changed:** `e2e/start-screen.spec.ts` — lines 258–278 only. `playwright.config.ts` was not touched (it is skip-worktree'd for port isolation).

## QA steps for the human

The automated smoke covers this end-to-end. Manual verification is optional but you can spot-check by:

1. Running `pnpm smoke:repeat 10 start-screen` from the main checkout and confirming 10/10.
2. Confirming there is no `60_000` remaining in `e2e/start-screen.spec.ts`.

## Automated coverage

`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` (1510 tests) ✓ · `pnpm smoke:repeat 10 start-screen` 10/10 ✓ (run on main checkout, port 8787)

Closes #415

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPxuYPnn86MKFyxwN1MXmR)_