### PR TITLE
Rename html-preview skill to html

### DIFF
--- a/.claude/skills/html/SKILL.md
+++ b/.claude/skills/html/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: html-preview
+name: html
 description: Build a single static HTML page and give the user a temporary URL to view it in their browser. Use whenever the user asks to "show", "preview", "mock up", "demo", or "build" a webpage, landing page, or one-file HTML design.
 ---
 


### PR DESCRIPTION
## Summary
Simplified the skill name from `html-preview` to `html` for better clarity and consistency.

## Changes
- Renamed the skill identifier in `SKILL.md` from `html-preview` to `html`
- The skill description and functionality remain unchanged

## Details
This change makes the skill name more concise while maintaining its purpose of building and previewing static HTML pages. The skill continues to be triggered when users request to "show", "preview", "mock up", "demo", or "build" a webpage.

https://claude.ai/code/session_019aA8hK8qKMjePyKF17XmXK