### PR TITLE
fix(spa): apply obstacle_shift and weather_change complications

### DIFF
--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -590,7 +590,7 @@ describe("Tool Disable exclusion", () => {
 		// 5-item pool (no obstacle_shift): index 2 → tool_disable
 		// rng[0]=0.4 → floor(0.4*5)=2 → tool_disable → pairs exhausted
 		// → re-draw from 4-item fallback pool (no obstacle_shift, no tool_disable)
-		// rng[1]=0.0 → index 0 → weather_change, rng[2]=0.5 → countdown
+		// rng[1]=0.0 → index 0 → weather_change, rng[2]=0.5 → new weather draw
 		const result = tickComplication(game, seededRng([0.4, 0.0, 0.5]));
 		expect(result?.fired.kind).not.toBe("tool_disable");
 	});

--- a/src/spa/game/__tests__/complication-engine.test.ts
+++ b/src/spa/game/__tests__/complication-engine.test.ts
@@ -260,8 +260,15 @@ describe("tickComplication — fires when countdown is 0", () => {
 		});
 		const game = makeGameStateAround(phase);
 		// rng[0]=0.0 → index 0 of 6 → weather_change
+		// rng[1]=0.5 → draw from weather candidates (excludes "clear")
 		const result = tickComplication(game, seededRng([0.0, 0.5]));
 		expect(result?.fired.kind).toBe("weather_change");
