### PR TITLE
feat(dev): Daemon dev inspector (9 seams, __DEV__-only)

### DIFF
--- a/src/spa/__tests__/build.test.ts
+++ b/src/spa/__tests__/build.test.ts
@@ -3,9 +3,10 @@
  * Uses vitest's ?raw import to read the HTML file as a string without node:fs.
  */
 // @ts-expect-error — node types not available in SPA project
-import { fileURLToPath } from "node:url";
+
 // @ts-expect-error — node types not available in SPA project
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import * as esbuild from "esbuild";
 import { describe, expect, it } from "vitest";
 // @ts-expect-error — vitest handles ?raw suffix; no TS type for it

--- a/src/spa/__tests__/build.test.ts
+++ b/src/spa/__tests__/build.test.ts
@@ -3,9 +3,8 @@
  * Uses vitest's ?raw import to read the HTML file as a string without node:fs.
  */
 // @ts-expect-error — node types not available in SPA project
-
-// @ts-expect-error — node types not available in SPA project
 import * as path from "node:path";
+// @ts-expect-error — node types not available in SPA project
 import { fileURLToPath } from "node:url";
 import * as esbuild from "esbuild";
 import { describe, expect, it } from "vitest";

--- a/src/spa/__tests__/build.test.ts
+++ b/src/spa/__tests__/build.test.ts
@@ -2,9 +2,17 @@
  * Verifies that src/spa/index.html uses sibling-relative asset paths.
  * Uses vitest's ?raw import to read the HTML file as a string without node:fs.
  */
+// @ts-expect-error — node types not available in SPA project
+import { fileURLToPath } from "node:url";
+// @ts-expect-error — node types not available in SPA project
+import * as path from "node:path";
+import * as esbuild from "esbuild";
 import { describe, expect, it } from "vitest";
 // @ts-expect-error — vitest handles ?raw suffix; no TS type for it
 import html from "../index.html?raw";
+
+const __dirname_bt = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname_bt, "../../..");
 
 describe("src/spa/index.html asset references", () => {
 	it('references CSS as sibling-relative path "./assets/index.css"', () => {
@@ -57,3 +65,33 @@ describe("src/spa/index.html asset references", () => {
 		);
 	});
 });
+
+describe("SPA prod bundle (__DEV__=false) tree-shakes the dev inspector", () => {
+	it("does not contain renderInspector or dev-daemon-footer", async () => {
+		const result = await esbuild.build({
+			entryPoints: [path.join(repoRoot, "src/spa/main.ts")],
+			bundle: true,
+			write: false,
+			outdir: path.join(repoRoot, "dist"),
+			format: "esm",
+			target: ["es2022"],
+			minify: true,
+			loader: { ".css": "css" },
+			define: {
+				__WORKER_BASE_URL__: JSON.stringify("https://example.com"),
+				__COMMIT_SHA__: JSON.stringify("test"),
+				__COMMIT_TIMESTAMP_MS__: "0",
+				__VERSION__: JSON.stringify("0.0.0"),
+				__RELEASE_VERSION__: "null",
+				__LATEST_RELEASE_VERSION__: "null",
+				__DEV__: "false",
+			},
+		});
+		const js = result.outputFiles
+			.filter((f) => f.path.endsWith(".js"))
+			.map((f) => f.text)
+			.join("\n");
+		expect(js).not.toContain("renderInspector");
+		expect(js).not.toContain("dev-daemon-footer");
+	});
+}, 60_000);

--- a/src/spa/__tests__/game-bootstrap.test.ts
+++ b/src/spa/__tests__/game-bootstrap.test.ts
@@ -67,10 +67,6 @@ const INDEX_BODY_HTML = `
   </form>
   <section id="cap-hit" hidden></section>
   <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
-  <aside id="action-log" hidden>
-    <h3>Action Log (debug)</h3>
-    <ul id="action-log-list"></ul>
-  </aside>
   <section id="endgame" hidden></section>
 </main>
 `;

--- a/src/spa/__tests__/game-ended.test.ts
+++ b/src/spa/__tests__/game-ended.test.ts
@@ -187,10 +187,6 @@ const INDEX_BODY_HTML = `
   </form>
   <section id="cap-hit" hidden></section>
   <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
-  <aside id="action-log" hidden>
-    <h3>Action Log (debug)</h3>
-    <ul id="action-log-list"></ul>
-  </aside>
 </main>
 <script type="module" src="./assets/index.js"></script>
 `;

--- a/src/spa/__tests__/game.test.ts
+++ b/src/spa/__tests__/game.test.ts
@@ -152,10 +152,6 @@ const INDEX_BODY_HTML = `
     </div>
   </section>
   <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
-  <aside id="action-log" hidden>
-    <h3>Action Log (debug)</h3>
-    <ul id="action-log-list"></ul>
-  </aside>
   <section id="endgame" hidden>
     <h2>hi-blue — endgame</h2>
     <div id="endgame-subtitle">The three phases are complete. The room is still.</div>
@@ -442,56 +438,6 @@ describe("renderGame (game route — three-AI)", () => {
 			"GREEN_RESPONSE_UNIQUE_TAG",
 		);
 		expect(redTranscript.textContent).not.toContain("CYAN_RESPONSE_UNIQUE_TAG");
-	});
-
-	it("action-log is hidden by default and visible with debug=1", async () => {
-		const mockFetch = makeThreeAiFetchMock(
-			PASS_ACTION,
-			PASS_ACTION,
-			PASS_ACTION,
-		);
-		vi.stubGlobal("fetch", mockFetch);
-		vi.spyOn(Math, "random").mockReturnValue(0.9);
-
-		vi.resetModules();
-		const { renderGame } = await import("../routes/game.js");
-
-		// Without debug param: action log should be hidden
-		await renderGame(getEl<HTMLElement>("main"));
-		const actionLog = getEl<HTMLElement>("#action-log");
-		expect(actionLog.hasAttribute("hidden")).toBe(true);
-
-		// With debug=1: action log should be visible
-		setSearch("debug=1");
-		await renderGame(getEl<HTMLElement>("main"));
-		expect(actionLog.hasAttribute("hidden")).toBe(false);
-	});
-
-	it("action-log entries are populated after a round (hidden or visible)", async () => {
-		const mockFetch = makeThreeAiFetchMock(
-			PASS_ACTION,
-			PASS_ACTION,
-			PASS_ACTION,
-		);
-		vi.stubGlobal("fetch", mockFetch);
-		vi.spyOn(Math, "random").mockReturnValue(0.9);
-
-		vi.resetModules();
-		const { renderGame } = await import("../routes/game.js");
-
-		// Show debug so we can verify entries
-		setSearch("debug=1");
-		await renderGame(getEl<HTMLElement>("main"));
-
-		const form = getEl<HTMLFormElement>("#composer");
-		const promptInput = getEl<HTMLInputElement>("#prompt");
-		promptInput.value = "*Sage test";
-		promptInput.dispatchEvent(new Event("input"));
-		form.dispatchEvent(
-			new Event("submit", { bubbles: true, cancelable: true }),
-		);
-		const logList = getEl<HTMLUListElement>("#action-log-list");
-		await vi.waitFor(() => expect(logList.children.length).toBeGreaterThan(0));
 	});
 
 	it("budgets decrement after a round (5 -> 4 for all AIs)", async () => {
@@ -1701,42 +1647,6 @@ describe("renderGame — panel-click addressee", () => {
 		cyanPanel.click();
 
 		expect(promptInput.value).toBe("*Frost *nonpersona hi");
-	});
-});
-
-describe("renderGame — URL param sourcing", () => {
-	beforeEach(async () => {
-		vi.stubGlobal("__WORKER_BASE_URL__", "http://localhost:8787");
-		vi.stubGlobal("__DEV__", true);
-		document.body.innerHTML = INDEX_BODY_HTML;
-		const _stub = makeLocalStorageStub();
-		await seedSessionInStub(_stub);
-		vi.stubGlobal("localStorage", _stub);
-	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-		vi.unstubAllGlobals();
-		vi.resetModules();
-		document.body.innerHTML = "";
-	});
-
-	it("reads debug=1 from location.search", async () => {
-		setSearch("debug=1");
-		const mockFetch = makeThreeAiFetchMock(
-			PASS_ACTION,
-			PASS_ACTION,
-			PASS_ACTION,
-		);
-		vi.stubGlobal("fetch", mockFetch);
-		vi.spyOn(Math, "random").mockReturnValue(0.9);
-
-		vi.resetModules();
-		const { renderGame } = await import("../routes/game.js");
-		await renderGame(getEl<HTMLElement>("main"));
-
-		const actionLog = getEl<HTMLElement>("#action-log");
-		expect(actionLog.hasAttribute("hidden")).toBe(false);
 	});
 });
 

--- a/src/spa/__tests__/migration-banner.test.ts
+++ b/src/spa/__tests__/migration-banner.test.ts
@@ -71,10 +71,6 @@ const INDEX_BODY_HTML = `
   </form>
   <section id="cap-hit" hidden></section>
   <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
-  <aside id="action-log" hidden>
-    <h3>Action Log (debug)</h3>
-    <ul id="action-log-list"></ul>
-  </aside>
   <section id="endgame" hidden>
     <h2>hi-blue — endgame</h2>
     <div id="endgame-subtitle">The three phases are complete. The room is still.</div>

--- a/src/spa/__tests__/pending-bootstrap.test.ts
+++ b/src/spa/__tests__/pending-bootstrap.test.ts
@@ -209,4 +209,65 @@ describe("pending-bootstrap.ts", () => {
 		// Personas should be gone
 		expect(getCachedPersonas()).toBeUndefined();
 	});
+
+	it("recordPendingCall sets callName + startedAtMs", async () => {
+		vi.resetModules();
+
+		const { recordPendingCall, getPendingCallMeta } = await import(
+			"../game/pending-bootstrap.js"
+		);
+
+		const beforeMs = Date.now();
+		recordPendingCall("persona-synthesis");
+		const afterMs = Date.now();
+
+		const meta = getPendingCallMeta();
+		expect(meta.callName).toBe("persona-synthesis");
+		expect(meta.startedAtMs).toBeGreaterThanOrEqual(beforeMs);
+		expect(meta.startedAtMs).toBeLessThanOrEqual(afterMs);
+		expect(meta.retryCount).toBe(0);
+		expect(meta.retryMax).toBe(3);
+		expect(meta.lastError).toBeUndefined();
+	});
+
+	it("recordPendingRetry increments retryCount and stores lastError", async () => {
+		vi.resetModules();
+
+		const { recordPendingCall, recordPendingRetry, getPendingCallMeta } =
+			await import("../game/pending-bootstrap.js");
+
+		recordPendingCall("content-pack");
+
+		recordPendingRetry(new Error("502 upstream"));
+
+		const meta = getPendingCallMeta();
+		expect(meta.callName).toBe("content-pack");
+		expect(meta.retryCount).toBe(1);
+		expect(meta.lastError).toBe("502 upstream");
+
+		// Retry again
+		recordPendingRetry(new Error("503 service unavailable"));
+
+		const meta2 = getPendingCallMeta();
+		expect(meta2.retryCount).toBe(2);
+		expect(meta2.lastError).toBe("503 service unavailable");
+	});
+
+	it("clearPendingBootstrap clears meta", async () => {
+		vi.resetModules();
+
+		const { recordPendingCall, clearPendingBootstrap, getPendingCallMeta } =
+			await import("../game/pending-bootstrap.js");
+
+		recordPendingCall("persona-synthesis");
+		expect(getPendingCallMeta().callName).toBe("persona-synthesis");
+
+		clearPendingBootstrap();
+
+		const meta = getPendingCallMeta();
+		expect(meta.callName).toBeUndefined();
+		expect(meta.startedAtMs).toBeUndefined();
+		expect(meta.retryCount).toBeUndefined();
+		expect(meta.lastError).toBeUndefined();
+	});
 });

--- a/src/spa/__tests__/pending-bootstrap.test.ts
+++ b/src/spa/__tests__/pending-bootstrap.test.ts
@@ -270,4 +270,155 @@ describe("pending-bootstrap.ts", () => {
 		expect(meta.retryCount).toBeUndefined();
 		expect(meta.lastError).toBeUndefined();
 	});
