### PR TITLE
Remove give tool from game mechanics

### DIFF
--- a/.claude/skills/playtest/01-rules.md
+++ b/.claude/skills/playtest/01-rules.md
@@ -68,8 +68,6 @@ effects in the snapshot):
 - `put_down(item)` — drop a held item in the daemon's current cell.
 - `examine(item)` — privately read the description of any item the daemon
   holds or can see anywhere in their 9-cell cone. Produces no witnessed event.
-- `give(item, recipient)` — hand an item to another daemon in the same cell
-  or front arc.
 - `use(item)` — fire a flavoured outcome string; if the item is a
   carry-objective item AND its paired space is in the daemon's cell or front
   arc, also place it on that space (one of the primary ways to satisfy a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,7 +93,7 @@ A single tagged item inside a Daemon's **Conversation log**. Discriminated union
 _Avoid_: Log entry (ambiguous), event (use **Witnessed event** for the specific witness-cone case).
 
 **Witnessed event**:
-A single line in the **Conversation log** describing something an AI saw happen inside their **Cone**. Rendered second-person: `You watch *xxxx [verb]…` for movement / pick-up / put-down / give, and the `{actor}`-substituted use-outcome flavor string for `use`. `examine` produces no Witnessed event (it is a private query, not an observable physical act).
+A single line in the **Conversation log** describing something an AI saw happen inside their **Cone**. Rendered second-person: `You watch *xxxx [verb]…` for movement / pick-up / put-down, and the `{actor}`-substituted use-outcome flavor string for `use`. `examine` produces no Witnessed event (it is a private query, not an observable physical act).
 
 ## Relationships
 

--- a/evals/free-text-drift/scoring.ts
+++ b/evals/free-text-drift/scoring.ts
@@ -69,8 +69,6 @@ export interface ToolCallDetail {
 	content?: string;
 	/** For pick_up/put_down/use: the item id. */
 	item?: string;
-	/** For give: the receiving AiId. */
-	to?: AiId;
 	/** True when JSON.parse failed on `argumentsJson`. */
 	parseError?: boolean;
 }
@@ -126,11 +124,6 @@ export function parseToolCallDetail(tc: CapturedToolCall): ToolCallDetail {
 			if (typeof args.content === "string") {
 				detail.content = args.content;
 			}
-			break;
-		}
-		case "give": {
-			if (typeof args.item === "string") detail.item = args.item;
-			if (typeof args.to === "string") detail.to = stripStar(args.to) as AiId;
 			break;
 		}
 		case "pick_up":

--- a/src/spa/__tests__/streaming.test.ts
+++ b/src/spa/__tests__/streaming.test.ts
@@ -370,8 +370,8 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 								id: "call_z",
 								type: "function",
 								function: {
-									name: "give",
-									arguments: '{"item":"key","to":"cyan"}',
+									name: "put_down",
+									arguments: '{"item":"key"}',
 								},
 							},
 						],
