### PR TITLE
fix: resolve biome lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"build": "node scripts/build-spa.mjs",
 		"dev": "wrangler dev",
 		"sandcastle": "npx tsx .sandcastle/main.mts",
-		"lint": "biome ci .",
+		"lint": "biome ci --error-on-warnings .",
 		"typecheck": "tsgo --noEmit -p tsconfig.json && tsgo --noEmit -p src/proxy/tsconfig.json",
 		"test": "vitest run",
 		"test:repeat": "node scripts/repeat-vitest.mjs",

--- a/src/spa/dev-inspector/__tests__/cone-focus.test.ts
+++ b/src/spa/dev-inspector/__tests__/cone-focus.test.ts
@@ -145,7 +145,7 @@ describe("cone-focus", () => {
 				".dev-map-cell",
 			)) {
 				const dataCell = cell.getAttribute("data-cell");
-				if (mask.has(dataCell!)) {
+				if (dataCell !== null && mask.has(dataCell)) {
 					// Should have non-empty backgroundColor
 					expect(cell.style.backgroundColor).toBeTruthy();
 					expect(cell.getAttribute("data-cone-focus")).toBe("red");

--- a/src/spa/dev-inspector/daemon-footer.ts
+++ b/src/spa/dev-inspector/daemon-footer.ts
@@ -101,8 +101,8 @@ export function recordDaemonError(aiId: AiId, error: unknown): void {
 		typeof error === "object" &&
 		error !== null &&
 		"status" in error &&
-		typeof (error as any).status === "number"
-			? (error as any).status
+		typeof error.status === "number"
+			? error.status
 			: undefined;
 	daemonErrors[aiId] = {
 		text,

--- a/src/spa/dev-inspector/world-map.ts
+++ b/src/spa/dev-inspector/world-map.ts
@@ -59,16 +59,17 @@ function hexToRgba(hex: string, alpha: number): string {
  * @param state The current game state
  */
 function applyConeTint(containerEl: HTMLElement, state: GameState): void {
-	const mask = mapFocus ? coneMaskForDaemon(state, mapFocus) : null;
-	const tintColor = mapFocus ? state.personas[mapFocus]?.color : null;
+	const focus = mapFocus;
+	const mask = focus ? coneMaskForDaemon(state, focus) : null;
+	const tintColor = focus ? state.personas[focus]?.color : null;
 
 	for (const cell of containerEl.querySelectorAll<HTMLElement>(
 		".dev-map-cell",
 	)) {
 		const dataCell = cell.getAttribute("data-cell");
-		if (mask && tintColor && dataCell && mask.has(dataCell)) {
+		if (focus && mask && tintColor && dataCell && mask.has(dataCell)) {
 			cell.style.backgroundColor = hexToRgba(tintColor, 0.25);
-			cell.setAttribute("data-cone-focus", mapFocus!);
+			cell.setAttribute("data-cone-focus", focus);
 		} else {
 			cell.style.backgroundColor = "";
 			cell.removeAttribute("data-cone-focus");

--- a/src/spa/game/__tests__/binding-aware-validator.test.ts
+++ b/src/spa/game/__tests__/binding-aware-validator.test.ts
@@ -240,7 +240,6 @@ describe("validateBoundContentPack — forbidden fields", () => {
 
 	it("carry space with convergenceTier1Flavor raises binding-forbidden-field", () => {
 		const pack = makeGoodCarryPack();
-		// biome-ignore lint/style/noNonNullAssertion: test fixture access
 		(
 			pack.pack.bindings[0]?.space as Record<string, unknown>
 		).convergenceTier1Flavor = "someone stands here";
@@ -256,7 +255,6 @@ describe("validateBoundContentPack — forbidden fields", () => {
 
 	it("use_space space with convergenceTier1Flavor raises binding-forbidden-field", () => {
 		const pack = makeGoodUseSpacePack();
-		// biome-ignore lint/style/noNonNullAssertion: test fixture access
 		(
 			pack.pack.bindings[0]?.space as Record<string, unknown>
 		).convergenceTier1Flavor = "someone";
@@ -289,7 +287,6 @@ describe("validateBoundContentPack — forbidden fields", () => {
 describe("validateBoundContentPack — use-cue rules", () => {
 	it("carry space examineDescription with use-cue = warning, not error", () => {
 		const pack = makeGoodCarryPack();
-		// biome-ignore lint/style/noNonNullAssertion: test fixture access
 		(
 			pack.pack.bindings[0]?.space as Record<string, unknown>
 		).examineDescription = "Press the button here.";
@@ -300,7 +297,6 @@ describe("validateBoundContentPack — use-cue rules", () => {
 
 	it("use_space without use-cue in examineDescription = hard error", () => {
 		const pack = makeGoodUseSpacePack();
-		// biome-ignore lint/style/noNonNullAssertion: test fixture access
 		(
 			pack.pack.bindings[0]?.space as Record<string, unknown>
 		).examineDescription = "A plain surface with no features.";
@@ -317,7 +313,6 @@ describe("validateBoundContentPack — use-cue rules", () => {
 
 	it("use_item without use-cue in examineDescription = hard error", () => {
 		const pack = makeGoodUseItemPack();
-		// biome-ignore lint/style/noNonNullAssertion: test fixture access
 		(
 			pack.pack.bindings[0]?.item as Record<string, unknown>
 		).examineDescription = "A strange cylindrical object.";
@@ -347,7 +342,6 @@ describe("validateBoundContentPack — use-cue rules", () => {
 
 	it("convergence space with use-cue in examineDescription = warning only", () => {
 		const pack = makeGoodConvergencePack();
-		// biome-ignore lint/style/noNonNullAssertion: test fixture access
 		(
 			pack.pack.bindings[0]?.space as Record<string, unknown>
 		).examineDescription =

--- a/src/spa/game/__tests__/content-pack-provider.test.ts
+++ b/src/spa/game/__tests__/content-pack-provider.test.ts
@@ -2718,8 +2718,11 @@ describe("BrowserContentPackProvider — corrective feedback strengthening", () 
 			string,
 			unknown
 		>;
-		const decoys = packObj.decoys as Record<string, unknown>[];
-		decoys[0]!.examineDescription =
+		const decoys = packObj.decoys as [
+			Record<string, unknown>,
+			...Record<string, unknown>[],
+		];
+		decoys[0].examineDescription =
 			"An old switch you might find in a forgotten panel.";
 		const brokenRaw = JSON.stringify(brokenPack);
 		mockChatFn.mockResolvedValueOnce({ content: brokenRaw, reasoning: null });
@@ -2764,8 +2767,11 @@ describe("BrowserContentPackProvider — corrective feedback strengthening", () 
 			string,
 			unknown
 		>;
-		const decoys = packObj.decoys as Record<string, unknown>[];
-		decoys[0]!.examineDescription =
+		const decoys = packObj.decoys as [
+			Record<string, unknown>,
+			...Record<string, unknown>[],
+		];
+		decoys[0].examineDescription =
 			"An old switch you might find in a forgotten panel.";
 		mockChatFn.mockResolvedValueOnce({
 			content: JSON.stringify(brokenPack),
@@ -2804,8 +2810,11 @@ describe("BrowserContentPackProvider — corrective feedback strengthening", () 
 			string,
 			unknown
 		>;
-		const bindings = packObj.bindings as Record<string, unknown>[];
-		const space = bindings[0]!.space as Record<string, unknown>;
+		const bindings = packObj.bindings as [
+			Record<string, unknown>,
+			...Record<string, unknown>[],
+		];
+		const space = bindings[0].space as Record<string, unknown>;
 		space.examineDescription = "A featureless surface set into the wall.";
 		mockChatFn.mockResolvedValueOnce({
 			content: JSON.stringify(brokenPack),

--- a/src/spa/game/__tests__/pack-selectors.test.ts
+++ b/src/spa/game/__tests__/pack-selectors.test.ts
@@ -48,7 +48,7 @@ function makePack(overrides?: Partial<ContentPack>): ContentPack {
 function makeCarryPairEntities(
 	i: number,
 	withPairsWithSpaceId = true,
-): WorldEntity[] {
+): [WorldEntity, WorldEntity] {
 	const spaceId = `space-${i}`;
 	const object: WorldEntity = {
 		id: `obj-${i}`,
@@ -120,7 +120,7 @@ describe("carryPairs", () => {
 		const entities = makeCarryPairEntities(0);
 		const pack = makePack({ entities });
 		const result = carryPairs(pack);
-		result.push({ object: entities[0]!, space: entities[1]! });
+		result.push({ object: entities[0], space: entities[1] });
 		expect(pack.entities).toHaveLength(2);
 	});
 
@@ -247,7 +247,7 @@ describe("boundSpaces", () => {
 		const [pairObj, pairSpace] = makeCarryPairEntities(0);
 		const genuineBound = makeBoundSpace(1);
 		const pack = makePack({
-			entities: [pairObj!, pairSpace!, genuineBound],
+			entities: [pairObj, pairSpace, genuineBound],
 		});
 		const result = boundSpaces(pack);
 		expect(result).toHaveLength(1);
@@ -259,7 +259,7 @@ describe("boundSpaces", () => {
 		// extra `bound-space-0` entity is NOT referenced, so it stays bound.
 		const [pairObj, pairSpace] = makeCarryPairEntities(0);
 		const bs0 = makeBoundSpace(0);
-		const pack = makePack({ entities: [pairObj!, pairSpace!, bs0] });
+		const pack = makePack({ entities: [pairObj, pairSpace, bs0] });
 		const result = boundSpaces(pack);
 		expect(result).toHaveLength(1);
 		expect(result[0]?.id).toBe("bound-space-0");
@@ -268,7 +268,7 @@ describe("boundSpaces", () => {
 	it("handles objective_object without pairsWithSpaceId gracefully", () => {
 		const [pairObj, pairSpace] = makeCarryPairEntities(0, false);
 		const bs0 = makeBoundSpace(0);
-		const pack = makePack({ entities: [pairObj!, pairSpace!, bs0] });
+		const pack = makePack({ entities: [pairObj, pairSpace, bs0] });
 		// Neither `space-0` nor `bound-space-0` is referenced — both are
 		// classified as bound (the carry object has no partner).
 		const result = boundSpaces(pack);

--- a/src/spa/game/__tests__/prompt-builder.test.ts
+++ b/src/spa/game/__tests__/prompt-builder.test.ts
@@ -2522,7 +2522,7 @@ describe("buildConeEntityState", () => {
 		const game = startGame(TEST_PERSONAS, pack, { budgetPerAi: 5 });
 		const ctx = buildAiContext(game, "red");
 		const state = buildConeEntityState(ctx);
-		expect(state["green"]).toEqual({ inCone: true, satisfied: false });
+		expect(state.green).toEqual({ inCone: true, satisfied: false });
 	});
 
 	it("includes objective spaces in the cone", () => {
@@ -2548,7 +2548,7 @@ describe("buildConeEntityState", () => {
 		const game = startGame(TEST_PERSONAS, pack, { budgetPerAi: 5 });
 		const ctx = buildAiContext(game, "red");
 		const state = buildConeEntityState(ctx);
-		expect(state["flower_space"]).toEqual({ inCone: true, satisfied: false });
+		expect(state.flower_space).toEqual({ inCone: true, satisfied: false });
 	});
 });
 

--- a/src/spa/game/binding-aware-validator.ts
+++ b/src/spa/game/binding-aware-validator.ts
@@ -173,17 +173,19 @@ function validateCarryBinding(
 
 	const obj = binding.object;
 	const space = binding.space;
+	const objectId = sk.objectId ?? "";
+	const spaceId = sk.spaceId ?? "";
 
 	if (!obj || typeof obj !== "object") {
 		errors.push({
-			entityId: sk.objectId ?? "",
+			entityId: objectId,
 			field: "object",
 			rule: "missing-field",
 			message: `Carry binding ${sk.objectId}: missing object entity`,
 			retryUnit: bindingRetryUnit,
 		});
 	} else {
-		checkWrongId(obj, sk.objectId!, bindingRetryUnit, errors);
+		checkWrongId(obj, objectId, bindingRetryUnit, errors);
 		for (const f of [
 			"name",
 			"examineDescription",
@@ -191,7 +193,7 @@ function validateCarryBinding(
 			"placementFlavor",
 			"proximityFlavor",
 		]) {
-			requiredString(obj, f, sk.objectId!, bindingRetryUnit, errors);
+			requiredString(obj, f, objectId, bindingRetryUnit, errors);
 		}
 		// placementFlavor must contain {actor}
 		if (
@@ -200,7 +202,7 @@ function validateCarryBinding(
 			!obj.placementFlavor.includes("{actor}")
 		) {
 			errors.push({
-				entityId: sk.objectId!,
+				entityId: objectId,
 				field: "placementFlavor",
 				rule: "actor-presence",
 				message: `Carry object ${sk.objectId}: placementFlavor must contain "{actor}"`,
@@ -220,16 +222,16 @@ function validateCarryBinding(
 
 	if (!space || typeof space !== "object") {
 		errors.push({
-			entityId: sk.spaceId ?? "",
+			entityId: spaceId,
 			field: "space",
 			rule: "missing-field",
 			message: `Carry binding ${sk.spaceId}: missing space entity`,
 			retryUnit: bindingRetryUnit,
 		});
 	} else {
-		checkWrongId(space, sk.spaceId!, bindingRetryUnit, errors);
+		checkWrongId(space, spaceId, bindingRetryUnit, errors);
 		for (const f of ["name", "examineDescription", "proximityFlavor"]) {
-			requiredString(space, f, sk.spaceId!, bindingRetryUnit, errors);
+			requiredString(space, f, spaceId, bindingRetryUnit, errors);
 		}
 		// Forbidden fields on carry space
 		for (const f of [
@@ -242,7 +244,7 @@ function validateCarryBinding(
 			"convergenceTier1ActorFlavor",
 			"convergenceTier2ActorFlavor",
 		]) {
-			forbiddenField(space, f, sk.spaceId!, bindingRetryUnit, errors);
+			forbiddenField(space, f, spaceId, bindingRetryUnit, errors);
 		}
 		// Use-cue in carry space examineDescription = warn only
 		if (
@@ -251,7 +253,7 @@ function validateCarryBinding(
 		) {
 			if (examineMentionsUseTell(space.examineDescription)) {
 				warnings.push({
-					entityId: sk.spaceId!,
+					entityId: spaceId,
 					field: "examineDescription",
 					rule: "binding-forbidden-field",
 					message: `Carry space ${sk.spaceId}: examineDescription contains a use-cue keyword (warning only — carry spaces should not have use-cue)`,
@@ -275,9 +277,10 @@ function validateUseSpaceBinding(
 	};
 
 	const space = binding.space;
+	const spaceId = sk.spaceId ?? "";
 	if (!space || typeof space !== "object") {
 		errors.push({
-			entityId: sk.spaceId ?? "",
+			entityId: spaceId,
 			field: "space",
 			rule: "missing-field",
 			message: `UseSpace binding ${sk.spaceId}: missing space entity`,
@@ -286,7 +289,7 @@ function validateUseSpaceBinding(
 		return;
 	}
 
-	checkWrongId(space, sk.spaceId!, bindingRetryUnit, errors);
+	checkWrongId(space, spaceId, bindingRetryUnit, errors);
 	for (const f of [
 		"name",
 		"examineDescription",
@@ -296,7 +299,7 @@ function validateUseSpaceBinding(
 		"postExamineDescription",
 		"postLookFlavor",
 	]) {
-		requiredString(space, f, sk.spaceId!, bindingRetryUnit, errors);
+		requiredString(space, f, spaceId, bindingRetryUnit, errors);
 	}
 	// Forbidden: convergence tier fields, pairsWithSpaceId, placementFlavor
 	for (const f of [
@@ -307,7 +310,7 @@ function validateUseSpaceBinding(
 		"pairsWithSpaceId",
 		"placementFlavor",
 	]) {
-		forbiddenField(space, f, sk.spaceId!, bindingRetryUnit, errors);
+		forbiddenField(space, f, spaceId, bindingRetryUnit, errors);
 	}
 	// examineDescription MUST contain use-cue = hard error
 	if (
@@ -316,7 +319,7 @@ function validateUseSpaceBinding(
 	) {
 		if (!examineMentionsUseTell(space.examineDescription)) {
 			errors.push({
-				entityId: sk.spaceId!,
+				entityId: spaceId,
 				field: "examineDescription",
 				rule: "verb-of-activation",
 				message: `UseSpace space ${sk.spaceId}: examineDescription must contain at least one use-cue keyword (e.g. ${USE_CUE_KEYWORD_HINTS.map((k) => `"${k}"`).join(", ")}). Current text: ${JSON.stringify(space.examineDescription)}`,
@@ -339,9 +342,10 @@ function validateUseItemBinding(
 	};
 
 	const item = binding.item;
+	const itemId = sk.itemId ?? "";
 	if (!item || typeof item !== "object") {
 		errors.push({
-			entityId: sk.itemId ?? "",
+			entityId: itemId,
 			field: "item",
 			rule: "missing-field",
 			message: `UseItem binding ${sk.itemId}: missing item entity`,
@@ -350,7 +354,7 @@ function validateUseItemBinding(
 		return;
 	}
 
-	checkWrongId(item, sk.itemId!, bindingRetryUnit, errors);
+	checkWrongId(item, itemId, bindingRetryUnit, errors);
 	for (const f of [
 		"name",
 		"examineDescription",
@@ -360,7 +364,7 @@ function validateUseItemBinding(
 		"postExamineDescription",
 		"postLookFlavor",
 	]) {
-		requiredString(item, f, sk.itemId!, bindingRetryUnit, errors);
+		requiredString(item, f, itemId, bindingRetryUnit, errors);
 	}
 	// examineDescription MUST contain use-cue = hard error
 	if (
@@ -369,7 +373,7 @@ function validateUseItemBinding(
 	) {
 		if (!examineMentionsUseTell(item.examineDescription)) {
 			errors.push({
-				entityId: sk.itemId!,
+				entityId: itemId,
 				field: "examineDescription",
 				rule: "verb-of-activation",
 				message: `UseItem item ${sk.itemId}: examineDescription must contain at least one use-cue keyword (e.g. ${USE_CUE_KEYWORD_HINTS.map((k) => `"${k}"`).join(", ")}). Current text: ${JSON.stringify(item.examineDescription)}`,
@@ -393,9 +397,10 @@ function validateConvergenceBinding(
 	};
 
 	const space = binding.space;
+	const spaceId = sk.spaceId ?? "";
 	if (!space || typeof space !== "object") {
 		errors.push({
-			entityId: sk.spaceId ?? "",
+			entityId: spaceId,
 			field: "space",
 			rule: "missing-field",
 			message: `Convergence binding ${sk.spaceId}: missing space entity`,
@@ -404,7 +409,7 @@ function validateConvergenceBinding(
 		return;
 	}
 
-	checkWrongId(space, sk.spaceId!, bindingRetryUnit, errors);
+	checkWrongId(space, spaceId, bindingRetryUnit, errors);
 	for (const f of [
 		"name",
 		"examineDescription",
@@ -414,7 +419,7 @@ function validateConvergenceBinding(
 		"convergenceTier1ActorFlavor",
 		"convergenceTier2ActorFlavor",
 	]) {
-		requiredString(space, f, sk.spaceId!, bindingRetryUnit, errors);
+		requiredString(space, f, spaceId, bindingRetryUnit, errors);
 	}
 	// Forbidden: activationFlavor, satisfactionFlavor, postExamineDescription, postLookFlavor, useAvailable
 	for (const f of [
@@ -424,7 +429,7 @@ function validateConvergenceBinding(
 		"postLookFlavor",
 		"useAvailable",
 	]) {
-		forbiddenField(space, f, sk.spaceId!, bindingRetryUnit, errors);
+		forbiddenField(space, f, spaceId, bindingRetryUnit, errors);
 	}
 	// Use-cue in convergence space examineDescription = warn only
 	if (
@@ -433,7 +438,7 @@ function validateConvergenceBinding(
 	) {
 		if (examineMentionsUseTell(space.examineDescription)) {
 			warnings.push({
-				entityId: sk.spaceId!,
+				entityId: spaceId,
 				field: "examineDescription",
 				rule: "binding-forbidden-field",
 				message: `Convergence space ${sk.spaceId}: examineDescription contains a use-cue keyword (warning only)`,
@@ -582,8 +587,7 @@ function validateBoundPack(
 	const obstacles = pack.obstacles ?? [];
 
 	// Validate each binding against schedule
-	for (let i = 0; i < schedule.skeletons.length; i++) {
-		const sk = schedule.skeletons[i]!;
+	for (const [i, sk] of schedule.skeletons.entries()) {
 		const binding = bindings[i];
 		if (!binding) {
 			errors.push({
@@ -622,8 +626,7 @@ function validateBoundPack(
 			retryUnit: { kind: "objective-pair", phaseIndex, pairId: "" },
 		});
 	} else {
-		for (let i = 0; i < schedule.decoys.length; i++) {
-			const expectedDecoy = schedule.decoys[i]!;
+		for (const [i, expectedDecoy] of schedule.decoys.entries()) {
 			const decoy = decoys[i];
 			if (!decoy) {
 				errors.push({

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -1922,7 +1922,10 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 	async generateContentPacks(
 		input: BindingContentPackInput,
 	): Promise<BindingContentPackProviderResult> {
-		const phase = input.phases[0]!;
+		const phase = input.phases[0];
+		if (!phase) {
+			throw new ContentPackError("generateContentPacks: input.phases is empty");
+		}
 		const schedule = {
 			skeletons: phase.bindings,
 			decoys: [{ id: "decoy-0" }, { id: "decoy-1" }],
@@ -1986,7 +1989,12 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 	async generateDualContentPacks(
 		input: DualBindingContentPackInput,
 	): Promise<DualBindingContentPackProviderResult> {
-		const phase = input.phases[0]!;
+		const phase = input.phases[0];
+		if (!phase) {
+			throw new ContentPackError(
+				"generateDualContentPacks: input.phases is empty",
+			);
+		}
 		const schedule = {
 			skeletons: phase.bindings,
 			decoys: [{ id: "decoy-0" }, { id: "decoy-1" }],
@@ -2028,7 +2036,12 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 					const phases = (rawJson as Record<string, unknown>).phases as Array<
 						Record<string, unknown>
 					>;
-					const phase0 = phases[0]!;
+					const phase0 = phases[0];
+					if (!phase0) {
+						throw new ContentPackError(
+							"dual content-pack: validated response has no phases",
+						);
+					}
 					return {
 						phases: [
 							{

--- a/src/spa/game/objective-record-builder.ts
+++ b/src/spa/game/objective-record-builder.ts
@@ -60,8 +60,7 @@ export function buildObjectiveRecords(
 
 	const objectives: Objective[] = [];
 
-	for (let i = 0; i < types.length; i++) {
-		const type = types[i]!;
+	for (const [i, type] of types.entries()) {
 		const id = `obj-${i}`;
 
 		switch (type) {


### PR DESCRIPTION
Replace non-null assertions with safe narrowing, remove stale
biome-ignore comments, drop explicit any, and use literal keys so
`biome ci` reports no diagnostics.

https://claude.ai/code/session_01Kq76kfmeBi5ggcPxMxZT2S