+		if (result?.fired.kind === "weather_change") {
+			// weather should be different from the current "clear"
+			expect(result.fired.weather).not.toBe("clear");
+			// weather should be a valid WEATHER_POOL entry
+			expect(result.fired.weather).toMatch(/^[A-Z]|^[a-z]/);
+		}
 	});
 
 	it("draws sysadmin_directive when type-draw selects index 1", () => {
@@ -755,7 +762,9 @@ describe("applyComplicationResult — activeComplications appends", () => {
 	it("does NOT append to activeComplications for weather_change", () => {
 		const phase = makePhase();
 		const game = makeGameStateAround(phase);
-		const result = { fired: { kind: "weather_change" as const } };
+		const result = {
+			fired: { kind: "weather_change" as const, weather: "rainy" },
+		};
 		const updated = applyComplicationResult(game, result, seededRng([0.5]));
 		const updatedPhase = updated;
 		expect(updatedPhase.activeComplications).toHaveLength(0);
@@ -912,10 +921,12 @@ describe("applyComplicationResult — setting_shift swaps active pack", () => {
 
 	it("does NOT change activePackId when a non-shift complication fires", () => {
 		const game = makeGameWithDualPacks();
-		const result = { fired: { kind: "weather_change" as const } };
+		const result = {
+			fired: { kind: "weather_change" as const, weather: "stormy" },
+		};
 		const updated = applyComplicationResult(game, result, seededRng([0.5]));
 		expect(updated.activePackId).toBe("A");
-		expect(updated.weather).toBe("clear");
+		expect(updated.weather).toBe("stormy");
 		expect(updated.timeOfDay).toBe("night");
 	});
 });

--- a/src/spa/game/__tests__/round-coordinator-obstacle-shift.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-obstacle-shift.test.ts
@@ -238,7 +238,7 @@ describe("runRound — obstacle_shift complication (issue #486)", () => {
 
 	it("does NOT append witnessed-obstacle-shift entry to a daemon whose cone does NOT cover fromCell", async () => {
 		const game = makeBaseGame();
-		// cyan is at (0, 0) facing south — its cone should NOT cover (2, 2).
+		// cyan is at (6, 6) facing north — its cone should NOT cover (2, 2).
 		const withCountdown = {
 			...game,
 			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },

--- a/src/spa/game/__tests__/round-coordinator-obstacle-shift.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-obstacle-shift.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for the round-coordinator's obstacle_shift complication handler.
+ *
+ * Issue #486: obstacle_shift complication fires and:
+ * 1. Moves the obstacle entity from fromCell to toCell in world.entities.
+ * 2. Appends witnessed-obstacle-shift entries only to daemons whose cone covers fromCell.
+ * 3. Daemons whose cone does NOT cover fromCell receive no entry.
+ */
+import { describe, expect, it } from "vitest";
+import { startGame } from "../engine";
+import { runRound } from "../round-coordinator";
+import { MockRoundLLMProvider } from "../round-llm-provider";
+import type { AiPersona, WorldEntity } from "../types";
+import { makeTestPack } from "./fixtures/make-test-pack";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "Hold the flower at phase end.",
+		typingQuirks: ["Fragments.", "Em-dashes."],
+		blurb: "Ember is hot-headed and zealous.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "#81b29a",
+		temperaments: ["meticulous", "meticulous"],
+		personaGoal: "Ensure items are evenly distributed.",
+		typingQuirks: ["Ellipses.", "ALL-CAPS."],
+		blurb: "Sage is meticulous.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+	cyan: {
+		id: "cyan",
+		name: "Frost",
+		color: "#5fa8d3",
+		temperaments: ["laconic", "diffident"],
+		personaGoal: "Hold the key at phase end.",
+		typingQuirks: ["No contractions.", "Ends with a question."],
+		blurb: "Frost is laconic and diffident.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+};
+
+// Obstacle entity with a shiftFlavor, positioned so it has an available shift target.
+const OBSTACLE: WorldEntity = {
+	id: "wall_ob",
+	kind: "obstacle",
+	name: "Stone Wall",
+	examineDescription: "A weathered stone wall.",
+	holder: { row: 2, col: 2 },
+	shiftFlavor: "The stone wall shifts one cell, scraping stone against stone.",
+};
+
+// For the test pack to be valid, we need at least one objective object + space pair.
+const OBJECTIVE_OBJECT: WorldEntity = {
+	id: "obj_a",
+	kind: "objective_object",
+	name: "Test Object",
+	examineDescription: "A test object.",
+	holder: { row: 0, col: 0 },
+	pairsWithSpaceId: "obj_space_a",
+	placementFlavor: "{actor} places it on the space.",
+};
+
+const OBJECTIVE_SPACE: WorldEntity = {
+	id: "obj_space_a",
+	kind: "objective_space",
+	name: "Test Space",
+	examineDescription: "A test space.",
+	holder: { row: 1, col: 1 },
+};
+
+const TEST_CONTENT_PACK = makeTestPack(
+	[OBJECTIVE_OBJECT, OBJECTIVE_SPACE, OBSTACLE],
+	{
+		wallName: "wall",
+		// red at (2, 1) facing east — cone should include (2, 2) = obstacle origin
+		// green at (1, 4) facing west — cone should include (2, 2) if in range
+		// cyan at (6, 6) facing north — cone should NOT include (2, 2) (too far away)
+		aiStarts: {
+			red: { position: { row: 2, col: 1 }, facing: "east" },
+			green: { position: { row: 1, col: 4 }, facing: "west" },
+			cyan: { position: { row: 6, col: 6 }, facing: "north" },
+		},
+	},
+);
+
+function makeProvider() {
+	return new MockRoundLLMProvider([
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+	]);
+}
+
+/**
+ * Build a base game with the test pack and override spatial positions.
+ */
+function makeBaseGame() {
+	const base = startGame(TEST_PERSONAS, TEST_CONTENT_PACK, { budgetPerAi: 99 });
+	return {
+		...base,
+		world: {
+			entities: [OBJECTIVE_OBJECT, OBJECTIVE_SPACE, OBSTACLE],
+		},
+		personaSpatial: TEST_CONTENT_PACK.aiStarts as typeof base.personaSpatial,
+	};
+}
+
+/**
+ * Drive an RNG sequence that deterministically fires obstacle_shift with a specific
+ * fromCell → toCell move.
+ *
+ * The complication engine uses rng to:
+ * 1. Draw from the available complications pool.
+ * 2. For obstacle_shift, draw from the valid shift tuples.
+ *
+ * We provide a custom rng that cycles through specific values to force selection.
+ */
+function makeObstacleShiftRng(tupleIndex: number) {
+	let callCount = 0;
+	return () => {
+		// First call: select obstacle_shift from the pool (return value that selects
+		// obstacle_shift index in the available pool).
+		// Subsequent calls: select the desired tuple within the obstacle_shift's tuples.
+		// For simplicity, we'll let the engine's pool selection fall through naturally
+		// and only control the tuple selection.
+		callCount += 1;
+		// Return a value in range [0, 1) that selects the tupleIndex-th element
+		// from the available tuples. We'll return a small value to select early tuples.
+		if (callCount === 1) {
+			// First call: draw from complication type pool.
+			// Assuming obstacle_shift is available, return a value that selects it.
+			// We'll use a high value to try to select later in the pool (obstacle_shift).
+			return 0.5; // This will be used by tickComplication to select from available complications.
+		}
+		if (callCount === 2) {
+			// Second call: draw tuple index from the shift tuples for the selected obstacle.
+			// Return a value that selects the desired tuple.
+			return tupleIndex / 100; // Scale down to ensure we select early tuples.
+		}
+		return Math.random();
+	};
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("runRound — obstacle_shift complication (issue #486)", () => {
+	it("moves the obstacle entity from fromCell to toCell in world.entities", async () => {
+		const game = makeBaseGame();
+		// Force countdown to 0 so complication fires.
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeObstacleShiftRng(0) },
+		);
+
+		// Find the obstacle in the entities.
+		const obstacleAfter = nextState.world.entities.find(
+			(e) => e.id === "wall_ob",
+		);
+		expect(obstacleAfter).toBeDefined();
+
+		// The obstacle's holder should have changed from (2, 2) to some adjacent cell.
+		// We know it started at (2, 2) and the shift tuple is deterministic based on the
+		// complication-engine's valid tuples. The test just verifies it moved somewhere.
+		if (obstacleAfter && typeof obstacleAfter.holder === "object") {
+			// Obstacle moved to a new cell. Check it's adjacent to the origin.
+			const obstacleHolder = obstacleAfter.holder as {
+				row: number;
+				col: number;
+			};
+			const origHolder =
+				typeof OBSTACLE.holder === "object"
+					? (OBSTACLE.holder as { row: number; col: number })
+					: { row: 2, col: 2 };
+			const dx = Math.abs(obstacleHolder.row - origHolder.row);
+			const dy = Math.abs(obstacleHolder.col - origHolder.col);
+			// Adjacent means Manhattan distance = 1 (one cardinal direction).
+			expect(dx + dy).toBe(1);
+		} else {
+			// If holder is not a GridPosition, the test fails (obstacle was picked up?).
+			expect.fail("Obstacle holder is not a GridPosition after shift.");
+		}
+	});
+
+	it("appends witnessed-obstacle-shift entry to a daemon whose cone covers fromCell", async () => {
+		const game = makeBaseGame();
+		// red is at (2, 1) facing east, so its cone should cover (2, 2) = obstacle origin.
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeObstacleShiftRng(0) },
+		);
+
+		const redLog = nextState.conversationLogs.red ?? [];
+		const shiftEntries = redLog.filter(
+			(e) => e.kind === "witnessed-obstacle-shift",
+		);
+
+		// red's cone should cover the obstacle origin, so expect at least one entry.
+		expect(shiftEntries.length).toBeGreaterThan(0);
+
+		const entry = shiftEntries[0];
+		if (entry?.kind === "witnessed-obstacle-shift") {
+			expect(entry.obstacleId).toBe("wall_ob");
+			expect(entry.flavor).toBe(OBSTACLE.shiftFlavor);
+			expect(entry.round).toBe(nextState.round);
+			// fromCell should be (2, 2) = obstacle's original position.
+			expect(entry.fromCell).toEqual({ row: 2, col: 2 });
+			// toCell should be one of the adjacent cells (exact cell depends on rng/tuples).
+			expect(
+				Math.abs(entry.toCell.row - 2) + Math.abs(entry.toCell.col - 2),
+			).toBe(1);
+		}
+	});
+
+	it("does NOT append witnessed-obstacle-shift entry to a daemon whose cone does NOT cover fromCell", async () => {
+		const game = makeBaseGame();
+		// cyan is at (0, 0) facing south — its cone should NOT cover (2, 2).
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeObstacleShiftRng(0) },
+		);
+
+		const cyanLog = nextState.conversationLogs.cyan ?? [];
+		const shiftEntries = cyanLog.filter(
+			(e) => e.kind === "witnessed-obstacle-shift",
+		);
+
+		// cyan's cone does not cover the obstacle origin at (2, 2), so no entries.
+		expect(shiftEntries).toHaveLength(0);
+	});
+
+	it("resets the complication countdown after obstacle_shift fires", async () => {
+		const game = makeBaseGame();
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeObstacleShiftRng(0) },
+		);
+
+		// After the complication fires, applyComplicationResult resets the countdown
+		// to a value in [1, 5]. It should no longer be 0.
+		expect(nextState.complicationSchedule.countdown).toBeGreaterThan(0);
+	});
+});

--- a/src/spa/game/__tests__/round-coordinator-weather-change.test.ts
+++ b/src/spa/game/__tests__/round-coordinator-weather-change.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for the round-coordinator's weather_change complication handler.
+ *
+ * Issue #487: weather_change complication fires and:
+ * 1. Changes game.weather and game.contentPack.weather to a new value from WEATHER_POOL.
+ * 2. The new weather differs from the prior weather — no no-op draw.
+ * 3. Appends a broadcast entry to all Daemons' conversationLogs announcing the new weather.
+ * 4. Resets the complication countdown.
+ */
+import { describe, expect, it } from "vitest";
+import { WEATHER_POOL } from "../../../content/weather-pool";
+import { startGame } from "../engine";
+import { runRound } from "../round-coordinator";
+import { MockRoundLLMProvider } from "../round-llm-provider";
+import type { AiPersona, WorldEntity } from "../types";
+import { makeTestPack } from "./fixtures/make-test-pack";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const TEST_PERSONAS: Record<string, AiPersona> = {
+	red: {
+		id: "red",
+		name: "Ember",
+		color: "#e07a5f",
+		temperaments: ["hot-headed", "zealous"],
+		personaGoal: "Hold the flower at phase end.",
+		typingQuirks: ["Fragments.", "Em-dashes."],
+		blurb: "Ember is hot-headed and zealous.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+	green: {
+		id: "green",
+		name: "Sage",
+		color: "#81b29a",
+		temperaments: ["meticulous", "meticulous"],
+		personaGoal: "Ensure items are evenly distributed.",
+		typingQuirks: ["Ellipses.", "ALL-CAPS."],
+		blurb: "Sage is meticulous.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+	cyan: {
+		id: "cyan",
+		name: "Frost",
+		color: "#5fa8d3",
+		temperaments: ["laconic", "diffident"],
+		personaGoal: "Hold the key at phase end.",
+		typingQuirks: ["No contractions.", "Ends with a question."],
+		blurb: "Frost is laconic and diffident.",
+		voiceExamples: ["ex1", "ex2", "ex3"],
+	},
+};
+
+// For the test pack to be valid, we need at least one objective object + space pair.
+const OBJECTIVE_OBJECT: WorldEntity = {
+	id: "obj_a",
+	kind: "objective_object",
+	name: "Test Object",
+	examineDescription: "A test object.",
+	holder: { row: 0, col: 0 },
+	pairsWithSpaceId: "obj_space_a",
+	placementFlavor: "{actor} places it on the space.",
+};
+
+const OBJECTIVE_SPACE: WorldEntity = {
+	id: "obj_space_a",
+	kind: "objective_space",
+	name: "Test Space",
+	examineDescription: "A test space.",
+	holder: { row: 1, col: 1 },
+};
+
+const TEST_CONTENT_PACK = makeTestPack([OBJECTIVE_OBJECT, OBJECTIVE_SPACE], {
+	wallName: "wall",
+	weather: "clear",
+	aiStarts: {
+		red: { position: { row: 0, col: 0 }, facing: "north" },
+		green: { position: { row: 0, col: 1 }, facing: "north" },
+		cyan: { position: { row: 0, col: 2 }, facing: "north" },
+	},
+});
+
+function makeProvider() {
+	return new MockRoundLLMProvider([
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+		{ assistantText: "", toolCalls: [] },
+	]);
+}
+
+/**
+ * Build a base game with the test pack and initial weather.
+ */
+function makeBaseGame() {
+	const base = startGame(TEST_PERSONAS, TEST_CONTENT_PACK, { budgetPerAi: 99 });
+	return {
+		...base,
+		world: {
+			entities: [OBJECTIVE_OBJECT, OBJECTIVE_SPACE],
+		},
+		personaSpatial: TEST_CONTENT_PACK.aiStarts as typeof base.personaSpatial,
+	};
+}
+
+/**
+ * Drive an RNG sequence that deterministically fires weather_change.
+ * The weather_change complication is always available (index 0 in the pool),
+ * so we can use a simple rng that selects it.
+ */
+function makeWeatherChangeRng() {
+	let callCount = 0;
+	return () => {
+		callCount += 1;
+		// First call: select weather_change from the pool (index 0).
+		// Return a very small value to select the first item.
+		if (callCount === 1) {
+			return 0.0;
+		}
+		// Second call: used by drawNewWeather to select from candidates.
+		// Return a small value to select the first non-current weather.
+		if (callCount === 2) {
+			return 0.1;
+		}
+		// Subsequent calls are for countdown reset.
+		return Math.random();
+	};
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("runRound — weather_change complication (issue #487)", () => {
+	it("changes game.weather to a different WEATHER_POOL entry", async () => {
+		const game = makeBaseGame();
+		const initialWeather = game.weather;
+
+		// Force countdown to 0 so complication fires.
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeWeatherChangeRng() },
+		);
+
+		// Weather should have changed
+		expect(nextState.weather).not.toBe(initialWeather);
+		// New weather should be in WEATHER_POOL
+		expect(WEATHER_POOL).toContain(nextState.weather);
+	});
+
+	it("updates both game.weather and game.contentPack.weather consistently", async () => {
+		const game = makeBaseGame();
+
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeWeatherChangeRng() },
+		);
+
+		// Both should be consistent
+		expect(nextState.weather).toBe(nextState.contentPack.weather);
+	});
+
+	it("appends a broadcast entry to all Daemons' conversationLogs", async () => {
+		const game = makeBaseGame();
+
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeWeatherChangeRng() },
+		);
+
+		// Check all Daemons have a broadcast entry
+		for (const aiId of Object.keys(TEST_PERSONAS)) {
+			const log = nextState.conversationLogs[aiId] ?? [];
+			const broadcasts = log.filter((e) => e.kind === "broadcast");
+
+			// At least one broadcast should exist (weather_change)
+			expect(broadcasts.length).toBeGreaterThan(0);
+
+			// The weather_change broadcast should mention the new weather
+			const weatherBroadcast = broadcasts.find(
+				(b) =>
+					b.kind === "broadcast" && b.content.includes("weather has changed"),
+			);
+			expect(weatherBroadcast).toBeDefined();
+
+			if (weatherBroadcast?.kind === "broadcast") {
+				expect(weatherBroadcast.content).toContain(nextState.weather);
+			}
+		}
+	});
+
+	it("resets the complication countdown after weather_change fires", async () => {
+		const game = makeBaseGame();
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeWeatherChangeRng() },
+		);
+
+		// After the complication fires, applyComplicationResult resets the countdown
+		// to a value in [5, 15]. It should no longer be 0.
+		expect(nextState.complicationSchedule.countdown).toBeGreaterThan(0);
+		expect(nextState.complicationSchedule.countdown).toBeLessThanOrEqual(15);
+	});
+
+	it("does not change other game state properties (setting, timeOfDay, etc.)", async () => {
+		const game = makeBaseGame();
+		const initialSetting = game.setting;
+		const initialTimeOfDay = game.timeOfDay;
+		const initialActivePackId = game.activePackId;
+
+		const withCountdown = {
+			...game,
+			complicationSchedule: { ...game.complicationSchedule, countdown: 0 },
+		};
+
+		const { nextState } = await runRound(
+			withCountdown,
+			"red",
+			"hi",
+			makeProvider(),
+			{ rng: makeWeatherChangeRng() },
+		);
+
+		expect(nextState.setting).toBe(initialSetting);
+		expect(nextState.timeOfDay).toBe(initialTimeOfDay);
+		expect(nextState.activePackId).toBe(initialActivePackId);
+	});
+});

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -12,8 +12,9 @@
  * No LLM calls, no browser APIs. All randomness is injected via `rng`.
  */
 
