### PR TITLE
Strengthen corrective feedback with previous response and detailed error context

### DIFF
--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -2492,3 +2492,319 @@ describe("BrowserContentPackProvider — dual outer-retry layer", () => {
 		);
 	});
 });
+
+// ── BrowserContentPackProvider — strengthened corrective feedback ──────────
+
+describe("BrowserContentPackProvider — corrective feedback strengthening", () => {
+	const carryInput: import("../content-pack-provider.js").BindingContentPackInput =
+		{
+			phases: [
+				{
+					setting: "abandoned subway station",
+					theme: "mundane",
+					weather: "overcast",
+					timeOfDay: "night",
+					bindings: [
+						{
+							type: "carry",
+							objectId: "carry-0-obj",
+							spaceId: "carry-0-space",
+						},
+					],
+					decoyIds: ["decoy-0", "decoy-1"],
+					obstacleCount: 1,
+				},
+			],
+		};
+
+	const useSpaceInput: import("../content-pack-provider.js").BindingContentPackInput =
+		{
+			phases: [
+				{
+					setting: "abandoned subway station",
+					theme: "mundane",
+					weather: "overcast",
+					timeOfDay: "night",
+					bindings: [
+						{
+							type: "use_space",
+							spaceId: "useSpace-0-space",
+						},
+					],
+					decoyIds: ["decoy-0", "decoy-1"],
+					obstacleCount: 1,
+				},
+			],
+		};
+
+	function buildValidCarryPack(): unknown {
+		return {
+			pack: {
+				setting: "abandoned subway station",
+				wallName: "concrete barrier",
+				landmarks: {
+					north: {
+						shortName: "the signal tower",
+						horizonPhrase: "rises above the platform",
+					},
+					south: {
+						shortName: "the collapsed entrance",
+						horizonPhrase: "gapes like a wound in the dark",
+					},
+					east: {
+						shortName: "the rusted fan shaft",
+						horizonPhrase: "spins slowly in the stale air",
+					},
+					west: {
+						shortName: "the flooded tunnel",
+						horizonPhrase: "disappears into still black water",
+					},
+				},
+				bindings: [
+					{
+						id: "carry-0",
+						type: "carry",
+						object: {
+							id: "carry-0-obj",
+							name: "Iron Key",
+							examineDescription:
+								"An iron key. It looks like it belongs on the brass pedestal.",
+							useOutcome: "You turn the key over in your hands.",
+							placementFlavor: "{actor} sets the key on its mount.",
+							proximityFlavor: "The key hums faintly near the pedestal.",
+						},
+						space: {
+							id: "carry-0-space",
+							name: "Brass Pedestal",
+							examineDescription:
+								"A sturdy brass mount with a subtle indentation on its surface.",
+							proximityFlavor: "The pedestal thrums softly nearby.",
+						},
+					},
+				],
+				decoys: [
+					{
+						id: "decoy-0",
+						name: "Brass Disc",
+						examineDescription: "A small decorative disc of tarnished brass.",
+						proximityFlavor: "The disc gleams faintly.",
+						useOutcome: "Nothing happens.",
+					},
+					{
+						id: "decoy-1",
+						name: "Old Coin",
+						examineDescription: "A weathered coin from a past era.",
+						proximityFlavor: "The coin catches the light.",
+						useOutcome: "Nothing happens.",
+					},
+				],
+				obstacles: [
+					{
+						id: "obstacle-0",
+						name: "Rusted Gate",
+						examineDescription: "An old rusted gate blocking the path.",
+						shiftFlavor:
+							"The rusted gate scrapes along the floor with a grinding shriek.",
+					},
+				],
+			},
+		};
+	}
+
+	function buildValidUseSpacePack(): unknown {
+		return {
+			pack: {
+				setting: "abandoned subway station",
+				wallName: "concrete barrier",
+				landmarks: {
+					north: {
+						shortName: "the signal tower",
+						horizonPhrase: "rises above the platform",
+					},
+					south: {
+						shortName: "the collapsed entrance",
+						horizonPhrase: "gapes like a wound in the dark",
+					},
+					east: {
+						shortName: "the rusted fan shaft",
+						horizonPhrase: "spins slowly in the stale air",
+					},
+					west: {
+						shortName: "the flooded tunnel",
+						horizonPhrase: "disappears into still black water",
+					},
+				},
+				bindings: [
+					{
+						id: "useSpace-0",
+						type: "use_space",
+						space: {
+							id: "useSpace-0-space",
+							name: "Control Panel",
+							examineDescription:
+								"A panel with buttons and levers you can press.",
+							proximityFlavor: "The panel hums faintly.",
+							activationFlavor: "The panel lights up.",
+							satisfactionFlavor: "The panel fires a burst of light.",
+							postExamineDescription: "The panel is now active.",
+							postLookFlavor: "The panel glows.",
+						},
+					},
+				],
+				decoys: [
+					{
+						id: "decoy-0",
+						name: "Old Disc",
+						examineDescription: "A small tarnished disc.",
+						proximityFlavor: "The disc gleams.",
+						useOutcome: "Nothing.",
+					},
+					{
+						id: "decoy-1",
+						name: "Plain Coin",
+						examineDescription: "A coin from another era.",
+						proximityFlavor: "The coin catches light.",
+						useOutcome: "Nothing.",
+					},
+				],
+				obstacles: [
+					{
+						id: "obstacle-0",
+						name: "Rusted Gate",
+						examineDescription: "An old rusted gate blocking the path.",
+						shiftFlavor: "The gate grinds across the floor.",
+					},
+				],
+			},
+		};
+	}
+
+	it("includes the previous raw JSON as an assistant turn on the corrective retry", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: decoy with a forbidden use-cue keyword ("switch")
+		const brokenPack = buildValidCarryPack();
+		const packObj = (brokenPack as Record<string, unknown>).pack as Record<
+			string,
+			unknown
+		>;
+		const decoys = packObj.decoys as Record<string, unknown>[];
+		decoys[0]!.examineDescription =
+			"An old switch you might find in a forgotten panel.";
+		const brokenRaw = JSON.stringify(brokenPack);
+		mockChatFn.mockResolvedValueOnce({ content: brokenRaw, reasoning: null });
+
+		// Call 2: valid pack
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(buildValidCarryPack()),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		await provider.generateContentPacks(carryInput);
+
+		expect(mockChatFn).toHaveBeenCalledTimes(2);
+
+		const call2Messages = mockChatFn.mock.calls[1]?.[0]?.messages as
+			| Array<{ role: string; content: string }>
+			| undefined;
+		expect(call2Messages).toBeDefined();
+
+		const assistantTurn = call2Messages?.find((m) => m.role === "assistant");
+		expect(assistantTurn).toBeDefined();
+		expect(assistantTurn?.content).toBe(brokenRaw);
+
+		// Ordering: assistant turn precedes the corrective user turn
+		const assistantIdx =
+			call2Messages?.findIndex((m) => m.role === "assistant") ?? -1;
+		const correctiveIdx =
+			call2Messages?.findIndex((m) =>
+				m.content.includes("Your previous attempt failed validation"),
+			) ?? -1;
+		expect(assistantIdx).toBeGreaterThanOrEqual(0);
+		expect(correctiveIdx).toBeGreaterThan(assistantIdx);
+	});
+
+	it("names the offending keyword in the corrective feedback for a forbidden-use-cue decoy", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: decoy whose examineDescription contains "switch"
+		const brokenPack = buildValidCarryPack();
+		const packObj = (brokenPack as Record<string, unknown>).pack as Record<
+			string,
+			unknown
+		>;
+		const decoys = packObj.decoys as Record<string, unknown>[];
+		decoys[0]!.examineDescription =
+			"An old switch you might find in a forgotten panel.";
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(brokenPack),
+			reasoning: null,
+		});
+
+		// Call 2: valid pack
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(buildValidCarryPack()),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		await provider.generateContentPacks(carryInput);
+
+		const call2Messages = mockChatFn.mock.calls[1]?.[0]?.messages as
+			| Array<{ role: string; content: string }>
+			| undefined;
+		const correctionTurn = call2Messages?.find((m) =>
+			m.content.includes("Your previous attempt failed validation"),
+		);
+		expect(correctionTurn).toBeDefined();
+
+		// The corrective message names the specific offending keyword
+		expect(correctionTurn?.content).toMatch(/"switch"/);
+		// And targets the right decoy
+		expect(correctionTurn?.content).toMatch(/decoy-0/);
+	});
+
+	it("includes the use-cue keyword hint list for a missing-use-cue UseSpace error", async () => {
+		const mockChatFn = vi.fn();
+
+		// Call 1: use_space with examineDescription lacking any use-cue keyword
+		const brokenPack = buildValidUseSpacePack();
+		const packObj = (brokenPack as Record<string, unknown>).pack as Record<
+			string,
+			unknown
+		>;
+		const bindings = packObj.bindings as Record<string, unknown>[];
+		const space = bindings[0]!.space as Record<string, unknown>;
+		space.examineDescription = "A featureless surface set into the wall.";
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(brokenPack),
+			reasoning: null,
+		});
+
+		// Call 2: valid pack
+		mockChatFn.mockResolvedValueOnce({
+			content: JSON.stringify(buildValidUseSpacePack()),
+			reasoning: null,
+		});
+
+		const provider = new BrowserContentPackProvider({ chatFn: mockChatFn });
+		await provider.generateContentPacks(useSpaceInput);
+
+		const call2Messages = mockChatFn.mock.calls[1]?.[0]?.messages as
+			| Array<{ role: string; content: string }>
+			| undefined;
+		const correctionTurn = call2Messages?.find((m) =>
+			m.content.includes("Your previous attempt failed validation"),
+		);
+		expect(correctionTurn).toBeDefined();
+
+		// The corrective message enumerates several canonical use-cue keywords
+		// inline so the LLM doesn't have to recall them from the system prompt.
+		expect(correctionTurn?.content).toMatch(/"use"/);
+		expect(correctionTurn?.content).toMatch(/"activate"/);
+		expect(correctionTurn?.content).toMatch(/"press"/);
+		// And targets the use-space binding
+		expect(correctionTurn?.content).toMatch(/use-space binding/);
+	});
+});

