### PR TITLE
Add v9→v10 migration to default wallName on ContentPack

### DIFF
--- a/src/spa/persistence/__tests__/session-codec.test.ts
+++ b/src/spa/persistence/__tests__/session-codec.test.ts
@@ -715,6 +715,160 @@ describe("serializeSession / deserializeSession", () => {
 		}
 	});
 
+	it("v8 save chains through to current: wallName defaulted alongside pack truncation", () => {
+		// v8 saves had neither wallName (v10 addition) nor single-pack arrays
+		// (v9 change). Chained migration must apply both fixes.
+		const game = makeFreshGame();
+		const packNoWall = {
+			setting: "v8 setting",
+			weather: "sunny",
+			timeOfDay: "noon",
+			objectivePairs: [],
+			interestingObjects: [] as WorldEntity[],
+			obstacles: [] as WorldEntity[],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		const v8SealedPayload = {
+			schemaVersion: 8,
+			world: game.world,
+			budgets: game.budgets,
+			lockedOut: Array.from(game.lockedOut),
+			personaSpatial: game.personaSpatial,
+			contentPacksA: [packNoWall, packNoWall, packNoWall],
+			contentPacksB: [packNoWall, packNoWall, packNoWall],
+			activePackId: "A" as const,
+			weather: game.weather,
+			objectives: game.objectives,
+			complicationSchedule: game.complicationSchedule,
+			activeComplications: game.activeComplications,
+			isComplete: game.isComplete,
+		};
+		const engine = obfuscate(JSON.stringify(v8SealedPayload));
+		const meta = JSON.stringify({
+			createdAt: CREATED_AT,
+			lastSavedAt: NOW,
+			epoch: 1,
+			round: 0,
+			personaOrder: Object.keys(game.personas),
+		});
+		const daemons: Record<AiId, string> = {};
+		for (const [aiId, persona] of Object.entries(game.personas)) {
+			const daemonFile: DaemonFile = { aiId, persona, conversationLog: [] };
+			daemons[aiId] = JSON.stringify(daemonFile);
+		}
+
+		const result = deserializeSession({ meta, daemons, engine });
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			expect(result.state.contentPacksA).toHaveLength(1);
+			expect(result.state.contentPacksB).toHaveLength(1);
+			expect(result.state.contentPacksA[0]?.wallName).toBe("");
+			expect(result.state.contentPacksB[0]?.wallName).toBe("");
+		}
+	});
+
+	it("v9 save without wallName is migrated to v10 by defaulting wallName to empty string", () => {
+		const game = makeFreshGame();
+		const packNoWall = {
+			setting: "v9 setting",
+			weather: "stormy",
+			timeOfDay: "dusk",
+			objectivePairs: [],
+			interestingObjects: [] as WorldEntity[],
+			obstacles: [] as WorldEntity[],
+			landmarks: DEFAULT_LANDMARKS,
+			aiStarts: {},
+		};
+		const v9SealedPayload = {
+			schemaVersion: 9,
+			world: game.world,
+			budgets: game.budgets,
+			lockedOut: Array.from(game.lockedOut),
+			personaSpatial: game.personaSpatial,
+			contentPacksA: [packNoWall],
+			contentPacksB: [packNoWall],
+			activePackId: "A" as const,
+			weather: game.weather,
+			objectives: game.objectives,
+			complicationSchedule: game.complicationSchedule,
+			activeComplications: game.activeComplications,
+			isComplete: game.isComplete,
+		};
+		const engine = obfuscate(JSON.stringify(v9SealedPayload));
+		const meta = JSON.stringify({
+			createdAt: CREATED_AT,
+			lastSavedAt: NOW,
+			epoch: 1,
+			round: 0,
+			personaOrder: Object.keys(game.personas),
+		});
+		const daemons: Record<AiId, string> = {};
+		for (const [aiId, persona] of Object.entries(game.personas)) {
+			const daemonFile: DaemonFile = { aiId, persona, conversationLog: [] };
+			daemons[aiId] = JSON.stringify(daemonFile);
+		}
+
+		const result = deserializeSession({ meta, daemons, engine });
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			expect(result.state.contentPacksA[0]?.wallName).toBe("");
+			expect(result.state.contentPacksB[0]?.wallName).toBe("");
+			expect(result.state.contentPacksA[0]?.setting).toBe("v9 setting");
+		}
+	});
+
+	it("v9 save preserves an existing string wallName if present", () => {
+		const game = makeFreshGame();
+		const pack: ContentPack = {
+			setting: "v9 with wall",
+			weather: "clear",
+			timeOfDay: "noon",
+			objectivePairs: [],
+			interestingObjects: [],
+			obstacles: [],
+			landmarks: DEFAULT_LANDMARKS,
+			wallName: "salt-encrusted edge",
+			aiStarts: {},
+		};
+		const v9SealedPayload = {
+			schemaVersion: 9,
+			world: game.world,
+			budgets: game.budgets,
+			lockedOut: Array.from(game.lockedOut),
+			personaSpatial: game.personaSpatial,
+			contentPacksA: [pack],
+			contentPacksB: [pack],
+			activePackId: "A" as const,
+			weather: game.weather,
+			objectives: game.objectives,
+			complicationSchedule: game.complicationSchedule,
+			activeComplications: game.activeComplications,
+			isComplete: game.isComplete,
+		};
+		const engine = obfuscate(JSON.stringify(v9SealedPayload));
+		const meta = JSON.stringify({
+			createdAt: CREATED_AT,
+			lastSavedAt: NOW,
+			epoch: 1,
+			round: 0,
+			personaOrder: Object.keys(game.personas),
+		});
+		const daemons: Record<AiId, string> = {};
+		for (const [aiId, persona] of Object.entries(game.personas)) {
+			const daemonFile: DaemonFile = { aiId, persona, conversationLog: [] };
+			daemons[aiId] = JSON.stringify(daemonFile);
+		}
+
+		const result = deserializeSession({ meta, daemons, engine });
+		expect(result.kind).toBe("ok");
+		if (result.kind === "ok") {
+			expect(result.state.contentPacksA[0]?.wallName).toBe(
+				"salt-encrusted edge",
+			);
+		}
+	});
+
 	it("round-trips correctly with flat state (no phase config re-attachment needed)", () => {
 		// In the flat model (#295), there are no nextPhaseConfig / winCondition
 		// fields to re-attach. The round-trip should still succeed.

--- a/src/spa/persistence/session-codec.ts
+++ b/src/spa/persistence/session-codec.ts
@@ -71,8 +71,11 @@ import {
  *     by keeping only the first entry of each array.
  *
  * v10 (issue #374): add `wallName` to `ContentPack`.
- *   - Old v9 saves have no `wallName`; version-mismatch result (consistent
- *     with v7/v8 policy — no migration provided).
+ *   - Old v9 saves have no `wallName`; migration defaults it to an empty
+ *     string on every `ContentPack` in `contentPacksA`/`contentPacksB`.
+ *     The empty default round-trips through the existing OOB cone
+ *     renderer (which already treats blank `wallName` as "no flavored
+ *     wall noun").
  *
  * Bumping this constant requires either a `migrateV<old>To...` function below
  * or a new entry in `SCHEMA_ARCHIVE_MAP` (see AGENTS.md → "Bumping
@@ -225,15 +228,34 @@ export function serializeSession(
 // ── Migration helpers ─────────────────────────────────────────────────────────
 
 /**
- * Migrate a v8 SealedEngine to v9 by truncating contentPacksA and contentPacksB
- * to their first entry.
+ * Migrate a v8 sealed payload to v9 by truncating contentPacksA and
+ * contentPacksB to their first entry. v8 stored one pack per phase (3
+ * entries); v9 keeps a single pack per side.
+ *
+ * Sets schemaVersion to 9 so callers can chain into `migrateV9ToV10`.
  */
 function migrateV8ToV9(sealed: SealedEngine): SealedEngine {
 	return {
 		...sealed,
-		schemaVersion: SESSION_SCHEMA_VERSION,
+		schemaVersion: 9 as unknown as typeof SESSION_SCHEMA_VERSION,
 		contentPacksA: (sealed.contentPacksA ?? []).slice(0, 1),
 		contentPacksB: (sealed.contentPacksB ?? []).slice(0, 1),
+	};
+}
+
+/**
+ * Migrate a v9 sealed payload to v10 by defaulting `wallName` to `""` on
+ * every ContentPack in `contentPacksA`/`contentPacksB`. v9 packs had no
+ * `wallName` field.
+ */
+function migrateV9ToV10(sealed: SealedEngine): SealedEngine {
+	const addWallName = (pack: ContentPack): ContentPack =>
+		typeof pack?.wallName === "string" ? pack : { ...pack, wallName: "" };
+	return {
+		...sealed,
+		schemaVersion: SESSION_SCHEMA_VERSION,
+		contentPacksA: (sealed.contentPacksA ?? []).map(addWallName),
+		contentPacksB: (sealed.contentPacksB ?? []).map(addWallName),
 	};
 }
 
@@ -272,13 +294,24 @@ export function deserializeSession(
 		return { kind: "broken" };
 	}
 
-	// Schema version check and migration
-	if ((sealed as { schemaVersion: number }).schemaVersion === 8) {
+	// Schema version check and migration chain.
+	// Migrations are stepwise (v8→v9→v10) so each entry stays focused on
+	// one schema diff and new bumps only need a single new step.
+	const rawVersion = (sealed as { schemaVersion: unknown }).schemaVersion;
+	if (typeof rawVersion !== "number" || !Number.isFinite(rawVersion)) {
+		return { kind: "broken" };
+	}
+	let version = rawVersion;
+	if (version === 8) {
 		sealed = migrateV8ToV9(sealed);
-	} else if (sealed.schemaVersion !== SESSION_SCHEMA_VERSION) {
-		const sv = Number(sealed.schemaVersion);
-		if (!Number.isFinite(sv)) return { kind: "broken" };
-		return { kind: "version-mismatch", schemaVersion: sv };
+		version = 9;
+	}
+	if (version === 9) {
+		sealed = migrateV9ToV10(sealed);
+		version = 10;
+	}
+	if (version !== SESSION_SCHEMA_VERSION) {
+		return { kind: "version-mismatch", schemaVersion: version };
 	}
 
 	// Parse meta.json


### PR DESCRIPTION
## Summary
Implements schema migration from v9 to v10 to handle the addition of the `wallName` field to `ContentPack`. Previously, v9 saves would result in a version-mismatch error. Now they are automatically migrated by defaulting `wallName` to an empty string on all content packs.

## Key Changes
- **Added `migrateV9ToV10()` function**: Defaults the `wallName` field to `""` on every `ContentPack` in `contentPacksA` and `contentPacksB` for v9 saves. Preserves existing `wallName` values if already present.
- **Refactored migration chain**: Changed from a single conditional check to a stepwise migration approach (v8→v9→v10) that applies migrations sequentially. This allows each migration to focus on a single schema diff and makes future bumps easier to maintain.
- **Updated `migrateV8ToV9()`**: Now sets `schemaVersion` to `9` (instead of `SESSION_SCHEMA_VERSION`) to enable chaining into the v9→v10 migration.
- **Improved version validation**: Added explicit type checking for `schemaVersion` before processing migrations.
- **Added comprehensive test coverage**: Three new test cases verify:
  - v8 saves are migrated through both v8→v9 and v9→v10 steps (pack truncation + wallName defaulting)
  - v9 saves without `wallName` are migrated to v10 with empty string default
  - v9 saves with existing `wallName` preserve the original value

## Implementation Details
The empty string default for `wallName` is intentional—it round-trips correctly through the existing OOB cone renderer, which already treats blank `wallName` as "no flavored wall noun", maintaining backward compatibility with v9 saves.

https://claude.ai/code/session_01JFSo1ZPtwtyrnLb449qWru