### PR TITLE
Add beta release script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"eval:directions": "npx tsx evals/relative-directions/runner.mts",
 		"eval:drift": "npx tsx evals/free-text-drift/runner.mts",
 		"prepare": "husky",
-		"release": "changelogen --release"
+		"release": "changelogen --release",
+		"release:beta": "changelogen --release --prerelease beta"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary
Added a new npm script to support beta releases using changelogen with prerelease versioning.

## Changes
- Added `release:beta` script that runs `changelogen --release --prerelease beta` to generate beta versions during the release process

## Details
This new script enables the project to create beta/prerelease versions alongside the standard release workflow. The script uses the same changelogen tool as the existing `release` script but adds the `--prerelease beta` flag to mark versions as beta releases.

https://claude.ai/code/session_01N1bX4oRLHaz1dqjtfayo68