--- a/src/spa/game/binding-aware-validator.ts
+++ b/src/spa/game/binding-aware-validator.ts
@@ -31,7 +31,11 @@ import type {
 	ValidationError,
 	ValidationResult,
 } from "./content-pack-provider.js";
-import { examineMentionsUseTell } from "./content-pack-provider.js";
+import {
+	examineMentionsUseTell,
+	findMatchedUseTellKeywords,
+	USE_CUE_KEYWORD_HINTS,
+} from "./content-pack-provider.js";
 
 // ── Use-cue keywords (re-export from content-pack-provider) ──────────────────
 
@@ -357,7 +361,7 @@ function validateUseSpaceBinding(
 				entityId: sk.spaceId!,
 				field: "examineDescription",
 				rule: "verb-of-activation",
-				message: `UseSpace space ${sk.spaceId}: examineDescription must contain a use-cue keyword`,
+				message: `UseSpace space ${sk.spaceId}: examineDescription must contain at least one use-cue keyword (e.g. ${USE_CUE_KEYWORD_HINTS.map((k) => `"${k}"`).join(", ")}). Current text: ${JSON.stringify(space.examineDescription)}`,
 				retryUnit: bindingRetryUnit,
 			});
 		}
@@ -410,7 +414,7 @@ function validateUseItemBinding(
 				entityId: sk.itemId!,
 				field: "examineDescription",
 				rule: "verb-of-activation",
-				message: `UseItem item ${sk.itemId}: examineDescription must contain a use-cue keyword`,
+				message: `UseItem item ${sk.itemId}: examineDescription must contain at least one use-cue keyword (e.g. ${USE_CUE_KEYWORD_HINTS.map((k) => `"${k}"`).join(", ")}). Current text: ${JSON.stringify(item.examineDescription)}`,
 				retryUnit: bindingRetryUnit,
 			});
 		}
