### PR TITLE
Enable action profiles by default and recalibrate temperament biases

### DIFF
--- a/src/content/__tests__/action-preference-bias.test.ts
+++ b/src/content/__tests__/action-preference-bias.test.ts
@@ -133,15 +133,9 @@ describe("action-preference-bias", () => {
 	});
 
 	it("falls through to the balanced default when no tool reaches ±threshold", () => {
-		// stoic + glib: go = -1+1 = 0, face = 0+0 = 0, pick_up = 0, put_down = 0,
-		// use = 0 + (-1) = -1 → use hits the avoided threshold.
-		// Use mercurial + earnest instead: go 1+0=1, face 1+1=2 → face preferred.
-		// Need a genuinely featureless pair. taciturn + glib:
-		//   go -1+1=0, face 0, pick_up 0, put_down 0, use -1+-1=-2→floored-1.
-		//   use hits avoided. Try haughty + verbose:
-		//   go 1+1=2 → go preferred. Not featureless.
 		// stoic + earnest: go -1+0=-1, face 0+1=1, pick_up 0, put_down 0,
-		//   use 0+1=1 → go hits avoided (-1), nothing ≥ 2.
+		// use 0+1=1 — nothing reaches the +2 preferred threshold, so no
+		// "leans toward"; go = -1 trips the avoided threshold instead.
 		const clause = actionProfileFor("e", "stoic", "earnest");
 		// No tool reaches +2, so no "leans toward"; go = -1 triggers hesitant.
 		expect(clause).not.toContain("leans toward");

--- a/src/content/action-preference-bias.ts
+++ b/src/content/action-preference-bias.ts
@@ -49,27 +49,27 @@ export type ActionTool = (typeof ACTION_TOOLS)[number];
  * had a strong (`≥ +2`) `examine` lean and dropped -1 for the one with
  * a strong (`≤ -2`) `examine` aversion (glib) — so the perception
  * signal that used to route through `examine` survives the tool's
- * removal. `go` / `pick_up` / `put_down` / `use` are unchanged from the
- * pre-#466 calibration.
+ * removal.
  */
 export const ACTION_TOOL_BIAS: Record<string, Record<ActionTool, number>> = {
 	"hot-headed": { go: 2, face: 1, pick_up: 1, put_down: 0, use: 0 },
 	taciturn: { go: -1, face: 0, pick_up: 0, put_down: 0, use: -1 },
 	meticulous: { go: -1, face: 2, pick_up: 0, put_down: 1, use: 1 },
-	erratic: { go: 2, face: 1, pick_up: 1, put_down: 0, use: 0 },
+	erratic: { go: 2, face: 0, pick_up: 1, put_down: 1, use: 0 },
 	melancholic: { go: -2, face: 0, pick_up: -1, put_down: -1, use: -1 },
 	glib: { go: 1, face: 0, pick_up: 0, put_down: 0, use: -1 },
 	pedantic: { go: -1, face: 2, pick_up: 0, put_down: 1, use: 1 },
-	effusive: { go: 1, face: 1, pick_up: 1, put_down: 0, use: 0 },
+	effusive: { go: 1, face: 1, pick_up: 0, put_down: 0, use: 0 },
 	sardonic: { go: 0, face: 1, pick_up: 0, put_down: 0, use: -1 },
-	mercurial: { go: 1, face: 1, pick_up: 0, put_down: 0, use: 0 },
+	mercurial: { go: 2, face: 1, pick_up: 0, put_down: 1, use: 0 },
 	diffident: { go: -2, face: -1, pick_up: -1, put_down: 0, use: -1 },
 	zealous: { go: 2, face: 1, pick_up: 1, put_down: 0, use: 1 },
-	verbose: { go: 1, face: 1, pick_up: 0, put_down: 0, use: 0 },
-	sweet: { go: 0, face: 1, pick_up: 1, put_down: 0, use: 0 },
+	// verbose is a pure messaging trait — it carries no action-tool lean.
+	verbose: { go: 0, face: 0, pick_up: 0, put_down: 0, use: 0 },
+	sweet: { go: 0, face: 1, pick_up: 0, put_down: 1, use: 0 },
 	anxious: { go: -1, face: 0, pick_up: -1, put_down: 1, use: -1 },
-	haughty: { go: 1, face: 1, pick_up: 0, put_down: 0, use: 0 },
-	sly: { go: 1, face: 1, pick_up: 1, put_down: 0, use: 0 },
+	haughty: { go: 0, face: 1, pick_up: -1, put_down: 0, use: -1 },
+	sly: { go: 1, face: 1, pick_up: 1, put_down: 0, use: 1 },
 	theatrical: { go: 2, face: 2, pick_up: 1, put_down: 0, use: -1 },
 	aloof: { go: -1, face: -1, pick_up: -2, put_down: 0, use: -1 },
 	cheery: { go: 1, face: 1, pick_up: 1, put_down: 0, use: 0 },

--- a/src/spa/game/bootstrap.ts
+++ b/src/spa/game/bootstrap.ts
@@ -59,10 +59,10 @@ export interface BootstrapOpts {
 	 */
 	engagementClauses?: boolean;
 	/**
-	 * Daemon-action-variation: opt-in per-persona action-tool preference
-	 * clause attached to each daemon and rendered as `<action_profile>` in
-	 * the system prompt. Off by default; production behaviour byte-identical
-	 * when unset. See `src/content/action-preference-bias.ts`.
+	 * Daemon-action-variation: per-persona action-tool preference clause
+	 * attached to each daemon and rendered as `<action_profile>` in the
+	 * system prompt. ON by default; pass `false` (via the `?actionProfiles=0`
+	 * kill-switch) to disable. See `src/content/action-preference-bias.ts`.
 	 */
 	actionProfiles?: boolean;
 }
@@ -86,7 +86,7 @@ export function generateNewGameAssetsSplit(
 
 	const personasPromise = generatePersonas(personasRng, synth, {
 		engagementClauses: opts?.engagementClauses ?? false,
-		actionProfiles: opts?.actionProfiles ?? false,
+		actionProfiles: opts?.actionProfiles ?? true,
 	}) as Promise<Record<AiId, AiPersona>>;
 	// Silence unhandled-rejection on derived promises if a downstream consumer
 	// chooses not to await one of them.

--- a/src/spa/routes/start.ts
+++ b/src/spa/routes/start.ts
@@ -494,10 +494,10 @@ export function renderStart(
 	// any value other than the literal "1" is treated as off.
 	const engagementClauses = searchParams.get("engagementClauses") === "1";
 
-	// Daemon-action-variation: `?actionProfiles=1` opts into per-persona
-	// `<action_profile>` clauses derived from temperaments. Off by default;
-	// any value other than the literal "1" is treated as off.
-	const actionProfiles = searchParams.get("actionProfiles") === "1";
+	// Daemon-action-variation: per-persona `<action_profile>` clauses derived
+	// from temperaments are ON by default. `?actionProfiles=0` is a kill-switch
+	// for A/B comparison and debugging; any other value leaves them on.
+	const actionProfilesDisabled = searchParams.get("actionProfiles") === "0";
 
 	// Kick off (or reuse) the in-flight bootstrap. If the user backed out to
 	// the start screen after a previous render, startBootstrap returns the
@@ -510,8 +510,8 @@ export function renderStart(
 	const engagementOpts = engagementClauses
 		? { engagementClauses: true }
 		: undefined;
-	const actionProfileOpts = actionProfiles
-		? { actionProfiles: true }
+	const actionProfileOpts = actionProfilesDisabled
+		? { actionProfiles: false }
 		: undefined;
 	const mergedOpts =
 		_testOverrides || spikeOpts || engagementOpts || actionProfileOpts


### PR DESCRIPTION
## Summary
This PR enables per-persona action-tool preference clauses (`actionProfiles`) by default and recalibrates the action-tool bias values for several temperaments to better reflect their intended behavioral characteristics.

## Key Changes

- **Default behavior change**: Action profiles are now ON by default instead of opt-in. The `?actionProfiles=0` query parameter serves as a kill-switch for A/B testing and debugging.

- **Recalibrated temperament biases** in `ACTION_TOOL_BIAS`:
  - `erratic`: Reduced `face` bias (1→0), increased `put_down` (0→1)
  - `effusive`: Reduced `pick_up` bias (1→0)
  - `mercurial`: Increased `go` bias (1→2), added `put_down` (0→1)
  - `verbose`: Zeroed all biases with explanatory comment (pure messaging trait)
  - `sweet`: Reduced `pick_up` (1→0), increased `put_down` (0→1)
  - `haughty`: Reduced `go` (1→0), added negative `pick_up` (-1) and `use` (-1) biases
  - `sly`: Increased `use` bias (0→1)

- **Updated documentation**: Clarified that action profiles are now enabled by default and removed outdated references to pre-#466 calibration.

- **Updated test expectations**: Simplified test comments to reflect the current behavior of the balanced default fallback.

## Implementation Details

The change from opt-in to opt-out for action profiles is reflected in:
- `src/spa/routes/start.ts`: Variable renamed from `actionProfiles` to `actionProfilesDisabled` with inverted logic
- `src/spa/game/bootstrap.ts`: Default value changed from `false` to `true` in `generateNewGameAssetsSplit()`
- Updated JSDoc comments to reflect the new default behavior

The temperament bias recalibrations appear to be fine-tuning adjustments to better align each temperament's action preferences with their intended personality traits.

https://claude.ai/code/session_01CrSeCdtEWbhrZbqwwaeDSk