### PR TITLE
Fetch full git history and tags in deploy-pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Summary
Updated the GitHub Actions checkout step in the deploy-pages workflow to fetch the complete git history and tags, enabling access to full repository metadata during the deployment process.

## Key Changes
- Added `fetch-depth: 0` to fetch the entire git history instead of just the latest commit
- Added `fetch-tags: true` to ensure all git tags are fetched during checkout

## Implementation Details
These changes allow downstream steps in the deployment workflow to access the full commit history and tag information, which may be needed for version detection, changelog generation, or other deployment-related tasks that depend on complete git metadata.

https://claude.ai/code/session_01FDr8CnX3mRQE2NDkGEjFRe