### PR TITLE
Update canonical URL to Cloudflare Pages domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Play
 
-The canonical play URL is **https://corvous.github.io/hi-blue/** (GitHub Pages).
+The canonical play URL is **https://hi-blue.cor.gg/** (Cloudflare Pages).
 
 The Cloudflare Worker is API-only (`POST /v1/chat/completions`, `POST /diagnostics`,
 and `OPTIONS` preflights). It does not serve the game UI; the SPA is built and

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,6 +48,6 @@
 		// Comma-separated list of origins allowed to call POST /v1/chat/completions
 		// via a browser (CORS). Add localhost ports via .dev.vars or
 		// `wrangler dev --var ALLOWED_ORIGINS=...` to keep local ports out of prod.
-		"ALLOWED_ORIGINS": "https://corvous.github.io"
+		"ALLOWED_ORIGINS": "https://hi-blue.cor.gg"
 	}
 }


### PR DESCRIPTION
## Summary
Updates the canonical play URL and CORS configuration to use the new Cloudflare Pages domain instead of GitHub Pages.

## Changes
- Updated README.md to reflect the new canonical play URL: `https://hi-blue.cor.gg/` (Cloudflare Pages) instead of `https://corvous.github.io/hi-blue/` (GitHub Pages)
- Updated `wrangler.jsonc` ALLOWED_ORIGINS configuration to allow requests from the new domain for CORS-enabled API endpoints

## Details
The game is now being served from Cloudflare Pages at `hi-blue.cor.gg`. The Cloudflare Worker API endpoints (`POST /v1/chat/completions`, `POST /diagnostics`) have been updated to accept requests from this new origin.

https://claude.ai/code/session_01WVTUjLauzFT5WxQAYCYiDN