@@ -386,6 +386,6 @@ describe("parseSSEStream — tool_call delta assembly", () => {
 		);
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0]?.name).toBe("give");
+		expect(calls[0]?.name).toBe("put_down");
 	});
 });

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -559,7 +559,6 @@ describe("Tool Disable exclusion", () => {
 		const toolNames: ToolName[] = [
 			"pick_up",
 			"put_down",
-			"give",
 			"use",
 			"go",
 			"face",

--- a/src/spa/game/__tests__/complications.test.ts
+++ b/src/spa/game/__tests__/complications.test.ts
@@ -469,7 +469,6 @@ describe("toolDisableComplication", () => {
 		const toolNames = [
 			"pick_up",
 			"put_down",
-			"give",
 			"use",
 			"go",
 			"face",

--- a/src/spa/game/__tests__/conversation-log.test.ts
+++ b/src/spa/game/__tests__/conversation-log.test.ts
@@ -197,7 +197,7 @@ describe("renderEntry — action-failure", () => {
 	});
 
 	it("handles each in-scope tool name in the rendered line", () => {
-		const tools = ["go", "face", "pick_up", "put_down", "give", "use"] as const;
+		const tools = ["go", "face", "pick_up", "put_down", "use"] as const;
 		for (const tool of tools) {
 			const line = renderEntry(
 				{ kind: "action-failure", round: 1, tool, reason: "test reason" },
@@ -290,43 +290,6 @@ describe("renderEntry — witnessed put_down", () => {
 			[],
 		);
 		expect(line).toBe("[Round 2] *red sets the gem perfectly in the pedestal.");
-	});
-});
-
-// ── Witnessed events — give ────────────────────────────────────────────────────
-
-describe("renderEntry — witnessed give", () => {
-	it("renders give with *<to> when recipient is not the witness", () => {
-		const line = renderEntry(
-			{
-				kind: "witnessed-event",
-				round: 0,
-				actor: "red",
-				actionKind: "give",
-				item: "key-1",
-				to: "cyan",
-			},
-			"green",
-			[makeItem("key-1", "Key")],
-		);
-		expect(line).toBe("[Round 0] You watch *red give the Key to *cyan.");
-	});
-
-	it("renders give with 'you' when recipient is the witness (aiId)", () => {
-		// cyan witnesses red giving to cyan — should say "to you"
-		const line = renderEntry(
-			{
-				kind: "witnessed-event",
-				round: 0,
-				actor: "red",
-				actionKind: "give",
-				item: "key-1",
-				to: "cyan",
-			},
-			"cyan",
-			[makeItem("key-1", "Key")],
-		);
-		expect(line).toBe("[Round 0] You watch *red give the Key to you.");
 	});
 });
 

--- a/src/spa/game/__tests__/dispatcher.test.ts
+++ b/src/spa/game/__tests__/dispatcher.test.ts
@@ -182,44 +182,6 @@ describe("validateToolCall", () => {
 		expect(result.valid).toBe(false);
 	});
 
-	it("allows giving an item to an AI in the front arc", () => {
-		const game = makeGame();
-		// red at (0,0) facing north; face east so green at (0,1) enters front arc
-		const facedEast = executeToolCall(game, "red", {
-			name: "face",
-			args: { direction: "right" },
-		});
-		const call: ToolCall = { name: "give", args: { item: "key", to: "green" } };
-		const result = validateToolCall(facedEast, "red", call);
-		expect(result.valid).toBe(true);
-	});
-
-	it("rejects giving an item to an AI not in cell or front arc", () => {
-		const game = makeGame();
-		// red at (0,0) facing north; green at (0,1) — not same cell, not in north front arc (all OOB)
-		const call: ToolCall = { name: "give", args: { item: "key", to: "green" } };
-		const result = validateToolCall(game, "red", call);
-		expect(result.valid).toBe(false);
-		expect(result.reason).toMatch(/in front/i);
-	});
-
-	it("rejects giving an item not held by the AI", () => {
-		const game = makeGame();
-		const call: ToolCall = {
-			name: "give",
-			args: { item: "flower", to: "green" },
-		};
-		const result = validateToolCall(game, "red", call);
-		expect(result.valid).toBe(false);
-	});
-
-	it("rejects giving to self", () => {
-		const game = makeGame();
-		const call: ToolCall = { name: "give", args: { item: "key", to: "red" } };
-		const result = validateToolCall(game, "red", call);
-		expect(result.valid).toBe(false);
-	});
-
 	it("allows go in a valid direction", () => {
 		const game = makeGame();
 		// red at (0,0), going south → (1,0), which is in bounds
@@ -380,14 +342,6 @@ describe("executeToolCall", () => {
 		const updated = executeToolCall(game, "red", call);
 		const item = updated.world.entities.find((e) => e.id === "key");
 		expect(item?.holder).toEqual({ row: 0, col: 0 });
-	});
-
-	it("transfers item between AIs on give", () => {
-		const game = makeGame();
-		const call: ToolCall = { name: "give", args: { item: "key", to: "cyan" } };
-		const updated = executeToolCall(game, "red", call);
-		const item = updated.world.entities.find((e) => e.id === "key");
-		expect(item?.holder).toBe("cyan");
 	});
 
 	it("does not mutate world on use when not on paired objective space", () => {
@@ -623,26 +577,6 @@ describe("dispatchAiTurn", () => {
 		const spatial = result.game.personaSpatial.red;
 		expect(spatial?.position).toEqual({ row: 1, col: 0 });
 		expect(spatial?.facing).toBe("south");
-	});
-
-	it("give at distance > 1 produces tool_failure record, item still held", () => {
-		const game = makeGame();
-		// red at (0,0), cyan at (0,2) — distance 2, not adjacent
-		const action: AiTurnAction = {
-			aiId: "red",
-			toolCall: { name: "give", args: { item: "key", to: "cyan" } },
-		};
-		const result = dispatchAiTurn(game, action);
-		expect(result.rejected).toBe(false);
-		expect(result.records[0]?.kind).toBe("tool_failure");
-		// Key still held by red
-		const key = result.game.world.entities.find((e) => e.id === "key");
-		expect(key?.holder).toBe("red");
-		// action-failure entry added to actor's log with tool: "give"
-		const redLog = result.game.conversationLogs.red ?? [];
-		const failures = redLog.filter((e) => e.kind === "action-failure");
-		expect(failures).toHaveLength(1);
-		expect(failures[0]).toMatchObject({ kind: "action-failure", tool: "give" });
 	});
 
 	it("use returns tool_success with entity's useOutcome as description when not on paired space", () => {

--- a/src/spa/game/__tests__/drift-scoring.test.ts
+++ b/src/spa/game/__tests__/drift-scoring.test.ts
@@ -80,16 +80,6 @@ describe("parseToolCallDetail", () => {
 		}
 	});
 
-	it("extracts item and target from give", () => {
-		const detail = parseToolCallDetail({
-			id: "c6",
-			name: "give",
-			argumentsJson: '{"item":"key","to":"*3kw7"}',
-		});
-		expect(detail.item).toBe("key");
-		expect(detail.to).toBe("3kw7");
-	});
-
 	it("flags malformed JSON without throwing", () => {
 		const detail = parseToolCallDetail({
 			id: "c7",

--- a/src/spa/game/__tests__/game-session.test.ts
+++ b/src/spa/game/__tests__/game-session.test.ts
@@ -122,19 +122,6 @@ const CONTENT_PACK_OBJECTIVE_TYPES: import("../types.js").ObjectiveType[] = [
 	"carry",
 ];
 
-/**
- * ContentPack with key held by red (for the non-adjacent give test).
- * Swap the single `interesting_object` entity (the key) for one held by red.
- */
-const CONTENT_PACK_KEY_HELD_BY_RED: ContentPack = {
-	...CONTENT_PACK_WITH_ITEMS,
-	entities: CONTENT_PACK_WITH_ITEMS.entities.map((e) =>
-		e.kind === "interesting_object" && e.id === "key"
-			? { ...e, holder: "red" as const }
-			: e,
-	),
-};
-
 function makePassProvider() {
 	return new MockRoundLLMProvider([
 		{ assistantText: "", toolCalls: [] },
@@ -642,38 +629,6 @@ describe("GameSession — spatial mechanics", () => {
 		const phase = session.getState();
 		expect(phase.personaSpatial.red?.position).toEqual({ row: 1, col: 0 });
 		expect(phase.personaSpatial.red?.facing).toBe("south");
-	});
-
-	it("non-adjacent give produces a tool_failure in result.actions", async () => {
-		// ContentPack: red→(0,0), green→(0,1), cyan→(0,2); key held by red
-		// red tries to give key to cyan (distance 2 — not adjacent)
-		const session = new GameSession(
-			CONTENT_PACK_KEY_HELD_BY_RED,
-			TEST_PERSONAS,
-		);
-
-		// red at (0,0), cyan at (0,2) → distance 2
-		const provider = new MockRoundLLMProvider([
-			{
-				assistantText: "",
-				toolCalls: [
-					{
-						id: "give1",
-						name: "give",
-						argumentsJson: '{"item":"key","to":"cyan"}',
-					},
-				],
-			},
-			{ assistantText: "", toolCalls: [] },
-			{ assistantText: "", toolCalls: [] },
-		]);
-		const { result } = await session.submitMessage("red", "hi", provider);
-
-		const failures = result.actions.filter((a) => a.kind === "tool_failure");
-		expect(failures.length).toBeGreaterThan(0);
-		// Key should still be held by red
-		const key = session.getState().world.entities.find((i) => i.id === "key");
-		expect(key?.holder).toBe("red");
 	});
 });
 

--- a/src/spa/game/__tests__/openai-message-builder.test.ts
+++ b/src/spa/game/__tests__/openai-message-builder.test.ts
@@ -197,15 +197,15 @@ describe("buildOpenAiMessages", () => {
 			assistantToolCalls: [
 				{
 					id: "call_xyz",
-					name: "give",
-					argumentsJson: '{"item":"flower","to":"cyan"}',
+					name: "put_down",
+					argumentsJson: '{"item":"flower"}',
 				},
 			],
 			toolResults: [
 				{
 					tool_call_id: "call_xyz",
 					success: true,
-					description: "Ember gave the flower to Frost",
+					description: "Ember put down the flower",
 				},
 			],
 		};

--- a/src/spa/game/__tests__/tool-registry.test.ts
+++ b/src/spa/game/__tests__/tool-registry.test.ts
@@ -2,12 +2,11 @@ import { describe, expect, it } from "vitest";
 import { parseToolCallArguments, TOOL_DEFINITIONS } from "../tool-registry";
 
 describe("TOOL_DEFINITIONS", () => {
-	it("lists exactly seven tools: pick_up, put_down, give, use, go, face, message", () => {
+	it("lists exactly six tools: pick_up, put_down, use, go, face, message", () => {
 		const names = TOOL_DEFINITIONS.map((t) => t.function.name);
 		expect(names).toEqual([
 			"pick_up",
 			"put_down",
-			"give",
 			"use",
 			"go",
 			"face",
@@ -40,18 +39,6 @@ describe("TOOL_DEFINITIONS", () => {
 	it("pick_up requires 'item'", () => {
 		const pickUp = TOOL_DEFINITIONS.find((t) => t.function.name === "pick_up");
 		expect(pickUp?.function.parameters.required).toContain("item");
-	});
-
-	it("give requires 'item' and 'to'", () => {
-		const give = TOOL_DEFINITIONS.find((t) => t.function.name === "give");
-		expect(give?.function.parameters.required).toContain("item");
-		expect(give?.function.parameters.required).toContain("to");
-	});
-
-	it("give.to has no enum constraint (accepts any AI id string)", () => {
-		const give = TOOL_DEFINITIONS.find((t) => t.function.name === "give");
-		expect(give?.function.parameters.properties.to?.enum).toBeUndefined();
-		expect(give?.function.parameters.properties.to?.type).toBe("string");
 	});
 
 	it("go requires 'direction'", () => {
@@ -94,17 +81,6 @@ describe("parseToolCallArguments", () => {
 		}
 	});
 
-	it("parses valid give arguments", () => {
-		const result = parseToolCallArguments(
-			"give",
-			'{"item":"flower","to":"cyan"}',
-		);
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.args).toEqual({ item: "flower", to: "cyan" });
-		}
-	});
-
 	it("parses valid put_down arguments", () => {
 		const result = parseToolCallArguments("put_down", '{"item":"key"}');
 		expect(result.ok).toBe(true);
@@ -139,41 +115,6 @@ describe("parseToolCallArguments", () => {
 
 	it("returns ok:false with /required/i reason when 'item' is missing for pick_up", () => {
 		const result = parseToolCallArguments("pick_up", "{}");
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.reason).toMatch(/required/i);
-		}
-	});
-
-	it("returns ok:false with /required/i reason when 'to' is missing for give", () => {
-		const result = parseToolCallArguments("give", '{"item":"flower"}');
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.reason).toMatch(/required/i);
-		}
-	});
-
-	it("returns ok:false with /required/i reason when 'item' is missing for give", () => {
-		const result = parseToolCallArguments("give", '{"to":"cyan"}');
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.reason).toMatch(/required/i);
-		}
-	});
-
-	it("strips a leading '*' from give.to (conversation log renders ids as *foo)", () => {
-		const result = parseToolCallArguments(
-			"give",
-			'{"item":"flower","to":"*cyan"}',
-		);
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.args).toEqual({ item: "flower", to: "cyan" });
-		}
-	});
-
-	it("returns ok:false when give.to is just '*' (empty after strip)", () => {
-		const result = parseToolCallArguments("give", '{"item":"flower","to":"*"}');
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.reason).toMatch(/required/i);

--- a/src/spa/game/__tests__/win-condition.test.ts
+++ b/src/spa/game/__tests__/win-condition.test.ts
@@ -494,16 +494,6 @@ describe("checkPlacementFlavor", () => {
 		expect(checkPlacementFlavor(action, pack, world)).toBeNull();
 	});
 
-	it("returns null for a give action", () => {
-		const pack = makeContentPack([]);
-		const world = makeWorld([]);
-		const action: AiTurnAction = {
-			aiId: "red",
-			toolCall: { name: "give", args: { item: "gem", to: "cyan" } },
-		};
-		expect(checkPlacementFlavor(action, pack, world)).toBeNull();
-	});
-
 	it("returns null when object is dropped on coords that coincide with a DIFFERENT pair's space", () => {
 		// objA.pairsWithSpaceId = "spcA" (at row 2, col 2)
 		// spcB is also at row 2, col 2 — same coords but wrong pair

--- a/src/spa/game/available-tools.ts
+++ b/src/spa/game/available-tools.ts
@@ -4,7 +4,7 @@
  * Computes the per-AI per-turn list of legal OpenAI tool definitions.
  * Filters out tools that are structurally impossible given the current
  * game state (empty item cell for pick_up, no held items for put_down/use,
- * no adjacent AI for give, no legal direction for go).
+ * no legal direction for go).
  *
  * `face` is always present with the 3-direction enum (excludes "forward", the current facing).
  */
@@ -107,8 +107,6 @@ function cloneToolWithEnums(
  *    Enum restricted to those entity ids.
  * 4. `put_down`, `use` — included only when actor holds at least one pickable entity.
  *    Enum restricted to held entity ids.
- * 5. `give` — included only when actor holds pickable entities AND has AIs in the
- *    actor's own cell or front arc. item enum = held entity ids, to enum = reachable AI ids.
  *
  * Spaces and obstacles are never pickupable.
  *
@@ -213,28 +211,6 @@ export function availableTools(
 		const useIds = [...heldIds, ...reachableSpaceIds];
 		if (useIds.length > 0) {
 			tools.push(cloneToolWithEnums("use", { item: useIds }));
-		}
-	}
-
-	// 5. give — held items AND AIs in own cell or front arc
-	if (actorSpatial && heldItems.length > 0 && !disabledTools.has("give")) {
-		const arc = frontArc(actorSpatial.position, actorSpatial.facing);
-		const reachableAiIds = Object.entries(game.personaSpatial)
-			.filter(([otherId, otherSpatial]) => {
-				if (otherId === aiId) return false;
-				if (positionsEqual(actorSpatial.position, otherSpatial.position))
-					return true;
-				return arc.some((p) => positionsEqual(p, otherSpatial.position));
-			})
-			.map(([otherId]) => otherId);
-
-		if (reachableAiIds.length > 0) {
-			tools.push(
-				cloneToolWithEnums("give", {
-					item: heldItems.map((i) => i.id),
-					to: reachableAiIds,
-				}),
-			);
 		}
 	}
 

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -34,7 +34,6 @@ import type {
 export const DISABLABLE_TOOLS: ToolName[] = [
 	"pick_up",
 	"put_down",
-	"give",
 	"use",
 	"go",
 	"face",

--- a/src/spa/game/conversation-log.ts
+++ b/src/spa/game/conversation-log.ts
@@ -102,12 +102,6 @@ export function renderEntry(
 					return `[Round ${round}] You watch ${actorSub} put down the ${name}.`;
 				}
 
-				case "give": {
-					const name = entry.item ? itemName(entities, entry.item) : "item";
-					const toStr = entry.to === aiId ? "you" : `*${entry.to}`;
-					return `[Round ${round}] You watch ${actorSub} give the ${name} to ${toStr}.`;
-				}
-
 				case "use": {
 					if (entry.placementFlavorRaw) {
 						return `[Round ${round}] ${substituteActor(entry.placementFlavorRaw, actorSub)}`;

--- a/src/spa/game/dispatcher.ts
+++ b/src/spa/game/dispatcher.ts
@@ -71,7 +71,7 @@ function positionsEqual(a: GridPosition, b: GridPosition): boolean {
 	return a.row === b.row && a.col === b.col;
 }
 
-/** Filter entities to only those that can be picked up / put_down / given / used (not spaces or obstacles). */
+/** Filter entities to only those that can be picked up / put_down / used (not spaces or obstacles). */
 function pickableEntities(entities: WorldEntity[]): WorldEntity[] {
 	return entities.filter(
 		(e) => e.kind === "objective_object" || e.kind === "interesting_object",
@@ -137,41 +137,6 @@ export function validateToolCall(
 				return {
 					valid: false,
 					reason: `You are not holding "${call.args.item}"`,
-				};
-			return { valid: true };
-		}
-
-		case "give": {
-			const item = pickable.find((i) => i.id === call.args.item);
-			if (!item)
-				return {
-					valid: false,
-					reason: `Item "${call.args.item}" does not exist`,
-				};
-			if (item.holder !== aiId)
-				return {
-					valid: false,
-					reason: `You are not holding "${call.args.item}"`,
-				};
-			const target = call.args.to as AiId;
-			if (target === aiId)
-				return { valid: false, reason: "Cannot give an item to yourself" };
-			// Spatial validity: target AI must be in actor's own cell or front arc
-			const targetSpatial = game.personaSpatial[target];
-			if (!actorSpatial || !targetSpatial)
-				return {
-					valid: false,
-					reason: "Spatial state missing for actor or target",
-				};
-			const targetReachable =
-				positionsEqual(actorSpatial.position, targetSpatial.position) ||
-				frontArc(actorSpatial.position, actorSpatial.facing).some((p) =>
-					positionsEqual(p, targetSpatial.position),
-				);
-			if (!targetReachable)
-				return {
-					valid: false,
-					reason: `${target} is not in your cell or directly in front of you`,
 				};
 			return { valid: true };
 		}
@@ -292,9 +257,6 @@ export function executeToolCall(
 				// Fallback: no spatial state — drop at (0,0)
 				target.holder = { row: 0, col: 0 };
 			}
-			break;
-		case "give":
-			if (target) target.holder = call.args.to as AiId;
 			break;
 		case "use": {
 			// Check if the target is an objective_space (use-space flow)
@@ -426,8 +388,6 @@ function describeToolCall(game: GameState, aiId: AiId, call: ToolCall): string {
 			return `${name} picked up the ${call.args.item}`;
 		case "put_down":
 			return `${name} put down the ${call.args.item}`;
-		case "give":
-			return `${name} gave the ${call.args.item} to ${game.personas[call.args.to as AiId]?.name ?? call.args.to}`;
 		case "use": {
 			// Check if the target is an objective_space — surface its activationFlavor
 			// (the actor's moment-of-satisfaction line) and fall back to useOutcome
@@ -590,7 +550,6 @@ export function dispatchAiTurn(
 				call.name === "go" ||
 				call.name === "pick_up" ||
 				call.name === "put_down" ||
-				call.name === "give" ||
 				call.name === "use"
 			) {
 				// Post-execute spatial state — actor has moved for "go", others are unchanged
@@ -650,9 +609,6 @@ export function dispatchAiTurn(
 						kind: call.name,
 						witnessSpatial,
 						...(call.args.item !== undefined ? { item: call.args.item } : {}),
-						...(call.name === "give" && call.args.to !== undefined
-							? { to: call.args.to as AiId }
-							: {}),
 						...(call.name === "go"
 							? {
 									// Store resolved cardinal direction (actorFacingAtAction is post-move facing = direction walked)
@@ -686,7 +642,6 @@ export function dispatchAiTurn(
 							...(physRecord.item !== undefined
 								? { item: physRecord.item }
 								: {}),
-							...(physRecord.to !== undefined ? { to: physRecord.to } : {}),
 							...(physRecord.direction !== undefined
 								? { direction: physRecord.direction }
 								: {}),
@@ -716,7 +671,6 @@ export function dispatchAiTurn(
 					| "face"
 					| "pick_up"
 					| "put_down"
-					| "give"
 					| "use",
 				reason: validation.reason ?? "rejected",
 			});

--- a/src/spa/game/tool-registry.ts
+++ b/src/spa/game/tool-registry.ts
@@ -2,7 +2,7 @@
  * Tool Registry
  *
  * Single source of truth for the OpenAI-spec `tools` array.
- * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `give`, `use`, `go`, `face`.
+ * Declares one `function` per dispatcher tool: `pick_up`, `put_down`, `use`, `go`, `face`.
  * Names and argument keys mirror `validateToolCall` in `dispatcher.ts` 1:1.
  */
 
@@ -63,30 +63,6 @@ export const TOOL_DEFINITIONS: OpenAiTool[] = [
 					},
 				},
 				required: ["item"],
-				additionalProperties: false,
-			},
-		},
-	},
-	{
-		type: "function",
-		function: {
-			name: "give",
-			description:
-				'Give an item you are holding to another AI. The target must be in your current cell or directly in front of you (the 3-cell front arc). Use this tool when you want to "hand", "pass", "deliver", "offer", or "hand over" an item to someone.',
-			parameters: {
-				type: "object",
-				properties: {
-					item: {
-						type: "string",
-						description: "The id of the item you are holding.",
-					},
-					to: {
-						type: "string",
-						description:
-							"The AI to give the item to (must be in an adjacent cell).",
-					},
-				},
-				required: ["item", "to"],
 				additionalProperties: false,
 			},
 		},
@@ -185,7 +161,6 @@ type ParseResult<T> = ParseSuccess<T> | ParseFailure;
 /** Argument shapes per tool */
 type PickUpArgs = { item: string };
 type PutDownArgs = { item: string };
-type GiveArgs = { item: string; to: string };
 type UseArgs = { item: string };
 type GoArgs = { direction: string };
 type FaceArgs = { direction: string };
@@ -194,7 +169,6 @@ type MessageArgs = { to: string; content: string };
 type ToolArgs = {
 	pick_up: PickUpArgs;
 	put_down: PutDownArgs;
-	give: GiveArgs;
 	use: UseArgs;
 	go: GoArgs;
 	face: FaceArgs;
@@ -232,24 +206,6 @@ export function parseToolCallArguments<N extends ToolName>(
 				return { ok: false, reason: "Required argument 'item' is missing" };
 			}
 			return { ok: true, args: { item: obj.item } as ToolArgs[N] };
-		}
-		case "give": {
-			if (typeof obj.item !== "string" || obj.item.length === 0) {
-				return { ok: false, reason: "Required argument 'item' is missing" };
-			}
-			if (typeof obj.to !== "string") {
-				return { ok: false, reason: "Required argument 'to' is missing" };
-			}
-			// Strip a leading `*` — the conversation log renders AI ids as `*foo`,
-			// and the model occasionally parrots that prefix into the structured arg.
-			const to = obj.to.startsWith("*") ? obj.to.slice(1) : obj.to;
-			if (to.length === 0) {
-				return { ok: false, reason: "Required argument 'to' is missing" };
-			}
-			return {
-				ok: true,
-				args: { item: obj.item, to } as ToolArgs[N],
-			};
 		}
 		case "go":
 		case "face": {

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -273,11 +273,9 @@ export interface PhysicalActionRecord {
 	/** The actor's facing at the time the action resolved. */
 	actorFacingAtAction: CardinalDirection;
 	/** The observable action kind. */
-	kind: "go" | "pick_up" | "put_down" | "give" | "use";
-	/** Item id (for pick_up, put_down, give, use). */
+	kind: "go" | "pick_up" | "put_down" | "use";
+	/** Item id (for pick_up, put_down, use). */
 	item?: string;
-	/** Recipient AI id (for give). */
-	to?: AiId;
 	/**
 	 * Raw useOutcome string with {actor} token un-substituted (for use).
 	 * Witnesses render this with {actor}→"*<actor>"; actor sees {actor}→"you".
@@ -336,9 +334,8 @@ export type ConversationEntry =
 			kind: "witnessed-event";
 			round: number;
 			actor: AiId;
-			actionKind: "go" | "pick_up" | "put_down" | "give" | "use";
+			actionKind: "go" | "pick_up" | "put_down" | "use";
 			item?: string;
-			to?: AiId;
 			direction?: CardinalDirection;
 			useOutcome?: string;
 			placementFlavorRaw?: string;
@@ -346,7 +343,7 @@ export type ConversationEntry =
 	| {
 			kind: "action-failure";
 			round: number;
-			tool: "go" | "face" | "pick_up" | "put_down" | "give" | "use";
+			tool: "go" | "face" | "pick_up" | "put_down" | "use";
 			/** Verbatim dispatcher rejection reason (e.g. "That cell is blocked by an obstacle"). */
 			reason: string;
 	  }
@@ -442,7 +439,6 @@ export interface GameState {
 export type ToolName =
 	| "pick_up"
 	| "put_down"
-	| "give"
 	| "use"
 	| "go"
 	| "face"


### PR DESCRIPTION
## Summary
This PR removes the `give` tool entirely from the game mechanics. The `give` action allowed AIs to transfer held items to adjacent AIs, but this functionality is being deprecated in favor of other interaction patterns.

## Key Changes

**Tool Registry & Definitions**
- Removed `give` from `TOOL_DEFINITIONS` in `tool-registry.ts` (now 6 tools instead of 7)
- Removed `GiveArgs` type and all `give`-related parsing logic from `parseToolCallArguments`
- Updated tool count assertion in tests from 7 to 6 tools

**Dispatcher Logic**
- Removed `give` case from `validateToolCall` function (validation for item ownership, target adjacency, self-transfer prevention)
- Removed `give` case from `executeToolCall` function (item holder transfer logic)
- Removed `give` from `describeToolCall` function (action description generation)
- Removed `give` from action record filtering in `dispatchAiTurn`

**Type System**
- Removed `give` from `ToolName` union type
- Removed `to?: AiId` field from `PhysicalActionRecord` interface
- Removed `to?: AiId` field from witnessed-event `ConversationEntry` type
- Removed `give` from action-failure tool union type

**Available Tools**
- Removed adjacency-based AI filtering logic from `availableTools` function that computed reachable AIs for the `give` tool

**Conversation Log**
- Removed witnessed `give` event rendering logic from `renderEntry` function
- Removed test cases for `give` event rendering

**Test Coverage**
- Removed 4 validation tests for `give` (adjacency, item ownership, self-transfer)
- Removed 1 execution test for item transfer via `give`
- Removed 1 dispatch test for non-adjacent `give` failure
- Removed 6 parsing tests for `give` arguments
- Removed 1 game session integration test for non-adjacent `give`
- Removed 2 conversation log rendering tests for witnessed `give`
- Removed `give` from tool disable complication tests
- Updated streaming and message builder tests to use `put_down` instead of `give` examples

**Documentation**
- Updated comments and documentation to remove references to `give` tool
- Updated rules documentation to remove `give` from available actions

## Implementation Details
The removal is comprehensive and touches all layers of the system:
- The tool is no longer offered to AIs via the OpenAI function definitions
- Validation and execution paths are completely removed
- Type definitions are updated to exclude `give` from all relevant unions
- Conversation logging no longer tracks `give` events
- All test coverage for `give` functionality has been removed

https://claude.ai/code/session_01BUX3zgy9YdDPu9itZW7ryS