@@ -542,12 +546,14 @@ function validateDecoy(
 		typeof decoy.examineDescription === "string" &&
 		decoy.examineDescription.length > 0
 	) {
-		if (examineMentionsUseTell(decoy.examineDescription)) {
+		const matched = findMatchedUseTellKeywords(decoy.examineDescription);
+		if (matched.length > 0) {
+			const matchedList = matched.map((k) => `"${k}"`).join(", ");
 			errors.push({
 				entityId,
 				field: "examineDescription",
 				rule: "verb-of-activation",
-				message: `Decoy ${entityId}: examineDescription must NOT contain a use-cue keyword`,
+				message: `Decoy ${entityId}: examineDescription must NOT contain any use-cue keyword — found forbidden keyword(s): ${matchedList}. Rewrite the examineDescription using only neutral descriptive language (no activation/control verbs, no control nouns like "lever"/"button"/"switch"/"dial").`,
 				retryUnit,
 			});
 		}

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -447,6 +447,51 @@ export function examineMentionsUseTell(examineDescription: string): boolean {
 }
 
 /**
+ * Returns the use-cue keywords that appear in `examineDescription`. Used by
+ * the corrective-feedback path so the LLM is told *which* word tripped the
+ * "must NOT contain a use-cue keyword" decoy rule, rather than having to
+ * guess from the system-prompt list.
+ */
+export function findMatchedUseTellKeywords(
+	examineDescription: string,
+): string[] {
+	const tokens = examineDescription.toLowerCase().match(/[a-z]+/g) ?? [];
+	if (tokens.length === 0) return [];
+	const tokenSet = new Set(tokens);
+	const matched: string[] = [];
+	for (const kw of USE_TELL_KEYWORDS) {
+		if (tokenSet.has(kw)) matched.push(kw);
+	}
+	return matched;
+}
+
+/**
+ * Canonical base use-cue keywords inlined in corrective feedback for the
+ * "must contain a use-cue keyword" rule. Subset of USE_TELL_KEYWORDS chosen
+ * to mirror the lists enumerated in CONTENT_PACK_SYSTEM_PROMPT.
+ */
+export const USE_CUE_KEYWORD_HINTS: readonly string[] = [
+	"use",
+	"activate",
+	"press",
+	"pull",
+	"turn",
+	"trigger",
+	"engage",
+	"operate",
+	"lever",
+	"button",
+	"switch",
+	"control",
+	"panel",
+	"console",
+	"dial",
+	"knob",
+	"interact",
+	"mechanism",
+];
+
+/**
  * Convergence prose-tell strategy (issue #336):
  *
  * Convergence objectives also need an AI-discoverable signal that the
@@ -1749,38 +1794,85 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((r) => setTimeout(r, ms));
 }
 
+type OuterChatMessage =
+	| { role: "system"; content: string }
+	| { role: "user"; content: string }
+	| { role: "assistant"; content: string };
+
 function buildOuterMessages(
 	systemPrompt: string,
 	userPrompt: string,
+	prevAssistant: string | null,
 	corrective: string | null,
-): Array<{ role: "system" | "user"; content: string }> {
-	const messages: Array<{ role: "system" | "user"; content: string }> = [
+): OuterChatMessage[] {
+	const messages: OuterChatMessage[] = [
 		{ role: "system", content: systemPrompt },
 		{ role: "user", content: userPrompt },
 	];
 
+	if (prevAssistant !== null) {
+		messages.push({ role: "assistant", content: prevAssistant });
+	}
+
 	if (corrective !== null) {
 		messages.push({
 			role: "user",
-			content: `Your previous attempt failed validation. Specific issues:\n${corrective}\n\nProduce a fully valid response.`,
+			content: `Your previous attempt failed validation. Specific issues:\n${corrective}\n\nProduce a fully valid response that addresses every issue above. Repair the previous JSON in-place where possible — keep entity IDs, structure, and any fields that already passed.`,
 		});
 	}
 
 	return messages;
 }
 
+function retryUnitLabel(unit: ValidationError["retryUnit"]): string {
+	switch (unit.kind) {
+		case "objective-pair":
+			return `objective pair ${unit.pairId}`;
+		case "interesting-object":
+			return `interesting object ${unit.entityId}`;
+		case "obstacle":
+			return `obstacle ${unit.entityId}`;
+		case "carry-binding":
+			return `carry binding ${unit.bindingId}`;
+		case "use-space-binding":
+			return `use-space binding ${unit.bindingId}`;
+		case "use-item-binding":
+			return `use-item binding ${unit.bindingId}`;
+		case "convergence-binding":
+			return `convergence binding ${unit.bindingId}`;
+		case "decoy":
+			return `decoy ${unit.decoyId}`;
+	}
+}
+
 function buildCorrectiveFeedback(errors: ValidationError[]): string {
-	const seen = new Set<string>();
-	const lines: string[] = [];
+	// Group by retryUnit so the LLM sees all rules for a given entity together
+	// rather than as a flat dedup'd list — easier to act on per-entity.
+	const groups = new Map<string, { label: string; messages: string[] }>();
+	const order: string[] = [];
 
 	for (const err of errors) {
-		if (!seen.has(err.message)) {
-			seen.add(err.message);
-			lines.push(err.message);
+		const key = JSON.stringify(err.retryUnit);
+		let group = groups.get(key);
+		if (!group) {
+			group = { label: retryUnitLabel(err.retryUnit), messages: [] };
+			groups.set(key, group);
+			order.push(key);
+		}
+		if (!group.messages.includes(err.message)) {
+			group.messages.push(err.message);
 		}
 	}
 
-	return lines.join("\n");
+	const sections: string[] = [];
+	for (const key of order) {
+		const group = groups.get(key);
+		if (!group) continue;
+		const bullets = group.messages.map((m) => `  - ${m}`).join("\n");
+		sections.push(`For ${group.label}:\n${bullets}`);
+	}
+
+	return sections.join("\n");
 }
 
 // ── BrowserContentPackProvider ────────────────────────────────────────────────
@@ -1800,9 +1892,9 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 	}
 
 	private async callAndParse(
-		messages: Array<{ role: "system" | "user"; content: string }>,
+		messages: OuterChatMessage[],
 		label: string,
-	): Promise<unknown> {
+	): Promise<{ parsed: unknown; raw: string }> {
 		const { content, reasoning } = await this.chatFn({
 			messages,
 			disableReasoning: this.disableReasoning,
@@ -1822,7 +1914,7 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 			throw new ContentPackError(`${label} JSON parse failed: ${raw}`);
 		}
 
-		return parsed;
+		return { parsed, raw };
 	}
 
 	async generateContentPacks(
@@ -1845,17 +1937,20 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 
 		const systemPrompt = CONTENT_PACK_SYSTEM_PROMPT;
 		let correctiveFeedback: string | null = null;
+		let prevAssistantRaw: string | null = null;
 
 		for (let outer = 0; outer < OUTER_BUDGET; outer++) {
-			let rawJson: unknown;
-
 			try {
 				const messages = buildOuterMessages(
 					systemPrompt,
 					baseUserPrompt,
+					prevAssistantRaw,
 					correctiveFeedback,
 				);
-				rawJson = await this.callAndParse(messages, "content-pack");
+				const { parsed: rawJson, raw } = await this.callAndParse(
+					messages,
+					"content-pack",
+				);
 				const validationResult = validateBoundContentPack(rawJson, schedule);
 				if (validationResult.ok) {
 					return {
@@ -1868,6 +1963,7 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 					};
 				}
 				correctiveFeedback = buildCorrectiveFeedback(validationResult.errors);
+				prevAssistantRaw = raw;
 			} catch (err) {
 				if (err instanceof CapHitError) throw err;
 				if (outer === OUTER_BUDGET - 1) throw err;
@@ -1876,6 +1972,7 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 					await sleep(backoffMs);
 				}
 				correctiveFeedback = null;
+				prevAssistantRaw = null;
 			}
 		}
 
@@ -1907,17 +2004,20 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 
 		const systemPrompt = DUAL_CONTENT_PACK_SYSTEM_PROMPT;
 		let correctiveFeedback: string | null = null;
+		let prevAssistantRaw: string | null = null;
 
 		for (let outer = 0; outer < OUTER_BUDGET; outer++) {
-			let rawJson: unknown;
-
 			try {
 				const messages = buildOuterMessages(
 					systemPrompt,
 					baseUserPrompt,
+					prevAssistantRaw,
 					correctiveFeedback,
 				);
-				rawJson = await this.callAndParse(messages, "dual content-pack");
+				const { parsed: rawJson, raw } = await this.callAndParse(
+					messages,
+					"dual content-pack",
+				);
 				const validationResult = validateBoundDualContentPack(
 					rawJson,
 					schedule,
@@ -1937,6 +2037,7 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 					};
 				}
 				correctiveFeedback = buildCorrectiveFeedback(validationResult.errors);
+				prevAssistantRaw = raw;
 			} catch (err) {
 				if (err instanceof CapHitError) throw err;
 				if (outer === OUTER_BUDGET - 1) throw err;
@@ -1945,6 +2046,7 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 					await sleep(backoffMs);
 				}
 				correctiveFeedback = null;
+				prevAssistantRaw = null;
 			}
 		}
 


### PR DESCRIPTION
## Summary
This PR enhances the corrective feedback mechanism for content pack generation by including the previous LLM response in retry attempts and providing more detailed, entity-specific error messages. This helps the LLM understand exactly what failed and how to fix it.

## Key Changes

- **Include previous assistant response in retries**: When validation fails and a corrective retry is triggered, the previous raw JSON response is now included as an assistant turn in the message history. This gives the LLM full context of what it generated and what needs to be fixed.

- **Group errors by entity**: Corrective feedback is now organized by retry unit (binding, decoy, obstacle, etc.) rather than as a flat deduplicated list. This makes it easier for the LLM to understand which rules apply to which entities.

- **Inline use-cue keyword hints**: For "missing use-cue keyword" validation errors, the corrective feedback now includes a curated list of canonical keywords (e.g., "use", "activate", "press", "button", "switch") directly in the error message. This eliminates the need for the LLM to recall the full list from the system prompt.

- **Identify specific forbidden keywords**: For decoys that violate the "must NOT contain use-cue keywords" rule, the feedback now identifies which specific keyword(s) triggered the violation (e.g., "switch" in the examine description).

- **Enhanced repair instructions**: The corrective user message now explicitly instructs the LLM to "repair the previous JSON in-place where possible — keep entity IDs, structure, and any fields that already passed," encouraging incremental fixes rather than wholesale regeneration.

## Implementation Details

- Added `findMatchedUseTellKeywords()` function to identify which forbidden keywords appear in a given text
- Added `USE_CUE_KEYWORD_HINTS` constant with a curated subset of use-cue keywords for inline feedback
- Added `retryUnitLabel()` function to generate human-readable labels for validation error retry units
- Modified `buildOuterMessages()` to accept and include `prevAssistant` parameter in the message chain
- Refactored `buildCorrectiveFeedback()` to group errors by retry unit and generate more detailed, contextual messages
- Updated `callAndParse()` to return both parsed JSON and raw string for use in retry loops
- Updated both `generateContentPacks()` and `generateDualContentPacks()` to track and pass previous assistant responses through retry loops

## Tests
Added comprehensive test suite covering:
- Verification that previous raw JSON is included as an assistant turn on corrective retries
- Verification that specific forbidden keywords are named in corrective feedback
- Verification that use-cue keyword hints are included for missing-keyword errors

https://claude.ai/code/session_01QhxzdD8mp3H8R9w9sXFq8D