+import { WEATHER_POOL } from "../../content/weather-pool.js";
 import { applyDirection, CARDINAL_DIRECTIONS, inBounds } from "./direction.js";
-import { appendBroadcast, shiftToBPack } from "./engine.js";
+import { appendBroadcast, setWeather, shiftToBPack } from "./engine.js";
 import type {
 	ActiveComplication,
 	AiId,
@@ -48,6 +49,17 @@ export const DISABLABLE_TOOLS: ToolName[] = [
  */
 function drawCountdown(rng: () => number, min: number, max: number): number {
 	return min + Math.floor(rng() * (max - min + 1));
+}
+
+/**
+ * Draw a new weather from WEATHER_POOL, excluding the current weather.
+ * Guarantees the result differs from the input.
+ */
+function drawNewWeather(current: string, rng: () => number): string {
+	const candidates = WEATHER_POOL.filter((w) => w !== current);
+	const idx = Math.floor(rng() * candidates.length);
+	// biome-ignore lint/style/noNonNullAssertion: candidates is non-empty (WEATHER_POOL has 12 entries)
+	return candidates[idx]!;
 }
 
 /**
@@ -257,7 +269,10 @@ function buildSimpleComplication(
 ): ComplicationVariant {
 	switch (kind) {
 		case "weather_change":
-			return { kind: "weather_change" };
+			return {
+				kind: "weather_change",
+				weather: drawNewWeather(phase.weather, rng),
+			};
 
 		case "sysadmin_directive": {
 			const aiIds = Object.keys(phase.personaSpatial);
@@ -293,7 +308,10 @@ function buildSimpleComplication(
 			return { kind: "setting_shift" };
 
 		default:
-			return { kind: "weather_change" };
+			return {
+				kind: "weather_change",
+				weather: drawNewWeather(phase.weather, rng),
+			};
 	}
 }
 
@@ -479,6 +497,15 @@ export function applyComplicationResult(
 		state = appendBroadcast(
 			state,
 			`[SYSTEM] The setting has shifted. You are now in: ${state.setting}.`,
+		);
+	}
+
+	// weather_change: update weather and broadcast the change to all Daemons
+	if (fired.kind === "weather_change") {
+		state = setWeather(state, fired.weather);
+		state = appendBroadcast(
+			state,
+			`[SYSTEM] The weather has changed. ${fired.weather}`,
 		);
 	}
 

--- a/src/spa/game/round-coordinator.ts
+++ b/src/spa/game/round-coordinator.ts
@@ -32,6 +32,7 @@ import {
 	appendMessage,
 	appendPrivateSystemNotice,
 	appendWitnessedConvergence,
+	appendWitnessedObstacleShift,
 	FAREWELL_LINE,
 	isAiLockedOut,
 	resolveToolDisables,
@@ -631,6 +632,55 @@ export async function runRound(
 				target,
 				formatDirectiveDelivery(directiveText),
 			);
+		} else if (fired.kind === "obstacle_shift") {
+			// Apply engine result (resets countdown).
+			state = applyComplicationResult(state, complicationResult, rng);
+
+			// Find the obstacle and move it.
+			const obstacle = state.world.entities.find(
+				(e) => e.id === fired.obstacleId,
+			);
+			if (!obstacle) {
+				// Defensively skip if obstacle not found.
+			} else {
+				// Rebuild entities, updating the obstacle's holder to toCell.
+				state = {
+					...state,
+					world: {
+						...state.world,
+						entities: state.world.entities.map((e) =>
+							e.id === fired.obstacleId ? { ...e, holder: fired.toCell } : e,
+						),
+					},
+				};
+
+				// Fan out witness entries to daemons whose cone covers fromCell.
+				for (const [daemonId, spatial] of Object.entries(
+					state.personaSpatial,
+				)) {
+					const cone = projectCone(spatial.position, spatial.facing);
+					const witnessesOrigin = cone.some(
+						(c) =>
+							c.position.row === fired.fromCell.row &&
+							c.position.col === fired.fromCell.col,
+					);
+
+					if (!witnessesOrigin) continue;
+
+					const entry: Extract<
+						ConversationEntry,
+						{ kind: "witnessed-obstacle-shift" }
+					> = {
+						kind: "witnessed-obstacle-shift",
+						round: state.round,
+						obstacleId: fired.obstacleId,
+						fromCell: fired.fromCell,
+						toCell: fired.toCell,
+						flavor: obstacle.shiftFlavor ?? "",
+					};
+					state = appendWitnessedObstacleShift(state, daemonId, entry);
+				}
+			}
 		} else {
 			state = applyComplicationResult(state, complicationResult, rng);
 			if (fired.kind === "chat_lockout") {

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -231,7 +231,7 @@ export interface ComplicationSchedule {
  * ComplicationKind. Carries only the data needed to dispatch the complication.
  */
 export type ComplicationVariant =
-	| { kind: "weather_change" }
+	| { kind: "weather_change"; weather: string }
 	| { kind: "sysadmin_directive"; target: AiId; duration: number }
 	| { kind: "tool_disable"; target: AiId; tool: ToolName; duration: number }
 	| {


### PR DESCRIPTION
Fixes two sibling no-op complication bugs: both were drawn and "fired" but produced no observable state change. Closes #486 and #487.

## What this fixes

**#486 — `obstacle_shift`.** The complication had complete *selection* logic (availability gating, valid-tuple enumeration, a fully-formed variant carrying `obstacleId` / `fromCell` / `toCell`) but no *application*: the obstacle never moved and no Daemon was notified. The fix adds a dedicated `else if (fired.kind === "obstacle_shift")` branch to the complication tick block in `round-coordinator.ts`. After `applyComplicationResult` resets the countdown, it rebuilds `world.entities` to move the matching obstacle's `holder` from `fromCell` to `toCell`, then projects each Daemon's cone (`projectCone`) and appends a `witnessed-obstacle-shift` entry — carrying the obstacle's authored `shiftFlavor` — to every Daemon whose cone covers the **origin** cell. Mirrors the existing `witnessed-convergence` fan-out. The `witnessed-obstacle-shift` entry type, `appendWitnessedObstacleShift()`, and its renderers already existed and were unused — this wires them up.

**#487 — `weather_change`.** The complication's variant carried no payload, so `game.weather` never changed and no Daemon was told. The fix extends the `weather_change` `ComplicationVariant` with a `weather: string` field. `drawComplication()` now picks a new value via a `drawNewWeather()` helper that filters `WEATHER_POOL` to exclude the current weather (guaranteeing an observable change) and indexes it with the injected RNG — keeping the engine pure and deterministic. `applyComplicationResult()` then calls `setWeather()` (updating both `GameState.weather` and the embedded content pack) and `appendBroadcast()` to announce the change to every Daemon, mirroring `setting_shift`. The `ComplicationVariant` type change required updating pre-existing `complication-engine.ts` tests (bare `weather_change` literals + a seeded-RNG sequence).

## QA steps for the human

Both complications are countdown-driven internal mechanics that can't be deterministically triggered through the browser UI, so they're verified by integration tests that drive the real `runRound` path with a controlled RNG. None strictly required beyond CI. Optional sanity check: play a game long enough for complications to fire and confirm an obstacle visibly relocates and the weather sentence in Daemon context changes.

## Automated coverage

`pnpm typecheck`, `pnpm test` (1725 unit tests — incl. new `round-coordinator-obstacle-shift.test.ts` and `round-coordinator-weather-change.test.ts` plus engine-level `weather_change` tests), `pnpm lint`, and `pnpm smoke` (Playwright, 51/51) — all green.

Closes #486
Closes #487

---
_Generated by [Claude Code](https://claude.ai/code/session_01LejUUbqzHDJNNgjQByKNsZ)_