### PR TITLE
feat: channel aliases + version-mismatch banner with archive URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Enable Corepack
         run: corepack enable
@@ -37,6 +39,10 @@ jobs:
       - name: Test
         if: ${{ !cancelled() }}
         run: pnpm run test
+
+      - name: Check schema-archive map
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        run: node scripts/check-schema-map.mjs
 
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
-          destination_dir: ''
+          destination_dir: nightly/
           keep_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,31 @@ jobs:
           publish_dir: ./dist
           destination_dir: v/${{ steps.path.outputs.version_path }}
           keep_files: true
+
+      - name: Check if highest stable
+        id: stable_check
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          PUSHED="${TAG}"
+          if [[ ! "$PUSHED" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_highest=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          HIGHEST=$(git tag --list 'v*' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)
+          if [ "$PUSHED" = "$HIGHEST" ]; then
+            echo "is_highest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_highest=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to root (latest stable mirror)
+        if: steps.stable_check.outputs.is_highest == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: ''
+          keep_files: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,21 @@ The pinned model is `z-ai/glm-4.7` (`src/model.ts`). Daemon system prompts are a
 ### Commit messages
 
 We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/#specification). Squash-merge PR titles are the source of truth — `changelogen` parses them to bump the version and write `CHANGELOG.md`. See `docs/agents/commits.md`.
+
+## Bumping SESSION_SCHEMA_VERSION
+
+When you bump SESSION_SCHEMA_VERSION in
+`src/spa/persistence/session-codec.ts`, you must do ONE of:
+
+- **Add a migrateV<old>To... function** in session-codec.ts so old
+  saves migrate in place. No further action needed.
+- **Add an entry to SCHEMA_ARCHIVE_MAP** in
+  `src/spa/persistence/archive-map.ts` mapping the OLD schema number to
+  the latest released version that shipped it. Find that version with:
+
+      git describe --tags --abbrev=0 --match 'v*' HEAD~1
+
+If the schema bumps twice without a release in between, the
+intermediate schema number was never shipped — skip its map entry.
+
+`scripts/check-schema-map.mjs` enforces this on PRs.

--- a/scripts/__tests__/check-schema-map.test.ts
+++ b/scripts/__tests__/check-schema-map.test.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "../..");
+const script = path.join(root, "scripts/check-schema-map.mjs");
+
+function git(args: string[], cwd: string): { status: number; stdout: string } {
+	const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+	return { status: result.status ?? 1, stdout: result.stdout ?? "" };
+}
+
+/**
+ * Spin up a temp git repo with a fake `origin/main` branch and a current HEAD,
+ * then invoke check-schema-map.mjs with GITHUB_BASE_REF=main so it compares
+ * HEAD against origin/main.
+ */
+function runScriptWith({
+	baselineFile,
+	headFile,
+	fileName,
+}: {
+	baselineFile: string;
+	headFile: string;
+	fileName: string;
+}): { status: number; stderr: string } {
+	const repo = mkdtempSync(path.join(tmpdir(), "schema-map-test-"));
+	try {
+		git(["init", "-q", "-b", "main"], repo);
+		git(["config", "user.email", "t@example.com"], repo);
+		git(["config", "user.name", "T"], repo);
+		git(["config", "commit.gpgsign", "false"], repo);
+
+		// Baseline commit on main
+		writeFileSync(path.join(repo, fileName), baselineFile);
+		git(["add", "."], repo);
+		git(["commit", "-q", "--no-gpg-sign", "-m", "baseline"], repo);
+
+		// Mirror to a fake remote named "origin" pointing at this same repo's main
+		git(["update-ref", "refs/remotes/origin/main", "HEAD"], repo);
+
+		// HEAD diverges from origin/main with the test diff
+		git(["checkout", "-q", "-b", "feature"], repo);
+		writeFileSync(path.join(repo, fileName), headFile);
+		git(["add", "."], repo);
+		git(["commit", "-q", "--no-gpg-sign", "-m", "change"], repo);
+
+		const result = spawnSync("node", [script], {
+			cwd: repo,
+			env: { ...process.env, GITHUB_BASE_REF: "main" },
+			encoding: "utf-8",
+		});
+		return { status: result.status ?? 1, stderr: result.stderr ?? "" };
+	} finally {
+		rmSync(repo, { recursive: true, force: true });
+	}
+}
+
+describe("check-schema-map.mjs", () => {
+	it("fails when SESSION_SCHEMA_VERSION bumps without a map entry or migration", () => {
+		const result = runScriptWith({
+			fileName: "session-codec.ts",
+			baselineFile: "export const SESSION_SCHEMA_VERSION = 9;\n",
+			headFile: "export const SESSION_SCHEMA_VERSION = 10;\n",
+		});
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("SESSION_SCHEMA_VERSION changed");
+	});
+
+	it("passes when SESSION_SCHEMA_VERSION bumps alongside a SCHEMA_ARCHIVE_MAP change", () => {
+		const result = runScriptWith({
+			fileName: "session-codec.ts",
+			baselineFile:
+				"export const SESSION_SCHEMA_VERSION = 9;\nexport const SCHEMA_ARCHIVE_MAP = {};\n",
+			headFile:
+				'export const SESSION_SCHEMA_VERSION = 10;\nexport const SCHEMA_ARCHIVE_MAP = { 9: "0.1.1" };\n',
+		});
+		expect(result.status).toBe(0);
+	});
+
+	it("passes when SESSION_SCHEMA_VERSION bumps alongside a new migrateV<n>To function", () => {
+		const result = runScriptWith({
+			fileName: "session-codec.ts",
+			baselineFile: "export const SESSION_SCHEMA_VERSION = 9;\n",
+			headFile:
+				"export const SESSION_SCHEMA_VERSION = 10;\nfunction migrateV9ToV10() {}\n",
+		});
+		expect(result.status).toBe(0);
+	});
+
+	it("passes when SESSION_SCHEMA_VERSION is untouched", () => {
+		const result = runScriptWith({
+			fileName: "session-codec.ts",
+			baselineFile:
+				"export const SESSION_SCHEMA_VERSION = 9;\nconst other = 1;\n",
+			headFile: "export const SESSION_SCHEMA_VERSION = 9;\nconst other = 2;\n",
+		});
+		expect(result.status).toBe(0);
+	});
+});

--- a/scripts/check-schema-map.mjs
+++ b/scripts/check-schema-map.mjs
@@ -1,0 +1,25 @@
+import { execSync } from "node:child_process";
+
+const base = process.env.GITHUB_BASE_REF ?? "main";
+const diff = execSync(`git diff origin/${base}...HEAD --unified=0`, {
+	encoding: "utf8",
+});
+
+const schemaChanged = /^[+-].*SESSION_SCHEMA_VERSION\s*=\s*\d+/m.test(diff);
+const mapChanged = /^[+-].*SCHEMA_ARCHIVE_MAP/m.test(diff);
+const migrationAdded = /^\+.*function\s+migrateV\d+/m.test(diff);
+
+if (schemaChanged && !mapChanged && !migrationAdded) {
+	console.error(
+		`SESSION_SCHEMA_VERSION changed without a SCHEMA_ARCHIVE_MAP entry
+or a new migrateV<n>To... function. Choose one:
+
+  (a) Add a SCHEMA_ARCHIVE_MAP entry mapping the OLD schema number
+      to the latest released version that shipped it.
+  (b) Add a migrateV<old>To... function in session-codec.ts so old
+      saves transparently migrate to the new schema.
+
+See AGENTS.md for the full schema-bump workflow.`,
+	);
+	process.exit(1);
+}

--- a/src/spa/__tests__/active-session-dispatcher.test.ts
+++ b/src/spa/__tests__/active-session-dispatcher.test.ts
@@ -68,11 +68,16 @@ describe("dispatchActiveSession — five-state truth table", () => {
 	it("Row 5 — version-mismatch load result → #/sessions, version-mismatch, needsMint false", () => {
 		const snapshot: DispatcherSnapshot = {
 			activeSessionId: "0xABCD",
-			loadResult: { kind: "version-mismatch", sessionId: "0xABCD" },
+			loadResult: {
+				kind: "version-mismatch",
+				sessionId: "0xABCD",
+				schemaVersion: 9,
+			},
 		};
 		const verdict = dispatchActiveSession(snapshot);
 		expect(verdict.route).toBe("#/sessions");
 		expect(verdict.reason).toBe("version-mismatch");
 		expect(verdict.needsMint).toBe(false);
+		expect(verdict.schemaVersion).toBe(9);
 	});
 });

--- a/src/spa/__tests__/sessions.test.ts
+++ b/src/spa/__tests__/sessions.test.ts
@@ -251,6 +251,30 @@ describe("renderSessions — banner", () => {
 		expect(banner?.textContent).toContain("older version");
 	});
 
+	it("?reason=version-mismatch with map-hit schemaVersion renders archive link", async () => {
+		vi.resetModules();
+		const archiveMapModule = await import("../persistence/archive-map.js");
+		archiveMapModule.SCHEMA_ARCHIVE_MAP[9] = "0.1.1";
+		try {
+			const { renderSessions } = await import("../routes/sessions.js");
+			renderSessions(getMain(), {
+				reason: "version-mismatch",
+				schemaVersion: 9,
+			});
+			const banner = document.querySelector<HTMLElement>("#sessions-banner");
+			expect(banner?.hidden).toBe(false);
+			expect(banner?.textContent).toContain(
+				"Your saved Session is from an older version",
+			);
+			expect(banner?.textContent).toContain("v0.1.1");
+			const link = banner?.querySelector("a");
+			expect(link).not.toBeNull();
+			expect(link?.getAttribute("href")).toBe("./v/0.1.1/");
+		} finally {
+			delete archiveMapModule.SCHEMA_ARCHIVE_MAP[9];
+		}
+	});
+
 	it("no reason param => banner hidden", async () => {
 		vi.resetModules();
 		const { renderSessions } = await import("../routes/sessions.js");

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -452,14 +452,18 @@ describe("renderStart — persistence warning banners", () => {
 		);
 	});
 
-	it("shows 'version-mismatch' banner text when reason=version-mismatch", async () => {
+	it("shows 'version-mismatch' map-miss banner text when no archive entry exists", async () => {
 		vi.spyOn(Math, "random").mockReturnValue(0.9);
 		vi.resetModules();
+		// Default SCHEMA_ARCHIVE_MAP is empty — any schemaVersion is a miss.
 		const { renderStart } = await import("../routes/start.js");
 
 		setSearch("skipDialup=1");
 		try {
-			await renderStart(getMain(), { reason: "version-mismatch" });
+			await renderStart(getMain(), {
+				reason: "version-mismatch",
+				schemaVersion: 9,
+			});
 		} catch {
 			// ok
 		}
@@ -471,6 +475,43 @@ describe("renderStart — persistence warning banners", () => {
 		expect(warningEl?.textContent).toContain(
 			"Saved game data is from an older version and has been discarded",
 		);
+		// Map miss: no anchor.
+		expect(warningEl?.querySelector("a")).toBeNull();
+	});
+
+	it("shows 'version-mismatch' map-hit banner with archive link when entry exists", async () => {
+		vi.spyOn(Math, "random").mockReturnValue(0.9);
+		vi.resetModules();
+		// Inject a test-only entry into SCHEMA_ARCHIVE_MAP before the route runs.
+		const archiveMapModule = await import("../persistence/archive-map.js");
+		archiveMapModule.SCHEMA_ARCHIVE_MAP[9] = "0.1.1";
+		try {
+			const { renderStart } = await import("../routes/start.js");
+
+			setSearch("skipDialup=1");
+			try {
+				await renderStart(getMain(), {
+					reason: "version-mismatch",
+					schemaVersion: 9,
+				});
+			} catch {
+				// ok
+			}
+
+			const warningEl = document.querySelector<HTMLElement>(
+				"#persistence-warning",
+			);
+			expect(warningEl?.hasAttribute("hidden")).toBe(false);
+			expect(warningEl?.textContent).toContain(
+				"Your saved Session is from an older version of hi-blue",
+			);
+			expect(warningEl?.textContent).toContain("v0.1.1");
+			const link = warningEl?.querySelector("a");
+			expect(link).not.toBeNull();
+			expect(link?.getAttribute("href")).toBe("./v/0.1.1/");
+		} finally {
+			delete archiveMapModule.SCHEMA_ARCHIVE_MAP[9];
+		}
 	});
 
 	it("shows 'legacy-save-discarded' banner text when reason=legacy-save-discarded", async () => {

--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -617,6 +617,21 @@ describe("serializeSession / deserializeSession", () => {
 		const tampered = obfuscate(JSON.stringify(sealed));
 		const result = deserializeSession({ ...files, engine: tampered });
 		expect(result.kind).toBe("version-mismatch");
+		if (result.kind === "version-mismatch") {
+			expect(result.schemaVersion).toBe(5);
+		}
+	});
+
+	it("version-mismatch: non-numeric schemaVersion → broken (NaN guard)", () => {
+		const game = makeFreshGame();
+		const files = serializeSession(game, NOW, CREATED_AT);
+		if (!files.engine) throw new Error("engine should not be null");
+		const rawJson = deobfuscate(files.engine);
+		const sealed = JSON.parse(rawJson);
+		sealed.schemaVersion = "not-a-number";
+		const tampered = obfuscate(JSON.stringify(sealed));
+		const result = deserializeSession({ ...files, engine: tampered });
+		expect(result.kind).toBe("broken");
 	});
 
 	it("v8 save with multi-entry contentPacksA/B is migrated to v9 by truncating to first entry", () => {

--- a/src/spa/persistence/__tests__/session-storage.test.ts
+++ b/src/spa/persistence/__tests__/session-storage.test.ts
@@ -303,6 +303,9 @@ describe("loadActiveSession", () => {
 
 		const result = loadActiveSession();
 		expect(result.kind).toBe("version-mismatch");
+		if (result.kind === "version-mismatch") {
+			expect(result.schemaVersion).toBe(999);
+		}
 	});
 
 	it("save → load round-trip returns ok with correct state", () => {

--- a/src/spa/persistence/active-session-dispatcher.ts
+++ b/src/spa/persistence/active-session-dispatcher.ts
@@ -27,6 +27,8 @@ export interface DispatcherVerdict {
 	route: "#/start" | "#/game" | "#/sessions";
 	reason: DispatcherReason;
 	needsMint: boolean;
+	/** Populated only when reason === "version-mismatch". */
+	schemaVersion?: number;
 }
 
 export interface DispatcherSnapshot {
@@ -66,6 +68,7 @@ export function dispatchActiveSession(
 				route: "#/sessions",
 				reason: "version-mismatch",
 				needsMint: false,
+				schemaVersion: loadResult.schemaVersion,
 			};
 	}
 }

--- a/src/spa/persistence/archive-map.ts
+++ b/src/spa/persistence/archive-map.ts
@@ -1,0 +1,21 @@
+/**
+ * Maps an old SESSION_SCHEMA_VERSION to the version string (no `v` prefix)
+ * of the latest released hi-blue build that shipped that schema. Used by
+ * the version-mismatch banner to link users to an archived /v/<version>/
+ * build that can still read their save.
+ *
+ * When you bump SESSION_SCHEMA_VERSION, see AGENTS.md.
+ */
+export const SCHEMA_ARCHIVE_MAP: Record<number, string> = {
+	// 9: "0.1.1",  // example: schema 9 last shipped in v0.1.1
+};
+
+/** Look up the archived version string for an old schema number. */
+export function lookupArchiveVersion(
+	schemaVersion: number | undefined,
+): string | null {
+	if (typeof schemaVersion !== "number" || !Number.isFinite(schemaVersion)) {
+		return null;
+	}
+	return SCHEMA_ARCHIVE_MAP[schemaVersion] ?? null;
+}

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -73,6 +73,10 @@ import {
  * v10 (issue #374): add `wallName` to `ContentPack`.
  *   - Old v9 saves have no `wallName`; version-mismatch result (consistent
  *     with v7/v8 policy — no migration provided).
+ *
+ * Bumping this constant requires either a `migrateV<old>To...` function below
+ * or a new entry in `SCHEMA_ARCHIVE_MAP` (see AGENTS.md → "Bumping
+ * SESSION_SCHEMA_VERSION"). `scripts/check-schema-map.mjs` enforces this on PRs.
  */
 export const SESSION_SCHEMA_VERSION = 10 as const;
 
@@ -148,7 +152,7 @@ export type DeserializeResult =
 			epoch: number;
 	  }
 	| { kind: "broken" }
-	| { kind: "version-mismatch" };
+	| { kind: "version-mismatch"; schemaVersion: number };
 
 // ── serializeSession ──────────────────────────────────────────────────────────
 
@@ -272,7 +276,9 @@ export function deserializeSession(
 	if ((sealed as { schemaVersion: number }).schemaVersion === 8) {
 		sealed = migrateV8ToV9(sealed);
 	} else if (sealed.schemaVersion !== SESSION_SCHEMA_VERSION) {
-		return { kind: "version-mismatch" };
+		const sv = Number(sealed.schemaVersion);
+		if (!Number.isFinite(sv)) return { kind: "broken" };
+		return { kind: "version-mismatch", schemaVersion: sv };
 	}
 
 	// Parse meta.json

--- a/src/spa/persistence/session-storage.ts
+++ b/src/spa/persistence/session-storage.ts
@@ -76,7 +76,7 @@ export type LoadResult =
 			epoch: number;
 	  }
 	| { kind: "broken"; sessionId: string }
-	| { kind: "version-mismatch"; sessionId: string };
+	| { kind: "version-mismatch"; sessionId: string; schemaVersion: number };
 
 // ── Session ID ────────────────────────────────────────────────────────────────
 
@@ -337,7 +337,11 @@ function _loadSessionById(
 			};
 		}
 		if (result.kind === "version-mismatch") {
-			return { kind: "version-mismatch", sessionId };
+			return {
+				kind: "version-mismatch",
+				sessionId,
+				schemaVersion: result.schemaVersion,
+			};
 		}
 		return { kind: "broken", sessionId };
 	} catch {

--- a/src/spa/render-app.ts
+++ b/src/spa/render-app.ts
@@ -31,6 +31,13 @@ export type RenderReason = DispatcherReason | "legacy-save-discarded" | "stuck";
 
 export interface RenderOpts {
 	reason?: RenderReason | null;
+	/**
+	 * The schema version embedded in the saved session that triggered a
+	 * version-mismatch. Threaded through from the dispatcher so the banner
+	 * can look up the archived build URL (see archive-map.ts). Only meaningful
+	 * when reason === "version-mismatch".
+	 */
+	schemaVersion?: number;
 }
 
 export type ViewRenderer = (
@@ -117,7 +124,20 @@ export function renderApp(
 		delete root.dataset.reason;
 	}
 
+	// Thread schemaVersion through to the route when the effective reason is
+	// version-mismatch. Explicit opts.schemaVersion (e.g. game.ts passing it
+	// through after clearActiveSession) wins over the dispatcher-derived value.
+	let effectiveSchemaVersion: number | undefined;
+	if (effectiveReason === "version-mismatch") {
+		effectiveSchemaVersion = opts?.schemaVersion ?? verdict.schemaVersion;
+	}
+
 	const renderer = renderers.get(view);
 	if (!renderer) return;
-	return renderer(root, { reason: effectiveReason });
+	return renderer(root, {
+		reason: effectiveReason,
+		...(effectiveSchemaVersion !== undefined
+			? { schemaVersion: effectiveSchemaVersion }
+			: {}),
+	});
 }

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -952,8 +952,15 @@ export function renderGame(
 					loadResult.kind === "version-mismatch"
 						? "version-mismatch"
 						: "broken";
+				const schemaVersion =
+					loadResult.kind === "version-mismatch"
+						? loadResult.schemaVersion
+						: undefined;
 				clearActiveSession();
-				renderApp(root, { reason: reasonParam });
+				renderApp(root, {
+					reason: reasonParam,
+					...(schemaVersion !== undefined ? { schemaVersion } : {}),
+				});
 				return Promise.resolve();
 			}
 		}

--- a/src/spa/routes/sessions.ts
+++ b/src/spa/routes/sessions.ts
@@ -18,6 +18,7 @@
  */
 
 import { paintBanner, paintTopInfo } from "../bbs-chrome.js";
+import { lookupArchiveVersion } from "../persistence/archive-map.js";
 import {
 	dupSession,
 	getActiveSessionId,
@@ -40,8 +41,36 @@ import { type RenderOpts, renderApp, setPickerOpen } from "../render-app.js";
 export const SESSIONS_BANNER_MESSAGES: Record<string, string> = {
 	broken: "The active Session was unreadable and could not be loaded.",
 	"version-mismatch":
-		"The active Session is from an older version of hi-blue and could not be loaded.",
+		"Saved game data is from an older version and has been discarded. Starting a new game.",
 };
+
+/**
+ * Paint the version-mismatch banner. When the schema number maps to a known
+ * archived release, the banner offers a link to `./v/<version>/` so the user
+ * can continue their Session in the build that last understood its schema.
+ */
+function renderVersionMismatchBanner(
+	doc: Document,
+	bannerEl: HTMLElement,
+	schemaVersion: number | undefined,
+): void {
+	bannerEl.textContent = "";
+	const archivedVersion = lookupArchiveVersion(schemaVersion);
+	if (archivedVersion === null) {
+		bannerEl.textContent = SESSIONS_BANNER_MESSAGES["version-mismatch"] ?? "";
+		return;
+	}
+	bannerEl.appendChild(
+		doc.createTextNode(
+			"Your saved Session is from an older version of hi-blue. Continue it in ",
+		),
+	);
+	const link = doc.createElement("a");
+	link.href = `./v/${archivedVersion}/`;
+	link.textContent = `v${archivedVersion} →`;
+	bannerEl.appendChild(link);
+	bannerEl.appendChild(doc.createTextNode(", or start a new Session below."));
+}
 
 // ── Visibility helpers ──────────────────────────────────────────────────────────
 
@@ -116,7 +145,10 @@ export function renderSessions(root: HTMLElement, opts?: RenderOpts): void {
 	const bannerEl = doc.querySelector<HTMLElement>("#sessions-banner");
 	const reason = opts?.reason ?? null;
 	if (bannerEl) {
-		if (reason && SESSIONS_BANNER_MESSAGES[reason]) {
+		if (reason === "version-mismatch") {
+			renderVersionMismatchBanner(doc, bannerEl, opts?.schemaVersion);
+			bannerEl.hidden = false;
+		} else if (reason && SESSIONS_BANNER_MESSAGES[reason]) {
 			bannerEl.textContent = SESSIONS_BANNER_MESSAGES[reason] ?? "";
 			bannerEl.hidden = false;
 		} else {

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -30,6 +30,7 @@ import {
 	startBootstrap,
 } from "../game/pending-bootstrap.js";
 import { getSpikeRng, setSpikeSeed } from "../game/spike-seed.js";
+import { lookupArchiveVersion } from "../persistence/archive-map.js";
 import { type RenderOpts, renderApp } from "../render-app.js";
 
 /** Warning reason strings shown in the persistence warning banner. */
@@ -43,6 +44,36 @@ export const PERSISTENCE_WARNING_MESSAGES: Record<string, string> = {
 	stuck:
 		"Game initialization took too long and was cancelled. Starting a new game.",
 };
+
+/**
+ * Render the version-mismatch banner. When the schema number maps to a known
+ * archived release, the banner offers a link to `./v/<version>/` so the user
+ * can continue their Session in the build that last understood its schema.
+ * Otherwise we fall back to the plain "discarded" copy.
+ */
+function renderVersionMismatchBanner(
+	doc: Document,
+	bannerEl: HTMLElement,
+	schemaVersion: number | undefined,
+): void {
+	bannerEl.textContent = "";
+	const archivedVersion = lookupArchiveVersion(schemaVersion);
+	if (archivedVersion === null) {
+		bannerEl.textContent =
+			PERSISTENCE_WARNING_MESSAGES["version-mismatch"] ?? "";
+		return;
+	}
+	bannerEl.appendChild(
+		doc.createTextNode(
+			"Your saved Session is from an older version of hi-blue. Continue it in ",
+		),
+	);
+	const link = doc.createElement("a");
+	link.href = `./v/${archivedVersion}/`;
+	link.textContent = `v${archivedVersion} →`;
+	bannerEl.appendChild(link);
+	bannerEl.appendChild(doc.createTextNode(", or start a new Session below."));
+}
 
 /** The password that gates entry. */
 const ACCEPTED_PASSWORD = "password";
@@ -293,8 +324,16 @@ export function renderStart(
 			"#persistence-warning",
 		);
 		if (persistenceWarningEl) {
-			persistenceWarningEl.textContent =
-				PERSISTENCE_WARNING_MESSAGES[reason] ?? "";
+			if (reason === "version-mismatch") {
+				renderVersionMismatchBanner(
+					doc,
+					persistenceWarningEl,
+					opts?.schemaVersion,
+				);
+			} else {
+				persistenceWarningEl.textContent =
+					PERSISTENCE_WARNING_MESSAGES[reason] ?? "";
+			}
 			persistenceWarningEl.removeAttribute("hidden");
 		}
 	}


### PR DESCRIPTION
PR 2 of the two-PR split for #146. PR 1 (#429) landed `/v/<version>/` hosting via peaceiris. This PR lands the user-visible feature.

## Summary

- **Channel routing.** `main` builds move from `/` to `/nightly/`. `/` becomes a mirror of the highest-stable release tag — overwritten on tag push only when the new tag is the highest `vX.Y.Z` (beta tags and hotfixes-on-old-lines don't reach root).
- **Version-mismatch banner with archive URL.** When a saved Session's `schemaVersion` doesn't match the current build, the banner offers a real `<a href="./v/X.Y.Z/">v0.1.1 →</a>` link to the archived build that last understood that schema (via `SCHEMA_ARCHIVE_MAP`). Map launches empty; misses get the existing "discarded" copy.
- **Schema-bump guardrail.** A new CI step fails PRs that bump `SESSION_SCHEMA_VERSION` without either a `migrateV<n>To...` function or a new `SCHEMA_ARCHIVE_MAP` entry. `AGENTS.md` documents the workflow.

## Implementation notes

`schemaVersion` is threaded from the codec out to the route opts so the persistence layer stays URL-ignorant:

`session-codec.ts:DeserializeResult` → `session-storage.ts:LoadResult` → `active-session-dispatcher.ts:DispatcherVerdict` → `render-app.ts:RenderOpts` → `routes/{start,sessions}.ts`

Both `start.ts` (post-clear path from `game.ts:947`) and `sessions.ts` (the dispatcher's natural route for version-mismatch) render the banner with the same helper. Banner DOM is built with `createElement`/`createTextNode`, never `innerHTML` interpolation. Codec also coerces `Number(sealed.schemaVersion)` to `broken` on `NaN`.

`release.yml` uses a shell `is_highest` check (`git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`) — no semver dep. Beta tags fail the stable regex on step 1.

`deploy-pages.yml` switches `destination_dir` from `''` to `nightly/`; `keep_files: true` is preserved so the gh-pages root and `v/<version>/` siblings aren't disturbed.

`scripts/check-schema-map.mjs` diffs `origin/<base>...HEAD` and exits 1 if the schema version line was touched without a corresponding map entry or migration function. CI's `actions/checkout@v4` in the `check:` job is bumped to `fetch-depth: 0` so the diff resolves.

## Test plan

- [x] `pnpm run lint` clean (biome ci)
- [x] `pnpm run typecheck` clean
- [x] `pnpm run test` — 1528 pass (was 1521; +7 new tests covering schemaVersion carry-through at every layer, banner map-hit/map-miss for `start.ts` + `sessions.ts`, NaN-guard in codec, and the `check-schema-map.mjs` script behavior across 4 scenarios)
- [x] Pre-push smoke specs ran during `git push` and passed
- [ ] Visual review of `deploy-pages.yml` + `release.yml`
- [ ] Post-merge: push a fresh patch tag (or `workflow_dispatch`), verify `/` and `/v/<version>/` both serve the latest stable
- [ ] Post-merge: after next main push, verify `/nightly/` is populated
- [ ] Post-merge: inject a fake `sealed.schemaVersion: 9` session into localStorage at `/`, reload — banner shows discarded copy (empty map). Temp-add `{ 9: "0.0.0" }` map entry locally to spot-check the link copy renders.

Closes the PR 2 portion of #146.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvxNgZSqBLqEkanGZe9QHi)_