### PR TITLE
Add boundSpaces to game world entities during initialization

### DIFF
--- a/src/spa/game/__tests__/engine.test.ts
+++ b/src/spa/game/__tests__/engine.test.ts
@@ -76,6 +76,44 @@ describe("advanceRound", () => {
 	});
 });
 
+describe("startGame world.entities", () => {
+	it("places use_space and convergence bound spaces on the grid", () => {
+		const packWithBoundSpaces: ContentPack = {
+			...TEST_CONTENT_PACK,
+			boundSpaces: [
+				{
+					id: "useSpace-0-space",
+					kind: "objective_space",
+					name: "cracked pedestal",
+					examineDescription: "",
+					holder: { row: 1, col: 1 },
+				},
+				{
+					id: "useSpace-1-space",
+					kind: "objective_space",
+					name: "rusted lever",
+					examineDescription: "",
+					holder: { row: 2, col: 2 },
+				},
+				{
+					id: "convergence-2-space",
+					kind: "objective_space",
+					name: "central tile",
+					examineDescription: "",
+					holder: { row: 3, col: 3 },
+				},
+			],
+		};
+		const game = startGame(TEST_PERSONAS, packWithBoundSpaces, {
+			budgetPerAi: 5,
+		});
+		const ids = game.world.entities.map((e) => e.id);
+		expect(ids).toContain("useSpace-0-space");
+		expect(ids).toContain("useSpace-1-space");
+		expect(ids).toContain("convergence-2-space");
+	});
+});
+
 describe("budget and lockout", () => {
 	it("reports an AI as not locked out when budget remains", () => {
 		const game = startGame(TEST_PERSONAS, TEST_CONTENT_PACK, {

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -69,6 +69,7 @@ export function startGame(
 	// Build WorldState from pack entities (all entities flat)
 	const worldEntities = [
 		...contentPack.objectivePairs.flatMap((pair) => [pair.object, pair.space]),
+		...(contentPack.boundSpaces ?? []),
 		...contentPack.interestingObjects,
 		...contentPack.obstacles,
 	];
@@ -189,6 +190,7 @@ function reprojectEntitiesOnto(
 		byId.set(pair.object.id, pair.object);
 		byId.set(pair.space.id, pair.space);
 	}
+	for (const space of bPack.boundSpaces ?? []) byId.set(space.id, space);
 	for (const obj of bPack.interestingObjects) byId.set(obj.id, obj);
 	for (const obs of bPack.obstacles) byId.set(obs.id, obs);
 


### PR DESCRIPTION
## Summary
This change ensures that bound spaces defined in a content pack are properly included in the game world's entity list when a game is started.

## Key Changes
- **startGame function**: Added `boundSpaces` from the content pack to the `worldEntities` array during world initialization
- **reprojectEntitiesOnto function**: Added iteration over `boundSpaces` to populate the entity lookup map, ensuring bound spaces are accessible during entity reprojection
- **Test coverage**: Added comprehensive test case verifying that use_space and convergence bound spaces are correctly placed on the grid and included in `world.entities`

## Implementation Details
The changes follow the existing pattern used for other entity types (objectivePairs, interestingObjects, obstacles) by:
1. Spreading bound spaces into the world entities array during game initialization
2. Populating the entity lookup map with bound space IDs during reprojection
3. Using optional chaining (`??`) to safely handle cases where boundSpaces may not be defined in the content pack

https://claude.ai/code/session_011AzKQ1Hcrm89GXbMGgeS1p