+
+	it("startBootstrap calls recordPendingCall('persona-synthesis') synchronously", async () => {
+		vi.doMock("../game/bootstrap.js", () => ({
+			generateNewGameAssetsSplit: () => ({
+				personasPromise: Promise.resolve(STATIC_PERSONAS),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+			generateContentPacksOnlySplit: (_personas: Record<AiId, AiPersona>) => ({
+				personasPromise: Promise.resolve(_personas),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+		}));
+		vi.resetModules();
+
+		const { startBootstrap, getPendingCallMeta } = await import(
+			"../game/pending-bootstrap.js"
+		);
+
+		startBootstrap();
+
+		// Check that recordPendingCall was called synchronously with "persona-synthesis"
+		const meta = getPendingCallMeta();
+		expect(meta.callName).toBe("persona-synthesis");
+		expect(meta.startedAtMs).toBeDefined();
+		expect(meta.retryCount).toBe(0);
+	});
+
+	it("startBootstrap calls recordPendingCall('content-pack') when personas resolve", async () => {
+		vi.doMock("../game/bootstrap.js", () => ({
+			generateNewGameAssetsSplit: () => ({
+				personasPromise: Promise.resolve(STATIC_PERSONAS),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+			generateContentPacksOnlySplit: (_personas: Record<AiId, AiPersona>) => ({
+				personasPromise: Promise.resolve(_personas),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+		}));
+		vi.resetModules();
+
+		const { startBootstrap, getPendingCallMeta } = await import(
+			"../game/pending-bootstrap.js"
+		);
+
+		const pending = startBootstrap();
+
+		// Initially should be persona-synthesis
+		expect(getPendingCallMeta().callName).toBe("persona-synthesis");
+
+		// Wait for personas to resolve
+		await pending.personasPromise;
+
+		// Should now be content-pack
+		expect(getPendingCallMeta().callName).toBe("content-pack");
+	});
+
+	it("startBootstrap calls recordPendingRetry when personas fail", async () => {
+		vi.doMock("../game/bootstrap.js", () => ({
+			generateNewGameAssetsSplit: () => ({
+				personasPromise: Promise.reject(new Error("persona generation failed")),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+			generateContentPacksOnlySplit: (_personas: Record<AiId, AiPersona>) => ({
+				personasPromise: Promise.resolve(_personas),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+		}));
+		vi.resetModules();
+
+		const { startBootstrap, getPendingCallMeta } = await import(
+			"../game/pending-bootstrap.js"
+		);
+
+		const pending = startBootstrap();
+
+		try {
+			await pending.personasPromise;
+		} catch {
+			// Expected to fail
+		}
+
+		const meta = getPendingCallMeta();
+		expect(meta.retryCount).toBe(1);
+		expect(meta.lastError).toBe("persona generation failed");
+	});
+
+	it("restartContentPacks calls recordPendingCall('content-pack') synchronously", async () => {
+		vi.doMock("../game/bootstrap.js", () => ({
+			generateNewGameAssetsSplit: () => ({
+				personasPromise: Promise.resolve(STATIC_PERSONAS),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+			generateContentPacksOnlySplit: (_personas: Record<AiId, AiPersona>) => ({
+				personasPromise: Promise.resolve(_personas),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+		}));
+		vi.resetModules();
+
+		const { startBootstrap, restartContentPacks, getPendingCallMeta } =
+			await import("../game/pending-bootstrap.js");
+
+		const initial = startBootstrap();
+		await initial.personasPromise;
+
+		// Reset meta by manually clearing it (simulating a clean state before restart)
+		const { recordPendingCall } = await import("../game/pending-bootstrap.js");
+		recordPendingCall("placeholder");
+
+		// Now restart content packs
+		restartContentPacks();
+
+		// Should be content-pack now
+		const meta = getPendingCallMeta();
+		expect(meta.callName).toBe("content-pack");
+		expect(meta.startedAtMs).toBeDefined();
+	});
+
+	it("restartContentPacks calls recordPendingRetry when content packs fail", async () => {
+		vi.doMock("../game/bootstrap.js", () => ({
+			generateNewGameAssetsSplit: () => ({
+				personasPromise: Promise.resolve(STATIC_PERSONAS),
+				contentPacksPromise: Promise.resolve(STATIC_CONTENT),
+			}),
+			generateContentPacksOnlySplit: (_personas: Record<AiId, AiPersona>) => ({
+				personasPromise: Promise.resolve(_personas),
+				contentPacksPromise: Promise.reject(
+					new Error("content pack generation failed"),
+				),
+			}),
+		}));
+		vi.resetModules();
+
+		const { startBootstrap, restartContentPacks, getPendingCallMeta } =
+			await import("../game/pending-bootstrap.js");
+
+		const initial = startBootstrap();
+		await initial.personasPromise;
+
+		const restarted = restartContentPacks();
+
+		try {
+			await restarted.contentPacksPromise;
+		} catch {
+			// Expected to fail
+		}
+
+		const meta = getPendingCallMeta();
+		expect(meta.retryCount).toBe(1);
+		expect(meta.lastError).toBe("content pack generation failed");
+	});
 });

--- a/src/spa/__tests__/stage-layout.test.ts
+++ b/src/spa/__tests__/stage-layout.test.ts
@@ -1,0 +1,23 @@
+// @ts-expect-error — node:fs types not in tsconfig
+import * as fs from "node:fs";
+// @ts-expect-error — node:path types not in tsconfig
+import * as path from "node:path";
+// @ts-expect-error — node:url types not in tsconfig
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cssPath = path.join(__dirname, "../styles.css");
+const cssStr = fs.readFileSync(cssPath, "utf-8");
+
+describe("#stage layout contract", () => {
+	it("uses min-height: 100dvh (not height) so dev surfaces can grow the page", () => {
+		expect(cssStr).toMatch(/#stage\s*\{[^}]*min-height:\s*100dvh/);
+		// Negative lookahead ensures "height: 100dvh" doesn't appear (only "min-height" is ok)
+		expect(cssStr).not.toMatch(/#stage\s*\{[^}]*\nheight:\s*100dvh/);
+	});
+
+	it("retains main { display: contents } so direct children flatten into #stage's grid", () => {
+		expect(cssStr).toMatch(/^main\s*\{\s*display:\s*contents/m);
+	});
+});

--- a/src/spa/__tests__/start.test.ts
+++ b/src/spa/__tests__/start.test.ts
@@ -88,10 +88,6 @@ const INDEX_BODY_HTML = `
   </form>
   <section id="cap-hit" hidden></section>
   <aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
-  <aside id="action-log" hidden>
-    <h3>Action Log (debug)</h3>
-    <ul id="action-log-list"></ul>
-  </aside>
   <section id="endgame" hidden></section>
 </main>
 `;

--- a/src/spa/dev-inspector/__tests__/cone-focus.test.ts
+++ b/src/spa/dev-inspector/__tests__/cone-focus.test.ts
@@ -304,12 +304,12 @@ describe("cone-focus", () => {
 			expect(greenBtn).toBeTruthy();
 
 			setMapFocus("red");
-			expect(redBtn!.getAttribute("data-focus-active")).toBe("true");
-			expect(greenBtn!.getAttribute("data-focus-active")).toBe("false");
+			expect(redBtn?.getAttribute("data-focus-active")).toBe("true");
+			expect(greenBtn?.getAttribute("data-focus-active")).toBe("false");
 
 			setMapFocus("green");
-			expect(redBtn!.getAttribute("data-focus-active")).toBe("false");
-			expect(greenBtn!.getAttribute("data-focus-active")).toBe("true");
+			expect(redBtn?.getAttribute("data-focus-active")).toBe("false");
+			expect(greenBtn?.getAttribute("data-focus-active")).toBe("true");
 		});
 	});
 

--- a/src/spa/dev-inspector/__tests__/cone-focus.test.ts
+++ b/src/spa/dev-inspector/__tests__/cone-focus.test.ts
@@ -228,7 +228,7 @@ describe("cone-focus", () => {
 	describe("focus button", () => {
 		it("button rendered in footer", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			const focusBtn = document.querySelector(
 				'[data-field="focus-cone"]',
@@ -239,7 +239,7 @@ describe("cone-focus", () => {
 
 		it("button click sets focus", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			const focusBtn = document.querySelector(
 				'[data-field="focus-cone"]',
@@ -257,7 +257,7 @@ describe("cone-focus", () => {
 
 		it("button click toggles focus off when already focused", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			const redPanel = document.querySelector('[data-ai="red"]') as HTMLElement;
 			expect(redPanel).toBeTruthy();
@@ -281,7 +281,7 @@ describe("cone-focus", () => {
 
 		it("data-focus-active reflects focus state", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			// Get all buttons
 			const allBtns = document.querySelectorAll(
@@ -316,7 +316,7 @@ describe("cone-focus", () => {
 	describe("Escape key handling", () => {
 		it("Escape clears active focus", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			setMapFocus("red");
 			expect(getMapFocus()).toBe("red");
@@ -335,7 +335,7 @@ describe("cone-focus", () => {
 			const containerEl = document.getElementById(
 				"dev-world-map",
 			) as HTMLElement;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 			renderWorldMap(containerEl, session);
 
 			setMapFocus("red");
@@ -360,7 +360,7 @@ describe("cone-focus", () => {
 
 		it("Escape no-op when no focus is active", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			expect(getMapFocus()).toBeNull();
 
@@ -378,11 +378,11 @@ describe("cone-focus", () => {
 			const root = document.body;
 
 			// First render
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			// Re-render (simulating re-init)
 			__resetInspectorForTests();
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			// Set focus and press Escape
 			setMapFocus("red");
@@ -398,7 +398,7 @@ describe("cone-focus", () => {
 
 		it("other keys do not clear focus", () => {
 			const root = document.body;
-			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderInspector(root, { session });
 
 			setMapFocus("red");
 			expect(getMapFocus()).toBe("red");

--- a/src/spa/dev-inspector/__tests__/cone-focus.test.ts
+++ b/src/spa/dev-inspector/__tests__/cone-focus.test.ts
@@ -1,0 +1,417 @@
+/**
+ * cone-focus.test.ts
+ *
+ * Tests for cone-focus tinting feature in the dev inspector.
+ * - Cone mask computation
+ * - Focus state management
+ * - Visual tinting
+ * - Button interaction
+ * - Escape key handling
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { STATIC_CONTENT_PACKS } from "../../__tests__/fixtures/static-content-packs";
+import { STATIC_PERSONAS } from "../../__tests__/fixtures/static-personas";
+import { GameSession } from "../../game/game-session";
+import { coneMaskForDaemon } from "../cone-mask";
+import { __resetInspectorForTests, renderInspector } from "../index";
+import {
+	getMapFocus,
+	renderWorldMap,
+	setMapFocus,
+	updateWorldMap,
+} from "../world-map";
+
+describe("cone-focus", () => {
+	let session: GameSession;
+	const contentPack = STATIC_CONTENT_PACKS[0];
+
+	beforeEach(() => {
+		// Build full inspector DOM
+		document.body.innerHTML = `
+      <div id="dev-game-strip"></div>
+      <div id="dev-world-map"></div>
+      <article class="ai-panel" data-ai="red">
+        <div class="dev-daemon-footer"></div>
+      </article>
+      <article class="ai-panel" data-ai="green">
+        <div class="dev-daemon-footer"></div>
+      </article>
+      <article class="ai-panel" data-ai="cyan">
+        <div class="dev-daemon-footer"></div>
+      </article>
+    `;
+
+		if (!contentPack) throw new Error("Content pack missing");
+		session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		// Reset inspector state
+		__resetInspectorForTests();
+	});
+
+	describe("mask computation", () => {
+		it("mask shape — corner cell facing north: red at inner (0,0) → only own cell in bounds", () => {
+			const state = session.getState();
+			const mask = coneMaskForDaemon(state, "red");
+
+			// Red starts at (0,0) corner facing north, so most cone cells are OOB (walls).
+			// Only the own cell (1,1) should be in the mask (the 8 others are filtered as walls).
+			expect(mask.size).toBeGreaterThanOrEqual(1);
+			// At least the own cell should be in the mask
+			expect(mask.has("1,1")).toBe(true);
+		});
+
+		it("mask omits OOB walls — corner: red at (0,0) facing north → only valid cells", () => {
+			const state = session.getState();
+			const mask = coneMaskForDaemon(state, "red");
+
+			// Red at corner (0,0), so many cells out of bounds.
+			// Expect no cells with invalid visual coords (row/col < 1 or > 5)
+			for (const cellStr of mask) {
+				const [rowStr, colStr] = cellStr.split(",");
+				const row = Number(rowStr);
+				const col = Number(colStr);
+				expect(row).toBeGreaterThanOrEqual(1);
+				expect(row).toBeLessThanOrEqual(5);
+				expect(col).toBeGreaterThanOrEqual(1);
+				expect(col).toBeLessThanOrEqual(5);
+			}
+		});
+
+		it("mask empty when daemon missing", () => {
+			const state = session.getState();
+			const mask = coneMaskForDaemon(state, "nonexistent");
+			expect(mask.size).toBe(0);
+		});
+	});
+
+	describe("focus state management", () => {
+		it("setMapFocus toggles getMapFocus: null → red → null", () => {
+			expect(getMapFocus()).toBe(null);
+
+			setMapFocus("red");
+			expect(getMapFocus()).toBe("red");
+
+			setMapFocus(null);
+			expect(getMapFocus()).toBe(null);
+		});
+
+		it("switching focus targets: red → green removes red tint, applies green tint", () => {
+			const containerEl = document.getElementById(
+				"dev-world-map",
+			) as HTMLElement;
+			renderWorldMap(containerEl, session);
+
+			setMapFocus("red");
+			let redCells = 0;
+			for (const cell of containerEl.querySelectorAll<HTMLElement>(
+				".dev-map-cell",
+			)) {
+				if (cell.getAttribute("data-cone-focus") === "red") {
+					redCells++;
+				}
+			}
+			expect(redCells).toBeGreaterThan(0);
+
+			setMapFocus("green");
+			const greenCells = containerEl.querySelectorAll<HTMLElement>(
+				'[data-cone-focus="green"]',
+			).length;
+			const stillRedCells = containerEl.querySelectorAll<HTMLElement>(
+				'[data-cone-focus="red"]',
+			).length;
+
+			expect(greenCells).toBeGreaterThan(0);
+			expect(stillRedCells).toBe(0);
+		});
+	});
+
+	describe("visual tinting", () => {
+		it("setMapFocus tints cone cells with persona-colored background", () => {
+			const containerEl = document.getElementById(
+				"dev-world-map",
+			) as HTMLElement;
+			renderWorldMap(containerEl, session);
+
+			setMapFocus("red");
+
+			const state = session.getState();
+			const mask = coneMaskForDaemon(state, "red");
+			const redColor = state.personas.red?.color;
+
+			expect(redColor).toBeTruthy();
+
+			for (const cell of containerEl.querySelectorAll<HTMLElement>(
+				".dev-map-cell",
+			)) {
+				const dataCell = cell.getAttribute("data-cell");
+				if (mask.has(dataCell!)) {
+					// Should have non-empty backgroundColor
+					expect(cell.style.backgroundColor).toBeTruthy();
+					expect(cell.getAttribute("data-cone-focus")).toBe("red");
+				} else {
+					// Should not be tinted
+					expect(cell.style.backgroundColor).toBe("");
+					expect(cell.getAttribute("data-cone-focus")).toBeNull();
+				}
+			}
+		});
+
+		it("setMapFocus(null) clears tint: all cells revert", () => {
+			const containerEl = document.getElementById(
+				"dev-world-map",
+			) as HTMLElement;
+			renderWorldMap(containerEl, session);
+
+			setMapFocus("red");
+			setMapFocus(null);
+
+			for (const cell of containerEl.querySelectorAll<HTMLElement>(
+				".dev-map-cell",
+			)) {
+				expect(cell.style.backgroundColor).toBe("");
+				expect(cell.getAttribute("data-cone-focus")).toBeNull();
+			}
+		});
+
+		it("truth-always — daemon glyph preserved when cone focused", () => {
+			const containerEl = document.getElementById(
+				"dev-world-map",
+			) as HTMLElement;
+			renderWorldMap(containerEl, session);
+
+			setMapFocus("red");
+
+			const redCell = containerEl.querySelector(
+				'[data-ai="red"]',
+			) as HTMLElement;
+			expect(redCell).toBeTruthy();
+
+			// Glyph should still be @<arrow>
+			const glyph = redCell.querySelector(".dev-map-glyph");
+			expect(glyph?.textContent).toMatch(/^@[<>^v]$/);
+
+			// AI marker should be preserved
+			expect(redCell.getAttribute("data-ai")).toBe("red");
+		});
+
+		it("updateWorldMap re-applies active tint after mutation", () => {
+			const containerEl = document.getElementById(
+				"dev-world-map",
+			) as HTMLElement;
+			renderWorldMap(containerEl, session);
+
+			setMapFocus("red");
+			const state1 = session.getState();
+			const mask1 = coneMaskForDaemon(state1, "red");
+
+			// Verify tint is applied
+			const tintedBefore =
+				containerEl.querySelectorAll<HTMLElement>("[data-cone-focus]").length;
+			expect(tintedBefore).toBeGreaterThan(0);
+
+			// Update the session (simulate a game step)
+			updateWorldMap(containerEl, session);
+
+			// Re-check tinted cells
+			const state2 = session.getState();
+			const mask2 = coneMaskForDaemon(state2, "red");
+			const tintedAfter =
+				containerEl.querySelectorAll<HTMLElement>("[data-cone-focus]").length;
+
+			// Masks should be identical if state hasn't changed
+			expect(mask1.size).toBe(mask2.size);
+			expect(tintedAfter).toBeGreaterThan(0);
+		});
+	});
+
+	describe("focus button", () => {
+		it("button rendered in footer", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			const focusBtn = document.querySelector(
+				'[data-field="focus-cone"]',
+			) as HTMLButtonElement;
+			expect(focusBtn).toBeTruthy();
+			expect(focusBtn.textContent).toBe("[ focus cone ]");
+		});
+
+		it("button click sets focus", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			const focusBtn = document.querySelector(
+				'[data-field="focus-cone"]',
+			) as HTMLButtonElement;
+			expect(focusBtn).toBeTruthy();
+
+			// Click should set focus to the button's daemon
+			focusBtn.click();
+
+			// The button's data-ai is determined by its closest .ai-panel
+			const panel = focusBtn.closest(".ai-panel") as HTMLElement;
+			const aiId = panel?.getAttribute("data-ai");
+			expect(getMapFocus()).toBe(aiId);
+		});
+
+		it("button click toggles focus off when already focused", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			const redPanel = document.querySelector('[data-ai="red"]') as HTMLElement;
+			expect(redPanel).toBeTruthy();
+
+			const focusBtnInPanel = redPanel?.querySelector(
+				'[data-field="focus-cone"]',
+			) as HTMLButtonElement;
+
+			// Try to find the button anywhere as a fallback
+			const allBtns = document.querySelectorAll('[data-field="focus-cone"]');
+			const focusBtn = focusBtnInPanel || (allBtns[0] as HTMLButtonElement);
+
+			expect(focusBtn).toBeTruthy();
+
+			setMapFocus("red");
+			expect(getMapFocus()).toBe("red");
+
+			focusBtn.click();
+			expect(getMapFocus()).toBeNull();
+		});
+
+		it("data-focus-active reflects focus state", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			// Get all buttons
+			const allBtns = document.querySelectorAll(
+				'[data-field="focus-cone"]',
+			) as NodeListOf<HTMLElement>;
+			expect(allBtns.length).toBeGreaterThanOrEqual(3);
+
+			// Find red and green buttons by their panel
+			let redBtn: HTMLElement | null = null;
+			let greenBtn: HTMLElement | null = null;
+
+			for (const btn of allBtns) {
+				const panel = btn.closest(".ai-panel") as HTMLElement;
+				const aiId = panel?.getAttribute("data-ai");
+				if (aiId === "red") redBtn = btn;
+				if (aiId === "green") greenBtn = btn;
+			}
+
+			expect(redBtn).toBeTruthy();
+			expect(greenBtn).toBeTruthy();
+
+			setMapFocus("red");
+			expect(redBtn!.getAttribute("data-focus-active")).toBe("true");
+			expect(greenBtn!.getAttribute("data-focus-active")).toBe("false");
+
+			setMapFocus("green");
+			expect(redBtn!.getAttribute("data-focus-active")).toBe("false");
+			expect(greenBtn!.getAttribute("data-focus-active")).toBe("true");
+		});
+	});
+
+	describe("Escape key handling", () => {
+		it("Escape clears active focus", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			setMapFocus("red");
+			expect(getMapFocus()).toBe("red");
+
+			const escapeEvent = new KeyboardEvent("keydown", {
+				key: "Escape",
+				bubbles: true,
+			});
+			document.dispatchEvent(escapeEvent);
+
+			expect(getMapFocus()).toBeNull();
+		});
+
+		it("Escape clears tint when focus is active", () => {
+			const root = document.body;
+			const containerEl = document.getElementById(
+				"dev-world-map",
+			) as HTMLElement;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+			renderWorldMap(containerEl, session);
+
+			setMapFocus("red");
+
+			// Verify tint is applied
+			const tintedBefore =
+				containerEl.querySelectorAll("[data-cone-focus]").length;
+			expect(tintedBefore).toBeGreaterThan(0);
+
+			// Press Escape
+			const escapeEvent = new KeyboardEvent("keydown", {
+				key: "Escape",
+				bubbles: true,
+			});
+			document.dispatchEvent(escapeEvent);
+
+			// Verify tint is cleared
+			const tintedAfter =
+				containerEl.querySelectorAll("[data-cone-focus]").length;
+			expect(tintedAfter).toBe(0);
+		});
+
+		it("Escape no-op when no focus is active", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			expect(getMapFocus()).toBeNull();
+
+			// Should not throw
+			const escapeEvent = new KeyboardEvent("keydown", {
+				key: "Escape",
+				bubbles: true,
+			});
+			document.dispatchEvent(escapeEvent);
+
+			expect(getMapFocus()).toBeNull();
+		});
+
+		it("Escape listener attached only once", () => {
+			const root = document.body;
+
+			// First render
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			// Re-render (simulating re-init)
+			__resetInspectorForTests();
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			// Set focus and press Escape
+			setMapFocus("red");
+			const escapeEvent = new KeyboardEvent("keydown", {
+				key: "Escape",
+				bubbles: true,
+			});
+			document.dispatchEvent(escapeEvent);
+
+			// Should still work correctly (and not have double-listeners)
+			expect(getMapFocus()).toBeNull();
+		});
+
+		it("other keys do not clear focus", () => {
+			const root = document.body;
+			renderInspector(root, { session, pendingBootstrap: undefined });
+
+			setMapFocus("red");
+			expect(getMapFocus()).toBe("red");
+
+			// Press Enter
+			const enterEvent = new KeyboardEvent("keydown", {
+				key: "Enter",
+				bubbles: true,
+			});
+			document.dispatchEvent(enterEvent);
+
+			// Focus should remain
+			expect(getMapFocus()).toBe("red");
+		});
+	});
+});

--- a/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
+++ b/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
@@ -1,0 +1,425 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { STATIC_CONTENT_PACKS } from "../../__tests__/fixtures/static-content-packs";
+import { STATIC_PERSONAS } from "../../__tests__/fixtures/static-personas";
+import { GameSession } from "../../game/game-session";
+import type { GameState } from "../../game/types";
+import {
+	clearDaemonTurnResults,
+	recordDaemonTurnResult,
+	renderDaemonFooter,
+	setDaemonFooterInFlight,
+	updateDaemonFooterSummary,
+} from "../daemon-footer";
+
+describe("daemon-footer", () => {
+	beforeEach(() => {
+		// Create three panels with footers matching the HTML structure
+		document.body.innerHTML = `
+      <article class="ai-panel" data-ai="red">
+        <div class="dev-daemon-footer" hidden></div>
+      </article>
+      <article class="ai-panel" data-ai="green">
+        <div class="dev-daemon-footer" hidden></div>
+      </article>
+      <article class="ai-panel" data-ai="cyan">
+        <div class="dev-daemon-footer" hidden></div>
+      </article>
+    `;
+		// Clear the side-channel storage between tests
+		clearDaemonTurnResults();
+	});
+
+	it("renderDaemonFooter builds the four field spans in order with pip initialized to idle ○", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		const summary = redPanel.querySelector('[data-line="summary"]');
+		expect(summary).toBeTruthy();
+
+		// Check the four spans exist in order
+		const pip = summary?.querySelector('[data-field="pip"]');
+		expect(pip).toBeTruthy();
+		expect(pip?.textContent).toBe("○");
+		expect(pip?.getAttribute("data-state")).toBe("idle");
+
+		const tools = summary?.querySelector('[data-field="last-tools"]');
+		expect(tools).toBeTruthy();
+
+		const llm = summary?.querySelector('[data-field="llm-line"]');
+		expect(llm).toBeTruthy();
+
+		const chips = summary?.querySelector('[data-field="complication-chips"]');
+		expect(chips).toBeTruthy();
+
+		// Verify order by checking that pip is first
+		const allSpans = Array.from(summary?.querySelectorAll("span") ?? []);
+		expect(allSpans[0]).toBe(pip);
+	});
+
+	it("renderDaemonFooter removes the hidden attribute from .dev-daemon-footer", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		const footerEl = redPanel.querySelector<HTMLElement>(".dev-daemon-footer");
+		expect(footerEl?.hasAttribute("hidden")).toBe(true);
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		expect(footerEl?.hasAttribute("hidden")).toBe(false);
+	});
+
+	it("setDaemonFooterInFlight flips pip glyph and data-state across all three values", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		// Start at idle
+		const pip = redPanel.querySelector<HTMLElement>('[data-field="pip"]');
+		expect(pip?.textContent).toBe("○");
+		expect(pip?.getAttribute("data-state")).toBe("idle");
+
+		// Flip to in-flight
+		setDaemonFooterInFlight(redPanel, "in-flight");
+		expect(pip?.textContent).toBe("●");
+		expect(pip?.getAttribute("data-state")).toBe("in-flight");
+
+		// Flip to errored
+		setDaemonFooterInFlight(redPanel, "errored");
+		expect(pip?.textContent).toBe("✕");
+		expect(pip?.getAttribute("data-state")).toBe("errored");
+
+		// Flip back to idle
+		setDaemonFooterInFlight(redPanel, "idle");
+		expect(pip?.textContent).toBe("○");
+		expect(pip?.getAttribute("data-state")).toBe("idle");
+	});
+
+	it("updateDaemonFooterSummary lists last-round tool calls from conversationLogs, comma-separated", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Create a modified state with tool calls in the conversation log
+		const modifiedState: GameState = {
+			...state,
+			conversationLogs: {
+				...state.conversationLogs,
+				red: [
+					{
+						kind: "tool-call",
+						round: 1,
+						aiId: "red",
+						toolCallId: "tc1",
+						toolArgumentsJson: "{}",
+						toolName: "go",
+						result: "moved",
+						success: true,
+					},
+					{
+						kind: "tool-call",
+						round: 1,
+						aiId: "red",
+						toolCallId: "tc2",
+						toolArgumentsJson: "{}",
+						toolName: "pick_up",
+						result: "picked up item",
+						success: true,
+					},
+				],
+			},
+		};
+
+		const restoredSession = GameSession.restore(modifiedState);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", restoredSession);
+		updateDaemonFooterSummary(redPanel, "red", restoredSession);
+
+		const toolsSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="last-tools"]',
+		);
+		expect(toolsSpan?.textContent).toBe("go, pick_up");
+	});
+
+	it("updateDaemonFooterSummary includes the message tool when the last round was a successful message-only turn", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Create a modified state with only a message in the last round
+		const modifiedState: GameState = {
+			...state,
+			conversationLogs: {
+				...state.conversationLogs,
+				red: [
+					{
+						kind: "message",
+						round: 1,
+						from: "red",
+						to: "blue",
+						content: "Hello",
+					},
+				],
+			},
+		};
+
+		const restoredSession = GameSession.restore(modifiedState);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", restoredSession);
+		updateDaemonFooterSummary(redPanel, "red", restoredSession);
+
+		const toolsSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="last-tools"]',
+		);
+		expect(toolsSpan?.textContent).toBe("message");
+	});
+
+	it("updateDaemonFooterSummary renders the LLM line from recordDaemonTurnResult data", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		// Record a turn result with specific token/cost data
+		recordDaemonTurnResult("red", {
+			promptTokens: 1200,
+			completionTokens: 80,
+			cachedPromptTokens: 600,
+			costUsd: 0.0042,
+		});
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterSummary(redPanel, "red", session);
+
+		const llmSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="llm-line"]',
+		);
+		expect(llmSpan?.textContent).toBe("[tok 1200→80 cache 50% $0.0042]");
+	});
+
+	it("updateDaemonFooterSummary renders empty LLM line when no turn result recorded yet", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		// Don't record any turn result for "red"
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterSummary(redPanel, "red", session);
+
+		const llmSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="llm-line"]',
+		);
+		expect(llmSpan?.textContent).toBe("");
+	});
+
+	it("updateDaemonFooterSummary renders complication chips filtered by target=aiId", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Create a modified state with complications targeting different AIs
+		const modifiedState: GameState = {
+			...state,
+			activeComplications: [
+				{
+					kind: "sysadmin_directive",
+					target: "red",
+					directive: "do something",
+					resolveAtRound: 5,
+				},
+				{
+					kind: "tool_disable",
+					target: "red",
+					tool: "pick_up",
+					resolveAtRound: 3,
+				},
+				{
+					kind: "chat_lockout",
+					target: "green",
+					resolveAtRound: 2,
+				},
+			],
+		};
+
+		const restoredSession = GameSession.restore(modifiedState);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", restoredSession);
+		updateDaemonFooterSummary(redPanel, "red", restoredSession);
+
+		const chipsSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="complication-chips"]',
+		);
+		const chips = chipsSpan?.querySelectorAll(".dev-footer-chip");
+		expect(chips?.length).toBe(2);
+
+		// Check the text content of the chips
+		const chipTexts = Array.from(chips ?? []).map((c) => c.textContent);
+		expect(chipTexts).toContain("[sysadm-dir]");
+		expect(chipTexts).toContain("[tool-dis:pick_up]");
+	});
+
+	it("updateDaemonFooterSummary does NOT mutate the pip span", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+		setDaemonFooterInFlight(redPanel, "in-flight");
+
+		const pip = redPanel.querySelector<HTMLElement>('[data-field="pip"]');
+		const pipId = pip;
+
+		// Update the summary
+		updateDaemonFooterSummary(redPanel, "red", session);
+
+		// Verify pip is still the same DOM node
+		const pipAfter = redPanel.querySelector<HTMLElement>('[data-field="pip"]');
+		expect(pipAfter).toBe(pipId);
+
+		// Verify it's still in-flight
+		expect(pipAfter?.textContent).toBe("●");
+		expect(pipAfter?.getAttribute("data-state")).toBe("in-flight");
+	});
+
+	it("per-Daemon footers show their own last-round number — three footers can disagree", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Create a modified state with different rounds for different AIs
+		const modifiedState: GameState = {
+			...state,
+			conversationLogs: {
+				...state.conversationLogs,
+				red: [
+					{
+						kind: "tool-call",
+						round: 3,
+						aiId: "red",
+						toolCallId: "tc1",
+						toolArgumentsJson: "{}",
+						toolName: "go",
+						result: "moved",
+						success: true,
+					},
+				],
+				green: [
+					{
+						kind: "tool-call",
+						round: 2,
+						aiId: "green",
+						toolCallId: "tc2",
+						toolArgumentsJson: "{}",
+						toolName: "pick_up",
+						result: "picked up",
+						success: true,
+					},
+				],
+				cyan: [
+					{
+						kind: "tool-call",
+						round: 1,
+						aiId: "cyan",
+						toolCallId: "tc3",
+						toolArgumentsJson: "{}",
+						toolName: "use",
+						result: "used",
+						success: true,
+					},
+				],
+			},
+		};
+
+		const restoredSession = GameSession.restore(modifiedState);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		const greenPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="green"]',
+		);
+		const cyanPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="cyan"]',
+		);
+
+		if (!redPanel || !greenPanel || !cyanPanel)
+			throw new Error("Panels not found");
+
+		renderDaemonFooter(redPanel, "red", restoredSession);
+		renderDaemonFooter(greenPanel, "green", restoredSession);
+		renderDaemonFooter(cyanPanel, "cyan", restoredSession);
+
+		updateDaemonFooterSummary(redPanel, "red", restoredSession);
+		updateDaemonFooterSummary(greenPanel, "green", restoredSession);
+		updateDaemonFooterSummary(cyanPanel, "cyan", restoredSession);
+
+		const redTools = redPanel.querySelector<HTMLElement>(
+			'[data-field="last-tools"]',
+		)?.textContent;
+		const greenTools = greenPanel.querySelector<HTMLElement>(
+			'[data-field="last-tools"]',
+		)?.textContent;
+		const cyanTools = cyanPanel.querySelector<HTMLElement>(
+			'[data-field="last-tools"]',
+		)?.textContent;
+
+		// Each should show only their own last tool
+		expect(redTools).toBe("go");
+		expect(greenTools).toBe("pick_up");
+		expect(cyanTools).toBe("use");
+	});
+});

--- a/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
+++ b/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
@@ -488,7 +488,7 @@ describe("daemon-footer", () => {
 
 		// Now renderInspector should clear the stale results
 		// First, renderInspector will call clearDaemonTurnResults internally
-		renderInspector(document.body, { session, pendingBootstrap: undefined });
+		renderInspector(document.body, { session });
 
 		// After renderInspector clears and renders, the daemonTurnResults should be empty
 		// Re-query for the llmSpan since renderInspector rebuilds the footer DOM
@@ -1019,7 +1019,7 @@ describe("daemon-footer", () => {
 		expect(systemPromptPre?.textContent).toBe("test prompt");
 
 		// renderInspector clears everything
-		renderInspector(document.body, { session, pendingBootstrap: undefined });
+		renderInspector(document.body, { session });
 
 		// Re-query and verify cleared
 		systemPromptPre = redPanel.querySelector(

--- a/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
+++ b/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
@@ -10,6 +10,7 @@ import {
 	setDaemonFooterInFlight,
 	updateDaemonFooterSummary,
 } from "../daemon-footer";
+import { renderInspector } from "../index";
 
 describe("daemon-footer", () => {
 	beforeEach(() => {
@@ -421,5 +422,76 @@ describe("daemon-footer", () => {
 		expect(redTools).toBe("go");
 		expect(greenTools).toBe("pick_up");
 		expect(cyanTools).toBe("use");
+	});
+
+	it("updateDaemonFooterSummary shows empty last-tools when conversation log is empty", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Create a modified state with an empty conversation log for red
+		const modifiedState: GameState = {
+			...state,
+			conversationLogs: {
+				...state.conversationLogs,
+				red: [],
+			},
+		};
+
+		const restoredSession = GameSession.restore(modifiedState);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", restoredSession);
+		updateDaemonFooterSummary(redPanel, "red", restoredSession);
+
+		const toolsSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="last-tools"]',
+		);
+		expect(toolsSpan?.textContent).toBe("");
+	});
+
+	it("renderInspector clears stale daemon turn results from previous sessions", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		// Record a turn result simulating a previous session
+		recordDaemonTurnResult("red", {
+			promptTokens: 1200,
+			completionTokens: 80,
+			cachedPromptTokens: 600,
+			costUsd: 0.0042,
+		});
+
+		// Verify the result was recorded
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterSummary(redPanel, "red", session);
+		let llmSpan = redPanel.querySelector<HTMLElement>(
+			'[data-field="llm-line"]',
+		);
+		expect(llmSpan?.textContent).toBe("[tok 1200→80 cache 50% $0.0042]");
+
+		// Now renderInspector should clear the stale results
+		// First, renderInspector will call clearDaemonTurnResults internally
+		renderInspector(document.body, { session, pendingBootstrap: undefined });
+
+		// After renderInspector clears and renders, the daemonTurnResults should be empty
+		// Re-query for the llmSpan since renderInspector rebuilds the footer DOM
+		llmSpan = redPanel.querySelector<HTMLElement>('[data-field="llm-line"]');
+
+		// Now if we update the summary again, the llm-line should be empty
+		// because the turn results were cleared
+		updateDaemonFooterSummary(redPanel, "red", session);
+		expect(llmSpan?.textContent).toBe("");
 	});
 });

--- a/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
+++ b/src/spa/dev-inspector/__tests__/daemon-footer.test.ts
@@ -3,11 +3,16 @@ import { STATIC_CONTENT_PACKS } from "../../__tests__/fixtures/static-content-pa
 import { STATIC_PERSONAS } from "../../__tests__/fixtures/static-personas";
 import { GameSession } from "../../game/game-session";
 import type { GameState } from "../../game/types";
+import { CapHitError } from "../../llm-client";
 import {
 	clearDaemonTurnResults,
+	recordDaemonError,
+	recordDaemonRound,
+	recordDaemonSystemPrompt,
 	recordDaemonTurnResult,
 	renderDaemonFooter,
 	setDaemonFooterInFlight,
+	updateDaemonFooterDetails,
 	updateDaemonFooterSummary,
 } from "../daemon-footer";
 import { renderInspector } from "../index";
@@ -493,5 +498,533 @@ describe("daemon-footer", () => {
 		// because the turn results were cleared
 		updateDaemonFooterSummary(redPanel, "red", session);
 		expect(llmSpan?.textContent).toBe("");
+	});
+
+	it("renderDaemonFooter builds five <details> blocks in stable order, all default closed", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		const details = redPanel.querySelectorAll(".dev-footer-details");
+		expect(details.length).toBe(5);
+
+		const disclosures = Array.from(details).map((d) =>
+			d.getAttribute("data-disclosure"),
+		);
+		expect(disclosures).toEqual([
+			"system-prompt",
+			"raw-completion",
+			"tool-calls",
+			"error",
+			"persona-card",
+		]);
+
+		// All should be default closed (no open attribute)
+		for (const detail of details) {
+			expect((detail as HTMLDetailsElement).open).toBe(false);
+		}
+	});
+
+	it("renderDaemonFooter initialises empty <pre> contents for the four non-persona disclosures", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		const disclosures = [
+			"system-prompt",
+			"raw-completion",
+			"tool-calls",
+			"error",
+		];
+		const preElements: (HTMLElement | null)[] = [];
+		for (const disclosure of disclosures) {
+			const pre = redPanel.querySelector<HTMLElement>(
+				`[data-disclosure="${disclosure}"] pre`,
+			);
+			preElements.push(pre);
+		}
+
+		expect(preElements.length).toBe(4);
+
+		for (const pre of preElements) {
+			expect(pre?.textContent).toBe("");
+		}
+	});
+
+	it("renderDaemonFooter initialises summaries without round suffix when no round captured yet", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		const disclosures = [
+			"system-prompt",
+			"raw-completion",
+			"tool-calls",
+			"error",
+		];
+		const expectedLabels = [
+			"last system prompt",
+			"last raw completion",
+			"last tool calls",
+			"last error",
+		];
+
+		for (let i = 0; i < disclosures.length; i++) {
+			const summary = redPanel.querySelector(
+				`[data-disclosure="${disclosures[i]}"] summary`,
+			);
+			expect(summary?.textContent).toBe(expectedLabels[i]);
+		}
+	});
+
+	it("renderDaemonFooter populates the persona-card content from state.personas[aiId]", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		const personaDiv = redPanel.querySelector(".dev-footer-persona");
+		expect(personaDiv).toBeTruthy();
+
+		const handleEl = personaDiv?.querySelector('[data-persona-field="handle"]');
+		expect(handleEl?.textContent).toBe("*Ember");
+
+		const colorEl = personaDiv?.querySelector('[data-persona-field="color"]');
+		const swatch = colorEl?.querySelector(".dev-footer-color-swatch");
+		expect(swatch).toBeTruthy();
+		// Check that backgroundColor is set (jsdom may normalize hex to rgb, so just check it's non-empty)
+		const bgColor = (swatch as HTMLElement)?.style.backgroundColor;
+		expect(bgColor?.length).toBeGreaterThan(0);
+
+		const tempEl = personaDiv?.querySelector(
+			'[data-persona-field="temperaments"]',
+		);
+		expect(tempEl?.textContent).toContain("/");
+
+		const goalEl = personaDiv?.querySelector(
+			'[data-persona-field="persona-goal"]',
+		);
+		expect(goalEl?.textContent?.length).toBeGreaterThan(0);
+
+		const blurbEl = personaDiv?.querySelector('[data-persona-field="blurb"]');
+		expect(blurbEl?.textContent?.length).toBeGreaterThan(0);
+	});
+
+	it("recordDaemonSystemPrompt + updateDaemonFooterDetails renders the prompt into pre[data-content='system-prompt']", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		const systemPrompt = "You are a helpful assistant.";
+		recordDaemonSystemPrompt("red", systemPrompt);
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		expect(pre?.textContent).toBe(systemPrompt);
+	});
+
+	it("updateDaemonFooterDetails renders lastRawCompletion from recordDaemonTurnResult", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		const completion = "This is the assistant response.";
+		recordDaemonTurnResult("red", {
+			lastRawCompletion: completion,
+		});
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="raw-completion"] pre[data-content="raw-completion"]',
+		);
+		expect(pre?.textContent).toBe(completion);
+	});
+
+	it("updateDaemonFooterDetails renders tool calls one per line in name(argsJson) format", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		recordDaemonTurnResult("red", {
+			lastToolCalls: [
+				{ name: "go", argumentsJson: '{"direction": "north"}' },
+				{ name: "pick_up", argumentsJson: '{"item": "key"}' },
+			],
+		});
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="tool-calls"] pre[data-content="tool-calls"]',
+		);
+		expect(pre?.textContent).toBe(
+			'go({"direction": "north"})\npick_up({"item": "key"})',
+		);
+	});
+
+	it("updateDaemonFooterDetails renders empty error pre when no error recorded", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="error"] pre[data-content="error"]',
+		);
+		expect(pre?.textContent).toBe("");
+	});
+
+	it("updateDaemonFooterDetails renders error with status code prefix when status present (CapHitError 429)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		const error = new CapHitError({
+			message: "rate limit exceeded",
+			reason: "per-ip-daily",
+			retryAfterSec: 60,
+		});
+
+		recordDaemonError("red", error);
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="error"] pre[data-content="error"]',
+		);
+		expect(pre?.textContent).toBe("429 rate limit exceeded");
+	});
+
+	it("updateDaemonFooterDetails renders error message only when no status field (generic Error)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		const error = new Error("something went wrong");
+
+		recordDaemonError("red", error);
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="error"] pre[data-content="error"]',
+		);
+		expect(pre?.textContent).toBe("something went wrong");
+	});
+
+	it("updateDaemonFooterDetails handles non-Error error payloads via String(error)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		recordDaemonError("red", "string error payload");
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const pre = redPanel.querySelector<HTMLElement>(
+			'[data-disclosure="error"] pre[data-content="error"]',
+		);
+		expect(pre?.textContent).toBe("string error payload");
+	});
+
+	it("recordDaemonRound suffixes round number into the four non-persona summaries", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		recordDaemonRound("red", 3);
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const disclosures = [
+			"system-prompt",
+			"raw-completion",
+			"tool-calls",
+			"error",
+		];
+
+		for (const disclosure of disclosures) {
+			const summary = redPanel.querySelector(
+				`[data-disclosure="${disclosure}"] summary`,
+			);
+			expect(summary?.textContent).toContain("(round 3)");
+		}
+
+		// Persona card summary should NOT have round suffix
+		const personaSummary = redPanel.querySelector(
+			'[data-disclosure="persona-card"] summary',
+		);
+		expect(personaSummary?.textContent).toBe("persona card");
+	});
+
+	it("updateDaemonFooterDetails preserves <details> open state across updates", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		// Open the system-prompt details
+		const details = redPanel.querySelector<HTMLDetailsElement>(
+			'[data-disclosure="system-prompt"]',
+		);
+		expect(details).toBeTruthy();
+		const detailsId = details;
+		(details as HTMLDetailsElement).open = true;
+
+		// Record content and update
+		recordDaemonSystemPrompt("red", "test prompt");
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		// Verify same node and still open
+		const detailsAfter = redPanel.querySelector<HTMLDetailsElement>(
+			'[data-disclosure="system-prompt"]',
+		);
+		expect(detailsAfter).toBe(detailsId);
+		expect((detailsAfter as HTMLDetailsElement).open).toBe(true);
+		expect(
+			detailsAfter?.querySelector('[data-content="system-prompt"]')
+				?.textContent,
+		).toBe("test prompt");
+	});
+
+	it("updateDaemonFooterDetails does NOT replace the persona-card outer details", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		renderDaemonFooter(redPanel, "red", session);
+
+		const personaDetails = redPanel.querySelector<HTMLDetailsElement>(
+			'[data-disclosure="persona-card"]',
+		);
+		expect(personaDetails).toBeTruthy();
+		const personaDetailsId = personaDetails;
+		(personaDetails as HTMLDetailsElement).open = true;
+
+		// Update and verify same node and still open
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		const personaDetailsAfter = redPanel.querySelector<HTMLDetailsElement>(
+			'[data-disclosure="persona-card"]',
+		);
+		expect(personaDetailsAfter).toBe(personaDetailsId);
+		expect((personaDetailsAfter as HTMLDetailsElement).open).toBe(true);
+	});
+
+	it("per-Daemon details are isolated — three Daemons can have different captured system prompts simultaneously", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		const greenPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="green"]',
+		);
+		const cyanPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="cyan"]',
+		);
+
+		if (!redPanel || !greenPanel || !cyanPanel)
+			throw new Error("Panels not found");
+
+		recordDaemonSystemPrompt("red", "red prompt");
+		recordDaemonSystemPrompt("green", "green prompt");
+		recordDaemonSystemPrompt("cyan", "cyan prompt");
+
+		renderDaemonFooter(redPanel, "red", session);
+		renderDaemonFooter(greenPanel, "green", session);
+		renderDaemonFooter(cyanPanel, "cyan", session);
+
+		updateDaemonFooterDetails(redPanel, "red", session);
+		updateDaemonFooterDetails(greenPanel, "green", session);
+		updateDaemonFooterDetails(cyanPanel, "cyan", session);
+
+		const redPre = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		const greenPre = greenPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		const cyanPre = cyanPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+
+		expect(redPre?.textContent).toBe("red prompt");
+		expect(greenPre?.textContent).toBe("green prompt");
+		expect(cyanPre?.textContent).toBe("cyan prompt");
+	});
+
+	it("clearDaemonTurnResults also clears system prompts, errors, and rounds", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		// Record multiple types of data
+		recordDaemonSystemPrompt("red", "test prompt");
+		recordDaemonError("red", new Error("test error"));
+		recordDaemonRound("red", 5);
+		recordDaemonTurnResult("red", { costUsd: 0.01 });
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		// Verify data is recorded
+		let systemPromptPre = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		expect(systemPromptPre?.textContent).toBe("test prompt");
+
+		let summaryText = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] summary',
+		)?.textContent;
+		expect(summaryText).toContain("(round 5)");
+
+		// Clear all
+		clearDaemonTurnResults();
+
+		// Re-render and update to verify cleared
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		systemPromptPre = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		expect(systemPromptPre?.textContent).toBe("");
+
+		summaryText = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] summary',
+		)?.textContent;
+		expect(summaryText).toBe("last system prompt"); // no round suffix
+	});
+
+	it("renderInspector clears the extended side-channel maps", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		const redPanel = document.querySelector<HTMLElement>(
+			'.ai-panel[data-ai="red"]',
+		);
+		if (!redPanel) throw new Error("Red panel not found");
+
+		// Record extended data
+		recordDaemonSystemPrompt("red", "test prompt");
+		recordDaemonError("red", new Error("test error"));
+		recordDaemonRound("red", 5);
+
+		renderDaemonFooter(redPanel, "red", session);
+		updateDaemonFooterDetails(redPanel, "red", session);
+
+		let systemPromptPre = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		expect(systemPromptPre?.textContent).toBe("test prompt");
+
+		// renderInspector clears everything
+		renderInspector(document.body, { session, pendingBootstrap: undefined });
+
+		// Re-query and verify cleared
+		systemPromptPre = redPanel.querySelector(
+			'[data-disclosure="system-prompt"] pre[data-content="system-prompt"]',
+		);
+		expect(systemPromptPre?.textContent).toBe("");
 	});
 });

--- a/src/spa/dev-inspector/__tests__/game-strip.test.ts
+++ b/src/spa/dev-inspector/__tests__/game-strip.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { STATIC_CONTENT_PACKS } from "../../__tests__/fixtures/static-content-packs";
+import { STATIC_PERSONAS } from "../../__tests__/fixtures/static-personas";
+import { GameSession } from "../../game/game-session";
+import type { GameState } from "../../game/types";
+import { renderGameStrip, updateGameStripSummary } from "../game-strip";
+
+describe("game-strip", () => {
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="dev-game-strip"></div>';
+	});
+
+	it("renders line 1 with round, countdown, pack id, and setting/weather/time-of-day", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const line1 = containerEl.querySelector('[data-line="1"]');
+		expect(line1).toBeTruthy();
+
+		const roundSpan = line1?.querySelector('[data-field="round"]');
+		expect(roundSpan?.textContent).toBe("0");
+
+		const countdownSpan = line1?.querySelector('[data-field="countdown"]');
+		expect(countdownSpan?.textContent).toBeTruthy();
+
+		const packSpan = line1?.querySelector('[data-field="pack"]');
+		expect(packSpan?.textContent).toBe("A");
+
+		const settingSpan = line1?.querySelector('[data-field="setting"]');
+		expect(settingSpan?.textContent).toBe("abandoned subway station");
+
+		const weatherSpan = line1?.querySelector('[data-field="weather"]');
+		expect(weatherSpan).toBeTruthy();
+
+		const timeSpan = line1?.querySelector('[data-field="time-of-day"]');
+		expect(timeSpan).toBeTruthy();
+	});
+
+	it("renders line 2 with cost, obj K/J satisfied, and active-complication count", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const line2 = containerEl.querySelector('[data-line="2"]');
+		expect(line2).toBeTruthy();
+
+		const costSpan = line2?.querySelector('[data-field="cost"]');
+		expect(costSpan?.textContent).toBeTruthy();
+		expect(costSpan?.textContent).toMatch(/^\d+\.\d{2}$/);
+
+		const objSatisfiedSpan = line2?.querySelector(
+			'[data-field="obj-satisfied"]',
+		);
+		expect(objSatisfiedSpan?.textContent).toBeTruthy();
+
+		const objTotalSpan = line2?.querySelector('[data-field="obj-total"]');
+		expect(objTotalSpan?.textContent).toBeTruthy();
+
+		const complicationsSpan = line2?.querySelector(
+			'[data-field="active-complications"]',
+		);
+		expect(complicationsSpan?.textContent).toBeTruthy();
+	});
+
+	it("lists every objective inside the details with its kind and satisfaction state", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const objectivesList = containerEl.querySelector(
+			'[data-list="objectives"]',
+		);
+		expect(objectivesList).toBeTruthy();
+
+		const objectiveItems = objectivesList?.querySelectorAll("li");
+		expect(objectiveItems?.length).toBeGreaterThan(0);
+
+		for (const li of objectiveItems || []) {
+			const objectiveId = li.getAttribute("data-objective-id");
+			expect(objectiveId).toBeTruthy();
+
+			const kind = li.getAttribute("data-kind");
+			expect(kind).toBeTruthy();
+
+			const satisfied = li.getAttribute("data-satisfied");
+			expect(["true", "false"]).toContain(satisfied);
+
+			const stateSpan = li.querySelector('[data-field="state"]');
+			expect(["pending", "satisfied"]).toContain(stateSpan?.textContent);
+		}
+	});
+
+	it("lists every active complication with parameters and resolution round", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Manually add an active complication for testing
+		const modifiedState = {
+			...state,
+			activeComplications: [
+				{
+					kind: "sysadmin_directive",
+					target: "red" as const,
+					directive: "do something",
+					resolveAtRound: 5,
+				},
+				{
+					kind: "tool_disable",
+					target: "green" as const,
+					tool: "pick_up" as const,
+					resolveAtRound: 3,
+				},
+				{
+					kind: "chat_lockout",
+					target: "cyan" as const,
+					resolveAtRound: 2,
+				},
+			],
+		};
+
+		const restoredSession = GameSession.restore(modifiedState as GameState);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, restoredSession);
+
+		const complicationsList = containerEl.querySelector(
+			'[data-list="complications"]',
+		);
+		expect(complicationsList).toBeTruthy();
+
+		const complicationItems = complicationsList?.querySelectorAll("li");
+		expect(complicationItems?.length).toBe(3);
+
+		const itemArray = Array.from(complicationItems || []);
+
+		// Check sysadmin_directive
+		const sysadminItem = itemArray[0];
+		expect(sysadminItem).toBeDefined();
+		if (sysadminItem) {
+			expect(sysadminItem.getAttribute("data-complication-kind")).toBe(
+				"sysadmin_directive",
+			);
+			expect(sysadminItem.textContent).toContain("sysadmin_directive");
+			expect(sysadminItem.textContent).toContain("target *red");
+			expect(sysadminItem.textContent).toContain("resolves round 5");
+			expect(sysadminItem.textContent).toContain('directive "do something"');
+		}
+
+		// Check tool_disable
+		const toolItem = itemArray[1];
+		expect(toolItem).toBeDefined();
+		if (toolItem) {
+			expect(toolItem.getAttribute("data-complication-kind")).toBe(
+				"tool_disable",
+			);
+			expect(toolItem.textContent).toContain("tool_disable");
+			expect(toolItem.textContent).toContain("target *green");
+			expect(toolItem.textContent).toContain("resolves round 3");
+			expect(toolItem.textContent).toContain("tool pick_up");
+		}
+
+		// Check chat_lockout
+		const chatItem = itemArray[2];
+		expect(chatItem).toBeDefined();
+		if (chatItem) {
+			expect(chatItem.getAttribute("data-complication-kind")).toBe(
+				"chat_lockout",
+			);
+			expect(chatItem.textContent).toContain("chat_lockout");
+			expect(chatItem.textContent).toContain("target *cyan");
+			expect(chatItem.textContent).toContain("resolves round 2");
+		}
+	});
+
+	it("details is closed by default", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const details = containerEl.querySelector(
+			'[data-section="strip-details"]',
+		) as HTMLDetailsElement;
+		expect(details).toBeTruthy();
+		expect(details.open).toBe(false);
+	});
+
+	it("updateGameStripSummary keeps details open after a re-render", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const details = containerEl.querySelector(
+			'[data-section="strip-details"]',
+		) as HTMLDetailsElement;
+		expect(details).toBeTruthy();
+
+		// Open the details
+		details.open = true;
+		expect(details.open).toBe(true);
+
+		// Update the strip
+		updateGameStripSummary(containerEl, session);
+
+		// Details should still be open
+		expect(details.open).toBe(true);
+	});
+
+	it("updateGameStripSummary updates line 1 + line 2 spans in place without re-creating the details element", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const details = containerEl.querySelector(
+			'[data-section="strip-details"]',
+		) as HTMLDetailsElement;
+
+		const line1Before = containerEl.querySelector('[data-line="1"]');
+		const roundSpanBefore = line1Before?.querySelector('[data-field="round"]');
+		const originalRoundText = roundSpanBefore?.textContent;
+
+		// Update the strip
+		updateGameStripSummary(containerEl, session);
+
+		const detailsAfter = containerEl.querySelector(
+			'[data-section="strip-details"]',
+		);
+		const line1After = containerEl.querySelector('[data-line="1"]');
+		const roundSpanAfter = line1After?.querySelector('[data-field="round"]');
+
+		// Same element identity (DOM element reference should be preserved)
+		expect(detailsAfter).toBe(details);
+		expect(line1After).toBe(line1Before);
+		expect(roundSpanAfter).toBe(roundSpanBefore);
+		// Content should be the same (since state hasn't changed)
+		expect(roundSpanAfter?.textContent).toBe(originalRoundText);
+	});
+
+	it("updateGameStripSummary refreshes the objectives and complications lists", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
+
+		renderGameStrip(containerEl, session);
+
+		const objectivesList = containerEl.querySelector(
+			'[data-list="objectives"]',
+		);
+		const _originalListId = objectivesList?.id; // or check identity
+
+		// Manually modify state to add a complication
+		const state = session.getState();
+		const modifiedState = {
+			...state,
+			activeComplications: [
+				{
+					kind: "chat_lockout",
+					target: "red" as const,
+					resolveAtRound: 10,
+				},
+			],
+		};
+
+		const restoredSession = GameSession.restore(modifiedState as GameState);
+
+		// Update the strip with new session
+		updateGameStripSummary(containerEl, restoredSession);
+
+		const complicationsList = containerEl.querySelector(
+			'[data-list="complications"]',
+		);
+		const complicationItems = complicationsList?.querySelectorAll("li");
+		expect(complicationItems?.length).toBe(1);
+
+		const item = complicationItems?.[0];
+		expect(item?.textContent).toContain("chat_lockout");
+	});
+});

--- a/src/spa/dev-inspector/__tests__/pending-strip.test.ts
+++ b/src/spa/dev-inspector/__tests__/pending-strip.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingBootstrap, PendingCallMeta } from "../../game/pending-bootstrap.js";
+import {
+	__resetPendingStripForTests,
+	clearPendingStrip,
+	renderPendingStrip,
+	updatePendingStrip,
+} from "../pending-strip.js";
+
+function makePending(
+	status: PendingBootstrap["status"],
+	error?: unknown,
+): PendingBootstrap {
+	return {
+		personasPromise: new Promise(() => {}),
+		contentPacksPromise: new Promise(() => {}),
+		status,
+		...(error !== undefined ? { error } : {}),
+	};
+}
+
+describe("pending-strip.ts", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		document.body.innerHTML = '<div id="dev-game-strip"></div>';
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		__resetPendingStripForTests();
+	});
+
+	it("renders pip + callName + elapsed for 'pending' status", () => {
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "persona-synthesis",
+			startedAtMs: Date.now(),
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		const pipEl = containerEl.querySelector('[data-field="pip"]');
+		expect(pipEl?.textContent).toBe("●");
+		expect(pipEl?.getAttribute("data-state")).toBe("in-flight");
+
+		const statusWordEl = containerEl.querySelector('[data-field="status-word"]');
+		expect(statusWordEl?.textContent).toBe("fetching");
+
+		const callNameEl = containerEl.querySelector('[data-field="call-name"]');
+		expect(callNameEl?.textContent).toBe("persona-synthesis");
+		expect(callNameEl?.hasAttribute("hidden")).toBe(false);
+
+		const elapsedEl = containerEl.querySelector('[data-field="elapsed"]');
+		expect(elapsedEl?.hasAttribute("hidden")).toBe(false);
+		expect(elapsedEl?.textContent).toMatch(/^0\.0s elapsed$/);
+	});
+
+	it("hides retry span when retryCount is 0 or undefined", () => {
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: Date.now(),
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		const retryEl = containerEl.querySelector('[data-field="retry"]');
+		expect(retryEl?.hasAttribute("hidden")).toBe(true);
+
+		const sepRetryEl = containerEl.querySelector('[data-field="sep-retry"]');
+		expect(sepRetryEl?.hasAttribute("hidden")).toBe(true);
+	});
+
+	it("shows retry 'retry N/M' when retryCount > 0", () => {
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: Date.now(),
+			retryCount: 1,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		const retryEl = containerEl.querySelector('[data-field="retry"]');
+		expect(retryEl?.textContent).toBe("retry 1/3");
+		expect(retryEl?.hasAttribute("hidden")).toBe(false);
+
+		const sepRetryEl = containerEl.querySelector('[data-field="sep-retry"]');
+		expect(sepRetryEl?.hasAttribute("hidden")).toBe(false);
+	});
+
+	it("shows last-error span when lastError is set", () => {
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: Date.now(),
+			retryCount: 1,
+			retryMax: 3,
+			lastError: "502 upstream",
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		const lastErrorEl = containerEl.querySelector('[data-field="last-error"]');
+		expect(lastErrorEl?.textContent).toBe("last error: 502 upstream");
+		expect(lastErrorEl?.hasAttribute("hidden")).toBe(false);
+
+		const sepErrorEl = containerEl.querySelector('[data-field="sep-error"]');
+		expect(sepErrorEl?.hasAttribute("hidden")).toBe(false);
+	});
+
+	it("pip → ✕ / 'errored' on status 'failed'", () => {
+		const pending = makePending("failed", new Error("test error"));
+		const meta: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: Date.now(),
+			retryCount: 3,
+			retryMax: 3,
+			lastError: "test error",
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		const pipEl = containerEl.querySelector('[data-field="pip"]');
+		expect(pipEl?.textContent).toBe("✕");
+		expect(pipEl?.getAttribute("data-state")).toBe("errored");
+
+		const statusWordEl = containerEl.querySelector('[data-field="status-word"]');
+		expect(statusWordEl?.textContent).toBe("errored");
+	});
+
+	it("pip → ○ / 'ready' on status 'ready'", () => {
+		const pending = makePending("ready");
+		const meta: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: Date.now(),
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		const pipEl = containerEl.querySelector('[data-field="pip"]');
+		expect(pipEl?.textContent).toBe("○");
+		expect(pipEl?.getAttribute("data-state")).toBe("idle");
+
+		const statusWordEl = containerEl.querySelector('[data-field="status-word"]');
+		expect(statusWordEl?.textContent).toBe("ready");
+	});
+
+	it("elapsed ticks via setInterval (~100ms) — advance fake timers, assert text updates", () => {
+		const pending = makePending("pending");
+		const startMs = Date.now();
+		const meta: PendingCallMeta = {
+			callName: "persona-synthesis",
+			startedAtMs: startMs,
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+
+		let elapsedEl = containerEl.querySelector('[data-field="elapsed"]');
+		expect(elapsedEl?.textContent).toBe("0.0s elapsed");
+
+		// Advance 5 seconds
+		vi.advanceTimersByTime(5000);
+
+		elapsedEl = containerEl.querySelector('[data-field="elapsed"]');
+		expect(elapsedEl?.textContent).toBe("5.0s elapsed");
+
+		// Advance another 2.5 seconds
+		vi.advanceTimersByTime(2500);
+
+		elapsedEl = containerEl.querySelector('[data-field="elapsed"]');
+		expect(elapsedEl?.textContent).toBe("7.5s elapsed");
+	});
+
+	it("updatePendingStrip swaps callName without restarting ticker (spy on setInterval, assert called once)", () => {
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+		const pending = makePending("pending");
+		const startMs = Date.now();
+		const meta1: PendingCallMeta = {
+			callName: "persona-synthesis",
+			startedAtMs: startMs,
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta1);
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+		// Update with different callName
+		const meta2: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: startMs,
+			retryCount: 0,
+			retryMax: 3,
+		};
+		updatePendingStrip(containerEl, pending, meta2);
+
+		// setInterval should still have been called only once
+		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+		// But the callName should be updated
+		const callNameEl = containerEl.querySelector('[data-field="call-name"]');
+		expect(callNameEl?.textContent).toBe("content-pack");
+
+		setIntervalSpy.mockRestore();
+	});
+
+	it("clearPendingStrip clears interval + DOM; advancing timers after clear is safe (no throw)", () => {
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "persona-synthesis",
+			startedAtMs: Date.now(),
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+		expect(containerEl.querySelector('[data-field="pip"]')).toBeTruthy();
+
+		clearPendingStrip(containerEl);
+
+		// DOM should be cleared
+		expect(containerEl.querySelector('[data-field="pip"]')).toBeFalsy();
+		expect(containerEl.classList.contains("dev-pending-strip")).toBe(false);
+
+		// Advancing timers after clear should not throw
+		expect(() => {
+			vi.advanceTimersByTime(500);
+		}).not.toThrow();
+	});
+
+	it("renderPendingStrip called twice clears the previous interval first", () => {
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "persona-synthesis",
+			startedAtMs: Date.now(),
+			retryCount: 0,
+			retryMax: 3,
+		};
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderPendingStrip(containerEl, pending, meta);
+		expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+		// Render again
+		renderPendingStrip(containerEl, pending, meta);
+		expect(clearIntervalSpy).toHaveBeenCalled();
+
+		clearIntervalSpy.mockRestore();
+	});
+
+	it("renderInspector branch: pendingBootstrap-only → pending strip renders, map hidden", async () => {
+		// Import after setup so fake timers are in place
+		const { renderInspector } = await import("../index.js");
+
+		const pending = makePending("pending");
+		const meta: PendingCallMeta = {
+			callName: "content-pack",
+			startedAtMs: Date.now(),
+			retryCount: 1,
+			retryMax: 3,
+		};
+
+		// Add map and footers to DOM
+		const mapEl = document.createElement("div");
+		mapEl.id = "dev-world-map";
+		document.body.appendChild(mapEl);
+
+		const footerEl = document.createElement("div");
+		footerEl.className = "dev-daemon-footer";
+		document.body.appendChild(footerEl);
+
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		// Mock getPendingCallMeta
+		vi.doMock("../../game/pending-bootstrap.js", () => ({
+			getPendingCallMeta: () => meta,
+		}));
+
+		renderInspector(document.body, { pendingBootstrap: pending });
+
+		expect(containerEl.getAttribute("hidden")).toBeNull();
+		expect(containerEl.getAttribute("data-strip")).toBe("pending");
+		expect(mapEl.getAttribute("hidden")).toBe("");
+		expect(footerEl.getAttribute("hidden")).toBe("");
+	});
+
+	it("renderInspector branch: session-set → pending strip cleared, game-strip renders", async () => {
+		const { renderInspector } = await import("../index.js");
+		const { STATIC_CONTENT_PACKS } = await import(
+			"../../__tests__/fixtures/static-content-packs.js"
+		);
+		const { STATIC_PERSONAS } = await import(
+			"../../__tests__/fixtures/static-personas.js"
+		);
+		const { GameSession } = await import("../../game/game-session.js");
+
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+
+		// Add map and footers to DOM
+		const mapEl = document.createElement("div");
+		mapEl.id = "dev-world-map";
+		document.body.appendChild(mapEl);
+
+		const footerEl = document.createElement("div");
+		footerEl.className = "dev-daemon-footer";
+		document.body.appendChild(footerEl);
+
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderInspector(document.body, { session });
+
+		// Strip should not have pending data
+		expect(containerEl.getAttribute("data-strip")).not.toBe("pending");
+		expect(containerEl.getAttribute("hidden")).toBeNull();
+		expect(mapEl.getAttribute("hidden")).toBeNull();
+		expect(footerEl.getAttribute("hidden")).toBeNull();
+	});
+
+	it("renderInspector branch: neither set → strip hidden + empty", async () => {
+		const { renderInspector } = await import("../index.js");
+
+		// Add map and footers to DOM
+		const mapEl = document.createElement("div");
+		mapEl.id = "dev-world-map";
+		document.body.appendChild(mapEl);
+
+		const footerEl = document.createElement("div");
+		footerEl.className = "dev-daemon-footer";
+		document.body.appendChild(footerEl);
+
+		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+
+		renderInspector(document.body, {});
+
+		expect(containerEl.getAttribute("hidden")).toBe("");
+		expect(containerEl.children.length).toBe(0);
+		expect(mapEl.getAttribute("hidden")).toBe("");
+		expect(footerEl.getAttribute("hidden")).toBe("");
+	});
+});

--- a/src/spa/dev-inspector/__tests__/pending-strip.test.ts
+++ b/src/spa/dev-inspector/__tests__/pending-strip.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PendingBootstrap, PendingCallMeta } from "../../game/pending-bootstrap.js";
+import type {
+	PendingBootstrap,
+	PendingCallMeta,
+} from "../../game/pending-bootstrap.js";
 import {
 	__resetPendingStripForTests,
 	clearPendingStrip,
@@ -38,7 +41,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -46,7 +51,9 @@ describe("pending-strip.ts", () => {
 		expect(pipEl?.textContent).toBe("●");
 		expect(pipEl?.getAttribute("data-state")).toBe("in-flight");
 
-		const statusWordEl = containerEl.querySelector('[data-field="status-word"]');
+		const statusWordEl = containerEl.querySelector(
+			'[data-field="status-word"]',
+		);
 		expect(statusWordEl?.textContent).toBe("fetching");
 
 		const callNameEl = containerEl.querySelector('[data-field="call-name"]');
@@ -66,7 +73,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -85,7 +94,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 1,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -106,7 +117,9 @@ describe("pending-strip.ts", () => {
 			retryMax: 3,
 			lastError: "502 upstream",
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -127,7 +140,9 @@ describe("pending-strip.ts", () => {
 			retryMax: 3,
 			lastError: "test error",
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -135,7 +150,9 @@ describe("pending-strip.ts", () => {
 		expect(pipEl?.textContent).toBe("✕");
 		expect(pipEl?.getAttribute("data-state")).toBe("errored");
 
-		const statusWordEl = containerEl.querySelector('[data-field="status-word"]');
+		const statusWordEl = containerEl.querySelector(
+			'[data-field="status-word"]',
+		);
 		expect(statusWordEl?.textContent).toBe("errored");
 	});
 
@@ -147,7 +164,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -155,7 +174,9 @@ describe("pending-strip.ts", () => {
 		expect(pipEl?.textContent).toBe("○");
 		expect(pipEl?.getAttribute("data-state")).toBe("idle");
 
-		const statusWordEl = containerEl.querySelector('[data-field="status-word"]');
+		const statusWordEl = containerEl.querySelector(
+			'[data-field="status-word"]',
+		);
 		expect(statusWordEl?.textContent).toBe("ready");
 	});
 
@@ -168,7 +189,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 
@@ -199,7 +222,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta1);
 		expect(setIntervalSpy).toHaveBeenCalledTimes(1);
@@ -231,7 +256,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 		expect(containerEl.querySelector('[data-field="pip"]')).toBeTruthy();
@@ -258,7 +285,9 @@ describe("pending-strip.ts", () => {
 			retryCount: 0,
 			retryMax: 3,
 		};
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderPendingStrip(containerEl, pending, meta);
 		expect(clearIntervalSpy).not.toHaveBeenCalled();
@@ -291,7 +320,9 @@ describe("pending-strip.ts", () => {
 		footerEl.className = "dev-daemon-footer";
 		document.body.appendChild(footerEl);
 
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		// Mock getPendingCallMeta
 		vi.doMock("../../game/pending-bootstrap.js", () => ({
@@ -329,7 +360,9 @@ describe("pending-strip.ts", () => {
 		footerEl.className = "dev-daemon-footer";
 		document.body.appendChild(footerEl);
 
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderInspector(document.body, { session });
 
@@ -352,7 +385,9 @@ describe("pending-strip.ts", () => {
 		footerEl.className = "dev-daemon-footer";
 		document.body.appendChild(footerEl);
 
-		const containerEl = document.getElementById("dev-game-strip") as HTMLElement;
+		const containerEl = document.getElementById(
+			"dev-game-strip",
+		) as HTMLElement;
 
 		renderInspector(document.body, {});
 

--- a/src/spa/dev-inspector/__tests__/world-map.test.ts
+++ b/src/spa/dev-inspector/__tests__/world-map.test.ts
@@ -1,0 +1,582 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { STATIC_CONTENT_PACKS } from "../../__tests__/fixtures/static-content-packs";
+import { STATIC_PERSONAS } from "../../__tests__/fixtures/static-personas";
+import { GameSession } from "../../game/game-session";
+import type { WorldEntity } from "../../game/types";
+import { renderWorldMap, updateWorldMap } from "../world-map";
+
+describe("world-map", () => {
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="dev-world-map"></div>';
+	});
+
+	it("renders a 7×7 grid (49 cells)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		const cells = containerEl.querySelectorAll(".dev-map-cell");
+		expect(cells.length).toBe(49);
+	});
+
+	it("has exactly 24 wall cells (outer ring)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		const wallCells = containerEl.querySelectorAll(
+			'.dev-map-cell[data-kind="wall"]',
+		);
+		expect(wallCells.length).toBe(24);
+	});
+
+	it("wall cells display tooltip 'wall (out of bounds)'", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		const wallCells = containerEl.querySelectorAll(
+			'.dev-map-cell[data-kind="wall"]',
+		);
+		for (const cell of wallCells) {
+			const tooltip = cell.querySelector(".dev-map-tooltip");
+			expect(tooltip?.textContent).toBe("wall (out of bounds)");
+		}
+	});
+
+	it("each inner cell has data-cell with r,c in [0..4]", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		const innerCells = containerEl.querySelectorAll(
+			'.dev-map-cell:not([data-kind="wall"])',
+		);
+		expect(innerCells.length).toBe(25);
+
+		for (const cell of innerCells) {
+			const cellStr = cell.getAttribute("data-cell");
+			expect(cellStr).toBeTruthy();
+			if (!cellStr) continue;
+			const [rowStr, colStr] = cellStr.split(",");
+			const row = Number(rowStr);
+			const col = Number(colStr);
+			expect(row).toBeGreaterThanOrEqual(1);
+			expect(row).toBeLessThanOrEqual(5);
+			expect(col).toBeGreaterThanOrEqual(1);
+			expect(col).toBeLessThanOrEqual(5);
+		}
+	});
+
+	it("daemon cell renders @<arrow> with persona color and data-ai", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// Red daemon starts at (0,0) = visual (1,1)
+		const daemonCell = containerEl.querySelector(
+			'.dev-map-cell[data-ai="red"]',
+		);
+		expect(daemonCell).toBeTruthy();
+
+		const glyph = daemonCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toMatch(/^@[<>^v]$/);
+
+		// Color is set; browsers convert hex to rgb, so just check it's not empty
+		if (daemonCell instanceof HTMLElement) {
+			expect(daemonCell.style.color).toBeTruthy();
+		}
+	});
+
+	it("facing-arrow mapping: north→^, south→v, east→>, west→<", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Red faces north initially
+		const redSpatial = state.personaSpatial.red;
+		expect(redSpatial).toBeTruthy();
+		if (!redSpatial) throw new Error("Red spatial state missing");
+		expect(redSpatial.facing).toBe("north");
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		const redCell = containerEl.querySelector('.dev-map-cell[data-ai="red"]');
+		const glyph = redCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("@^");
+	});
+
+	it("daemon tooltip format: *<name> — facing <N|S|E|W> — holds: <item> (<id>)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		const redCell = containerEl.querySelector('.dev-map-cell[data-ai="red"]');
+		const tooltip = redCell?.querySelector(".dev-map-tooltip");
+		expect(tooltip?.textContent).toMatch(
+			/^\*Ember — facing N — holds: nothing$/,
+		);
+	});
+
+	it("daemon tooltip 'holds: nothing' when no held entity", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// All daemons start without holding anything
+		const daemonCells = containerEl.querySelectorAll(".dev-map-cell[data-ai]");
+		for (const cell of daemonCells) {
+			const tooltip = cell.querySelector(".dev-map-tooltip");
+			expect(tooltip?.textContent).toContain("holds: nothing");
+		}
+	});
+
+	it("obstacle cell renders ## with data-kind and data-entity-id", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Add an obstacle at (1,1)
+		const obstacle: WorldEntity = {
+			id: "test_obstacle",
+			kind: "obstacle",
+			name: "Test Block",
+			examineDescription: "A test block",
+			holder: { row: 1, col: 1 },
+		};
+		state.world.entities.push(obstacle);
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		const obstacleCell = containerEl.querySelector(
+			'.dev-map-cell[data-entity-id="test_obstacle"]',
+		);
+		expect(obstacleCell).toBeTruthy();
+		expect(obstacleCell?.getAttribute("data-kind")).toBe("obstacle");
+
+		const glyph = obstacleCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("##");
+	});
+
+	it("objective_object alone renders '* ' with data-kind='objective-object'", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Move the objective object away from its space
+		const objEntity = state.world.entities.find(
+			(e) => e.kind === "objective_object",
+		);
+		if (objEntity) {
+			objEntity.holder = { row: 2, col: 2 };
+		}
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		const objCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="objective-object"]',
+		);
+		expect(objCell).toBeTruthy();
+
+		const glyph = objCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("* ");
+	});
+
+	it("objective_space alone renders '+ ' with data-kind='objective-space'", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Move the objective object away from its space
+		const objEntity = state.world.entities.find(
+			(e) => e.kind === "objective_object",
+		);
+		if (objEntity) {
+			objEntity.holder = { row: 2, col: 2 };
+		}
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		const spaceCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="objective-space"]',
+		);
+		expect(spaceCell).toBeTruthy();
+
+		const glyph = spaceCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("+ ");
+	});
+
+	it("objective object on paired space renders '**' with data-kind='objective-object-on-space'", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Both object and space start at their default positions which form a pair
+		const objEntity = state.world.entities.find(
+			(e) => e.kind === "objective_object",
+		);
+		const spaceEntity = state.world.entities.find(
+			(e) => e.kind === "objective_space",
+		);
+
+		// Put them at the same location
+		if (objEntity && spaceEntity) {
+			objEntity.holder = { row: 3, col: 3 };
+			spaceEntity.holder = { row: 3, col: 3 };
+		}
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		const pairCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="objective-object-on-space"]',
+		);
+		expect(pairCell).toBeTruthy();
+
+		const glyph = pairCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("**");
+	});
+
+	it("interesting_object renders 'o ' with data-kind='interesting-object'", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Add an interesting object
+		const interesting: WorldEntity = {
+			id: "test_interesting",
+			kind: "interesting_object",
+			name: "Shiny Thing",
+			examineDescription: "A shiny thing",
+			holder: { row: 2, col: 2 },
+		};
+		state.world.entities.push(interesting);
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		const interestingCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="interesting-object"]',
+		);
+		expect(interestingCell).toBeTruthy();
+
+		const glyph = interestingCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("o ");
+	});
+
+	it("floor cell renders '. ' with tooltip 'floor (r,c)'", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		const floorCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="floor"]',
+		);
+		expect(floorCell).toBeTruthy();
+
+		const glyph = floorCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe(". ");
+
+		const tooltip = floorCell?.querySelector(".dev-map-tooltip");
+		expect(tooltip?.textContent).toMatch(/^floor \(\d,\d\)$/);
+	});
+
+	it("daemon glyph beats obstacle on same cell (precedence)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Place obstacle at red daemon's position
+		const obstacle: WorldEntity = {
+			id: "test_obstacle",
+			kind: "obstacle",
+			name: "Test Block",
+			examineDescription: "A test block",
+			holder: { row: 0, col: 0 },
+		};
+		state.world.entities.push(obstacle);
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		// Should show daemon, not obstacle
+		const cell = containerEl.querySelector('.dev-map-cell[data-ai="red"]');
+		expect(cell).toBeTruthy();
+
+		const glyph = cell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toMatch(/^@[<>^v]$/);
+	});
+
+	it("obstacle glyph beats objective object on same cell", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Get objective object and move it to (1,1)
+		const objEntity = state.world.entities.find(
+			(e) => e.kind === "objective_object",
+		);
+		if (objEntity) {
+			objEntity.holder = { row: 1, col: 1 };
+		}
+
+		// Add obstacle at same location
+		const obstacle: WorldEntity = {
+			id: "test_obstacle",
+			kind: "obstacle",
+			name: "Test Block",
+			examineDescription: "A test block",
+			holder: { row: 1, col: 1 },
+		};
+		state.world.entities.push(obstacle);
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		// Should show obstacle, not objective object
+		const cell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="obstacle"]',
+		);
+		expect(cell).toBeTruthy();
+
+		const glyph = cell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("##");
+	});
+
+	it("objective object held by daemon does not render on floor; appears in daemon tooltip", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+
+		// Make red daemon hold the objective object
+		const objEntity = state.world.entities.find(
+			(e) => e.kind === "objective_object",
+		);
+		if (objEntity) {
+			objEntity.holder = "red";
+		}
+
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+		renderWorldMap(containerEl, session);
+
+		// Objective object should not have a floor cell
+		const objCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="objective-object"]',
+		);
+		expect(objCell).toBeFalsy();
+
+		// But it should appear in red daemon's tooltip
+		const redCell = containerEl.querySelector('.dev-map-cell[data-ai="red"]');
+		const tooltip = redCell?.querySelector(".dev-map-tooltip");
+		expect(tooltip?.textContent).toContain("cracked lantern");
+	});
+
+	it("updateWorldMap preserves cell span identity (no re-creation)", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// Get the first cell's identity
+		const firstCell = containerEl.querySelector(".dev-map-cell");
+		const firstCellIdentity = firstCell;
+
+		// Update the map
+		updateWorldMap(containerEl, session);
+
+		// First cell should be the same object
+		const firstCellAfter = containerEl.querySelector(".dev-map-cell");
+		expect(firstCellAfter).toBe(firstCellIdentity);
+	});
+
+	it("updateWorldMap does not modify wall spans", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// Get wall cell contents before update
+		const wallCell = containerEl.querySelector(
+			'.dev-map-cell[data-kind="wall"]',
+		);
+		const wallGlyphBefore =
+			wallCell?.querySelector(".dev-map-glyph")?.textContent;
+		const wallTooltipBefore =
+			wallCell?.querySelector(".dev-map-tooltip")?.textContent;
+
+		// Update
+		updateWorldMap(containerEl, session);
+
+		// Wall cells should be unchanged
+		const wallGlyphAfter =
+			wallCell?.querySelector(".dev-map-glyph")?.textContent;
+		const wallTooltipAfter =
+			wallCell?.querySelector(".dev-map-tooltip")?.textContent;
+
+		expect(wallGlyphAfter).toBe(wallGlyphBefore);
+		expect(wallTooltipAfter).toBe(wallTooltipBefore);
+	});
+
+	it("updateWorldMap reflects new daemon position after mutation", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// Move red daemon to (2,2)
+		const redSpatial = state.personaSpatial.red;
+		if (!redSpatial) throw new Error("Red spatial state missing");
+		redSpatial.position = { row: 2, col: 2 };
+
+		// Update
+		updateWorldMap(containerEl, session);
+
+		// Visual position should be (3,3) = data-cell="3,3"
+		const redCellAfter = containerEl.querySelector(
+			'.dev-map-cell[data-cell="3,3"]',
+		);
+		expect(redCellAfter?.getAttribute("data-ai")).toBe("red");
+	});
+
+	it("updateWorldMap reflects facing-only changes", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// Change red daemon facing from north to east
+		const redSpatial = state.personaSpatial.red;
+		if (!redSpatial) throw new Error("Red spatial state missing");
+		redSpatial.facing = "east";
+
+		// Update
+		updateWorldMap(containerEl, session);
+
+		// Glyph should now be @>
+		const redCell = containerEl.querySelector('.dev-map-cell[data-ai="red"]');
+		const glyph = redCell?.querySelector(".dev-map-glyph");
+		expect(glyph?.textContent).toBe("@>");
+	});
+
+	it("updateWorldMap reflects satisfaction state change in data-satisfaction and tooltip", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const state = session.getState();
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		// Find objective object and move it away from space first
+		const objEntity = state.world.entities.find(
+			(e) => e.kind === "objective_object",
+		);
+		if (objEntity) {
+			objEntity.holder = { row: 1, col: 1 };
+		}
+
+		renderWorldMap(containerEl, session);
+
+		// Verify it was rendered with initial satisfaction state
+		const objCellBefore = containerEl.querySelector(
+			'.dev-map-cell[data-cell="2,2"]',
+		);
+		expect(objCellBefore?.getAttribute("data-kind")).toBe("objective-object");
+
+		// Change its satisfaction
+		if (objEntity) {
+			objEntity.satisfactionState = "satisfied";
+		}
+
+		// Update
+		updateWorldMap(containerEl, session);
+
+		// Check that the cell has the updated satisfaction
+		const objCell = containerEl.querySelector('.dev-map-cell[data-cell="2,2"]');
+		expect(objCell?.getAttribute("data-satisfaction")).toBe("satisfied");
+
+		const tooltip = objCell?.querySelector(".dev-map-tooltip");
+		expect(tooltip?.textContent).toContain("satisfied");
+	});
+
+	it("tooltip is a child span, not a native title attribute", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+
+		// No cells should have [title] attribute
+		const cellsWithTitle = containerEl.querySelectorAll(".dev-map-cell[title]");
+		expect(cellsWithTitle.length).toBe(0);
+
+		// All cells should have a .dev-map-tooltip child
+		const cells = containerEl.querySelectorAll(".dev-map-cell");
+		for (const cell of cells) {
+			const tooltip = cell.querySelector(".dev-map-tooltip");
+			expect(tooltip).toBeTruthy();
+		}
+	});
+
+	it("renderWorldMap is idempotent — second call leaves exactly one .dev-map-grid child", () => {
+		const contentPack = STATIC_CONTENT_PACKS[0];
+		if (!contentPack) throw new Error("Content pack missing");
+		const session = new GameSession(contentPack, STATIC_PERSONAS);
+		const containerEl = document.getElementById("dev-world-map") as HTMLElement;
+
+		renderWorldMap(containerEl, session);
+		const firstGrids = containerEl.querySelectorAll(".dev-map-grid");
+		expect(firstGrids.length).toBe(1);
+
+		// Call renderWorldMap again
+		renderWorldMap(containerEl, session);
+		const secondGrids = containerEl.querySelectorAll(".dev-map-grid");
+		expect(secondGrids.length).toBe(1);
+	});
+});

--- a/src/spa/dev-inspector/cone-mask.ts
+++ b/src/spa/dev-inspector/cone-mask.ts
@@ -1,0 +1,38 @@
+/**
+ * cone-mask.ts
+ *
+ * Computes the set of visual cells that form a cone from an AI's position and facing direction.
+ * Used for rendering cone-focus tinting on the world map.
+ */
+
+import { projectCone } from "../game/cone-projector.js";
+import type { AiId, GameState } from "../game/types.js";
+
+/**
+ * Compute the cone mask for a daemon in visual coordinates (7×7 grid with wall ring).
+ * Returns a Set of visual cell coordinates ("row,col") that represent the visible cone.
+ * Out-of-bounds cells (walls) are excluded from the mask.
+ *
+ * @param state The current game state
+ * @param aiId The daemon's AI ID
+ * @returns Set of visual cell coordinate strings ("row,col")
+ */
+export function coneMaskForDaemon(state: GameState, aiId: AiId): Set<string> {
+	const spatial = state.personaSpatial[aiId];
+	if (!spatial) return new Set();
+
+	const cells = projectCone(spatial.position, spatial.facing);
+	const mask = new Set<string>();
+
+	for (const cell of cells) {
+		// Skip out-of-bounds walls
+		if (cell.isWall) continue;
+
+		// Map inner coordinates to visual coordinates (+1 for wall ring)
+		const vRow = cell.position.row + 1;
+		const vCol = cell.position.col + 1;
+		mask.add(`${vRow},${vCol}`);
+	}
+
+	return mask;
+}

--- a/src/spa/dev-inspector/daemon-footer.ts
+++ b/src/spa/dev-inspector/daemon-footer.ts
@@ -1,0 +1,301 @@
+/**
+ * daemon-footer.ts
+ *
+ * Renders per-Daemon footer summary lines in the dev inspector showing:
+ * - Pip (lifecycle indicator: ○ idle, ● in-flight, ✕ errored)
+ * - Last-round tool calls and messages
+ * - LLM metrics (tokens, cache %, cost)
+ * - Active complications affecting this Daemon
+ */
+
+import type { GameSession } from "../game/game-session";
+import type { AiId, ConversationEntry } from "../game/types";
+
+/**
+ * Side-channel storage for per-AI turn results (tokens, cost).
+ * RoundTurnResult is not stored in GameState, so we maintain this
+ * map separately. The provider wrapper populates it; updateDaemonFooterSummary
+ * reads from it.
+ */
+export const daemonTurnResults: Record<
+	string,
+	{
+		promptTokens?: number;
+		completionTokens?: number;
+		cachedPromptTokens?: number;
+		costUsd?: number;
+	}
+> = {};
+
+/**
+ * Record a turn result for an AI (called by the provider wrapper in routes/game.ts).
+ * Stores token/cost data for later rendering in the footer summary.
+ */
+export function recordDaemonTurnResult(
+	aiId: AiId,
+	result: {
+		promptTokens?: number;
+		completionTokens?: number;
+		cachedPromptTokens?: number;
+		costUsd?: number;
+	},
+): void {
+	daemonTurnResults[aiId] = result;
+}
+
+/**
+ * Clear all recorded turn results (used by tests).
+ */
+export function clearDaemonTurnResults(): void {
+	for (const key of Object.keys(daemonTurnResults)) {
+		delete daemonTurnResults[key];
+	}
+}
+
+/**
+ * Build the four field spans inside the footer summary line.
+ * Returns an array of span elements ready to append to a container.
+ */
+function buildFooterFields(): HTMLElement[] {
+	const spans: HTMLElement[] = [];
+
+	const pipSpan = document.createElement("span");
+	pipSpan.className = "dev-footer-pip";
+	pipSpan.setAttribute("data-field", "pip");
+	pipSpan.setAttribute("data-state", "idle");
+	pipSpan.textContent = "○";
+	spans.push(pipSpan);
+
+	const toolsSpan = document.createElement("span");
+	toolsSpan.className = "dev-footer-tools";
+	toolsSpan.setAttribute("data-field", "last-tools");
+	toolsSpan.textContent = "";
+	spans.push(toolsSpan);
+
+	const llmSpan = document.createElement("span");
+	llmSpan.className = "dev-footer-llm";
+	llmSpan.setAttribute("data-field", "llm-line");
+	llmSpan.textContent = "";
+	spans.push(llmSpan);
+
+	const chipsSpan = document.createElement("span");
+	chipsSpan.className = "dev-footer-chips";
+	chipsSpan.setAttribute("data-field", "complication-chips");
+	chipsSpan.textContent = "";
+	spans.push(chipsSpan);
+
+	return spans;
+}
+
+/**
+ * Initialize the footer DOM for a Daemon. Builds the summary line with
+ * four field spans. Removes the hidden attribute.
+ */
+export function renderDaemonFooter(
+	panelEl: HTMLElement,
+	_aiId: AiId,
+	_session: GameSession,
+): void {
+	const footerEl = panelEl.querySelector<HTMLElement>(".dev-daemon-footer");
+	if (!footerEl) return;
+
+	// Clear and build the summary line
+	footerEl.replaceChildren();
+	const summaryDiv = panelEl.ownerDocument.createElement("div");
+	summaryDiv.className = "dev-footer-summary";
+	summaryDiv.setAttribute("data-line", "summary");
+
+	const fields = buildFooterFields();
+	for (const field of fields) {
+		summaryDiv.appendChild(field);
+	}
+
+	footerEl.appendChild(summaryDiv);
+
+	// Remove hidden attribute
+	footerEl.removeAttribute("hidden");
+}
+
+/**
+ * Change the pip state (lifecycle indicator).
+ * Finds [data-field="pip"] within panelEl's .dev-daemon-footer and updates
+ * both textContent and dataset.state.
+ */
+export function setDaemonFooterInFlight(
+	panelEl: HTMLElement,
+	state: "in-flight" | "idle" | "errored",
+): void {
+	const footerEl = panelEl.querySelector<HTMLElement>(".dev-daemon-footer");
+	if (!footerEl) return;
+
+	const pipSpan = footerEl.querySelector<HTMLElement>('[data-field="pip"]');
+	if (!pipSpan) return;
+
+	switch (state) {
+		case "idle":
+			pipSpan.textContent = "○";
+			pipSpan.dataset.state = "idle";
+			break;
+		case "in-flight":
+			pipSpan.textContent = "●";
+			pipSpan.dataset.state = "in-flight";
+			break;
+		case "errored":
+			pipSpan.textContent = "✕";
+			pipSpan.dataset.state = "errored";
+			break;
+	}
+}
+
+/**
+ * Compute the last-round tool calls for an AI from conversationLogs.
+ * Returns a comma-separated list of tool names and "message" for the last round,
+ * or empty string if no entries exist.
+ */
+function computeLastRoundTools(
+	conversationLog: ConversationEntry[],
+	aiId: AiId,
+): string {
+	if (conversationLog.length === 0) return "";
+
+	// Find the max round number from entries where kind == "tool-call" && aiId == aiId
+	// or kind == "message" && from == aiId
+	let maxRound = -1;
+	for (const entry of conversationLog) {
+		if (entry.kind === "tool-call" && entry.aiId === aiId) {
+			maxRound = Math.max(maxRound, entry.round);
+		} else if (entry.kind === "message" && entry.from === aiId) {
+			maxRound = Math.max(maxRound, entry.round);
+		}
+	}
+
+	if (maxRound === -1) return "";
+
+	// Collect all tools/messages from that round
+	const tools: string[] = [];
+	let seenMessage = false;
+
+	for (const entry of conversationLog) {
+		if (entry.round === maxRound) {
+			if (entry.kind === "tool-call" && entry.aiId === aiId) {
+				tools.push(entry.toolName);
+			} else if (entry.kind === "message" && entry.from === aiId) {
+				seenMessage = true;
+			}
+		}
+	}
+
+	// Add "message" if this AI sent a message in the last round
+	if (seenMessage) {
+		tools.push("message");
+	}
+
+	return tools.join(", ");
+}
+
+/**
+ * Compute the LLM line from the side-channel turn result data.
+ * Format: [tok N→M cache P% $C]
+ * Returns empty string if no result recorded.
+ */
+function computeLlmLine(aiId: AiId): string {
+	const result = daemonTurnResults[aiId];
+	if (!result) return "";
+
+	const N = result.promptTokens ?? "?";
+	const M = result.completionTokens ?? "?";
+
+	let cachePercent = 0;
+	if (
+		result.promptTokens !== undefined &&
+		result.promptTokens > 0 &&
+		result.cachedPromptTokens !== undefined
+	) {
+		cachePercent = Math.round(
+			(result.cachedPromptTokens / result.promptTokens) * 100,
+		);
+	}
+
+	const C = result.costUsd !== undefined ? result.costUsd.toFixed(4) : "0.0000";
+
+	return `[tok ${N}→${M} cache ${cachePercent}% $${C}]`;
+}
+
+/**
+ * Build complication chip spans for an AI.
+ * Filters state.activeComplications by target===aiId and renders
+ * appropriate text + data-chip-kind attributes.
+ */
+function buildComplicationChips(
+	doc: Document,
+	aiId: AiId,
+	session: GameSession,
+): HTMLElement[] {
+	const state = session.getState();
+	const chips: HTMLElement[] = [];
+
+	for (const comp of state.activeComplications) {
+		if (comp.target !== aiId) continue;
+
+		const span = doc.createElement("span");
+		span.className = "dev-footer-chip";
+
+		if (comp.kind === "sysadmin_directive") {
+			span.textContent = "[sysadm-dir]";
+			span.setAttribute("data-chip-kind", "sysadm-dir");
+		} else if (comp.kind === "tool_disable") {
+			span.textContent = `[tool-dis:${comp.tool}]`;
+			span.setAttribute("data-chip-kind", "tool-dis");
+		} else if (comp.kind === "chat_lockout") {
+			span.textContent = "[chat-lock]";
+			span.setAttribute("data-chip-kind", "chat-lock");
+		}
+
+		chips.push(span);
+	}
+
+	return chips;
+}
+
+/**
+ * Update the footer summary line (all fields except pip, which is managed separately).
+ * MUST NOT modify [data-field="pip"] — only updates the three non-pip fields:
+ * - last-tools, llm-line, complication-chips
+ */
+export function updateDaemonFooterSummary(
+	panelEl: HTMLElement,
+	aiId: AiId,
+	session: GameSession,
+): void {
+	const footerEl = panelEl.querySelector<HTMLElement>(".dev-daemon-footer");
+	if (!footerEl) return;
+
+	const state = session.getState();
+	const doc = panelEl.ownerDocument;
+
+	// Update last-tools
+	const toolsSpan = footerEl.querySelector<HTMLElement>(
+		'[data-field="last-tools"]',
+	);
+	if (toolsSpan) {
+		const conversationLog = state.conversationLogs[aiId] ?? [];
+		toolsSpan.textContent = computeLastRoundTools(conversationLog, aiId);
+	}
+
+	// Update llm-line
+	const llmSpan = footerEl.querySelector<HTMLElement>(
+		'[data-field="llm-line"]',
+	);
+	if (llmSpan) {
+		llmSpan.textContent = computeLlmLine(aiId);
+	}
+
+	// Update complication-chips
+	const chipsSpan = footerEl.querySelector<HTMLElement>(
+		'[data-field="complication-chips"]',
+	);
+	if (chipsSpan) {
+		const newChips = buildComplicationChips(doc, aiId, session);
+		chipsSpan.replaceChildren(...newChips);
+	}
+}

--- a/src/spa/dev-inspector/daemon-footer.ts
+++ b/src/spa/dev-inspector/daemon-footer.ts
@@ -8,6 +8,7 @@
  * - Active complications affecting this Daemon
  */
 
+import { getMapFocus, setMapFocus } from "./world-map.js";
 import type { GameSession } from "../game/game-session";
 import type { AiId, AiPersona, ConversationEntry } from "../game/types";
 
@@ -117,8 +118,8 @@ export function recordDaemonRound(aiId: AiId, round: number): void {
 }
 
 /**
- * Build the four field spans inside the footer summary line.
- * Returns an array of span elements ready to append to a container.
+ * Build the footer fields (pip, tools, llm, chips, focus button).
+ * Returns an array of elements ready to append to a container.
  */
 function buildFooterFields(): HTMLElement[] {
 	const spans: HTMLElement[] = [];
@@ -147,6 +148,14 @@ function buildFooterFields(): HTMLElement[] {
 	chipsSpan.setAttribute("data-field", "complication-chips");
 	chipsSpan.textContent = "";
 	spans.push(chipsSpan);
+
+	const focusBtn = document.createElement("button");
+	focusBtn.className = "dev-footer-focus-cone";
+	focusBtn.setAttribute("data-field", "focus-cone");
+	focusBtn.setAttribute("type", "button");
+	focusBtn.textContent = "[ focus cone ]";
+	focusBtn.setAttribute("data-focus-active", "false");
+	spans.push(focusBtn);
 
 	return spans;
 }
@@ -288,6 +297,17 @@ export function renderDaemonFooter(
 
 	// Remove hidden attribute
 	footerEl.removeAttribute("hidden");
+
+	// Attach click handler to focus-cone button
+	const focusBtnEl = panelEl.querySelector<HTMLButtonElement>(
+		'[data-field="focus-cone"]',
+	);
+	if (focusBtnEl) {
+		focusBtnEl.addEventListener("click", () => {
+			const current = getMapFocus();
+			setMapFocus(current === aiId ? null : aiId);
+		});
+	}
 }
 
 /**

--- a/src/spa/dev-inspector/daemon-footer.ts
+++ b/src/spa/dev-inspector/daemon-footer.ts
@@ -8,9 +8,9 @@
  * - Active complications affecting this Daemon
  */
 
-import { getMapFocus, setMapFocus } from "./world-map.js";
 import type { GameSession } from "../game/game-session";
 import type { AiId, AiPersona, ConversationEntry } from "../game/types";
+import { getMapFocus, setMapFocus } from "./world-map.js";
 
 /**
  * Side-channel storage for per-AI turn results (tokens, cost, completion, tool calls).

--- a/src/spa/dev-inspector/daemon-footer.ts
+++ b/src/spa/dev-inspector/daemon-footer.ts
@@ -9,10 +9,10 @@
  */
 
 import type { GameSession } from "../game/game-session";
-import type { AiId, ConversationEntry } from "../game/types";
+import type { AiId, AiPersona, ConversationEntry } from "../game/types";
 
 /**
- * Side-channel storage for per-AI turn results (tokens, cost).
+ * Side-channel storage for per-AI turn results (tokens, cost, completion, tool calls).
  * RoundTurnResult is not stored in GameState, so we maintain this
  * map separately. The provider wrapper populates it; updateDaemonFooterSummary
  * reads from it.
@@ -24,8 +24,25 @@ export const daemonTurnResults: Record<
 		completionTokens?: number;
 		cachedPromptTokens?: number;
 		costUsd?: number;
+		lastRawCompletion?: string;
+		lastToolCalls?: Array<{ name: string; argumentsJson: string }>;
 	}
 > = {};
+
+/**
+ * Side-channel storage for per-AI system prompts.
+ */
+const daemonSystemPrompts: Record<string, string> = {};
+
+/**
+ * Side-channel storage for per-AI errors with optional status codes.
+ */
+const daemonErrors: Record<string, { text: string; statusCode?: number }> = {};
+
+/**
+ * Side-channel storage for per-AI round numbers.
+ */
+const daemonRounds: Record<string, number> = {};
 
 /**
  * Record a turn result for an AI (called by the provider wrapper in routes/game.ts).
@@ -38,6 +55,8 @@ export function recordDaemonTurnResult(
 		completionTokens?: number;
 		cachedPromptTokens?: number;
 		costUsd?: number;
+		lastRawCompletion?: string;
+		lastToolCalls?: Array<{ name: string; argumentsJson: string }>;
 	},
 ): void {
 	daemonTurnResults[aiId] = result;
@@ -50,6 +69,51 @@ export function clearDaemonTurnResults(): void {
 	for (const key of Object.keys(daemonTurnResults)) {
 		delete daemonTurnResults[key];
 	}
+	for (const key of Object.keys(daemonSystemPrompts)) {
+		delete daemonSystemPrompts[key];
+	}
+	for (const key of Object.keys(daemonErrors)) {
+		delete daemonErrors[key];
+	}
+	for (const key of Object.keys(daemonRounds)) {
+		delete daemonRounds[key];
+	}
+}
+
+/**
+ * Record a system prompt for an AI (called by the provider wrapper in routes/game.ts).
+ */
+export function recordDaemonSystemPrompt(
+	aiId: AiId,
+	systemPrompt: string,
+): void {
+	daemonSystemPrompts[aiId] = systemPrompt;
+}
+
+/**
+ * Record an error for an AI (called by the provider wrapper in routes/game.ts).
+ * Extracts the error message and status code (if present).
+ */
+export function recordDaemonError(aiId: AiId, error: unknown): void {
+	const text = error instanceof Error ? error.message : String(error);
+	const statusCode =
+		typeof error === "object" &&
+		error !== null &&
+		"status" in error &&
+		typeof (error as any).status === "number"
+			? (error as any).status
+			: undefined;
+	daemonErrors[aiId] = {
+		text,
+		...(statusCode !== undefined && { statusCode }),
+	};
+}
+
+/**
+ * Record the current round number for an AI (called by the provider wrapper in routes/game.ts).
+ */
+export function recordDaemonRound(aiId: AiId, round: number): void {
+	daemonRounds[aiId] = round;
 }
 
 /**
@@ -89,19 +153,21 @@ function buildFooterFields(): HTMLElement[] {
 
 /**
  * Initialize the footer DOM for a Daemon. Builds the summary line with
- * four field spans. Removes the hidden attribute.
+ * four field spans, then five <details> disclosure blocks. Removes the hidden attribute.
  */
 export function renderDaemonFooter(
 	panelEl: HTMLElement,
-	_aiId: AiId,
-	_session: GameSession,
+	aiId: AiId,
+	session: GameSession,
 ): void {
 	const footerEl = panelEl.querySelector<HTMLElement>(".dev-daemon-footer");
 	if (!footerEl) return;
 
+	const doc = panelEl.ownerDocument;
+
 	// Clear and build the summary line
 	footerEl.replaceChildren();
-	const summaryDiv = panelEl.ownerDocument.createElement("div");
+	const summaryDiv = doc.createElement("div");
 	summaryDiv.className = "dev-footer-summary";
 	summaryDiv.setAttribute("data-line", "summary");
 
@@ -111,6 +177,114 @@ export function renderDaemonFooter(
 	}
 
 	footerEl.appendChild(summaryDiv);
+
+	// Build the five <details> blocks
+	const detailsBlocks = [
+		{
+			disclosure: "system-prompt",
+			summary: "last system prompt",
+		},
+		{
+			disclosure: "raw-completion",
+			summary: "last raw completion",
+		},
+		{
+			disclosure: "tool-calls",
+			summary: "last tool calls",
+		},
+		{
+			disclosure: "error",
+			summary: "last error",
+		},
+		{
+			disclosure: "persona-card",
+			summary: "persona card",
+		},
+	];
+
+	for (const block of detailsBlocks) {
+		const details = doc.createElement("details");
+		details.className = "dev-footer-details";
+		details.setAttribute("data-disclosure", block.disclosure);
+
+		const summaryEl = doc.createElement("summary");
+		summaryEl.textContent = block.summary;
+		details.appendChild(summaryEl);
+
+		if (block.disclosure === "persona-card") {
+			// Persona card has a special div structure
+			const personaDiv = doc.createElement("div");
+			personaDiv.className = "dev-footer-persona";
+			personaDiv.setAttribute("data-content", "persona-card");
+
+			const personaFields = [
+				"handle",
+				"color",
+				"temperaments",
+				"persona-goal",
+				"blurb",
+			];
+			for (const field of personaFields) {
+				const fieldDiv = doc.createElement("div");
+				fieldDiv.setAttribute("data-persona-field", field);
+				personaDiv.appendChild(fieldDiv);
+			}
+
+			details.appendChild(personaDiv);
+
+			// Populate persona card content immediately (static within session)
+			const state = session.getState();
+			const persona = state.personas[aiId] as AiPersona | undefined;
+			if (persona) {
+				const handleEl = personaDiv.querySelector<HTMLElement>(
+					'[data-persona-field="handle"]',
+				);
+				if (handleEl) {
+					handleEl.textContent = `*${persona.name}`;
+				}
+
+				const colorEl = personaDiv.querySelector<HTMLElement>(
+					'[data-persona-field="color"]',
+				);
+				if (colorEl) {
+					const swatch = doc.createElement("span");
+					swatch.className = "dev-footer-color-swatch";
+					swatch.style.backgroundColor = persona.color;
+					colorEl.appendChild(swatch);
+					colorEl.appendChild(doc.createTextNode(persona.color));
+				}
+
+				const tempEl = personaDiv.querySelector<HTMLElement>(
+					'[data-persona-field="temperaments"]',
+				);
+				if (tempEl) {
+					tempEl.textContent = `${persona.temperaments[0]} / ${persona.temperaments[1]}`;
+				}
+
+				const goalEl = personaDiv.querySelector<HTMLElement>(
+					'[data-persona-field="persona-goal"]',
+				);
+				if (goalEl) {
+					goalEl.textContent = persona.personaGoal;
+				}
+
+				const blurbEl = personaDiv.querySelector<HTMLElement>(
+					'[data-persona-field="blurb"]',
+				);
+				if (blurbEl) {
+					blurbEl.textContent = persona.blurb;
+				}
+			}
+		} else {
+			// Non-persona blocks have a <pre> with data-content
+			const pre = doc.createElement("pre");
+			pre.setAttribute("data-content", block.disclosure);
+			pre.textContent = "";
+			details.appendChild(pre);
+		}
+
+		footerEl.appendChild(details);
+	}
 
 	// Remove hidden attribute
 	footerEl.removeAttribute("hidden");
@@ -298,4 +472,78 @@ export function updateDaemonFooterSummary(
 		const newChips = buildComplicationChips(doc, aiId, session);
 		chipsSpan.replaceChildren(...newChips);
 	}
+}
+
+/**
+ * Update the five <details> disclosure blocks with current daemon state.
+ * MUST NOT modify the <details> element itself or its open attribute.
+ * Persona card is already populated in renderDaemonFooter and is not re-touched.
+ */
+export function updateDaemonFooterDetails(
+	panelEl: HTMLElement,
+	aiId: AiId,
+	_session: GameSession,
+): void {
+	const footerEl = panelEl.querySelector<HTMLElement>(".dev-daemon-footer");
+	if (!footerEl) return;
+
+	const round = daemonRounds[aiId];
+
+	// Helper to update a disclosure block's summary with optional round suffix
+	const updateSummary = (disclosure: string, baseLabel: string): void => {
+		const details = footerEl.querySelector<HTMLElement>(
+			`[data-disclosure="${disclosure}"]`,
+		);
+		if (!details) return;
+		const summary = details.querySelector<HTMLElement>("summary");
+		if (summary) {
+			summary.textContent = `${baseLabel}${round ? ` (round ${round})` : ""}`;
+		}
+	};
+
+	// Helper to update pre content
+	const updatePreContent = (disclosure: string, content: string): void => {
+		const details = footerEl.querySelector<HTMLElement>(
+			`[data-disclosure="${disclosure}"]`,
+		);
+		if (!details) return;
+		const pre = details.querySelector<HTMLElement>(
+			`[data-content="${disclosure}"]`,
+		);
+		if (pre) {
+			pre.textContent = content;
+		}
+	};
+
+	// Update system-prompt
+	updateSummary("system-prompt", "last system prompt");
+	updatePreContent("system-prompt", daemonSystemPrompts[aiId] ?? "");
+
+	// Update raw-completion
+	updateSummary("raw-completion", "last raw completion");
+	updatePreContent(
+		"raw-completion",
+		daemonTurnResults[aiId]?.lastRawCompletion ?? "",
+	);
+
+	// Update tool-calls
+	updateSummary("tool-calls", "last tool calls");
+	const toolCalls = daemonTurnResults[aiId]?.lastToolCalls ?? [];
+	const toolCallsText = toolCalls
+		.map((tc) => `${tc.name}(${tc.argumentsJson})`)
+		.join("\n");
+	updatePreContent("tool-calls", toolCallsText);
+
+	// Update error
+	updateSummary("error", "last error");
+	const error = daemonErrors[aiId];
+	let errorText = "";
+	if (error) {
+		errorText = error.statusCode
+			? `${error.statusCode} ${error.text}`
+			: error.text;
+	}
+	updatePreContent("error", errorText);
+
+	// Note: persona-card is NOT updated here — it's already populated in renderDaemonFooter
 }

--- a/src/spa/dev-inspector/game-strip.ts
+++ b/src/spa/dev-inspector/game-strip.ts
@@ -1,0 +1,342 @@
+/**
+ * game-strip.ts
+ *
+ * Renders a sticky dev inspector strip showing game state summaries:
+ *  - Line 1: round, countdown, pack id, setting/weather/time-of-day
+ *  - Line 2: cost, objectives satisfied/total, active complications count
+ *  - Details: expandable list of objectives and active complications
+ */
+
+import type { GameSession } from "../game/game-session";
+import type { GameState, Objective } from "../game/types";
+import {
+	isCarryObjectiveSatisfied,
+	isUseItemObjectiveSatisfied,
+	isUseSpaceObjectiveSatisfied,
+} from "../game/win-condition";
+
+/**
+ * Compute the total spent USD across all AI budgets.
+ * Cost = sum of (budget.total - budget.remaining) for each AI.
+ */
+function computeSpentUsd(state: GameState): string {
+	let totalSpent = 0;
+	for (const budget of Object.values(state.budgets)) {
+		totalSpent += budget.total - budget.remaining;
+	}
+	return totalSpent.toFixed(2);
+}
+
+/**
+ * Determine if an objective is satisfied based on its kind.
+ * Uses helpers from win-condition.ts for carry objectives.
+ */
+function isSatisfied(objective: Objective, state: GameState): boolean {
+	switch (objective.kind) {
+		case "carry":
+			return isCarryObjectiveSatisfied(objective, state.world);
+		case "use_item":
+			return isUseItemObjectiveSatisfied(objective);
+		case "use_space":
+			return isUseSpaceObjectiveSatisfied(objective);
+		case "convergence":
+			return objective.satisfactionState === "satisfied";
+		default: {
+			const _exhaustive: never = objective;
+			return _exhaustive;
+		}
+	}
+}
+
+/**
+ * Build a single objective list item DOM element.
+ */
+function buildObjectiveItem(
+	doc: Document,
+	objective: Objective,
+	state: GameState,
+): HTMLLIElement {
+	const li = doc.createElement("li");
+	li.setAttribute("data-objective-id", objective.id);
+	li.setAttribute("data-kind", objective.kind);
+
+	const satisfied = isSatisfied(objective, state);
+	li.setAttribute("data-satisfied", String(satisfied));
+
+	const stateText = satisfied ? "satisfied" : "pending";
+
+	li.textContent = `[${objective.kind}] ${objective.description} — `;
+	const stateSpan = doc.createElement("span");
+	stateSpan.setAttribute("data-field", "state");
+	stateSpan.textContent = stateText;
+	li.appendChild(stateSpan);
+
+	return li;
+}
+
+/**
+ * Build a single complication list item DOM element.
+ */
+function buildComplicationItem(
+	doc: Document,
+	complication: GameState["activeComplications"][number],
+): HTMLLIElement {
+	const li = doc.createElement("li");
+	li.setAttribute("data-complication-kind", complication.kind);
+
+	const parts: string[] = [complication.kind];
+	parts.push(`target *${complication.target}`);
+	parts.push(`resolves round ${complication.resolveAtRound}`);
+
+	if (complication.kind === "sysadmin_directive") {
+		parts.push(`directive "${complication.directive}"`);
+	} else if (complication.kind === "tool_disable") {
+		parts.push(`tool ${complication.tool}`);
+	}
+
+	li.textContent = parts.join(" · ");
+	return li;
+}
+
+/**
+ * Render the full game strip DOM structure.
+ * Clears the container and builds line 1, line 2, and details sections.
+ */
+export function renderGameStrip(
+	containerEl: HTMLElement,
+	session: GameSession,
+): void {
+	const state = session.getState();
+	const doc = containerEl.ownerDocument;
+
+	// Add dev-strip class and clear children
+	containerEl.classList.add("dev-strip");
+	containerEl.replaceChildren();
+
+	// Line 1
+	const line1 = doc.createElement("div");
+	line1.className = "dev-strip-line";
+	line1.setAttribute("data-line", "1");
+
+	const line1Text = doc.createTextNode("round ");
+	line1.appendChild(line1Text);
+
+	const roundSpan = doc.createElement("span");
+	roundSpan.setAttribute("data-field", "round");
+	roundSpan.textContent = String(state.round);
+	line1.appendChild(roundSpan);
+
+	line1.appendChild(doc.createTextNode(" · countdown "));
+
+	const countdownSpan = doc.createElement("span");
+	countdownSpan.setAttribute("data-field", "countdown");
+	countdownSpan.textContent = String(state.complicationSchedule.countdown);
+	line1.appendChild(countdownSpan);
+
+	line1.appendChild(doc.createTextNode(" · pack "));
+
+	const packSpan = doc.createElement("span");
+	packSpan.setAttribute("data-field", "pack");
+	packSpan.textContent = state.activePackId;
+	line1.appendChild(packSpan);
+
+	line1.appendChild(doc.createTextNode(" · "));
+
+	const settingSpan = doc.createElement("span");
+	settingSpan.setAttribute("data-field", "setting");
+	settingSpan.textContent = state.setting;
+	line1.appendChild(settingSpan);
+
+	line1.appendChild(doc.createTextNode(" / "));
+
+	const weatherSpan = doc.createElement("span");
+	weatherSpan.setAttribute("data-field", "weather");
+	weatherSpan.textContent = state.weather;
+	line1.appendChild(weatherSpan);
+
+	line1.appendChild(doc.createTextNode(" / "));
+
+	const timeSpan = doc.createElement("span");
+	timeSpan.setAttribute("data-field", "time-of-day");
+	timeSpan.textContent = state.timeOfDay;
+	line1.appendChild(timeSpan);
+
+	containerEl.appendChild(line1);
+
+	// Line 2
+	const line2 = doc.createElement("div");
+	line2.className = "dev-strip-line";
+	line2.setAttribute("data-line", "2");
+
+	line2.appendChild(doc.createTextNode("cost $"));
+
+	const costSpan = doc.createElement("span");
+	costSpan.setAttribute("data-field", "cost");
+	costSpan.textContent = computeSpentUsd(state);
+	line2.appendChild(costSpan);
+
+	line2.appendChild(doc.createTextNode(" · obj "));
+
+	const satisfiedCount = state.objectives.filter((obj) =>
+		isSatisfied(obj, state),
+	).length;
+
+	const objSatisfiedSpan = doc.createElement("span");
+	objSatisfiedSpan.setAttribute("data-field", "obj-satisfied");
+	objSatisfiedSpan.textContent = String(satisfiedCount);
+	line2.appendChild(objSatisfiedSpan);
+
+	line2.appendChild(doc.createTextNode("/"));
+
+	const objTotalSpan = doc.createElement("span");
+	objTotalSpan.setAttribute("data-field", "obj-total");
+	objTotalSpan.textContent = String(state.objectives.length);
+	line2.appendChild(objTotalSpan);
+
+	line2.appendChild(doc.createTextNode(" satisfied · "));
+
+	const complicationsSpan = doc.createElement("span");
+	complicationsSpan.setAttribute("data-field", "active-complications");
+	complicationsSpan.textContent = String(state.activeComplications.length);
+	line2.appendChild(complicationsSpan);
+
+	line2.appendChild(doc.createTextNode(" active complications"));
+
+	containerEl.appendChild(line2);
+
+	// Details section
+	const details = doc.createElement("details");
+	details.className = "dev-strip-details";
+	details.setAttribute("data-section", "strip-details");
+
+	const summary = doc.createElement("summary");
+	summary.textContent = "objectives + complications";
+	details.appendChild(summary);
+
+	// Objectives section
+	const objectivesSection = doc.createElement("div");
+	objectivesSection.className = "dev-strip-section";
+	objectivesSection.setAttribute("data-section", "objectives");
+
+	const objectivesHeading = doc.createElement("h4");
+	objectivesHeading.textContent = "objectives";
+	objectivesSection.appendChild(objectivesHeading);
+
+	const objectivesList = doc.createElement("ul");
+	objectivesList.className = "dev-strip-list";
+	objectivesList.setAttribute("data-list", "objectives");
+
+	for (const objective of state.objectives) {
+		const li = buildObjectiveItem(doc, objective, state);
+		objectivesList.appendChild(li);
+	}
+
+	objectivesSection.appendChild(objectivesList);
+	details.appendChild(objectivesSection);
+
+	// Complications section
+	const complicationsSection = doc.createElement("div");
+	complicationsSection.className = "dev-strip-section";
+	complicationsSection.setAttribute("data-section", "complications");
+
+	const complicationsHeading = doc.createElement("h4");
+	complicationsHeading.textContent = "active complications";
+	complicationsSection.appendChild(complicationsHeading);
+
+	const complicationsList = doc.createElement("ul");
+	complicationsList.className = "dev-strip-list";
+	complicationsList.setAttribute("data-list", "complications");
+
+	for (const complication of state.activeComplications) {
+		const li = buildComplicationItem(doc, complication);
+		complicationsList.appendChild(li);
+	}
+
+	complicationsSection.appendChild(complicationsList);
+	details.appendChild(complicationsSection);
+
+	containerEl.appendChild(details);
+}
+
+/**
+ * Update the game strip in place without re-creating the details element.
+ * - Updates all [data-field="…"] spans on lines 1 and 2
+ * - Refreshes the objectives and complications lists
+ * - Preserves the details element (including open state)
+ */
+export function updateGameStripSummary(
+	containerEl: HTMLElement,
+	session: GameSession,
+): void {
+	const state = session.getState();
+	const doc = containerEl.ownerDocument;
+
+	// Update Line 1 fields
+	const line1 = containerEl.querySelector('[data-line="1"]');
+	if (line1) {
+		const roundSpan = line1.querySelector('[data-field="round"]');
+		if (roundSpan) roundSpan.textContent = String(state.round);
+
+		const countdownSpan = line1.querySelector('[data-field="countdown"]');
+		if (countdownSpan)
+			countdownSpan.textContent = String(state.complicationSchedule.countdown);
+
+		const packSpan = line1.querySelector('[data-field="pack"]');
+		if (packSpan) packSpan.textContent = state.activePackId;
+
+		const settingSpan = line1.querySelector('[data-field="setting"]');
+		if (settingSpan) settingSpan.textContent = state.setting;
+
+		const weatherSpan = line1.querySelector('[data-field="weather"]');
+		if (weatherSpan) weatherSpan.textContent = state.weather;
+
+		const timeSpan = line1.querySelector('[data-field="time-of-day"]');
+		if (timeSpan) timeSpan.textContent = state.timeOfDay;
+	}
+
+	// Update Line 2 fields
+	const line2 = containerEl.querySelector('[data-line="2"]');
+	if (line2) {
+		const costSpan = line2.querySelector('[data-field="cost"]');
+		if (costSpan) costSpan.textContent = computeSpentUsd(state);
+
+		const satisfiedCount = state.objectives.filter((obj) =>
+			isSatisfied(obj, state),
+		).length;
+
+		const objSatisfiedSpan = line2.querySelector(
+			'[data-field="obj-satisfied"]',
+		);
+		if (objSatisfiedSpan) objSatisfiedSpan.textContent = String(satisfiedCount);
+
+		const objTotalSpan = line2.querySelector('[data-field="obj-total"]');
+		if (objTotalSpan)
+			objTotalSpan.textContent = String(state.objectives.length);
+
+		const complicationsSpan = line2.querySelector(
+			'[data-field="active-complications"]',
+		);
+		if (complicationsSpan)
+			complicationsSpan.textContent = String(state.activeComplications.length);
+	}
+
+	// Refresh objectives list (replace children but keep the ul)
+	const objectivesList = containerEl.querySelector('[data-list="objectives"]');
+	if (objectivesList) {
+		const newObjectiveItems = state.objectives.map((obj) =>
+			buildObjectiveItem(doc, obj, state),
+		);
+		objectivesList.replaceChildren(...newObjectiveItems);
+	}
+
+	// Refresh complications list (replace children but keep the ul)
+	const complicationsList = containerEl.querySelector(
+		'[data-list="complications"]',
+	);
+	if (complicationsList) {
+		const newComplicationItems = state.activeComplications.map((comp) =>
+			buildComplicationItem(doc, comp),
+		);
+		complicationsList.replaceChildren(...newComplicationItems);
+	}
+}

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -2,12 +2,14 @@ import type { GameSession } from "../game/game-session.js";
 import type { PendingBootstrap } from "../game/pending-bootstrap.js";
 import { clearDaemonTurnResults, renderDaemonFooter } from "./daemon-footer.js";
 import { renderGameStrip } from "./game-strip.js";
-import { renderWorldMap } from "./world-map.js";
+import { getMapFocus, renderWorldMap, setMapFocus } from "./world-map.js";
 
 export interface RenderInspectorOpts {
 	session?: GameSession;
 	pendingBootstrap: PendingBootstrap | undefined;
 }
+
+let escapeListenerAttached = false;
 
 export function renderInspector(
 	root: HTMLElement,
@@ -39,4 +41,22 @@ export function renderInspector(
 			renderDaemonFooter(panel, aiId, opts.session);
 		}
 	}
+
+	// Attach Escape listener (only once per document)
+	if (!escapeListenerAttached) {
+		escapeListenerAttached = true;
+		doc.addEventListener("keydown", (e) => {
+			if (e.key === "Escape" && getMapFocus() !== null) {
+				setMapFocus(null);
+			}
+		});
+	}
+}
+
+/**
+ * Test-only helper to reset inspector state between tests.
+ */
+export function __resetInspectorForTests(): void {
+	escapeListenerAttached = false;
+	setMapFocus(null);
 }

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -1,0 +1,23 @@
+import type { GameSession } from "../game/game-session.js";
+import type { PendingBootstrap } from "../game/pending-bootstrap.js";
+
+export interface RenderInspectorOpts {
+	session?: GameSession;
+	pendingBootstrap: PendingBootstrap | undefined;
+}
+
+export function renderInspector(
+	root: HTMLElement,
+	opts: RenderInspectorOpts,
+): void {
+	if (!__DEV__) return;
+	if (!opts.session) return;
+
+	const doc = root.ownerDocument;
+	const strip = doc.querySelector<HTMLElement>("#dev-game-strip");
+	const map = doc.querySelector<HTMLElement>("#dev-world-map");
+	if (strip) strip.removeAttribute("hidden");
+	if (map) map.removeAttribute("hidden");
+	const footers = doc.querySelectorAll<HTMLElement>(".dev-daemon-footer");
+	for (const f of footers) f.removeAttribute("hidden");
+}

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -1,5 +1,6 @@
 import type { GameSession } from "../game/game-session.js";
 import type { PendingBootstrap } from "../game/pending-bootstrap.js";
+import { renderDaemonFooter } from "./daemon-footer.js";
 import { renderGameStrip } from "./game-strip.js";
 
 export interface RenderInspectorOpts {
@@ -22,4 +23,15 @@ export function renderInspector(
 	const footers = doc.querySelectorAll<HTMLElement>(".dev-daemon-footer");
 	for (const f of footers) f.removeAttribute("hidden");
 	if (strip && opts.session) renderGameStrip(strip, opts.session);
+
+	// Render per-Daemon footers for each AI
+	const state = opts.session.getState();
+	for (const aiId of Object.keys(state.personas)) {
+		const panel = doc.querySelector<HTMLElement>(
+			`.ai-panel[data-ai="${aiId}"]`,
+		);
+		if (panel) {
+			renderDaemonFooter(panel, aiId, opts.session);
+		}
+	}
 }

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -1,6 +1,6 @@
 import type { GameSession } from "../game/game-session.js";
 import type { PendingBootstrap } from "../game/pending-bootstrap.js";
-import { renderDaemonFooter } from "./daemon-footer.js";
+import { clearDaemonTurnResults, renderDaemonFooter } from "./daemon-footer.js";
 import { renderGameStrip } from "./game-strip.js";
 
 export interface RenderInspectorOpts {
@@ -14,6 +14,9 @@ export function renderInspector(
 ): void {
 	if (!__DEV__) return;
 	if (!opts.session) return;
+
+	// Clear stale daemon turn results from previous sessions
+	clearDaemonTurnResults();
 
 	const doc = root.ownerDocument;
 	const strip = doc.querySelector<HTMLElement>("#dev-game-strip");

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -1,5 +1,6 @@
 import type { GameSession } from "../game/game-session.js";
 import type { PendingBootstrap } from "../game/pending-bootstrap.js";
+import { renderGameStrip } from "./game-strip.js";
 
 export interface RenderInspectorOpts {
 	session?: GameSession;
@@ -20,4 +21,5 @@ export function renderInspector(
 	if (map) map.removeAttribute("hidden");
 	const footers = doc.querySelectorAll<HTMLElement>(".dev-daemon-footer");
 	for (const f of footers) f.removeAttribute("hidden");
+	if (strip && opts.session) renderGameStrip(strip, opts.session);
 }

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -1,12 +1,14 @@
 import type { GameSession } from "../game/game-session.js";
 import type { PendingBootstrap } from "../game/pending-bootstrap.js";
+import { getPendingCallMeta } from "../game/pending-bootstrap.js";
 import { clearDaemonTurnResults, renderDaemonFooter } from "./daemon-footer.js";
 import { renderGameStrip } from "./game-strip.js";
+import { clearPendingStrip, renderPendingStrip } from "./pending-strip.js";
 import { getMapFocus, renderWorldMap, setMapFocus } from "./world-map.js";
 
 export interface RenderInspectorOpts {
 	session?: GameSession;
-	pendingBootstrap: PendingBootstrap | undefined;
+	pendingBootstrap?: PendingBootstrap;
 }
 
 let escapeListenerAttached = false;
@@ -16,41 +18,64 @@ export function renderInspector(
 	opts: RenderInspectorOpts,
 ): void {
 	if (!__DEV__) return;
-	if (!opts.session) return;
-
-	// Clear stale daemon turn results from previous sessions
-	clearDaemonTurnResults();
 
 	const doc = root.ownerDocument;
 	const strip = doc.querySelector<HTMLElement>("#dev-game-strip");
 	const map = doc.querySelector<HTMLElement>("#dev-world-map");
-	if (strip) strip.removeAttribute("hidden");
-	if (map) map.removeAttribute("hidden");
 	const footers = doc.querySelectorAll<HTMLElement>(".dev-daemon-footer");
-	for (const f of footers) f.removeAttribute("hidden");
-	if (strip && opts.session) renderGameStrip(strip, opts.session);
-	if (map && opts.session) renderWorldMap(map, opts.session);
 
-	// Render per-Daemon footers for each AI
-	const state = opts.session.getState();
-	for (const aiId of Object.keys(state.personas)) {
-		const panel = doc.querySelector<HTMLElement>(
-			`.ai-panel[data-ai="${aiId}"]`,
-		);
-		if (panel) {
-			renderDaemonFooter(panel, aiId, opts.session);
-		}
-	}
+	// Branch 1: Full inspector (session exists)
+	if (opts.session) {
+		clearPendingStrip(strip);
+		clearDaemonTurnResults();
+		if (strip) strip.removeAttribute("hidden");
+		if (map) map.removeAttribute("hidden");
+		for (const f of footers) f.removeAttribute("hidden");
+		if (strip) renderGameStrip(strip, opts.session);
+		if (map) renderWorldMap(map, opts.session);
 
-	// Attach Escape listener (only once per document)
-	if (!escapeListenerAttached) {
-		escapeListenerAttached = true;
-		doc.addEventListener("keydown", (e) => {
-			if (e.key === "Escape" && getMapFocus() !== null) {
-				setMapFocus(null);
+		// Render per-Daemon footers for each AI
+		const state = opts.session.getState();
+		for (const aiId of Object.keys(state.personas)) {
+			const panel = doc.querySelector<HTMLElement>(
+				`.ai-panel[data-ai="${aiId}"]`,
+			);
+			if (panel) {
+				renderDaemonFooter(panel, aiId, opts.session);
 			}
-		});
+		}
+
+		// Attach Escape listener (only once per document)
+		if (!escapeListenerAttached) {
+			escapeListenerAttached = true;
+			doc.addEventListener("keydown", (e) => {
+				if (e.key === "Escape" && getMapFocus() !== null) {
+					setMapFocus(null);
+				}
+			});
+		}
+		return;
 	}
+
+	// Branch 2: Pending bootstrap (no session, bootstrap in flight)
+	if (opts.pendingBootstrap) {
+		if (strip) {
+			strip.removeAttribute("hidden");
+			renderPendingStrip(strip, opts.pendingBootstrap, getPendingCallMeta());
+		}
+		if (map) map.setAttribute("hidden", "");
+		for (const f of footers) f.setAttribute("hidden", "");
+		return;
+	}
+
+	// Branch 3: No session, no pending — clear everything
+	clearPendingStrip(strip);
+	if (strip) {
+		strip.setAttribute("hidden", "");
+		strip.replaceChildren();
+	}
+	if (map) map.setAttribute("hidden", "");
+	for (const f of footers) f.setAttribute("hidden", "");
 }
 
 /**

--- a/src/spa/dev-inspector/index.ts
+++ b/src/spa/dev-inspector/index.ts
@@ -2,6 +2,7 @@ import type { GameSession } from "../game/game-session.js";
 import type { PendingBootstrap } from "../game/pending-bootstrap.js";
 import { clearDaemonTurnResults, renderDaemonFooter } from "./daemon-footer.js";
 import { renderGameStrip } from "./game-strip.js";
+import { renderWorldMap } from "./world-map.js";
 
 export interface RenderInspectorOpts {
 	session?: GameSession;
@@ -26,6 +27,7 @@ export function renderInspector(
 	const footers = doc.querySelectorAll<HTMLElement>(".dev-daemon-footer");
 	for (const f of footers) f.removeAttribute("hidden");
 	if (strip && opts.session) renderGameStrip(strip, opts.session);
+	if (map && opts.session) renderWorldMap(map, opts.session);
 
 	// Render per-Daemon footers for each AI
 	const state = opts.session.getState();

--- a/src/spa/dev-inspector/pending-strip.ts
+++ b/src/spa/dev-inspector/pending-strip.ts
@@ -1,0 +1,299 @@
+/**
+ * pending-strip.ts
+ *
+ * Renders a dev inspector strip for pending-bootstrap state, showing call
+ * metadata during async loading: pip (●/✕/○), status word, call name, retry count,
+ * elapsed time, and last error.
+ *
+ * Uses a setInterval ticker (~100ms) to update the elapsed time display.
+ */
+
+import type {
+	PendingBootstrap,
+	PendingCallMeta,
+} from "../game/pending-bootstrap.js";
+
+let _tickerInterval: ReturnType<typeof setInterval> | undefined;
+let _tickerContainer: HTMLElement | undefined;
+let _currentMeta: PendingCallMeta | undefined;
+
+/**
+ * Helper: format the status word and data-state for the pip based on bootstrap status.
+ */
+function getStatusInfo(status: PendingBootstrap["status"]): {
+	pip: string;
+	word: string;
+	state: string;
+} {
+	switch (status) {
+		case "pending":
+		case "personas-ready":
+			return { pip: "●", word: "fetching", state: "in-flight" };
+		case "failed":
+			return { pip: "✕", word: "errored", state: "errored" };
+		case "ready":
+			return { pip: "○", word: "ready", state: "idle" };
+	}
+}
+
+/**
+ * Helper: format elapsed time in seconds with one decimal place.
+ */
+function formatElapsed(startedAtMs: number | undefined): string | undefined {
+	if (startedAtMs === undefined) return undefined;
+	const elapsed = (Date.now() - startedAtMs) / 1000;
+	return `${elapsed.toFixed(1)}s elapsed`;
+}
+
+/**
+ * Update the text content of all data fields in the strip.
+ */
+function updatePendingStripContent(
+	containerEl: HTMLElement,
+	pending: PendingBootstrap,
+	callMeta?: PendingCallMeta,
+): void {
+	const statusInfo = getStatusInfo(pending.status);
+
+	// Pip
+	const pipEl = containerEl.querySelector<HTMLElement>('[data-field="pip"]');
+	if (pipEl) {
+		pipEl.textContent = statusInfo.pip;
+		pipEl.setAttribute("data-state", statusInfo.state);
+	}
+
+	// Status word
+	const statusWordEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="status-word"]',
+	);
+	if (statusWordEl) {
+		statusWordEl.textContent = statusInfo.word;
+	}
+
+	// Call name
+	const callNameEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="call-name"]',
+	);
+	if (callNameEl) {
+		if (callMeta?.callName) {
+			callNameEl.textContent = callMeta.callName;
+			callNameEl.removeAttribute("hidden");
+		} else {
+			callNameEl.setAttribute("hidden", "");
+		}
+	}
+
+	// Retry separator and retry count
+	const sepRetryEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="sep-retry"]',
+	);
+	const retryEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="retry"]',
+	);
+	const showRetry = callMeta && callMeta.retryCount && callMeta.retryCount > 0;
+	if (sepRetryEl) {
+		sepRetryEl.setAttribute("hidden", "");
+		if (showRetry) sepRetryEl.removeAttribute("hidden");
+	}
+	if (retryEl) {
+		if (showRetry) {
+			retryEl.textContent = `retry ${callMeta.retryCount}/${callMeta.retryMax ?? 3}`;
+			retryEl.removeAttribute("hidden");
+		} else {
+			retryEl.setAttribute("hidden", "");
+		}
+	}
+
+	// Elapsed separator and elapsed time
+	const sepElapsedEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="sep-elapsed"]',
+	);
+	const elapsedEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="elapsed"]',
+	);
+	const elapsedText = formatElapsed(callMeta?.startedAtMs);
+	if (sepElapsedEl) {
+		sepElapsedEl.setAttribute("hidden", "");
+		if (elapsedText) sepElapsedEl.removeAttribute("hidden");
+	}
+	if (elapsedEl) {
+		if (elapsedText) {
+			elapsedEl.textContent = elapsedText;
+			elapsedEl.removeAttribute("hidden");
+		} else {
+			elapsedEl.setAttribute("hidden", "");
+		}
+	}
+
+	// Last error separator and error message
+	const sepErrorEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="sep-error"]',
+	);
+	const lastErrorEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="last-error"]',
+	);
+	const showError = callMeta && callMeta.lastError;
+	if (sepErrorEl) {
+		sepErrorEl.setAttribute("hidden", "");
+		if (showError) sepErrorEl.removeAttribute("hidden");
+	}
+	if (lastErrorEl) {
+		if (showError) {
+			lastErrorEl.textContent = `last error: ${callMeta.lastError}`;
+			lastErrorEl.removeAttribute("hidden");
+		} else {
+			lastErrorEl.setAttribute("hidden", "");
+		}
+	}
+}
+
+/**
+ * Update the elapsed time span (called by ticker).
+ */
+function updateElapsedSpan(
+	containerEl: HTMLElement,
+	callMeta?: PendingCallMeta,
+): void {
+	const elapsedEl = containerEl.querySelector<HTMLElement>(
+		'[data-field="elapsed"]',
+	);
+	if (!elapsedEl) return;
+	const elapsedText = formatElapsed(callMeta?.startedAtMs);
+	if (elapsedText) {
+		elapsedEl.textContent = elapsedText;
+	}
+}
+
+/**
+ * Render the pending-bootstrap strip in the given container.
+ * Initializes DOM structure and starts a ~100ms ticker for elapsed time updates.
+ */
+export function renderPendingStrip(
+	containerEl: HTMLElement,
+	pending: PendingBootstrap,
+	callMeta?: PendingCallMeta,
+): void {
+	// Clean up any existing interval
+	if (_tickerInterval) {
+		clearInterval(_tickerInterval);
+		_tickerInterval = undefined;
+	}
+
+	_currentMeta = callMeta;
+	_tickerContainer = containerEl;
+
+	containerEl.classList.add("dev-strip", "dev-pending-strip");
+	containerEl.setAttribute("data-strip", "pending");
+	containerEl.replaceChildren();
+
+	// Build DOM structure
+	const line = containerEl.ownerDocument.createElement("div");
+	line.className = "dev-strip-line";
+	line.setAttribute("data-line", "pending");
+
+	// Pip
+	const pipEl = containerEl.ownerDocument.createElement("span");
+	pipEl.className = "dev-pending-pip dev-footer-pip";
+	pipEl.setAttribute("data-field", "pip");
+	line.appendChild(pipEl);
+
+	// Status word
+	const statusWord = containerEl.ownerDocument.createElement("span");
+	statusWord.setAttribute("data-field", "status-word");
+	line.appendChild(statusWord);
+
+	// Call name
+	const callName = containerEl.ownerDocument.createElement("span");
+	callName.setAttribute("data-field", "call-name");
+	line.appendChild(callName);
+
+	// Separator for retry
+	const sepRetry = containerEl.ownerDocument.createElement("span");
+	sepRetry.setAttribute("data-field", "sep-retry");
+	sepRetry.textContent = "·";
+	line.appendChild(sepRetry);
+
+	// Retry count
+	const retry = containerEl.ownerDocument.createElement("span");
+	retry.setAttribute("data-field", "retry");
+	line.appendChild(retry);
+
+	// Separator for elapsed
+	const sepElapsed = containerEl.ownerDocument.createElement("span");
+	sepElapsed.setAttribute("data-field", "sep-elapsed");
+	sepElapsed.textContent = "·";
+	line.appendChild(sepElapsed);
+
+	// Elapsed time
+	const elapsed = containerEl.ownerDocument.createElement("span");
+	elapsed.setAttribute("data-field", "elapsed");
+	line.appendChild(elapsed);
+
+	// Separator for error
+	const sepError = containerEl.ownerDocument.createElement("span");
+	sepError.setAttribute("data-field", "sep-error");
+	sepError.textContent = "·";
+	line.appendChild(sepError);
+
+	// Last error
+	const lastError = containerEl.ownerDocument.createElement("span");
+	lastError.setAttribute("data-field", "last-error");
+	line.appendChild(lastError);
+
+	containerEl.appendChild(line);
+
+	// Populate content
+	updatePendingStripContent(containerEl, pending, _currentMeta);
+
+	// Start ticker for elapsed time updates (~100ms)
+	_tickerInterval = setInterval(() => {
+		if (!_tickerContainer || !_tickerContainer.isConnected) {
+			if (_tickerInterval) {
+				clearInterval(_tickerInterval);
+				_tickerInterval = undefined;
+			}
+			_tickerContainer = undefined;
+			return;
+		}
+		updateElapsedSpan(_tickerContainer, _currentMeta);
+	}, 100);
+}
+
+/**
+ * Update the pending strip with new state without restarting the ticker.
+ * Used when bootstrap state changes (e.g., error occurs, retry happens).
+ */
+export function updatePendingStrip(
+	containerEl: HTMLElement,
+	pending: PendingBootstrap,
+	callMeta?: PendingCallMeta,
+): void {
+	_currentMeta = callMeta;
+	updatePendingStripContent(containerEl, pending, _currentMeta);
+}
+
+/**
+ * Clear the pending strip and stop the ticker.
+ */
+export function clearPendingStrip(containerEl: HTMLElement | null): void {
+	if (_tickerInterval) {
+		clearInterval(_tickerInterval);
+		_tickerInterval = undefined;
+	}
+	_tickerContainer = undefined;
+	_currentMeta = undefined;
+	if (!containerEl) return;
+	containerEl.classList.remove("dev-strip", "dev-pending-strip");
+	containerEl.removeAttribute("data-strip");
+	containerEl.replaceChildren();
+}
+
+/**
+ * Test-only helper to reset pending strip state.
+ */
+export function __resetPendingStripForTests(): void {
+	if (_tickerInterval) clearInterval(_tickerInterval);
+	_tickerInterval = undefined;
+	_tickerContainer = undefined;
+	_currentMeta = undefined;
+}

--- a/src/spa/dev-inspector/pending-strip.ts
+++ b/src/spa/dev-inspector/pending-strip.ts
@@ -90,7 +90,7 @@ function updatePendingStripContent(
 	const retryEl = containerEl.querySelector<HTMLElement>(
 		'[data-field="retry"]',
 	);
-	const showRetry = callMeta && callMeta.retryCount && callMeta.retryCount > 0;
+	const showRetry = callMeta?.retryCount && callMeta.retryCount > 0;
 	if (sepRetryEl) {
 		sepRetryEl.setAttribute("hidden", "");
 		if (showRetry) sepRetryEl.removeAttribute("hidden");
@@ -132,7 +132,7 @@ function updatePendingStripContent(
 	const lastErrorEl = containerEl.querySelector<HTMLElement>(
 		'[data-field="last-error"]',
 	);
-	const showError = callMeta && callMeta.lastError;
+	const showError = callMeta?.lastError;
 	if (sepErrorEl) {
 		sepErrorEl.setAttribute("hidden", "");
 		if (showError) sepErrorEl.removeAttribute("hidden");
@@ -247,7 +247,7 @@ export function renderPendingStrip(
 
 	// Start ticker for elapsed time updates (~100ms)
 	_tickerInterval = setInterval(() => {
-		if (!_tickerContainer || !_tickerContainer.isConnected) {
+		if (!_tickerContainer?.isConnected) {
 			if (_tickerInterval) {
 				clearInterval(_tickerInterval);
 				_tickerInterval = undefined;

--- a/src/spa/dev-inspector/world-map.ts
+++ b/src/spa/dev-inspector/world-map.ts
@@ -13,7 +13,6 @@
  * - getMapFocus(): check if focus is active
  */
 
-import { coneMaskForDaemon } from "./cone-mask.js";
 import type { GameSession } from "../game/game-session.js";
 import type {
 	AiId,
@@ -21,6 +20,7 @@ import type {
 	GridPosition,
 	WorldEntity,
 } from "../game/types.js";
+import { coneMaskForDaemon } from "./cone-mask.js";
 
 // Module-level state for cone focus
 let mapFocus: AiId | null = null;
@@ -40,7 +40,12 @@ type CardinalDirection = "north" | "south" | "east" | "west";
 function hexToRgba(hex: string, alpha: number): string {
 	const h = hex.replace("#", "");
 	const expanded =
-		h.length === 3 ? h.split("").map((c) => c + c).join("") : h;
+		h.length === 3
+			? h
+					.split("")
+					.map((c) => c + c)
+					.join("")
+			: h;
 	const r = parseInt(expanded.substring(0, 2), 16);
 	const g = parseInt(expanded.substring(2, 4), 16);
 	const b = parseInt(expanded.substring(4, 6), 16);

--- a/src/spa/dev-inspector/world-map.ts
+++ b/src/spa/dev-inspector/world-map.ts
@@ -1,0 +1,344 @@
+/**
+ * world-map.ts
+ *
+ * Renders a 5×5 ASCII grid inspector with 7×7 visual layout (wall ring + 25 inner cells).
+ * Displays daemon positions, held items, obstacles, objectives, and interesting objects.
+ *
+ * Two-function API:
+ * - renderWorldMap: builds the DOM skeleton once
+ * - updateWorldMap: mutates existing cell contents in-place
+ */
+
+import type { GameSession } from "../game/game-session.js";
+import type {
+	AiId,
+	GameState,
+	GridPosition,
+	WorldEntity,
+} from "../game/types.js";
+
+const VISUAL_ROWS = 7;
+const VISUAL_COLS = 7;
+
+type CardinalDirection = "north" | "south" | "east" | "west";
+
+function isGridPosition(holder: AiId | GridPosition): holder is GridPosition {
+	return typeof holder === "object" && holder !== null;
+}
+
+function facingArrow(facing: CardinalDirection): string {
+	switch (facing) {
+		case "north":
+			return "^";
+		case "south":
+			return "v";
+		case "east":
+			return ">";
+		case "west":
+			return "<";
+	}
+}
+
+function facingLetter(facing: CardinalDirection): string {
+	switch (facing) {
+		case "north":
+			return "N";
+		case "south":
+			return "S";
+		case "east":
+			return "E";
+		case "west":
+			return "W";
+	}
+}
+
+/**
+ * Get the entity held by the given AI, or undefined.
+ */
+function findHeldEntity(
+	aiId: AiId,
+	entities: WorldEntity[],
+): WorldEntity | undefined {
+	return entities.find((e) => e.holder === aiId);
+}
+
+/**
+ * Determine the glyph and tooltip for a single cell.
+ * Precedence (highest → lowest):
+ * 1. Daemon (@<arrow>)
+ * 2. Obstacle (##)
+ * 3. Objective object on paired space (**)
+ * 4. Objective object alone (* )
+ * 5. Objective space alone (+ )
+ * 6. Interesting object (o )
+ * 7. Floor (. )
+ *
+ * Returns { glyph, tooltip, kind, entityId?, aiId?, satisfaction? }.
+ */
+interface CellInfo {
+	glyph: string;
+	tooltip: string;
+	kind: string;
+	entityId?: string;
+	aiId?: AiId;
+	satisfaction?: string;
+}
+
+function computeCellInfo(visualPos: GridPosition, state: GameState): CellInfo {
+	// Wall cells (outer ring)
+	if (
+		visualPos.row === 0 ||
+		visualPos.row === VISUAL_ROWS - 1 ||
+		visualPos.col === 0 ||
+		visualPos.col === VISUAL_COLS - 1
+	) {
+		return {
+			glyph: "##",
+			tooltip: "wall (out of bounds)",
+			kind: "wall",
+		};
+	}
+
+	const innerPos: GridPosition = {
+		row: visualPos.row - 1,
+		col: visualPos.col - 1,
+	};
+
+	// Check for daemon at this position
+	for (const [aiId, spatial] of Object.entries(state.personaSpatial)) {
+		if (
+			spatial &&
+			spatial.position.row === innerPos.row &&
+			spatial.position.col === innerPos.col
+		) {
+			const persona = state.personas[aiId];
+			if (!persona) continue; // Skip if persona is missing
+
+			const heldEntity = findHeldEntity(aiId, state.world.entities);
+			const arrow = facingArrow(spatial.facing);
+			const facing = facingLetter(spatial.facing);
+			const holdText = heldEntity
+				? `${heldEntity.name} (${heldEntity.id})`
+				: "nothing";
+
+			return {
+				glyph: `@${arrow}`,
+				tooltip: `*${persona.name} — facing ${facing} — holds: ${holdText}`,
+				kind: "daemon",
+				aiId,
+			};
+		}
+	}
+
+	// Collect all entities at this position (not held by an AI)
+	const entitiesAtPos = state.world.entities.filter((e) => {
+		if (!isGridPosition(e.holder)) return false;
+		return e.holder.row === innerPos.row && e.holder.col === innerPos.col;
+	});
+
+	// Check for obstacle
+	const obstacle = entitiesAtPos.find((e) => e.kind === "obstacle");
+	if (obstacle) {
+		const satisfaction = obstacle.satisfactionState ?? "pending";
+		return {
+			glyph: "##",
+			tooltip: `${obstacle.name} · ${obstacle.id} · obstacle`,
+			kind: "obstacle",
+			entityId: obstacle.id,
+			satisfaction,
+		};
+	}
+
+	// Check for objective object on its paired space
+	const objObj = entitiesAtPos.find((e) => e.kind === "objective_object");
+	const objSpace = entitiesAtPos.find((e) => e.kind === "objective_space");
+
+	if (objObj && objSpace && objObj.pairsWithSpaceId === objSpace.id) {
+		const objSatisfaction = objObj.satisfactionState ?? "pending";
+		const spaceSatisfaction = objSpace.satisfactionState ?? "pending";
+		return {
+			glyph: "**",
+			tooltip: `${objObj.name} on ${objSpace.name} · ${objObj.id}+${objSpace.id} · ${objSatisfaction}/${spaceSatisfaction}`,
+			kind: "objective-object-on-space",
+			entityId: objObj.id,
+			satisfaction: objSatisfaction,
+		};
+	}
+
+	// Objective object alone
+	if (objObj) {
+		const satisfaction = objObj.satisfactionState ?? "pending";
+		const holderPersona = isGridPosition(objObj.holder)
+			? null
+			: state.personas[objObj.holder];
+		const holder = !holderPersona ? "(none)" : `*${holderPersona.name}`;
+		return {
+			glyph: "* ",
+			tooltip: `${objObj.name} · ${objObj.id} · ${satisfaction} · ${holder}`,
+			kind: "objective-object",
+			entityId: objObj.id,
+			satisfaction,
+		};
+	}
+
+	// Objective space alone
+	if (objSpace) {
+		const satisfaction = objSpace.satisfactionState ?? "pending";
+		return {
+			glyph: "+ ",
+			tooltip: `${objSpace.name} · ${objSpace.id} · ${satisfaction} · (none)`,
+			kind: "objective-space",
+			entityId: objSpace.id,
+			satisfaction,
+		};
+	}
+
+	// Interesting object
+	const interesting = entitiesAtPos.find(
+		(e) => e.kind === "interesting_object",
+	);
+	if (interesting) {
+		const satisfaction = interesting.satisfactionState ?? "pending";
+		const holderPersona = isGridPosition(interesting.holder)
+			? null
+			: state.personas[interesting.holder];
+		const holder = !holderPersona ? "(none)" : `*${holderPersona.name}`;
+		return {
+			glyph: "o ",
+			tooltip: `${interesting.name} · ${interesting.id} · ${satisfaction} · ${holder}`,
+			kind: "interesting-object",
+			entityId: interesting.id,
+			satisfaction,
+		};
+	}
+
+	// Floor
+	return {
+		glyph: ". ",
+		tooltip: `floor (${innerPos.row},${innerPos.col})`,
+		kind: "floor",
+	};
+}
+
+/**
+ * Render the full world map DOM structure.
+ * Builds a 7×7 grid of cells with nested glyph and tooltip spans.
+ */
+export function renderWorldMap(
+	containerEl: HTMLElement,
+	session: GameSession,
+): void {
+	const state = session.getState();
+	const doc = containerEl.ownerDocument;
+
+	containerEl.classList.add("dev-map");
+	containerEl.replaceChildren();
+
+	const grid = doc.createElement("div");
+	grid.className = "dev-map-grid";
+	grid.setAttribute("data-rows", String(VISUAL_ROWS));
+	grid.setAttribute("data-cols", String(VISUAL_COLS));
+
+	for (let row = 0; row < VISUAL_ROWS; row++) {
+		for (let col = 0; col < VISUAL_COLS; col++) {
+			const visualPos: GridPosition = { row, col };
+			const cellInfo = computeCellInfo(visualPos, state);
+
+			const cell = doc.createElement("span");
+			cell.className = "dev-map-cell";
+			cell.setAttribute("data-cell", `${row},${col}`);
+			cell.setAttribute("data-kind", cellInfo.kind);
+
+			if (cellInfo.entityId) {
+				cell.setAttribute("data-entity-id", cellInfo.entityId);
+			}
+			if (cellInfo.aiId) {
+				cell.setAttribute("data-ai", cellInfo.aiId);
+				const persona = state.personas[cellInfo.aiId];
+				if (persona?.color) {
+					cell.style.color = persona.color;
+				}
+			}
+			if (cellInfo.satisfaction) {
+				cell.setAttribute("data-satisfaction", cellInfo.satisfaction);
+			}
+
+			const glyphSpan = doc.createElement("span");
+			glyphSpan.className = "dev-map-glyph";
+			glyphSpan.textContent = cellInfo.glyph;
+			cell.appendChild(glyphSpan);
+
+			const tooltipSpan = doc.createElement("span");
+			tooltipSpan.className = "dev-map-tooltip";
+			tooltipSpan.textContent = cellInfo.tooltip;
+			cell.appendChild(tooltipSpan);
+
+			grid.appendChild(cell);
+		}
+	}
+
+	containerEl.appendChild(grid);
+}
+
+/**
+ * Update the world map in place without recreating the grid.
+ * Mutates cell contents and attributes only (no node creation/removal).
+ */
+export function updateWorldMap(
+	containerEl: HTMLElement,
+	session: GameSession,
+): void {
+	const state = session.getState();
+
+	const grid = containerEl.querySelector(".dev-map-grid");
+	if (!grid) return;
+
+	const cells = grid.querySelectorAll<HTMLElement>(".dev-map-cell");
+	cells.forEach((cell) => {
+		const cellStr = cell.getAttribute("data-cell");
+		if (!cellStr) return;
+
+		const [rowStr, colStr] = cellStr.split(",");
+		const row = Number(rowStr);
+		const col = Number(colStr);
+
+		if (Number.isNaN(row) || Number.isNaN(col)) return;
+
+		const visualPos: GridPosition = { row, col };
+		const cellInfo = computeCellInfo(visualPos, state);
+
+		// Update glyph and tooltip
+		const glyphSpan = cell.querySelector(".dev-map-glyph");
+		if (glyphSpan) glyphSpan.textContent = cellInfo.glyph;
+
+		const tooltipSpan = cell.querySelector(".dev-map-tooltip");
+		if (tooltipSpan) tooltipSpan.textContent = cellInfo.tooltip;
+
+		// Update data attributes
+		cell.setAttribute("data-kind", cellInfo.kind);
+
+		// Remove entity-id, ai, satisfaction if not present; re-add if present
+		if (cellInfo.entityId) {
+			cell.setAttribute("data-entity-id", cellInfo.entityId);
+		} else {
+			cell.removeAttribute("data-entity-id");
+		}
+
+		if (cellInfo.aiId) {
+			cell.setAttribute("data-ai", cellInfo.aiId);
+			const persona = state.personas[cellInfo.aiId];
+			if (persona?.color) {
+				cell.style.color = persona.color;
+			}
+		} else {
+			cell.removeAttribute("data-ai");
+			cell.style.color = "";
+		}
+
+		if (cellInfo.satisfaction) {
+			cell.setAttribute("data-satisfaction", cellInfo.satisfaction);
+		} else {
+			cell.removeAttribute("data-satisfaction");
+		}
+	});
+}

--- a/src/spa/dev-inspector/world-map.ts
+++ b/src/spa/dev-inspector/world-map.ts
@@ -7,8 +7,13 @@
  * Two-function API:
  * - renderWorldMap: builds the DOM skeleton once
  * - updateWorldMap: mutates existing cell contents in-place
+ *
+ * Cone-focus feature:
+ * - setMapFocus(aiId): tint cells in a daemon's cone view with persona color
+ * - getMapFocus(): check if focus is active
  */
 
+import { coneMaskForDaemon } from "./cone-mask.js";
 import type { GameSession } from "../game/game-session.js";
 import type {
 	AiId,
@@ -17,10 +22,83 @@ import type {
 	WorldEntity,
 } from "../game/types.js";
 
+// Module-level state for cone focus
+let mapFocus: AiId | null = null;
+let activeSession: GameSession | null = null;
+
 const VISUAL_ROWS = 7;
 const VISUAL_COLS = 7;
 
 type CardinalDirection = "north" | "south" | "east" | "west";
+
+/**
+ * Convert hex color to rgba with given alpha.
+ * @param hex Color in hex format (e.g., "#e07a5f")
+ * @param alpha Alpha value in range [0, 1]
+ * @returns CSS rgba string
+ */
+function hexToRgba(hex: string, alpha: number): string {
+	const h = hex.replace("#", "");
+	const expanded =
+		h.length === 3 ? h.split("").map((c) => c + c).join("") : h;
+	const r = parseInt(expanded.substring(0, 2), 16);
+	const g = parseInt(expanded.substring(2, 4), 16);
+	const b = parseInt(expanded.substring(4, 6), 16);
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * Apply cone tint to world map cells based on active focus.
+ * Tints cells in the focused daemon's cone with persona color at 0.25 alpha.
+ * @param containerEl The map container element
+ * @param state The current game state
+ */
+function applyConeTint(containerEl: HTMLElement, state: GameState): void {
+	const mask = mapFocus ? coneMaskForDaemon(state, mapFocus) : null;
+	const tintColor = mapFocus ? state.personas[mapFocus]?.color : null;
+
+	for (const cell of containerEl.querySelectorAll<HTMLElement>(
+		".dev-map-cell",
+	)) {
+		const dataCell = cell.getAttribute("data-cell");
+		if (mask && tintColor && dataCell && mask.has(dataCell)) {
+			cell.style.backgroundColor = hexToRgba(tintColor, 0.25);
+			cell.setAttribute("data-cone-focus", mapFocus!);
+		} else {
+			cell.style.backgroundColor = "";
+			cell.removeAttribute("data-cone-focus");
+		}
+	}
+}
+
+/**
+ * Set the active focus daemon and update tint on the map.
+ * @param aiId The daemon to focus, or null to clear focus
+ */
+export function setMapFocus(aiId: AiId | null): void {
+	mapFocus = aiId;
+	const containerEl = document.querySelector<HTMLElement>("#dev-world-map");
+	if (containerEl && activeSession) {
+		applyConeTint(containerEl, activeSession.getState());
+	}
+
+	// Sweep all focus-cone buttons to update data-focus-active
+	for (const btn of document.querySelectorAll<HTMLElement>(
+		'[data-field="focus-cone"]',
+	)) {
+		const panel = btn.closest<HTMLElement>(".ai-panel");
+		const panelAi = panel?.getAttribute("data-ai") ?? null;
+		btn.setAttribute("data-focus-active", String(panelAi === mapFocus));
+	}
+}
+
+/**
+ * Get the currently focused daemon, or null if no focus is active.
+ * @returns The focused AiId, or null
+ */
+export function getMapFocus(): AiId | null {
+	return mapFocus;
+}
 
 function isGridPosition(holder: AiId | GridPosition): holder is GridPosition {
 	return typeof holder === "object" && holder !== null;
@@ -278,6 +356,10 @@ export function renderWorldMap(
 	}
 
 	containerEl.appendChild(grid);
+
+	// Update active session and apply cone tint
+	activeSession = session;
+	applyConeTint(containerEl, state);
 }
 
 /**
@@ -341,4 +423,8 @@ export function updateWorldMap(
 			cell.removeAttribute("data-satisfaction");
 		}
 	});
+
+	// Update active session and re-apply cone tint
+	activeSession = session;
+	applyConeTint(containerEl, state);
 }

--- a/src/spa/game/__tests__/browser-llm-provider.test.ts
+++ b/src/spa/game/__tests__/browser-llm-provider.test.ts
@@ -203,15 +203,9 @@ describe("BrowserLLMProvider.streamRound — onLifecycle callback", () => {
 		const provider = new BrowserLLMProvider();
 		const events: string[] = [];
 
-		await provider.streamRound(
-			[],
-			[],
-			undefined,
-			undefined,
-			(event) => {
-				events.push(event.phase);
-			},
-		);
+		await provider.streamRound([], [], undefined, undefined, (event) => {
+			events.push(event.phase);
+		});
 
 		const firstTokenCount = events.filter((p) => p === "first-token").length;
 		expect(firstTokenCount).toBe(1);
@@ -235,17 +229,11 @@ describe("BrowserLLMProvider.streamRound — onLifecycle callback", () => {
 		const provider = new BrowserLLMProvider();
 		const events: Array<string> = [];
 
-		await provider.streamRound(
-			[],
-			[],
-			undefined,
-			"daemon-456",
-			(event) => {
-				events.push(
-					event.daemonId ? `${event.phase}:${event.daemonId}` : event.phase,
-				);
-			},
-		);
+		await provider.streamRound([], [], undefined, "daemon-456", (event) => {
+			events.push(
+				event.daemonId ? `${event.phase}:${event.daemonId}` : event.phase,
+			);
+		});
 
 		expect(events).toEqual([
 			"started:daemon-456",
@@ -259,24 +247,15 @@ describe("BrowserLLMProvider.streamRound — onLifecycle callback", () => {
 	it("fires started then errored when fetch rejects", async () => {
 		const fetchError = new Error("Network failed");
 
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockRejectedValue(fetchError),
-		);
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(fetchError));
 
 		const provider = new BrowserLLMProvider();
 		const events: Array<string> = [];
 
 		try {
-			await provider.streamRound(
-				[],
-				[],
-				undefined,
-				undefined,
-				(event) => {
-					events.push(event.phase);
-				},
-			);
+			await provider.streamRound([], [], undefined, undefined, (event) => {
+				events.push(event.phase);
+			});
 		} catch {
 			// Expected to throw
 		}
@@ -310,15 +289,9 @@ describe("BrowserLLMProvider.streamRound — onLifecycle callback", () => {
 		const events: string[] = [];
 
 		try {
-			await provider.streamRound(
-				[],
-				[],
-				undefined,
-				undefined,
-				(event) => {
-					events.push(event.phase);
-				},
-			);
+			await provider.streamRound([], [], undefined, undefined, (event) => {
+				events.push(event.phase);
+			});
 		} catch {
 			// Expected to throw
 		}

--- a/src/spa/game/__tests__/browser-llm-provider.test.ts
+++ b/src/spa/game/__tests__/browser-llm-provider.test.ts
@@ -153,3 +153,179 @@ describe("BrowserLLMProvider — reasoning default (issue #169)", () => {
 		vi.restoreAllMocks();
 	});
 });
+
+describe("BrowserLLMProvider.streamRound — onLifecycle callback", () => {
+	it("fires started → first-token → completed for a normal stream", async () => {
+		const words = ["hello ", "world"];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(makeSseBody(words), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const events: string[] = [];
+
+		const result = await provider.streamRound(
+			[],
+			[],
+			undefined,
+			undefined,
+			(event) => {
+				events.push(event.phase);
+			},
+		);
+
+		expect(events).toEqual(["started", "first-token", "completed"]);
+		expect(result.assistantText).toBe("hello world");
+
+		vi.restoreAllMocks();
+	});
+
+	it("fires first-token only once across multiple deltas", async () => {
+		const words = ["a", "b", "c", "d"];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(makeSseBody(words), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const events: string[] = [];
+
+		await provider.streamRound(
+			[],
+			[],
+			undefined,
+			undefined,
+			(event) => {
+				events.push(event.phase);
+			},
+		);
+
+		const firstTokenCount = events.filter((p) => p === "first-token").length;
+		expect(firstTokenCount).toBe(1);
+
+		vi.restoreAllMocks();
+	});
+
+	it("forwards daemonId on every event", async () => {
+		const words = ["test"];
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(makeSseBody(words), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const events: Array<string> = [];
+
+		await provider.streamRound(
+			[],
+			[],
+			undefined,
+			"daemon-456",
+			(event) => {
+				events.push(
+					event.daemonId ? `${event.phase}:${event.daemonId}` : event.phase,
+				);
+			},
+		);
+
+		expect(events).toEqual([
+			"started:daemon-456",
+			"first-token:daemon-456",
+			"completed:daemon-456",
+		]);
+
+		vi.restoreAllMocks();
+	});
+
+	it("fires started then errored when fetch rejects", async () => {
+		const fetchError = new Error("Network failed");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockRejectedValue(fetchError),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const events: Array<string> = [];
+
+		try {
+			await provider.streamRound(
+				[],
+				[],
+				undefined,
+				undefined,
+				(event) => {
+					events.push(event.phase);
+				},
+			);
+		} catch {
+			// Expected to throw
+		}
+
+		expect(events).toEqual(["started", "errored"]);
+
+		vi.restoreAllMocks();
+	});
+
+	it("does not fire first-token if no deltas arrive (errored before first chunk)", async () => {
+		const streamError = new Error("Stream failed");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.error(streamError);
+						},
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "text/event-stream" },
+					},
+				),
+			),
+		);
+
+		const provider = new BrowserLLMProvider();
+		const events: string[] = [];
+
+		try {
+			await provider.streamRound(
+				[],
+				[],
+				undefined,
+				undefined,
+				(event) => {
+					events.push(event.phase);
+				},
+			);
+		} catch {
+			// Expected to throw
+		}
+
+		expect(events).toEqual(["started", "errored"]);
+		expect(events).not.toContain("first-token");
+
+		vi.restoreAllMocks();
+	});
+});

--- a/src/spa/game/__tests__/round-llm-provider-lifecycle.test.ts
+++ b/src/spa/game/__tests__/round-llm-provider-lifecycle.test.ts
@@ -12,9 +12,15 @@ describe("MockRoundLLMProvider — onLifecycle callback", () => {
 		const provider = new MockRoundLLMProvider(["hello world"]);
 		const events: string[] = [];
 
-		const result = await provider.streamRound([], [], undefined, undefined, (event) => {
-			events.push(event.phase);
-		});
+		const result = await provider.streamRound(
+			[],
+			[],
+			undefined,
+			undefined,
+			(event) => {
+				events.push(event.phase);
+			},
+		);
 
 		expect(events).toEqual(["started", "first-token", "completed"]);
 		expect(result.assistantText).toBe("hello world");

--- a/src/spa/game/__tests__/round-llm-provider-lifecycle.test.ts
+++ b/src/spa/game/__tests__/round-llm-provider-lifecycle.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for MockRoundLLMProvider — onLifecycle callback (issue #437).
+ *
+ * Verifies that the lifecycle callback fires on started, first-token,
+ * completed phases, and that daemonId is propagated correctly.
+ */
+import { describe, expect, it } from "vitest";
+import { MockRoundLLMProvider } from "../round-llm-provider";
+
+describe("MockRoundLLMProvider — onLifecycle callback", () => {
+	it("fires started → first-token → completed in order when result resolves", async () => {
+		const provider = new MockRoundLLMProvider(["hello world"]);
+		const events: string[] = [];
+
+		const result = await provider.streamRound([], [], undefined, undefined, (event) => {
+			events.push(event.phase);
+		});
+
+		expect(events).toEqual(["started", "first-token", "completed"]);
+		expect(result.assistantText).toBe("hello world");
+	});
+
+	it("forwards daemonId on every phase", async () => {
+		const provider = new MockRoundLLMProvider(["test"]);
+		const events: Array<string> = [];
+
+		await provider.streamRound([], [], undefined, "daemon-123", (event) => {
+			events.push(
+				event.daemonId ? `${event.phase}:${event.daemonId}` : event.phase,
+			);
+		});
+
+		expect(events).toEqual([
+			"started:daemon-123",
+			"first-token:daemon-123",
+			"completed:daemon-123",
+		]);
+	});
+
+	it("omits daemonId when not passed", async () => {
+		const provider = new MockRoundLLMProvider(["test"]);
+		const events: Array<string> = [];
+
+		await provider.streamRound([], [], undefined, undefined, (event) => {
+			events.push(event.phase);
+		});
+
+		expect(events).toEqual(["started", "first-token", "completed"]);
+	});
+
+	it("does not call onLifecycle when callback is absent", async () => {
+		const provider = new MockRoundLLMProvider(["hello"]);
+
+		const result = await provider.streamRound([], []);
+
+		expect(result.assistantText).toBe("hello");
+	});
+});

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -87,35 +87,10 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 			});
 
 			if (promptTokens !== undefined && cachedPromptTokens !== undefined) {
-				const pct =
-					promptTokens > 0
-						? Math.round((cachedPromptTokens / promptTokens) * 100)
-						: 0;
-				if (__DEV__) {
-					console.log(
-						`[cache] prompt ${cachedPromptTokens}/${promptTokens} cached (${pct}%)`,
-					);
-				}
+				// Inspector provides visibility into cache behavior; devtools logging removed
 			}
 
-			// Spike #239: log the per-turn tool-name array so an A/B playtest can
-			// compute parallel-emission rate = rounds-with-≥2-calls / rounds-with-≥1-call.
-			// For `message` calls, append the recipient so per-recipient counts can
-			// be derived (e.g. "message:blue" vs "message:*xqr9"). Devtools-only
-			// signal; not persisted.
-			if (__DEV__) {
-				const calls = toolCalls.map((c) => {
-					try {
-						const args = JSON.parse(c.argumentsJson);
-						return { name: c.name, args };
-					} catch {
-						return { name: c.name, args: c.argumentsJson };
-					}
-				});
-				console.log(
-					`[tools] daemon=${daemonId ?? "?"} toolCalls=${JSON.stringify(calls)}`,
-				);
-			}
+			// Inspector provides visibility into tool calling patterns; devtools logging removed
 
 			const assistantText = textParts.join("") || reasoningParts.join("");
 			onLifecycle?.(

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -15,6 +15,7 @@
 
 import { streamCompletion } from "../llm-client.js";
 import type {
+	LifecyclePhase,
 	OpenAiMessage,
 	RoundLLMProvider,
 	RoundTurnResult,
@@ -33,82 +34,112 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 		tools: OpenAiTool[],
 		onDelta?: (text: string) => void,
 		daemonId?: string,
+		onLifecycle?: (event: LifecyclePhase) => void,
 	): Promise<RoundTurnResult> {
-		const textParts: string[] = [];
-		const reasoningParts: string[] = [];
-		const toolCalls: RoundTurnResult["toolCalls"] = [];
-		let costUsd: number | undefined;
-		let promptTokens: number | undefined;
-		let completionTokens: number | undefined;
-		let cachedPromptTokens: number | undefined;
+		try {
+			const textParts: string[] = [];
+			const reasoningParts: string[] = [];
+			const toolCalls: RoundTurnResult["toolCalls"] = [];
+			let costUsd: number | undefined;
+			let promptTokens: number | undefined;
+			let completionTokens: number | undefined;
+			let cachedPromptTokens: number | undefined;
+			let firstTokenFired = false;
 
-		await streamCompletion({
-			messages,
-			tools,
-			onDelta: (text) => {
-				textParts.push(text);
-				onDelta?.(text);
-			},
-			onReasoning: (text) => {
-				reasoningParts.push(text);
-			},
-			onToolCall: (call) => {
-				toolCalls.push(call);
-			},
-			onUsage: (usage) => {
-				if (typeof usage.cost === "number") costUsd = usage.cost;
-				if (typeof usage.prompt_tokens === "number") {
-					promptTokens = usage.prompt_tokens;
-				}
-				if (typeof usage.completion_tokens === "number") {
-					completionTokens = usage.completion_tokens;
-				}
-				if (typeof usage.cached_tokens === "number") {
-					cachedPromptTokens = usage.cached_tokens;
-				}
-			},
-			disableReasoning: this.disableReasoning,
-		});
+			onLifecycle?.(
+				daemonId
+					? { phase: "started", daemonId }
+					: { phase: "started" },
+			);
 
-		if (promptTokens !== undefined && cachedPromptTokens !== undefined) {
-			const pct =
-				promptTokens > 0
-					? Math.round((cachedPromptTokens / promptTokens) * 100)
-					: 0;
+			await streamCompletion({
+				messages,
+				tools,
+				onDelta: (text) => {
+					textParts.push(text);
+					onDelta?.(text);
+					if (!firstTokenFired) {
+						firstTokenFired = true;
+						onLifecycle?.(
+							daemonId
+								? { phase: "first-token", daemonId }
+								: { phase: "first-token" },
+						);
+					}
+				},
+				onReasoning: (text) => {
+					reasoningParts.push(text);
+				},
+				onToolCall: (call) => {
+					toolCalls.push(call);
+				},
+				onUsage: (usage) => {
+					if (typeof usage.cost === "number") costUsd = usage.cost;
+					if (typeof usage.prompt_tokens === "number") {
+						promptTokens = usage.prompt_tokens;
+					}
+					if (typeof usage.completion_tokens === "number") {
+						completionTokens = usage.completion_tokens;
+					}
+					if (typeof usage.cached_tokens === "number") {
+						cachedPromptTokens = usage.cached_tokens;
+					}
+				},
+				disableReasoning: this.disableReasoning,
+			});
+
+			if (promptTokens !== undefined && cachedPromptTokens !== undefined) {
+				const pct =
+					promptTokens > 0
+						? Math.round((cachedPromptTokens / promptTokens) * 100)
+						: 0;
+				if (__DEV__) {
+					console.log(
+						`[cache] prompt ${cachedPromptTokens}/${promptTokens} cached (${pct}%)`,
+					);
+				}
+			}
+
+			// Spike #239: log the per-turn tool-name array so an A/B playtest can
+			// compute parallel-emission rate = rounds-with-≥2-calls / rounds-with-≥1-call.
+			// For `message` calls, append the recipient so per-recipient counts can
+			// be derived (e.g. "message:blue" vs "message:*xqr9"). Devtools-only
+			// signal; not persisted.
 			if (__DEV__) {
+				const calls = toolCalls.map((c) => {
+					try {
+						const args = JSON.parse(c.argumentsJson);
+						return { name: c.name, args };
+					} catch {
+						return { name: c.name, args: c.argumentsJson };
+					}
+				});
 				console.log(
-					`[cache] prompt ${cachedPromptTokens}/${promptTokens} cached (${pct}%)`,
+					`[tools] daemon=${daemonId ?? "?"} toolCalls=${JSON.stringify(calls)}`,
 				);
 			}
-		}
 
-		// Spike #239: log the per-turn tool-name array so an A/B playtest can
-		// compute parallel-emission rate = rounds-with-≥2-calls / rounds-with-≥1-call.
-		// For `message` calls, append the recipient so per-recipient counts can
-		// be derived (e.g. "message:blue" vs "message:*xqr9"). Devtools-only
-		// signal; not persisted.
-		if (__DEV__) {
-			const calls = toolCalls.map((c) => {
-				try {
-					const args = JSON.parse(c.argumentsJson);
-					return { name: c.name, args };
-				} catch {
-					return { name: c.name, args: c.argumentsJson };
-				}
-			});
-			console.log(
-				`[tools] daemon=${daemonId ?? "?"} toolCalls=${JSON.stringify(calls)}`,
+			const assistantText = textParts.join("") || reasoningParts.join("");
+			onLifecycle?.(
+				daemonId
+					? { phase: "completed", daemonId }
+					: { phase: "completed" },
 			);
+			return {
+				assistantText,
+				toolCalls,
+				...(costUsd !== undefined ? { costUsd } : {}),
+				...(promptTokens !== undefined ? { promptTokens } : {}),
+				...(completionTokens !== undefined ? { completionTokens } : {}),
+				...(cachedPromptTokens !== undefined ? { cachedPromptTokens } : {}),
+			};
+		} catch (error) {
+			onLifecycle?.(
+				daemonId
+					? { phase: "errored", daemonId, error }
+					: { phase: "errored", error },
+			);
+			throw error;
 		}
-
-		const assistantText = textParts.join("") || reasoningParts.join("");
-		return {
-			assistantText,
-			toolCalls,
-			...(costUsd !== undefined ? { costUsd } : {}),
-			...(promptTokens !== undefined ? { promptTokens } : {}),
-			...(completionTokens !== undefined ? { completionTokens } : {}),
-			...(cachedPromptTokens !== undefined ? { cachedPromptTokens } : {}),
-		};
 	}
 }

--- a/src/spa/game/browser-llm-provider.ts
+++ b/src/spa/game/browser-llm-provider.ts
@@ -47,9 +47,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 			let firstTokenFired = false;
 
 			onLifecycle?.(
-				daemonId
-					? { phase: "started", daemonId }
-					: { phase: "started" },
+				daemonId ? { phase: "started", daemonId } : { phase: "started" },
 			);
 
 			await streamCompletion({
@@ -121,9 +119,7 @@ export class BrowserLLMProvider implements RoundLLMProvider {
 
 			const assistantText = textParts.join("") || reasoningParts.join("");
 			onLifecycle?.(
-				daemonId
-					? { phase: "completed", daemonId }
-					: { phase: "completed" },
+				daemonId ? { phase: "completed", daemonId } : { phase: "completed" },
 			);
 			return {
 				assistantText,

--- a/src/spa/game/game-session.ts
+++ b/src/spa/game/game-session.ts
@@ -109,6 +109,9 @@ export class GameSession {
 		initiative?: AiId[],
 		onAiDelta?: (aiId: AiId, text: string) => void,
 		onAiTurnComplete?: (aiId: AiId) => void,
+		onLifecycle?: (
+			event: import("./round-llm-provider.js").LifecyclePhase,
+		) => void,
 	): Promise<SubmitMessageResult> {
 		const turnOrder = initiative ?? Object.keys(this.state.personas);
 
@@ -136,6 +139,7 @@ export class GameSession {
 			onAiDelta,
 			this.coneSnapshots,
 			onAiTurnComplete,
+			onLifecycle,
 		);
 
 		// Fill in empty string for AIs whose completions weren't captured

--- a/src/spa/game/pending-bootstrap.ts
+++ b/src/spa/game/pending-bootstrap.ts
@@ -36,7 +36,16 @@ export interface PendingBootstrap {
 	personas?: Record<AiId, AiPersona>;
 }
 
+export interface PendingCallMeta {
+	callName?: string;
+	startedAtMs?: number;
+	retryCount?: number;
+	retryMax?: number;
+	lastError?: string;
+}
+
 let _current: PendingBootstrap | undefined;
+let _meta: PendingCallMeta = {};
 
 /**
  * Kick off (or reuse) a bootstrap and stash it in module scope so the game
@@ -137,4 +146,46 @@ export function restartContentPacks(opts?: BootstrapOpts): PendingBootstrap {
  */
 export function clearPendingBootstrap(): void {
 	_current = undefined;
+	recordPendingDone();
+}
+
+/**
+ * Record the start of a pending call (e.g., "persona-synthesis" or "content-pack").
+ * Sets the call name, start timestamp, and initializes retry count.
+ */
+export function recordPendingCall(callName: string): void {
+	_meta = {
+		callName,
+		startedAtMs: Date.now(),
+		retryCount: 0,
+		retryMax: 3,
+	};
+}
+
+/**
+ * Record a retry attempt on the pending call, with an optional error.
+ * Increments retry count and stores the error message if provided.
+ */
+export function recordPendingRetry(error?: unknown): void {
+	const text = error instanceof Error ? error.message : String(error);
+	_meta = {
+		..._meta,
+		retryCount: (_meta.retryCount ?? 0) + 1,
+		lastError: text,
+	};
+}
+
+/**
+ * Record successful completion of a pending call. Clears the metadata.
+ */
+export function recordPendingDone(): void {
+	_meta = {};
+}
+
+/**
+ * Get the current pending call metadata. Returns a shallow copy to prevent
+ * external mutations.
+ */
+export function getPendingCallMeta(): PendingCallMeta {
+	return { ..._meta };
 }

--- a/src/spa/game/pending-bootstrap.ts
+++ b/src/spa/game/pending-bootstrap.ts
@@ -62,14 +62,18 @@ export function startBootstrap(opts?: BootstrapOpts): PendingBootstrap {
 		status: "pending",
 	};
 
+	recordPendingCall("persona-synthesis");
+
 	split.personasPromise.then(
 		(personas) => {
 			entry.personas = personas;
 			if (entry.status === "pending") entry.status = "personas-ready";
+			recordPendingCall("content-pack");
 		},
 		(err: unknown) => {
 			entry.status = "failed";
 			entry.error = err;
+			recordPendingRetry(err);
 		},
 	);
 	split.contentPacksPromise.then(
@@ -79,6 +83,7 @@ export function startBootstrap(opts?: BootstrapOpts): PendingBootstrap {
 		(err: unknown) => {
 			entry.status = "failed";
 			entry.error = err;
+			recordPendingRetry(err);
 		},
 	);
 
@@ -117,6 +122,8 @@ export function restartContentPacks(opts?: BootstrapOpts): PendingBootstrap {
 		return startBootstrap(opts);
 	}
 
+	recordPendingCall("content-pack");
+
 	const split = generateContentPacksOnlySplit(cached, opts);
 	const entry: PendingBootstrap = {
 		personasPromise: split.personasPromise,
@@ -132,6 +139,7 @@ export function restartContentPacks(opts?: BootstrapOpts): PendingBootstrap {
 		(err: unknown) => {
 			entry.status = "failed";
 			entry.error = err;
+			recordPendingRetry(err);
 		},
 	);
 

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -132,6 +132,9 @@ export async function runRound(
 	onAiDelta?: (aiId: AiId, text: string) => void,
 	priorConeSnapshots?: Partial<Record<AiId, string>>,
 	onAiTurnComplete?: (aiId: AiId) => void,
+	onLifecycle?: (
+		event: import("./round-llm-provider.js").LifecyclePhase,
+	) => void,
 ): Promise<RunRoundResult> {
 	const aiOrder = Object.keys(game.personas);
 
@@ -204,6 +207,7 @@ export async function runRound(
 			tools,
 			onAiDelta ? (text) => onAiDelta(aiId, text) : undefined,
 			aiId,
+			onLifecycle,
 		);
 
 		// Drift-to-silence recovery (#254): if the model returned free-form
@@ -227,6 +231,7 @@ export async function runRound(
 				tools,
 				onAiDelta ? (text) => onAiDelta(aiId, text) : undefined,
 				aiId,
+				onLifecycle,
 			);
 			assistantText = retry.assistantText;
 			toolCalls = retry.toolCalls;

--- a/src/spa/game/round-llm-provider.ts
+++ b/src/spa/game/round-llm-provider.ts
@@ -99,9 +99,7 @@ export class MockRoundLLMProvider implements RoundLLMProvider {
 		try {
 			this.calls.push({ messages, tools });
 			onLifecycle?.(
-				daemonId
-					? { phase: "started", daemonId }
-					: { phase: "started" },
+				daemonId ? { phase: "started", daemonId } : { phase: "started" },
 			);
 
 			const raw =
@@ -128,9 +126,7 @@ export class MockRoundLLMProvider implements RoundLLMProvider {
 			}
 
 			onLifecycle?.(
-				daemonId
-					? { phase: "completed", daemonId }
-					: { phase: "completed" },
+				daemonId ? { phase: "completed", daemonId } : { phase: "completed" },
 			);
 			return result;
 		} catch (error) {

--- a/src/spa/game/round-llm-provider.ts
+++ b/src/spa/game/round-llm-provider.ts
@@ -44,12 +44,19 @@ export interface RoundTurnResult {
 	cachedPromptTokens?: number;
 }
 
+export type LifecyclePhase =
+	| { phase: "started"; daemonId?: string }
+	| { phase: "first-token"; daemonId?: string }
+	| { phase: "completed"; daemonId?: string }
+	| { phase: "errored"; daemonId?: string; error: unknown };
+
 export interface RoundLLMProvider {
 	streamRound(
 		messages: OpenAiMessage[],
 		tools: OpenAiTool[],
 		onDelta?: (text: string) => void,
 		daemonId?: string,
+		onLifecycle?: (event: LifecyclePhase) => void,
 	): Promise<RoundTurnResult>;
 }
 
@@ -86,23 +93,53 @@ export class MockRoundLLMProvider implements RoundLLMProvider {
 		messages: OpenAiMessage[],
 		tools: OpenAiTool[],
 		_onDelta?: (text: string) => void,
-		_daemonId?: string,
+		daemonId?: string,
+		onLifecycle?: (event: LifecyclePhase) => void,
 	): Promise<RoundTurnResult> {
-		this.calls.push({ messages, tools });
-		const raw =
-			this.results[this.index % this.results.length] ??
-			({ assistantText: "", toolCalls: [] } satisfies RoundTurnResult);
-		this.index++;
+		try {
+			this.calls.push({ messages, tools });
+			onLifecycle?.(
+				daemonId
+					? { phase: "started", daemonId }
+					: { phase: "started" },
+			);
 
-		if (typeof raw === "string") {
-			return { assistantText: raw, toolCalls: [] };
+			const raw =
+				this.results[this.index % this.results.length] ??
+				({ assistantText: "", toolCalls: [] } satisfies RoundTurnResult);
+			this.index++;
+
+			onLifecycle?.(
+				daemonId
+					? { phase: "first-token", daemonId }
+					: { phase: "first-token" },
+			);
+
+			let result: RoundTurnResult;
+			if (typeof raw === "string") {
+				result = { assistantText: raw, toolCalls: [] };
+			} else if ("toolCall" in raw) {
+				result = {
+					assistantText: raw.assistantText ?? "",
+					toolCalls: [raw.toolCall],
+				};
+			} else {
+				result = raw;
+			}
+
+			onLifecycle?.(
+				daemonId
+					? { phase: "completed", daemonId }
+					: { phase: "completed" },
+			);
+			return result;
+		} catch (error) {
+			onLifecycle?.(
+				daemonId
+					? { phase: "errored", daemonId, error }
+					: { phase: "errored", error },
+			);
+			throw error;
 		}
-		if ("toolCall" in raw) {
-			return {
-				assistantText: raw.assistantText ?? "",
-				toolCalls: [raw.toolCall],
-			};
-		}
-		return raw;
 	}
 }

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -105,6 +105,7 @@
 							<span class="brow-fill brow-fill-heavy"></span>
 							<span class="corner corner-br"></span>
 						</div>
+						<div class="dev-daemon-footer" hidden></div>
 					</article>
 					<article class="ai-panel panel">
 						<div class="brow brow-top">
@@ -131,6 +132,7 @@
 							<span class="brow-fill brow-fill-heavy"></span>
 							<span class="corner corner-br"></span>
 						</div>
+						<div class="dev-daemon-footer" hidden></div>
 					</article>
 					<article class="ai-panel panel">
 						<div class="brow brow-top">
@@ -157,8 +159,11 @@
 							<span class="brow-fill brow-fill-heavy"></span>
 							<span class="corner corner-br"></span>
 						</div>
+						<div class="dev-daemon-footer" hidden></div>
 					</article>
 				</div>
+				<div id="dev-game-strip" hidden></div>
+				<div id="dev-world-map" hidden></div>
 				<form id="composer" class="cmd">
 					<span class="prompt-prefix"><span class="prompt-host"><b>root</b><span class="at">@</span>hi-blue:</span><span class="prompt-target">/?????</span><span class="at">&gt; </span></span>
 					<div class="prompt-wrap">

--- a/src/spa/index.html
+++ b/src/spa/index.html
@@ -189,10 +189,6 @@ come back tomorrow — they wake at midnight UTC.</pre>
 					</div>
 				</section>
 				<aside id="persistence-warning" hidden role="status" aria-live="polite"></aside>
-				<aside id="action-log" hidden>
-					<h3>action_log :: debug</h3>
-					<ul id="action-log-list"></ul>
-				</aside>
 				<section id="endgame" hidden>
 					<h2>hi-blue — endgame</h2>
 					<div id="endgame-subtitle">The three phases are complete. The room is still.</div>

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -250,8 +250,6 @@ export function renderGame(
 	const promptInput = doc.querySelector<HTMLInputElement>("#prompt");
 	const sendBtn = doc.querySelector<HTMLButtonElement>("#send");
 	const capHitEl = doc.querySelector<HTMLElement>("#cap-hit");
-	const actionLogEl = doc.querySelector<HTMLElement>("#action-log");
-	const actionLogList = doc.querySelector<HTMLUListElement>("#action-log-list");
 	const persistenceWarningEl = doc.querySelector<HTMLElement>(
 		"#persistence-warning",
 	);
@@ -267,9 +265,6 @@ export function renderGame(
 		session = null;
 		cachedSessionId = null;
 		gameEnded = false;
-		// Action log is live-only (no restore), so clear it for parity with
-		// a hard refresh — otherwise entries from the previous session linger.
-		if (actionLogList) actionLogList.textContent = "";
 	}
 
 	// Mention-based addressing state — built lazily after session init below,
@@ -1166,16 +1161,6 @@ export function renderGame(
 		});
 	}
 
-	// Debug toggle: show action log if ?debug=1
-	const debug = searchParams.get("debug") === "1";
-	if (actionLogEl) {
-		if (debug) {
-			actionLogEl.removeAttribute("hidden");
-		} else {
-			actionLogEl.setAttribute("hidden", "");
-		}
-	}
-
 	// Helper: get transcript element for an AI
 	function getTranscript(aiId: AiId): HTMLElement | null {
 		return doc.querySelector<HTMLElement>(`[data-transcript="${aiId}"]`);
@@ -1554,12 +1539,8 @@ export function renderGame(
 						break;
 
 					case "action_log":
-						// Always accumulate in the DOM (even if hidden) so ?debug=1 shows history
-						if (actionLogList) {
-							const li = doc.createElement("li");
-							li.textContent = `[Round ${event.entry.round}] ${event.entry.description}`;
-							actionLogList.appendChild(li);
-						}
+						// Event type still produced by round-result-encoder but no longer
+						// rendered in player-facing UI. Inspector supersedes this debug surface.
 						break;
 
 					case "phase_advanced": {
@@ -1628,13 +1609,10 @@ export function renderGame(
 						const panelsEl = doc.querySelector<HTMLElement>("#panels");
 						const composerEl = doc.querySelector<HTMLElement>("#composer");
 						const capHitSection = doc.querySelector<HTMLElement>("#cap-hit");
-						const actionLogSection =
-							doc.querySelector<HTMLElement>("#action-log");
 						const endgameEl = doc.querySelector<HTMLElement>("#endgame");
 						if (panelsEl) panelsEl.hidden = true;
 						if (composerEl) composerEl.hidden = true;
 						if (capHitSection) capHitSection.hidden = true;
-						if (actionLogSection) actionLogSection.hidden = true;
 
 						// Show endgame screen
 						if (endgameEl) endgameEl.removeAttribute("hidden");

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -8,8 +8,12 @@ import {
 	topInfoStatus,
 } from "../bbs-chrome.js";
 import {
+	recordDaemonError,
+	recordDaemonRound,
+	recordDaemonSystemPrompt,
 	recordDaemonTurnResult,
 	setDaemonFooterInFlight,
+	updateDaemonFooterDetails,
 	updateDaemonFooterSummary,
 } from "../dev-inspector/daemon-footer.js";
 import { updateGameStripSummary } from "../dev-inspector/game-strip.js";
@@ -1397,6 +1401,9 @@ export function renderGame(
 				disableReasoning: !enableReasoning,
 			});
 
+			// session is guaranteed non-null here due to the check above; capture for closure
+			const sessionRef = session;
+
 			// Wrap provider in __DEV__ gate that records turn results for dev inspector footers
 			const provider: RoundLLMProvider = __DEV__
 				? {
@@ -1407,6 +1414,11 @@ export function renderGame(
 							daemonId,
 							onLifecycle,
 						) => {
+							if (daemonId && messages[0]?.role === "system") {
+								recordDaemonSystemPrompt(daemonId, messages[0].content);
+								if (sessionRef)
+									recordDaemonRound(daemonId, sessionRef.getState().round);
+							}
 							const result = await rawProvider.streamRound(
 								messages,
 								tools,
@@ -1414,7 +1426,16 @@ export function renderGame(
 								daemonId,
 								onLifecycle,
 							);
-							if (daemonId) recordDaemonTurnResult(daemonId, result);
+							if (daemonId) {
+								recordDaemonTurnResult(daemonId, {
+									...result,
+									lastRawCompletion: result.assistantText,
+									lastToolCalls: result.toolCalls.map((tc) => ({
+										name: tc.name,
+										argumentsJson: tc.argumentsJson,
+									})),
+								});
+							}
 							return result;
 						},
 					}
@@ -1432,8 +1453,10 @@ export function renderGame(
 							setDaemonFooterInFlight(panel, "in-flight");
 						else if (event.phase === "completed")
 							setDaemonFooterInFlight(panel, "idle");
-						else if (event.phase === "errored")
+						else if (event.phase === "errored") {
 							setDaemonFooterInFlight(panel, "errored");
+							recordDaemonError(event.daemonId, event.error);
+						}
 						// first-token: no-op
 					}
 				: undefined;
@@ -1798,7 +1821,7 @@ export function renderGame(
 				const stripEl = document.querySelector<HTMLElement>("#dev-game-strip");
 				if (stripEl) updateGameStripSummary(stripEl, session);
 
-				// Update per-Daemon footer summaries
+				// Update per-Daemon footer summaries and details
 				const aiIdList = Object.keys(nextState.personas);
 				for (const aiId of aiIdList) {
 					const panel = document.querySelector<HTMLElement>(
@@ -1806,6 +1829,7 @@ export function renderGame(
 					);
 					if (panel) {
 						updateDaemonFooterSummary(panel, aiId, session);
+						updateDaemonFooterDetails(panel, aiId, session);
 					}
 				}
 			}

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -7,11 +7,11 @@ import {
 	renderTopInfoLeft,
 	topInfoStatus,
 } from "../bbs-chrome.js";
+import { renderInspector } from "../dev-inspector/index.js";
 import {
 	buildSameDaemonsSession,
 	buildSessionFromAssets,
 } from "../game/bootstrap.js";
-import { renderInspector } from "../dev-inspector/index.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { isPlayerChatLockedOut } from "../game/complication-engine.js";
 import { deriveComposerState } from "../game/composer-reducer.js";

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -533,6 +533,10 @@ export function renderGame(
 		setStageLoadState("loading-daemons");
 		renderLoadingTopInfo("loading-daemons");
 
+		if (__DEV__) {
+			renderInspector(root, { pendingBootstrap: pending });
+		}
+
 		// Braille spinner machinery — duplicated from the round-submit path so
 		// we can ride spinners on the panel-name labels while content packs
 		// load (no session yet, so we can't share that closure).
@@ -619,6 +623,9 @@ export function renderGame(
 					buildLoadingPersonaShape(personas);
 					setStageLoadState("generating-room");
 					renderLoadingTopInfo("generating-room");
+					if (__DEV__) {
+						renderInspector(root, { pendingBootstrap });
+					}
 					startSpinners();
 					startBrightnessWipe();
 					return pendingBootstrap.contentPacksPromise.then(
@@ -701,6 +708,10 @@ export function renderGame(
 		// Run the initial bootstrap chain with error handling
 		return runBootstrapChain(pending).catch(async (err: unknown) => {
 			cleanupLoadingTimers();
+
+			if (__DEV__) {
+				renderInspector(root, { pendingBootstrap: pending });
+			}
 
 			if (err instanceof CapHitError && capHitEl) {
 				capHitEl.removeAttribute("hidden");

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -8,6 +8,7 @@ import {
 	topInfoStatus,
 } from "../bbs-chrome.js";
 import { renderInspector } from "../dev-inspector/index.js";
+import { updateGameStripSummary } from "../dev-inspector/game-strip.js";
 import {
 	buildSameDaemonsSession,
 	buildSessionFromAssets,
@@ -1739,6 +1740,11 @@ export function renderGame(
 						break;
 					}
 				}
+			}
+
+			if (__DEV__ && session) {
+				const stripEl = document.querySelector<HTMLElement>("#dev-game-strip");
+				if (stripEl) updateGameStripSummary(stripEl, session);
 			}
 
 			// Persist state after the encoder render loop completes.

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -7,8 +7,8 @@ import {
 	renderTopInfoLeft,
 	topInfoStatus,
 } from "../bbs-chrome.js";
-import { renderInspector } from "../dev-inspector/index.js";
 import { updateGameStripSummary } from "../dev-inspector/game-strip.js";
+import { renderInspector } from "../dev-inspector/index.js";
 import {
 	buildSameDaemonsSession,
 	buildSessionFromAssets,

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -7,6 +7,11 @@ import {
 	renderTopInfoLeft,
 	topInfoStatus,
 } from "../bbs-chrome.js";
+import {
+	recordDaemonTurnResult,
+	setDaemonFooterInFlight,
+	updateDaemonFooterSummary,
+} from "../dev-inspector/daemon-footer.js";
 import { updateGameStripSummary } from "../dev-inspector/game-strip.js";
 import { renderInspector } from "../dev-inspector/index.js";
 import {
@@ -30,6 +35,10 @@ import {
 	getPendingBootstrap,
 	restartContentPacks,
 } from "../game/pending-bootstrap.js";
+import type {
+	LifecyclePhase,
+	RoundLLMProvider,
+} from "../game/round-llm-provider.js";
 import { encodeRoundResult } from "../game/round-result-encoder.js";
 import { getSpikeRng } from "../game/spike-seed.js";
 import type { AiId, AiPersona } from "../game/types";
@@ -1384,9 +1393,51 @@ export function renderGame(
 		let roundGameEnded = false;
 
 		try {
-			const provider = new BrowserLLMProvider({
+			const rawProvider = new BrowserLLMProvider({
 				disableReasoning: !enableReasoning,
 			});
+
+			// Wrap provider in __DEV__ gate that records turn results for dev inspector footers
+			const provider: RoundLLMProvider = __DEV__
+				? {
+						streamRound: async (
+							messages,
+							tools,
+							onDelta,
+							daemonId,
+							onLifecycle,
+						) => {
+							const result = await rawProvider.streamRound(
+								messages,
+								tools,
+								onDelta,
+								daemonId,
+								onLifecycle,
+							);
+							if (daemonId) recordDaemonTurnResult(daemonId, result);
+							return result;
+						},
+					}
+				: rawProvider;
+
+			// Lifecycle callback (dev-only) for per-Daemon footer pip state
+			const onLifecycle: ((event: LifecyclePhase) => void) | undefined = __DEV__
+				? (event: LifecyclePhase) => {
+						if (!event.daemonId) return;
+						const panel = document.querySelector<HTMLElement>(
+							`.ai-panel[data-ai="${event.daemonId}"]`,
+						);
+						if (!panel) return;
+						if (event.phase === "started")
+							setDaemonFooterInFlight(panel, "in-flight");
+						else if (event.phase === "completed")
+							setDaemonFooterInFlight(panel, "idle");
+						else if (event.phase === "errored")
+							setDaemonFooterInFlight(panel, "errored");
+						// first-token: no-op
+					}
+				: undefined;
+
 			// Strip each daemon's spinner as the coordinator finishes its
 			// turn (post-retry per #254). Coordinator awaits AIs serially in
 			// initiative order, so this fires staged in real time —
@@ -1399,6 +1450,7 @@ export function renderGame(
 				initiative,
 				undefined,
 				(aiId) => stripSpinner(aiId),
+				onLifecycle,
 			);
 
 			const events = encodeRoundResult(
@@ -1745,6 +1797,17 @@ export function renderGame(
 			if (__DEV__ && session) {
 				const stripEl = document.querySelector<HTMLElement>("#dev-game-strip");
 				if (stripEl) updateGameStripSummary(stripEl, session);
+
+				// Update per-Daemon footer summaries
+				const aiIdList = Object.keys(nextState.personas);
+				for (const aiId of aiIdList) {
+					const panel = document.querySelector<HTMLElement>(
+						`.ai-panel[data-ai="${aiId}"]`,
+					);
+					if (panel) {
+						updateDaemonFooterSummary(panel, aiId, session);
+					}
+				}
 			}
 
 			// Persist state after the encoder render loop completes.

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -18,6 +18,7 @@ import {
 } from "../dev-inspector/daemon-footer.js";
 import { updateGameStripSummary } from "../dev-inspector/game-strip.js";
 import { renderInspector } from "../dev-inspector/index.js";
+import { updateWorldMap } from "../dev-inspector/world-map.js";
 import {
 	buildSameDaemonsSession,
 	buildSessionFromAssets,
@@ -1820,6 +1821,9 @@ export function renderGame(
 			if (__DEV__ && session) {
 				const stripEl = document.querySelector<HTMLElement>("#dev-game-strip");
 				if (stripEl) updateGameStripSummary(stripEl, session);
+
+				const mapEl = document.querySelector<HTMLElement>("#dev-world-map");
+				if (mapEl) updateWorldMap(mapEl, session);
 
 				// Update per-Daemon footer summaries and details
 				const aiIdList = Object.keys(nextState.personas);

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -11,6 +11,7 @@ import {
 	buildSameDaemonsSession,
 	buildSessionFromAssets,
 } from "../game/bootstrap.js";
+import { renderInspector } from "../dev-inspector/index.js";
 import { BrowserLLMProvider } from "../game/browser-llm-provider.js";
 import { isPlayerChatLockedOut } from "../game/complication-engine.js";
 import { deriveComposerState } from "../game/composer-reducer.js";
@@ -1132,6 +1133,13 @@ export function renderGame(
 	}
 
 	registerPanelClickHandlers(aiIdList);
+
+	if (__DEV__ && session !== null) {
+		renderInspector(root, {
+			session,
+			pendingBootstrap: getPendingBootstrap(),
+		});
+	}
 
 	// Debug toggle: show action log if ?debug=1
 	const debug = searchParams.get("debug") === "1";

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1152,7 +1152,6 @@ export function renderGame(
 	if (__DEV__ && session !== null) {
 		renderInspector(root, {
 			session,
-			pendingBootstrap: getPendingBootstrap(),
 		});
 	}
 

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1739,3 +1739,48 @@ main {
 	font-size: 11px;
 	min-height: 14px;
 }
+
+.dev-footer-summary {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.dev-footer-pip {
+	font-weight: bold;
+	min-width: 1ch;
+}
+
+.dev-footer-pip[data-state="in-flight"] {
+	color: var(--amber-bright);
+	animation: pulse-bright 0.5s ease-in-out infinite;
+}
+
+.dev-footer-pip[data-state="errored"] {
+	color: #ff6b6b;
+}
+
+.dev-footer-tools,
+.dev-footer-llm,
+.dev-footer-chips {
+	font-size: 10px;
+}
+
+.dev-footer-chip {
+	display: inline-block;
+	margin-right: 2px;
+	opacity: 0.8;
+}
+
+.dev-footer-chip[data-chip-kind="sysadm-dir"] {
+	color: #ff9900;
+}
+
+.dev-footer-chip[data-chip-kind="tool-dis"] {
+	color: #ffcc00;
+}
+
+.dev-footer-chip[data-chip-kind="chat-lock"] {
+	color: #ff6b6b;
+}

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1832,3 +1832,22 @@ main {
 	color: var(--amber);
 	border-color: rgba(255, 180, 84, 0.8);
 }
+
+/* Pending bootstrap strip */
+.dev-pending-strip {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	font-family: var(--mono);
+	font-size: 11px;
+}
+
+.dev-pending-strip [hidden] {
+	display: none !important;
+}
+
+.dev-strip-line {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+}

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1718,3 +1718,24 @@ main {
 #sessions-icon:hover {
 	color: var(--amber);
 }
+
+#dev-game-strip,
+#dev-world-map {
+	margin-top: 8px;
+	padding: 6px 8px;
+	border: 1px dashed rgba(255, 180, 84, 0.3);
+	color: var(--amber-dim);
+	font-family: var(--mono);
+	font-size: 11px;
+	min-height: 16px;
+}
+
+.dev-daemon-footer {
+	margin-top: 4px;
+	padding: 4px 6px;
+	border-top: 1px dashed rgba(255, 180, 84, 0.3);
+	color: var(--amber-dim);
+	font-family: var(--mono);
+	font-size: 11px;
+	min-height: 14px;
+}

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1816,3 +1816,19 @@ main {
 .dev-map-cell:hover .dev-map-tooltip {
 	display: inline-block;
 }
+
+/* Focus cone button */
+.dev-footer-focus-cone {
+	background: none;
+	border: 1px dashed rgba(255, 180, 84, 0.4);
+	color: var(--amber-dim);
+	font-family: var(--mono);
+	font-size: 10px;
+	padding: 0 4px;
+	cursor: pointer;
+}
+
+.dev-footer-focus-cone[data-focus-active="true"] {
+	color: var(--amber);
+	border-color: rgba(255, 180, 84, 0.8);
+}

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -74,7 +74,7 @@ body::before {
 
 /* Layout — single screen */
 #stage {
-	height: 100dvh;
+	min-height: 100dvh;
 	display: grid;
 	grid-template-rows: auto auto auto auto 1fr auto;
 	gap: 6px;

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1843,7 +1843,7 @@ main {
 }
 
 .dev-pending-strip [hidden] {
-	display: none !important;
+	display: none;
 }
 
 .dev-strip-line {

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -1784,3 +1784,35 @@ main {
 .dev-footer-chip[data-chip-kind="chat-lock"] {
 	color: #ff6b6b;
 }
+
+.dev-map-grid {
+	display: grid;
+	grid-template-columns: repeat(7, 1ch);
+	column-gap: 1ch;
+	row-gap: 0;
+	font-family: var(--mono);
+	white-space: pre;
+	line-height: 1;
+}
+
+.dev-map-cell {
+	position: relative;
+}
+
+.dev-map-tooltip {
+	display: none;
+	position: absolute;
+	bottom: 100%;
+	left: 0;
+	background: #000;
+	color: #ffb454;
+	border: 1px dashed rgba(255, 180, 84, 0.5);
+	padding: 2px 4px;
+	white-space: nowrap;
+	z-index: 10;
+	font-size: 10px;
+}
+
+.dev-map-cell:hover .dev-map-tooltip {
+	display: inline-block;
+}

--- a/src/spa/styles.css
+++ b/src/spa/styles.css
@@ -710,53 +710,6 @@ main {
 	text-shadow: 0 0 6px rgba(255, 245, 224, 0.5);
 }
 
-/* Action log (?debug=1) */
-#action-log {
-	margin-top: 8px;
-	padding: 8px 10px;
-	color: var(--amber-dim);
-	border: 1px solid transparent;
-	background-color: rgba(255, 180, 84, 0.04);
-	background-image:
-		linear-gradient(to right, rgba(255, 180, 84, 0.3) 6px, transparent 6px),
-		linear-gradient(to right, rgba(255, 180, 84, 0.3) 6px, transparent 6px),
-		linear-gradient(to bottom, rgba(255, 180, 84, 0.3) 6px, transparent 6px),
-		linear-gradient(to bottom, rgba(255, 180, 84, 0.3) 6px, transparent 6px);
-	background-size:
-		9px 1px,
-		9px 1px,
-		1px 9px,
-		1px 9px;
-	background-position:
-		0 0,
-		0 100%,
-		0 0,
-		100% 0;
-	background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
-	background-origin: border-box;
-	background-clip: border-box;
-	font-family: var(--mono);
-	font-size: 11px;
-}
-
-#action-log h3 {
-	margin: 0 0 4px;
-	font-size: 11px;
-	font-weight: 500;
-	color: var(--amber);
-	letter-spacing: 0.08em;
-}
-
-#action-log-list {
-	margin: 0;
-	padding-left: 14px;
-	list-style: square;
-}
-
-#action-log-list li {
-	margin-bottom: 2px;
-}
-
 /* Start screen — CRT dial-up login */
 :root {
 	--amber-faint: #4a3618;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 				test: {
 					name: "browser",
 					include: ["src/**/*.test.ts", "scripts/__tests__/**/*.test.ts"],
-					exclude: ["src/proxy/**"],
+					exclude: ["src/proxy/**", "src/spa/__tests__/build.test.ts"],
 					environment: "jsdom",
 					// Match the wrangler-dev origin so SPA dev-affordance gates
 					// (`location.origin === __WORKER_BASE_URL__`) hold under test.
@@ -17,6 +17,14 @@ export default defineConfig({
 						jsdom: { url: "http://localhost:8787/" },
 					},
 					setupFiles: ["src/spa/test-setup.ts"],
+				},
+			},
+			{
+				extends: true,
+				test: {
+					name: "build",
+					include: ["src/spa/__tests__/build.test.ts"],
+					environment: "node",
 				},
 			},
 			{


### PR DESCRIPTION
Implements the Daemon dev inspector PRD across 9 build seams. Adds a `__DEV__`-gated diagnostic surface that consolidates engine-side and LLM-side per-Daemon state into the running game UI, and removes the legacy `#action-log` aside, the `?debug=1` toggle, and the two `console.log` lines in `browser-llm-provider.ts` that it supersedes.

The inspector is entirely tree-shaken from production builds — `__DEV__=false` bundles contain zero references to `renderInspector`, `dev-daemon-footer`, or any inspector module identifier. Guarded by an esbuild build-time test (`src/spa/__tests__/build.test.ts`).

## What this fixes

The PRD called out that tuning the game (prompt iteration, persona synthesis, complication pacing, content-pack debugging) required developers to reason about three Daemons' parallel state without seeing it. This PR adds three diagnostic regions inside `#main`:

- **Game-global strip** (`src/spa/dev-inspector/game-strip.ts`) — round/countdown/pack/setting/weather/time-of-day on line 1; cost / objectives K/J satisfied / active complication count on line 2; full lists in a sticky-open `<details>`.
- **God-view 5×5 ASCII map** (`src/spa/dev-inspector/world-map.ts`) — Daemons (persona-coloured `@` + facing arrow), obstacles, objectives, interesting objects, with CSS-positioned hover tooltips and a `[ focus cone ]` toggle per Daemon that tints cone cells in persona colour via `coneMaskForDaemon` (reuses `projectCone`).
- **Per-Daemon footers** (`src/spa/dev-inspector/daemon-footer.ts`) — one footer per `.ai-panel` with a summary line (in-flight pip · last-round tool calls · `[tok N→M cache P% $C]` · complication chips) and five sticky-open `<details>` disclosures (last system prompt, raw completion, tool calls with full arg JSON, last error with status code, persona card).

In-flight pip transitions come from a new `onLifecycle` callback on `RoundLLMProvider.streamRound` — the only seam that touches production code paths, an optional parameter so all existing callers compile unchanged.

A separate **pending-bootstrap strip** (`src/spa/dev-inspector/pending-strip.ts`) renders during the pre-session phase when there's no `GameState` yet. It shows pip · call name · retry count · elapsed seconds · last error, driven by a meta-recorder side channel in `pending-bootstrap.ts` and an `~100ms` setInterval for the elapsed tick.

The legacy `#action-log` aside (its `?debug=1` toggle, event handler, session-change clear, game-ended hide, and CSS), plus the two `console.log` lines in `browser-llm-provider.ts:78,90`, are all removed in seam 9. The `action_log` event type itself is preserved because `round-result-encoder.ts` still emits it.

## Seam-by-seam commits

| Seam | Issue | Topic |
| --- | --- | --- |
| 1 | #437 | `onLifecycle` callback on `RoundLLMProvider` (only seam that touches prod code) |
| 2 | #438 | Inspector skeleton + `__DEV__` build-time gating test |
| 3 | #439 | Game-global strip |
| 4 | #440 | Per-Daemon footer summary line |
| 5 | #443 | Per-Daemon footer `<details>` disclosures |
| 6 | #444 | God-view 5×5 ASCII map |
| 7 | #445 | Cone-focus tinting on map |
| 8 | #446 | Pending-bootstrap strip |
| 9 | #447 | Cleanup: remove `#action-log` aside, `?debug=1`, `console.log`s |

Companion ADR: `docs/adr/0013-dev-inspector-build-time-only.md` (already on `main`).

## QA steps for the human

- **Pure smoke**: open the SPA with `__DEV__=true`, start a new game, confirm:
  - Each `.ai-panel` shows a footer below its budget chip with the four summary fields.
  - The 5×5 map shows Daemons coloured + facing-arrowed in their start positions.
  - The game-strip above the map shows the round/countdown/pack/setting/weather/time-of-day line.
  - Click `[ focus cone ]` in any footer — that Daemon's cone cells tint in their persona colour. Click again or press Escape to clear.
- **Prod safety**: run `pnpm build` and confirm `dist/assets/index-*.js` contains zero matches for `renderInspector` or `dev-daemon-footer` (the build-time test enforces this).
- **Legacy surfaces gone**: open with `?debug=1` — confirm no `#action-log` aside appears (it was removed entirely).
- **Console clean**: open devtools console during a normal round — no `cache=` or `tools=` log lines from `browser-llm-provider.ts` should appear.

## Automated coverage

- `pnpm typecheck` — clean (1638 unit tests). Tree-shake test `src/spa/__tests__/build.test.ts` confirms `__DEV__=false` bundle is inspector-free.
- `pnpm test` — 67 test files, 1638 tests pass. New tests cover each seam: cone-mask projection, footer sticky-open behaviour, world-map glyph stacking precedence, pending-strip ticker, build-time gating.
- `pnpm exec playwright test e2e/smoke.spec.ts` — 2/2 pass.

Closes #437
Closes #438
Closes #439
Closes #440
Closes #443
Closes #444
Closes #445
Closes #446
Closes #447

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMQo3tFWKEbBgNcy3zHzA2)_