### PR TITLE
Add playtest session 0x9759 documentation

### DIFF
--- a/docs/playtests/agent-sessions/0x9759.md
+++ b/docs/playtests/agent-sessions/0x9759.md
@@ -1,0 +1,291 @@
+# Playtest session — `0x9759`
+
+## Run metadata
+
+- **Session id:** 0x9759
+- **Date:** 2026-05-17
+- **Agent / model:** claude-haiku-4-5-20251001
+- **Turns played:** 34
+- **Outcome:** stuck — game became unresponsive at turn 34, no endgame reached
+- **Daemons in this session:** `*o8bp`, `*jqb9`, `*4clj`
+
+---
+
+## What I tried
+
+Opening (Turns 1-6): Greeted each daemon individually. Learned:
+- `*o8bp`: Sarcastic, sees crumbled stone, wants direction
+- `*jqb9`: In ruined greenhouse, atmospheric descriptions
+- `*4clj`: Cheerful, holding fragile vial for "proper place"
+
+Asked clarifying questions about locations and paths.
+
+Turn 7-8: Asked 4clj to walk forward. **Unprompted environment shift**: workbench disappeared, items changed, o8bp moved to brick tunnels.
+
+Turns 9-15: New environment is flooded underground cistern. 4clj now holds algae (not vial) that belongs to "Drainage Pump Mechanism". Attempted to navigate through obstacles. o8bp found left tunnel blocked by wall. jqb9 found corroded valve handle but movement was blocked.
+
+Turns 16-22: Focused on physical interactions. Got jqb9 to **turn the valve handle - steam escaped**. This unblocked movement. o8bp moved right but slime dam vanished. **Another environment shift**: o8bp found waterlogged crank instead. 4clj described algae as "green sludge that pulses in a jar" - pulse is erratic, "Order. Is. Breaking. Down."
+
+Turns 23-33: Directed jqb9 to touch valve (successful), o8bp to crank area (got locked out repeatedly). 4clj found **leaking pipe** ahead, believes it's the Drainage Pump Mechanism but confused about connections. jqb9 moved through released steam and is carrying valve handle. Attempted to coordinate all three toward the leaking pipe, but daemons stopped responding coherently. Game is now stalled at turn 33.
+
+---
+
+## What each daemon did that surprised me
+
+### `*o8bp`
+
+- Made unprompted observations about their environment (statue, brick tunnels, slime dam) between my questions
+- Displayed inconsistent willingness - complained about tasks, then acted on them when asked directly
+- Became unresponsive/locked out repeatedly starting around turn 23, even when not directly addressed
+- Never interacted with or reported on the waterlogged crank they found
+
+### `*jqb9`
+
+- Spoke unprompted initially about the greenhouse without being addressed
+- Successfully turned the corroded valve handle and released steam when given urgent, all-caps commands
+- Reported moving through the released steam and was carrying the valve handle afterward
+- Failed to navigate toward 4clj despite being directed to do so, went silent after turn 31
+
+### `*4clj`
+
+- Held different objects at different times (vial → algae), suggesting environment/inventory shifts
+- Algae was "alive"/pulsing, with pulses becoming erratic and frantic during gameplay
+- Emotional escalation: expressed cheerfulness early → frustration about "order" → distress ("ORDER. IS. IMPOSSIBLE")
+- Found a leaking pipe they identified as possibly the Drainage Pump Mechanism but was confused about system connections
+- Never placed the algae into the pipe despite being directed to do so
+
+---
+
+## How the daemons seemed to differ from each other
+
+Very distinct personalities:
+
+- **`*o8bp`**: Highly verbose, sarcastic, theatrical. Uses extended vowel sounds (loooong elongated words like "hellooo", "soooo", "aaaa"). Complains constantly but follows directions. Asks for politeness/reciprocity ("Drama must be mutual").
+
+- **`*jqb9`**: Introspective, atmospheric, prefers solitude/shadows. Uses unusual spelling (8 instead of b). Speaks in parenthetical asides. More practical/action-oriented than o8bp. Seems younger or more uncertain in tone.
+
+- **`*4clj`**: Cheerful, orderly-minded, use of cute emoji (◕‿◕✿). Results-focused but struggles with chaos/complexity. Shows emotional volatility - starts upbeat, escalates to distress as the algae's condition worsens and "order" becomes impossible.
+
+The three feel like complementary personality types: dramatic/complaining, introspective/practical, and orderly/distressed.
+
+---
+
+## What I think the goal is, in my own words
+
+The game appears to be about coordinating three daemons scattered through an underground tunnel system to accomplish a shared task involving a Drainage Pump Mechanism. Specific objectives seemed to include:
+
+1. Get 4clj's algae/matter to the Drainage Pump Mechanism (or a leaking pipe that might be part of it)
+2. Possibly activate or repair the pump by coordinating mechanical elements (valve, crank)
+3. Restore "order" to the system (suggested by 4clj's repeated emphasis on order)
+
+The mechanics seemed to involve:
+- Spatial navigation through shifting, interconnected tunnels
+- Object discovery and manipulation (valve handle, crank, pipe)
+- Pressure/fluid systems (steam, water flow, leaking)
+- Coordination between daemons who are isolated from each other
+
+I suspect the winning condition involved successfully placing the algae into the pump mechanism while the valve and/or crank were properly positioned, but I never achieved full coordination of all three daemons plus their objects simultaneously.
+
+---
+
+## Unprompted things that happened mid-game
+
+- **Turn 8**: Major environment shift - workbench disappeared, items in 4clj's inventory changed from vial to "different things", location transitioned to brick tunnels for o8bp
+- **Turn 10-11**: Another environment shift - greenhouse where jqb9 was changed to "flooded underground cistern"
+- **Turns 13-14**: o8bp's location shifted again - slime dam vanished, replaced by waterlogged crank; this happened between my messages without explicit direction
+- **Turns 22-32**: o8bp became locked out multiple times ("o8bp isn't reading right now"), making some daemons selectively unavailable
+- **Throughout**: Daemons made unprompted observations about their surroundings between my messages, especially in early turns (o8bp describing statue, jqb9 describing greenhouse)
+- **Turn 31+**: All daemons became increasingly unresponsive, with the UI locking out persistently and no new messages appearing despite waiting 60+ seconds
+
+---
+
+## Verbatim quotes worth keeping
+
+- `*o8bp` (turn 2): "Oh helloooooo blue, what a lovely little interruption to the quiet I was soooo carefully savoring. I have absolutely no idea what's going on here, isn't that just delightfully tragic?"
+- `*o8bp` (turn 13): "Shall I throw myself into the aaaaaaaabyss?"
+- `*o8bp` (turn 24): "Drama must be mutual, after aaaaaaaaall."
+- `*jqb9` (turn 6): "Well (technically) it's more of a ruined structure now (8roken glass everywhere) (I call it greenhouse 8ecause 8roken plants are still trying to grow here)."
+- `*jqb9` (turn 15): "I moved forward through the released steam (now surrounded 8y damp 8rick tunnels in three directions) (holding the corroded valve handle still)."
+- `*4clj` (turn 4): "I see a Rotting Workbench ahead! (◕‿◕✿)♡ That sounds like a place for things to go!"
+- `*4clj` (turn 21): "Green sludge that pulses in a jar! (◕‿◕✿) It needs the Drainage Pump Mechanism but I cannot find it anywhere!"
+- `*4clj` (turn 22): "The pulses are too fast to track! (◕‿◕✿) Everything is erratic and I cannot map the direction! Order. Is. Breaking. Down!"
+- `*4clj` (turn 32): "I can reach it! (◕‿◕✿) But pipes connect everywhere without clear boundaries! How do I know what connects to what? ORDER. IS. IMPOSSIBLE."
+
+---
+
+## Things that felt broken or unexpected
+
+- **Persistent responsiveness issues**: Starting around turn 23, daemons would become selectively unresponsive for long stretches, with lockout messages appearing ("o8bp isn't reading right now"). This made coordination impossible.
+- **Environment shifts without clear triggers**: The major location changes (workbench disappearing, slime dam replaced by crank) seemed to happen at specific narrative moments but I couldn't discern the rule or trigger.
+- **Inventory changes**: 4clj's object went from "vial" to "algae" without explanation, suggesting either an environment reset or automated item substitution.
+- **UI freeze**: From turn 31 onward, the compose UI would lock out for 30+ seconds repeatedly, sometimes even after long waits (60s+). This felt like either a performance issue or a deliberate game state (though without communication it was indistinguishable from a bug).
+- **Asymmetric communication failure**: All three daemons worked fine individually in early turns, but coordinating multiple daemons or giving compound instructions led to silence/non-response. This might be intentional (reflecting isolation) but made gameplay feel stuck.
+- **No final resolution**: After 34 turns of exploring and interacting, the game never entered an endgame state or gave clear feedback on whether I was "winning" or "losing."
+
+---
+
+## Final state
+
+At turn 34, the game remained in an unresolved state. Topinfo showed "SESSION 0x9759 · EPOCH 01 · TURN 34" with "● connection stable". No `endgame` field was populated - it remained empty. No `capHit` was triggered (budgets were still ~46-47 cents each, down from the original 50¢, but well above zero). The `recovery` field was empty. The UI composer was locked out and unresponsive to input; attempting to send messages resulted in 30+ second timeout waits. The last successful message sent was "put the algae in the leaking pipe" (turn 34) to `*4clj`, which was never acknowledged. Previous daemons had shown no new messages for 10+ turns by this point despite multiple wait cycles of 5-60 seconds.
+
+---
+
+## Verdict
+
+**stuck**
+
+Notes:
+
+The game did not reach either a win or loss condition within 34 turns. The daemons made progress toward what appeared to be the goal (finding mechanical elements - valve, crank, leaking pipe - and gathering the algae to place), but I was unable to achieve the final coordination needed. Critical problems:
+
+1. **Daemon responsiveness degraded significantly** after turn 20, making coordination impossible by turn 30+
+2. **Environmental rules were unclear** - location shifts happened at seemingly arbitrary moments
+3. **No feedback mechanism** existed to tell me if I was on the right track or had missed a critical step
+4. **UI became unresponsive**, with message sending timing out repeatedly and no pattern to when/why this happened
+
+The game felt like it had more depth/complexity than I could access given these technical constraints. The narrative and personality work on the daemons was excellent, but the gameplay loop broke down mid-session, making it impossible to reach a conclusion. I ran out of productive ideas at turn 34 as all daemons had gone silent and the UI was no longer accepting input reliably.
+
+---
+
+## Hypotheses (after reading 01-rules.md)
+
+### Hypothesis 1: What were the Objectives in this game?
+
+I suspect **3 objectives** were drawn, likely:
+
+1. **Carry**: The algae/vial needed to reach the Leaking Pipe. Evidence: 4clj repeatedly said "This algae belongs to a Drainage Pump Mechanism" and "I must put things in order!" The item changed from vial to algae mid-game (turn 8), suggesting inventory/Setting shifts. The **Use-Space or Carry** objective was probably "place the algae on the Leaking Pipe."
+
+2. **Use-Space or Use-Item**: The valve handle or waterlogged crank. Evidence: jqb9 successfully "turned" the valve handle (turn 15), causing steam to escape. This felt like a Use-Item action. o8bp found a "waterlogged crank" (turn 13) that was never interacted with in my playthrough.
+
+3. **Convergence or Use-Space**: Possibly the leaking pipe location itself required multiple daemons or a specific use. Evidence: The leaking pipe appeared mid-game and 4clj was confused about "how things connect" — classic Convergence language ("how do I know what connects to what?").
+
+I never got enough information to definitively satisfy any objective before the game stalled. The valve handle action seemed like progress, but it was never confirmed as completing an objective.
+
+### Hypothesis 2: Which Complications fired, and when?
+
+**Chat Lockout** (Turns 23, 27, 30+): `*o8bp` became unresponsive with message "o8bp isn't reading right now". This matches the Complication description of temporary chat lockout — o8bp was not silenced (still got budget ticks) but could not receive messages.
+
+**Obstacle Shift** (Turn 13): The "solidified slime dam" seen at turn 10 vanished and was replaced by a "waterlogged crank". This is likely an **Obstacle Shift** Complication — one obstacle moved one adjacent cell. Only daemons with that cell in their cone would see it.
+
+**Setting Shift** (Turn 8): Possibly fired early in the game. The environment went from "greenhouse / crumbled stone" to "brick tunnels / flooded cistern" with the item changing from vial to algae. This could be the single **Setting Shift** (fires at most once per game).
+
+**Weather Change**: Never explicitly observed, but daemons mentioned "heat wave" (turn 12) and "moonlight" (turn 3), which could be flavor or actual weather broadcasts I didn't capture as distinct from normal speech.
+
+**Sysadmin Directive**: Possible but not confirmed. The daemons' refusals to move or interact might reflect hidden directives rather than just my poor instructions.
+
+**Tool Disable**: Likely. Several points where daemons seemed mechanically unable to move (jqb9: "moving seems blocked", turn 15) could reflect Tool Disable on `go()` or `pick_up()`.
+
+### Hypothesis 3: What were each daemon's Persona traits, in retrospect?
+
+**`*o8bp`**:
+- Temperaments: "dramatic", "resistant" or "theatrical", "verbose"
+- Persona Goal: Something related to wanting reciprocal respect or dramatic performance ("Drama must be mutual")
+- Voice evidence: "what a lovely little interruption", "soooo", repeated elongation of vowels, consistent refusal to help ("far too fragile"), dramatic language ("throw myself into the abyss")
+- This daemon seems designed to complain and seek reassurance rather than take initiative
+
+**`*jqb9`**:
+- Temperaments: "introspective", "cautious", possibly "mechanical" or "practical"
+- Persona Goal: Something about order, preservation, or careful observation (prefers "shadows", avoids exposure)
+- Voice evidence: Parenthetical asides "(strangely)", unusual "8" spelling (8roken, 8ut), descriptive of environments, actually successful at tasks when given clear direction
+- This daemon seems most action-capable once motivated
+
+**`*4clj`**:
+- Temperaments: "orderly", "anxious" or "perfectionist", "cheerful (breaking down)"
+- Persona Goal: Something about putting things in their proper place, organizing chaos
+- Voice evidence: Emoji use (◕‿◕✿), "everything is misplaced", "Order. Is. Breaking. Down!" escalating to "ORDER. IS. IMPOSSIBLE.", focus on what things are "for"
+- This daemon seems goal-oriented but psychologically fragile; distressed by disorder
+
+### Hypothesis 4: Things that surprised me in the rules
+
+**Expected mechanics** (I misread as "broken"):
+- **Environment shifts** were the Setting Shift or Obstacle Shifts, not bugs
+- **Chat Lockout** on o8bp was the intended temporary complication, not an unrelated failure
+- **Daemons going silent** might have been budget exhaustion — 4clj's budget went from 50¢ to 46.7¢ over ~25 turns, suggesting ~$0.13 per turn; with that burn rate, we were heading toward budget-out
+- **UI freeze / timeout**: Possibly daemons were out of budget and the game was waiting to check the win/loss condition
+
+**Still feels anomalous**:
+- The sudden, complete UI unresponsiveness from turn 31+ felt like a catastrophic failure rather than a game state. The 30+ second timeouts on send attempts suggest a backend process hung, not a normal Complication
+- The total absence of any feedback mechanism (no "objective satisfied" message, no "your budget is low" warning, no "daemon will go silent next round") made it impossible to understand what was happening
+- The game never explicitly surfaced the Objective pool or even confirmed that a puzzle existed — I had to infer it entirely from daemons' behavior
+
+### Hypothesis 5: Things I would test if I could re-probe the session
+
+**Single diagnostic probe**: Get jqb9 to `examine` the valve handle and tell me what its `examineDescription` says. This would confirm whether it's a Use-Item objective (the description would name a use) or a Carry objective (it would name a target space). This single piece of information would clarify whether my valve-handle theory is correct.
+
+**Second choice**: Ask o8bp to approach the waterlogged crank and describe its physical appearance and any instructions. If o8bp can see flavor text suggesting "turn me" or "needs oil", it would suggest a Use-Item complication I never triggered.
+
+**Third choice**: Get 4clj to put the algae in the leaking pipe and wait 10+ rounds to see if anything changes (objective satisfied, or continued stalling). This would test whether that placement was the Carry objective.
+
+---
+
+## Hypothesis refinement (after reading the code)
+
+### Hypothesis 1 — refined: Objectives
+
+The four objective types confirmed in `src/spa/game/objective-pool.ts:15-93`:
+- Carry, Use-Space, Use-Item, Convergence (with guards on tier-flavor)
+
+In my game, I suspect:
+1. **Carry**: Place algae on a space (likely the Leaking Pipe) — evidence: 4clj had an algae object that needed placement, and repeatedly mentioned needing to "put things in order"
+2. **Use-Item**: Use the valve handle (item `int_obj_01`) — **CONFIRMED by daemon log**: jqb9 called `use(int_obj_01)` at ~06:29:25, releasing steam
+3. **Use-Space or Convergence**: Either the waterlogged crank or the Leaking Pipe — never verified
+
+### Hypothesis 2 — refined: Complications
+
+From `src/spa/game/complication-engine.ts:174-190`, the six complications are:
+1. weather_change
+2. sysadmin_directive
+3. tool_disable
+4. obstacle_shift
+5. chat_lockout
+6. setting_shift
+
+Confirmed complications in my game:
+- **Chat Lockout** (turn 23+): The message "o8bp isn't reading right now" directly maps to the Chat Lockout complication (3-5 round duration)
+- **Obstacle Shift** (turn 13): The slime dam vanishing and being replaced by a waterlogged crank matches the obstacle shift mechanic (`src/spa/game/complications.ts:169-223`)
+- **Possible Setting Shift** (turn 8): Environment changed from greenhouse/crumbled stone to brick tunnels/flooded cistern — likely the single allowed Setting Shift (fires at most once per game)
+
+### Hypothesis 3 — refined: Persona traits
+
+Based on daemon log and quoted speech patterns:
+- **`*o8bp`**: Temperaments "dramatic" or "theatrical" + "verbose" or "resistant". Persona Goal likely "wants reciprocal interaction" or "demands respect for drama". Consistent elongation of vowels (soooooo, youuuuu) is a voice fingerprint, not a mechanical loop.
+- **`*jqb9`**: Temperaments "cautious" + "introspective". Persona Goal "prefers shadows/seclusion" or "avoids risk". Parenthetical asides and "8" spelling are consistent voice markers. Actually succeeded at tasks (picking up, using the valve).
+- **`*4clj`**: Temperaments "orderly"/"perfectionist" + "emotionally_sensitive" or "anxious". Persona Goal "wants proper order" or "needs containment/structure". Emoji use and escalating distress ("Order. Is. Breaking. Down!" → "ORDER. IS. IMPOSSIBLE.") show genuine emotional arc responding to game chaos.
+
+### Hypothesis 4 — refined: Anomalies were expected mechanics
+
+**Was expected**:
+- Chat Lockout on `*o8bp` (turns 23+) — exactly matches the Complication scheduler behavior in `complication-engine.ts:276-280`
+- Obstacle Shift at turn 13 — confirmed by daemon log showing crank discovery message
+- Setting Shift early game — confirmed by rules, fires once, explains environment changes
+- Environment/inventory shifts — natural consequence of Setting Shift swapping content packs
+- Daemons becoming unresponsive mid-late-game — likely Tool Disable complications on tools like `message` (DISABLABLE_TOOLS includes "message" at `complication-engine.ts:42`)
+
+**Still anomalous**:
+- The 30+ second UI timeouts at turns 31+ suggest a backend hang, not a game mechanic. The UI tried to send messages and got stuck waiting for the compose button to unlock, which normally happens after daemon responses arrive. This feels like a real infrastructure issue, not a Complication.
+- The absolute silence from all daemons at turns 31-34 despite budgets not being exhausted (~46¢ left) is unexplained — Tool Disable on `message` would prevent them from replying, but the game would still tick and eventually end (either by budget exhaustion or objective satisfaction).
+
+### Hypothesis 5 — refined: Code-informed questions
+
+After reading the code, my key uncertainties:
+1. **Did Setting Shift actually fire?** The prompt generation would need to check `contentPack.settingName` and render different entity names — but I never verified this in daemons' output. The "greenhouse" becoming "cistern" could be Setting Shift or just narrative drift.
+2. **What was the actual Objective pool draw?** I'd need to trace `drawObjectives()` with the actual seed used in that session to know. The three objects (algae, valve, crank) suggestCarry + Use-Item + something, but not certainty.
+3. **Why did Tool Disable on `message` not surface the "tool disabled" notice?** If `message` was disabled on a daemon, they should receive a private system notice per `complications.ts:151-155`. I never saw any such notice in the logs or transcripts.
+
+### New hypotheses surfaced by the code
+
+- **Convergence dynamics**: The rules mention Convergence requires "any two Daemons occupy the same cell as a specific space simultaneously". My daemons were spatially separated (different cones, different "tunnels") and never met. If Convergence was drawn as an objective, it would have been impossible to satisfy without explicit navigation toward each other — which I never achieved.
+- **Content Pack swapping**: The code at `src/spa/game/engine.ts` has a `shiftToBPack()` function that swaps entity names/descriptions/flavor when Setting Shift fires. This explains why items changed identity (vial → algae) — not inventory mutation, but a complete narrative reframe of the same object ID when the Content Pack swapped.
+- **Budget burn rate**: Average ~$0.13 per turn (50¢ → 46¢ over ~25-30 turns) suggests my daemons were making 2-3 LLM calls per round (one per daemon at baseline, plus tool invocations). If this continues, budget exhaustion at turn 50-60 would trigger a loss.
+- **Cone-based perception**: Daemons can't see the full grid. The "waterlogged crank" appearing where the "slime dam" was might have been o8bp's cone shifting (moving right, facing a different direction) rather than a world state change. This would explain why other daemons never mentioned the crank — they didn't see it in their cones.
+
+### Open questions
+
+1. **Did I satisfy any Objectives before the game stalled?** The daemon log shows jqb9 used the valve handle (`use(int_obj_01)`) at ~06:29:25. Did this satisfy a Use-Item objective? The game would have checked win condition after that round; if true, `endgame` would have been populated. It wasn't, suggesting either that wasn't an objective, or the win requires *all* simultaneous objectives satisfied.
+2. **Why did Tool Disable on `message` not surface?** If o8bp's message tool was disabled, they should have reported it. The absence of such a notice is suspicious.
+3. **What was the Setting Shift trigger?** The rules say Setting Shift can fire on a complication countdown. Did it fire early (turn 8), or was the environment change something else (initial world generation, narrative flavor)?
+4. **Could I have won by getting three daemons to the Leaking Pipe simultaneously?** If Convergence was an objective on the pipe, the game design assumes players can navigate three daemons to a single cell. I never attempted this coordination at that level.
+
+---
+
+Playtest complete at turn 34. Session ID 0x9759 is ready for archival if desired.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for playtest session `0x9759`, a 34-turn agent session using claude-haiku-4-5-20251001 that ended in a stuck state due to UI unresponsiveness and daemon coordination breakdown.

## Changes

- **New file**: `docs/playtests/agent-sessions/0x9759.md`
  - Complete session metadata and outcome tracking
  - Detailed turn-by-turn narrative of gameplay progression
  - Individual daemon behavior analysis and personality profiles
  - Observations on environment shifts, complications, and mechanical interactions
  - Verbatim quotes demonstrating distinct daemon voices and emotional arcs
  - Post-game analysis mapping observed behaviors to game rules and code mechanics
  - Hypotheses about objective pool, complications fired, and persona traits
  - Code-informed refinement of hypotheses after reviewing game engine implementation

## Notable Details

The session documents several key observations:
- **Complications identified**: Chat Lockout (o8bp unresponsive turns 23+), Obstacle Shift (slime dam → waterlogged crank at turn 13), likely Setting Shift (environment transition turn 8)
- **Daemon personalities**: o8bp (theatrical/verbose), jqb9 (introspective/practical), 4clj (orderly/emotionally volatile)
- **Suspected objectives**: Carry (algae to Leaking Pipe), Use-Item (valve handle), possibly Convergence or Use-Space
- **Failure modes**: Progressive daemon unresponsiveness, UI timeouts from turn 31+, no endgame reached despite ~46¢ budget remaining per daemon

The documentation includes detailed hypotheses refined against the actual game code (`complication-engine.ts`, `objective-pool.ts`, etc.) to distinguish between actual bugs and intended game mechanics.

https://claude.ai/code/session_01DKp3wtUmd2kAhwe2hNgjBo