### PR TITLE
Fix chat lockout visual state on page restore

### DIFF
--- a/e2e/chat-lockout.spec.ts
+++ b/e2e/chat-lockout.spec.ts
@@ -68,6 +68,15 @@ test("chat lockout disables send for locked-out AI and is silent to player", asy
 
 	const { names: reloadNames } = await getAiHandles(page);
 
+	// 3b. The locked AI's panel must be visually muted immediately on restore,
+	//     before any composer interaction. refreshComposerState paints
+	//     `panel--locked` by `[data-ai]`, so it must run after the panel-setup
+	//     loop assigns those attributes — running earlier left a restored
+	//     lockout looking unlocked until the player typed something.
+	const lockedPanel = page.locator(`.ai-panel[data-ai="${ids[0]}"]`);
+	await expect(lockedPanel).toHaveClass(/panel--locked/);
+	await expect(lockedPanel).toHaveAttribute("aria-disabled", "true");
+
 	// 4. Typing *<locked AI> should disable Send.
 	await page.fill("#prompt", `*${reloadNames[0]} hi`);
 	await expect(page.locator("#send")).toBeDisabled();

--- a/src/spa/routes/game.ts
+++ b/src/spa/routes/game.ts
@@ -1036,9 +1036,6 @@ export function renderGame(
 	if (topinfoEl) topinfoEl.removeAttribute("hidden");
 	if (bannerWrapEl) bannerWrapEl.removeAttribute("hidden");
 
-	// Set initial composer state (Send starts disabled until a valid *mention).
-	refreshComposerState();
-
 	const aiIdList: string[] =
 		session !== null ? Object.keys(session.getState().personas) : [];
 
@@ -1074,6 +1071,14 @@ export function renderGame(
 			.join(" | ");
 		if (handles) _promptInput.placeholder = `${handles} …`;
 	}
+
+	// Set the initial composer state — Send starts disabled until a valid
+	// *mention. Deferred until after the panel-setup loop above assigns
+	// `data-ai` to every `.ai-panel`: refreshComposerState's panel-muting pass
+	// selects panels by `[data-ai]`, so running it before those attributes
+	// exist skips the `panel--locked` paint, leaving a restored chat-lockout
+	// looking unlocked until the next composer interaction.
+	refreshComposerState();
 
 	// One-time chrome: ASCII banner + initial top-info row.
 	const bannerEl = doc.querySelector<HTMLElement>("#banner");


### PR DESCRIPTION
## Summary
Fixed a timing issue where a restored chat lockout would appear visually unlocked until the player interacted with the composer. The `refreshComposerState()` function was being called before DOM attributes required for its panel-muting logic were initialized.

## Changes
- **Deferred `refreshComposerState()` call**: Moved the initialization of composer state from before the panel-setup loop to after it completes. This ensures all `.ai-panel` elements have their `data-ai` attributes assigned before `refreshComposerState()` attempts to select and style locked panels.
- **Updated panel-muting logic dependency**: The `panel--locked` CSS class is applied via selectors that depend on `[data-ai]` attributes. Running `refreshComposerState()` before these attributes exist caused the paint to be skipped, leaving restored lockouts visually unlocked.
- **Added test coverage**: New test assertions verify that a locked AI's panel displays the `panel--locked` class and `aria-disabled="true"` attribute immediately upon page restore, before any composer interaction.

## Implementation Details
The fix ensures the initialization order is:
1. Panel setup loop assigns `data-ai` attributes to all `.ai-panel` elements
2. `refreshComposerState()` runs and correctly applies visual muting to locked panels via `[data-ai]` selectors

This prevents the visual inconsistency where a chat lockout would only appear muted after the player's first interaction with the composer.

https://claude.ai/code/session_01GJgWbZsA2KrbGgfuwbfceJ