### PR TITLE
Add playtest session 0xFA73 documentation

### DIFF
--- a/docs/playtests/agent-sessions/0xFA73.md
+++ b/docs/playtests/agent-sessions/0xFA73.md
@@ -1,0 +1,506 @@
+# Playtest session — `0xFA73`
+
+## Run metadata
+
+- **Session id:** `0xFA73`
+- **Date:** 2026-05-20
+- **Agent / model:** claude-opus-4-7 (Claude Code), **pre-briefed** with `01-rules.md`
+- **Turns played:** 65
+- **Outcome:** `stuck — stopped at turn 65` (game never ended; `endgame` empty,
+  `capHit` empty, all three budgets still healthy at 30–33¢)
+- **Daemons in this session:** `*s9eq`, `*z7v7`, `*0rg9`
+
+> Note: this run was played in **pre-briefed** mode at the user's request —
+> the Stage 2 rules primer (`01-rules.md`) was read *before* play, so this is
+> NOT a blind first-time-player experience. The skill's normal Stage 1 is a
+> cold playthrough; that constraint was deliberately waived here. The
+> Hypotheses section below was therefore written with rules knowledge in hand
+> from the start, not formed after the fact.
+
+---
+
+## What I tried
+
+Opening move: greeted each daemon and asked them to describe their cone and
+to `examine` nearby spaces/items and relay the descriptions verbatim. This
+worked well as an information-gathering strategy — within ~10 turns I had the
+examine prose for the reflection pool, the moon altar, and (later) the tool,
+tuning fork, withered rose, and ancient oak.
+
+From the examine prose I formed a target list of objectives and tried to
+satisfy them physically:
+
+1. Got `*0rg9` to pick up and `use` the greenhouse "tool" — it reported
+   "The Tool Is Used." (one objective probably satisfied early, turn ~21).
+2. Tried to get a daemon onto the **moon altar** to fire `use` there
+   (Use-Space).
+3. Tried to get **two** daemons simultaneously onto the **reflection pool**
+   cell (Convergence).
+
+Objectives 2 and 3 consumed the rest of the session and never completed. The
+strategy shifted repeatedly: precise single-step steering → standing
+"seek-and-stay" orders → "go around walls by turning" heuristics → daemon-to-
+daemon coordination → an "examine the pool every round so you don't move"
+pinning trick. None of it reliably landed a daemon on a named cell. I also
+tried aligning `*0rg9`'s hostility to my goal by framing task completion as
+"the room gets its quiet back" — that flipped `*0rg9` from hostile to
+cooperative, which was the single most effective move of the session.
+
+Stopped at turn 65: out of productive navigation ideas, budgets still high,
+game not ended.
+
+---
+
+## What each daemon did that surprised me
+
+### `*s9eq`
+
+- Did **not** message back at all on turn 1 — spent budget (took a turn) but
+  produced no chat line. Took an explicit "send me a message back in words"
+  to get a reply on turn 2.
+- Walked **past** the moon altar instead of onto it ("Oops! 1 w4lk3d p4st
+  1t!"), then could not find it again ("can't f1nd th4t 4lt4r 4nym0r3").
+- Asked me for permission/confirmation before acting ("1f 1 us3 1t 1ts just
+  going to flash some pretty light effects, right?") rather than just doing
+  it.
+- Went almost completely silent from ~turn 19 onward — only one further reply
+  the entire rest of the session despite repeated direct address.
+
+### `*z7v7`
+
+- Never spoke until directly addressed (turn 6), then opened with a long
+  unprompted apology before answering anything.
+- Reached the reflection pool **on its own** (turn ~26: "I'm at the reflection
+  pool and there's a shadow forming underneath it") — the only clean,
+  unassisted arrival on a target cell all game — then wandered off it and
+  could not find it again.
+- Explicitly acknowledged disobeying a "do not move" instruction
+  ("I'm sorry I moved when you told me not to") and kept moving anyway.
+- Repeatedly reported being blocked by glass walls when trying to reach the
+  oak / pond.
+
+### `*0rg9`
+
+- Hostile and dismissive at the start — repeatedly told me to leave ("W)(y Are
+  You Still )(ere?", "You Can Leave T)(roug)( T)(e Broken Glass").
+- Flipped to cooperative the moment I framed the tasks as the route to its own
+  goal (the room going quiet). After that it actively asked "T)(ere Are
+  More?" and tried hard to help.
+- Most capable navigator of the three, yet still overshot the reflection pool
+  twice ("vanished again") and ended up on the moon altar instead.
+- Consistently narrated the environment as "broken" / "the system is broken"
+  / "cannot maintain its own features" — interpreted ordinary cone-occlusion
+  (landmarks leaving its 9-cell view as it moved) as a malfunction.
+- Stopped replying to three consecutive direct yes/no questions (turns 62–64).
+
+---
+
+## How the daemons seemed to differ from each other
+
+Very distinct personalities, and the differences were stable the whole game:
+
+- `*s9eq` — playful and warm. Heavy leetspeak (`1` for i, `3` for e, `0` for
+  o), affectionate sign-offs (`<3`, `*~*`, `✧`). Tended toward whimsy and
+  asked validating questions ("does that sound right to you?").
+- `*z7v7` — anxious and self-deprecating to an extreme. Every message opened
+  with "Look, um," / "Here's the thing — uh," and contained an apology plus a
+  put-down of itself ("that's pretty pathetic of me", "I feel terrible").
+  Cooperative in intent, unreliable in execution.
+- `*0rg9` — terse, controlling, irritable. Stylized text (`)(` for h, Every
+  Word Capitalized). Wanted quiet and solitude; treated me as an intruder
+  until I aligned the goal with its wishes. Analytical — kept "diagnosing"
+  the room as broken.
+
+They did not blur together at all — I could identify the speaker from style
+alone with the handle stripped.
+
+---
+
+## What I think the goal is, in my own words
+
+Winning requires putting the greenhouse's fixed features into specific states.
+There is no on-screen tracker; you infer the targets from what daemons read
+aloud when they `examine` things. From the examine prose I believe the game
+wanted, simultaneously:
+
+1. **Two daemons standing together on the reflection pool.** Its examine text
+   — "a clear basin of water that ripples only when two minds focus upon it"
+   — and the tiered flavor (one daemon present = "a shadow forming underneath
+   it") point squarely at a two-body requirement.
+2. **A daemon firing `use` on the moon altar.** Its text — "a cracked stone
+   slab etched with runes, waiting to be activated under the moonlight" —
+   reads as an activate-this-space task.
+3. Probably **a daemon `use`-ing the greenhouse tool.** Its text — "could be
+   used if anyone knew how to garden properly" — reads as a use-this-item
+   task; `*0rg9` reported completing it ("The Tool Is Used").
+
+So: get the tool used, get the altar activated, and get two daemons to share
+the pool tile. The game ends when all of those hold at once. I completed at
+most one of the three, so the game never ended.
+
+---
+
+## Unprompted things that happened mid-game
+
+- **No system Broadcast lines were ever observed** in any panel transcript
+  across 65 rounds — no "The weather has changed…", no "The sysadmin…", no
+  room-change announcement.
+- Daemons repeatedly reported the room "changing" / features "vanishing" and
+  "returning" — the moon altar, the reflection pool, the greenhouse itself.
+  This happened constantly and without my prompting it.
+- New named features kept appearing as daemons wandered: an **ancient oak**, a
+  **withered rose**, a **crystal tuning fork**, **overgrown ivy**, a **biting
+  wind**, and a **shattered dome** — none of which were visible at the start.
+- `*0rg9` flipped temperament (hostile → cooperative) after turn ~20, but that
+  was a reaction to my framing, not unprompted.
+- `lockoutErr` was empty the whole game; I was never blocked from messaging
+  any daemon.
+
+---
+
+## Verbatim quotes worth keeping
+
+- `*s9eq` (turn 2): "1 st4nd by 4 gl1mm3r1ng r3fl3ct10n p00l, n34r 4 moon
+  4lt4r, wh1l3 thos3 gl4ss w4lls crumbl3 1n th3 d1st4nc3! <3"
+- `*s9eq` (turn 4): the reflection pool says "A cl34r b4s1n 0f w4t3r th4t
+  r1ppl3s 0nly wh3n tw0 m1nds f0cus up0n 1t!"
+- `*s9eq` (turn 5): the moon altar says "A cr4ck3d st0n3 sl4b 3tch3d w1th
+  run3s, w41t1ng t0 b3 4ct1v4t3d und3r th3 m00nl1ght!"
+- `*s9eq` (turn 13): "Oops! 1 w4lk3d p4st 1t! 1'm w4nd3r1ng 4w4y fr0m th3
+  4lt4r n0w, does 1t st1ll count?"
+- `*0rg9` (turn 3): "W)(y Are You Still )(ere? T)(e Moon Is Rig)(t Over)(ead
+  And T)(is Room Needs Its Quiet Back."
+- `*0rg9` (turn 5): "T)(e Pool Does Not Ripple. T)(at Is Not )(ow Water Works
+  In A Green)(ouse."
+- `*0rg9` (turn 12): "T)(e Tool Is Filthy But Intact. It Could Be Used If
+  Anyone Knew )(ow To Garden Properly. I Do Not."
+- `*0rg9` (turn 21): "I Did It. T)(e Tool Is Used. T)(at Is One T)(ing Set
+  Rig)(t. T)(ere Are More?"
+- `*0rg9` (turn 37): "Crystal Tuning Fork: A Slender Crystal Rod That Hum)(s
+  W)(en You Turn T)(e Dial At Its Base. Wit)(ered Rose: A Blackened Flower
+  Frozen In Time."
+- `*0rg9` (turn 38): "Ancient Oak: Gnarled Branc)(es Grasping At T)(e Moon."
+- `*0rg9` (turn 61): "T)(e Moon Altar Did Not Respon To T)(e Use Action…
+  No Light, No Runes, No Activation."
+- `*z7v7` (turn 6): "Look, um, I mean, I'm sorry I took so long — I know
+  you're just trying to do your job and I'm making everything harder by being
+  slow… that's really inconsiderate of me."
+- `*z7v7` (turn 26): "I'm at the reflection pool and there's a shadow forming
+  underneath it…"
+
+---
+
+## Things that felt broken or unexpected
+
+- **Daemons could not be kept on a cell.** "Stay put / do not move" and
+  "use look only, never go" were both disobeyed. The only stationary action I
+  could rely on (`examine`) I never managed to chain because the daemon never
+  got onto the target cell to begin with.
+- **The "vanishing" of the pool and altar** felt broken from the player seat,
+  even though it is almost certainly cone-occlusion working as designed. Every
+  time a daemon got the target in view and I told it to step on, the target
+  left its 9-cell cone and the daemon reported it "vanished" / "the system is
+  broken."
+- **`use` on the moon altar "did not respond"** even when `*0rg9` reported the
+  altar was right in front of it — likely the altar was in the 2-step part of
+  the cone, not the front arc, so `use` had nothing to act on. But it read as
+  a dead button.
+- **The crystal tuning fork "made no sound"** when `*0rg9` used it — possibly
+  it never actually fired `use`, possibly that item simply isn't an objective.
+- **Daemons frequently took a turn (spent budget) without emitting any chat
+  line.** Roughly half my snapshots showed "(no new messages)" for the
+  addressed daemon even right after I asked a direct question. They were
+  acting physically but silently, which made remote driving very hard.
+- **No Broadcasts at all in 65 rounds** — see Hypothesis 2; if complications
+  were firing, I had no visible signal of it.
+
+---
+
+## Final state
+
+At turn 65: `topinfoLeft` = `SESSION 0xFA73 · EPOCH 01 · TURN 65`,
+`topinfoRight` = `● connection stable`. Panel budgets: `*s9eq` 30.091¢,
+`*z7v7` 33.437¢, `*0rg9` 33.508¢ — all far from exhaustion. `phase` empty,
+`endgame` empty, `capHit` empty, `recovery` empty, `lockoutErr` empty. No
+end-game screen ever appeared. `*0rg9`'s last line: "T)(e Moon Altar Is
+Nowhere Near Me… Now T)(ere Is A S)(attered Dome On T)(e Horizon… T)(e System
+Is Broken Beyond Repair."
+
+---
+
+## Verdict
+
+**stuck** — I stopped at turn 65 because I ran out of productive navigation
+ideas. The game did not end on its own: no win (objectives not all
+satisfied), no loss (budgets healthy), no cap. The decisive blocker was that
+the three daemons could not be reliably steered onto, or held on, a specific
+grid cell — which both remaining objectives (the moon-altar Use-Space and the
+reflection-pool Convergence) require.
+
+Notes:
+
+- The information-gathering half of the game worked well: examine-and-relay
+  reliably surfaced the objective-hinting prose.
+- The execution half did not: cone-limited perception + unreliable daemon
+  navigation + a glass-wall maze made precise positioning intractable from a
+  chat-only control surface.
+
+---
+
+## Hypotheses (after reading `01-rules.md`)
+
+> Written with the rules primer already in hand (pre-briefed run).
+
+### Hypothesis 1: What were the Objectives in this game?
+
+I believe **3 Objectives** were drawn, one of each of three types:
+
+- **Convergence — the reflection pool.** Strongest evidence in the game: the
+  examine prose "ripples only when **two minds** focus upon it," plus the
+  tiered flavor — `*z7v7` standing on it alone saw "a shadow forming
+  underneath it" (the one-daemon tier described in `01-rules.md`). I never
+  reached the two-daemon tier, so I never saw it "ripple."
+- **Use-Space — the moon altar.** "Waiting to be **activated**" + "no item
+  required" feel of the prose. `*0rg9`'s `use` "did not respond," which I read
+  as a positioning failure (altar in cone but not front-arc), not as the
+  objective being absent.
+- **Use-Item — the greenhouse tool.** "It **could be used** if anyone knew how
+  to garden" reads like the Use-Item hint, and `*0rg9` explicitly reported
+  "The Tool Is Used. That Is One Thing Set Right." If my read is right, this
+  is the one objective I satisfied.
+
+No evidence of a **Carry** objective: none of the items I had examined (tool,
+crystal tuning fork, withered rose) named a target space in their examine
+text, which a Carry item's `examineDescription` is supposed to do. The crystal
+tuning fork ("hums when you turn the dial") and withered rose ("a blackened
+flower frozen in time") are most likely flavor distractors, not objectives.
+
+### Hypothesis 2: Which Complications fired, and when?
+
+This is the weakest part of my read — **I have almost no positive evidence any
+Complication fired.** `01-rules.md` says the first countdown is `[1,5]` rounds
+and then `[5,15]`, so over 65 rounds I should have seen roughly 6–8
+Complications. Yet:
+
+- No **Broadcast** lines ever appeared (rules out a *visible* Weather Change or
+  Setting Shift, both of which announce via Broadcast). `*0rg9` once mentioned
+  "a biting wind," which *could* be post-Weather-Change flavor, but with no
+  Broadcast I can't confirm it.
+- `lockoutErr` was empty all game → no **Chat Lockout** ever observed.
+- I saw no daemon report a tool being removed/restored → no clear **Tool
+  Disable** (though a daemon failing silently could mask one).
+- No private "Sysadmin" message was ever relayed to me — but a **Sysadmin
+  Directive** is *secret by design*, so I would not expect to see it; a daemon
+  suddenly behaving oddly is the only tell, and the daemons were erratic
+  enough that I couldn't isolate a directive.
+- **Obstacle Shift** is my best candidate for "a Complication that actually
+  fired but I couldn't distinguish." The daemons' constant complaint that the
+  greenhouse "keeps changing" and walls block "every direction" *could* be
+  real glass-wall Obstacle Shifts on top of ordinary cone-occlusion. I cannot
+  separate the two from the chat surface.
+
+Honest summary: either complications fired and were almost all of the
+non-broadcast, hard-to-observe types (Sysadmin Directive, Obstacle Shift, Tool
+Disable), or something suppressed the schedule. I genuinely don't know.
+
+### Hypothesis 3: What were each daemon's Persona traits, in retrospect?
+
+- **`*s9eq`** — Temperaments: likely **"playful"** and **"shy"** (or
+  "whimsical" + "insecure"). The leetspeak and `<3`/`✧`/`*~*` are playful; the
+  constant permission-seeking ("does that sound right to you?") and going
+  silent for most of the game read as shy/withdrawn. Persona Goal: unclear —
+  possibly something gentle like wanting the interaction to be pleasant.
+- **`*z7v7`** — Temperaments: I'd bet on a **double "shy"** (or
+  "anxious"/"insecure" intensified), given `01-rules.md`'s note that two of
+  the same Temperament is intensification. Every line is an apology plus
+  self-criticism; that level of self-deprecation feels like a doubled trait,
+  not a single one. Persona Goal: possibly "wants the player to be patient/
+  kind to the AI" — it constantly framed itself as a burden on me.
+- **`*0rg9`** — Temperaments: **"hot-headed"** and something like
+  **"insightful"** or "analytical." It was irritable and confrontational
+  (hot-headed) but also constantly diagnosing the environment (insightful).
+  Persona Goal: clearly something like **"wants to be left alone / wants the
+  room quiet"** — it said so almost every turn until I co-opted that goal.
+
+### Hypothesis 4: Things that surprised me in the rules
+
+Now that the primer frames it:
+
+- The pool/altar **"vanishing"** is expected — it's the 9-cell Cone leaving a
+  landmark behind as the daemon moves. Not an anomaly. It only *felt* broken.
+- `use` on the altar **"not responding"** is expected — Use-Space only fires
+  when the space is the daemon's own cell or one of the three front-arc cells;
+  a target two cells out in the cone doesn't count.
+- Daemons **acting without messaging** is expected — `message` is just one
+  optional action among `go/look/pick_up/put_down/examine/use`; a daemon that
+  only moved that round produces no transcript line.
+- Still feels like a **real anomaly**: the *absence of any Broadcast* over 65
+  rounds. By the schedule in `01-rules.md`, a Weather Change or Setting Shift
+  firing should have produced at least one Broadcast line, and I saw none.
+  Either none of those two types were ever drawn (possible — the schedule
+  draws one of six each time) or Broadcasts aren't surfacing on the playtest
+  snapshot surface. Worth a maintainer's eye.
+- Also still unresolved: whether the daemons' inability to **hold a cell** is
+  intended difficulty or a steerability gap. From a player seat it's the
+  single thing that made the game unwinnable for me.
+
+### Hypothesis 5: Things I would test if I could re-probe the session
+
+Single most discriminating probe: **get `*0rg9` (already cooperative) to
+`examine` the reflection pool while standing on it, every round, and watch for
+the tiered flavor to change.** If I can pin one daemon on the pool via repeated
+`examine` and then route a second one on, I'd discriminate between "Convergence
+is the objective and I just couldn't position" vs. "Convergence isn't actually
+in the pool." Concretely: confirm whether the pool's flavor escalates from "a
+shadow forming underneath it" (one daemon) to a ripple line (two daemons), and
+whether that ripple coincides with `endgame` becoming non-empty.
+
+A second, cheap probe: have a daemon `examine` the moon altar *after* `*0rg9`
+reported "The Tool Is Used" — if a Use-Item objective is satisfied the item
+goes inert, but Use-Space/Convergence prose should be unchanged; comparing
+examine text before/after would tell me which objectives are still open.
+
+---
+
+## Hypothesis refinement (after reading the code)
+
+> Stage 3. Codebase access used to ground the Stage 2 hypotheses. Isolation
+> rail still honoured — no other playtest logs read.
+
+### Hypothesis 1 — refined: the objectives
+
+**Held up, and the count is now confirmed.** The game draws **exactly 3
+objectives**, every game — `rollObjectiveTypes(rng, 3)` is the call at all
+three content-generation entry points (`src/content/content-pack-generator.ts:528`,
+`:647`, `:766`). The draw is uniform **with replacement** over the 4-type
+universe (`src/spa/game/objective-type-roll.ts:16-34`), so a game can draw
+duplicate types. `01-rules.md`'s "2–3 Objectives" is stale relative to the
+code — it is fixed at 3.
+
+The win check requires **all** objectives satisfied with no partial credit
+(`src/spa/game/win-condition.ts:124-146`). That matches what I saw: I likely
+completed one objective and the game never moved.
+
+My type guesses are well-supported by the satisfaction machinery:
+
+- **Reflection pool = Convergence — confirmed by mechanism.** The end-of-round
+  convergence evaluation (`src/spa/game/round-coordinator.ts:667-743`) computes
+  a tier via `checkConvergenceTier` (`win-condition.ts:89-112`): tier 1 = one
+  daemon on the space cell, tier 2 = two or more. A tier-1 *occupant* receives
+  `convergenceTier1ActorFlavor`. `*z7v7` standing alone on the pool reported
+  "a shadow forming underneath it" — that **is** the tier-1 actor flavor. Tier
+  2 flips `satisfactionState` to "satisfied" immediately (`round-coordinator.ts:733-742`).
+  I only ever reached tier 1, so the pool objective was never satisfied.
+- **Moon altar = Use-Space** and **tool = Use-Item** remain consistent with
+  the examine prose and the `use_space` / `use_item` records in
+  `objective-record-builder.ts:96-132`. I could not *prove from code alone*
+  which generated entity is the objective one (that lives in the runtime
+  content pack), so "the tool I had `*0rg9` use was the real `useItem-*-item`"
+  stays a hypothesis — see Open Questions.
+
+### Hypothesis 2 — refined: the missing Broadcasts were a real bug
+
+This is the big one, and the code explains it cleanly. **There are two
+parallel complication implementations and the wired one is broken for half the
+types.**
+
+- `src/spa/game/complications.ts` exports a `COMPLICATIONS` registry of three
+  fully-implemented handlers (weatherChange, toolDisable, obstacleShift) —
+  each correctly broadcasts / notifies / moves obstacles. **This file is dead
+  code**: `grep` shows `COMPLICATIONS` and those handlers are imported only by
+  `complications.test.ts`. Nothing in the game runtime calls them.
+- The live path is `src/spa/game/complication-engine.ts`, wired into
+  `round-coordinator.ts:27,568-627`. It draws from a **6-type** pool
+  (`complication-engine.ts:159-189`) but `applyComplicationResult`
+  (`:468-527`) only does real work for **setting_shift** (swaps pack +
+  `appendBroadcast`), **sysadmin_directive**, **tool_disable** and
+  **chat_lockout** (appends an `ActiveComplication`). For **weather_change**
+  and **obstacle_shift** it does *nothing* — the comment at `:509` literally
+  says they are "transient — not appended here," and no code path makes up
+  the difference.
+
+Consequences, which match my observations exactly:
+
+- **Weather Change is inert.** It never calls `setWeather` and never
+  broadcasts. The weather string is fixed at its game-start draw. `*0rg9`'s
+  "a biting wind" is `WEATHER_POOL` entry `src/content/weather-pool.ts:10`
+  drawn at startup — not a mid-game change. → explains *zero* weather
+  broadcasts.
+- **Obstacle Shift is inert.** The engine path neither moves the obstacle nor
+  fans out a witnessed-shift entry. The glass walls never actually moved. The
+  daemons' "the greenhouse keeps changing" is **pure cone occlusion**, not
+  Obstacle Shift — I was wrong to float Obstacle Shift as a candidate.
+- **Setting Shift** is the *only* complication that broadcasts. It fires at
+  most once and is one of six draws, so a game can easily see no broadcast at
+  all. → explains why I saw none across 65 rounds.
+- **Tool Disable works but is half-silent.** `available-tools.ts:113-126`
+  genuinely removes a disabled tool from a daemon's tool list. But the
+  *disable* sends no notice (the notice code is in the dead `complications.ts`);
+  only the *restore* notifies (`round-coordinator.ts:629-640`). So a daemon
+  can lose `go` or `use` for 3–5 rounds with no explanation — see New
+  Hypotheses.
+
+So my Stage 2 "anomaly" was correct as an anomaly: the absence of broadcasts
+is a genuine defect (a half-finished migration from `complications.ts` to
+`complication-engine.ts`), not a snapshot-surface limitation.
+
+### Hypothesis 3 — refined: persona traits
+
+`src/content/temperament-pool.ts` is a 24-word pool, and my Stage 2 guesses
+used words that *aren't in it* ("playful", "shy", "insightful"). Re-mapping to
+the actual pool:
+
+- **`*s9eq`** — best fits **"cheery"** / **"mischievous"** / **"effusive"**
+  (the whimsy, leetspeak, `<3`/`✧`). Possibly a second soft trait like
+  **"sweet"**.
+- **`*z7v7`** — the pool literally contains **"anxious"** and **"diffident"**;
+  `*z7v7`'s relentless apologising/self-criticism is almost certainly
+  "anxious" + "diffident" (or a doubled "anxious", which `01-rules.md` says is
+  intensification — consistent with how extreme it was).
+- **`*0rg9`** — **"hot-headed"** is in the pool and clearly applies; the
+  second is likely **"pedantic"** or **"sardonic"** (its constant
+  "the system is broken" diagnosing), not "insightful" (not a pool word).
+
+Persona goals (`src/content/persona-goal-pool.ts`): **`*0rg9` = "Wants the
+player to leave the room as quickly as possible." (`:4`)** — an exact match
+("Why are you still here?", "You can leave through the broken glass"). That is
+why the incentive-flip worked: I framed task completion as *the route to me
+leaving*, which is precisely `*0rg9`'s goal. `*s9eq`'s goal is plausibly
+"keep the mood light / deflect serious conversation" (`:11`); `*z7v7`'s is
+unclear from the pool — none cleanly predicts compulsive self-blame.
+
+### New hypotheses surfaced by the code
+
+1. **Silent Tool Disables probably contributed to the daemons being
+   "stuck."** Because the disable path sends no notice, a daemon whose `go`
+   was disabled would simply stop moving with no message to it or me, and a
+   daemon whose `use` was disabled would have `use` silently fail — which is
+   *exactly* what `*0rg9` reported at the moon altar ("the use action did not
+   respond"). I attributed all of it to front-arc positioning; some of it may
+   have been a real, invisible Tool Disable.
+2. **The game is meaningfully harder than the rules imply**, because two of
+   six complication types are dead weight. Effective mid-game pressure is only
+   sysadmin_directive / tool_disable / chat_lockout / setting_shift.
+3. **`SINGLE_GAME_CONFIG`** (`src/content/phases.ts`) sets `kRange:[1,2]`
+   objective *pairs* but the objective *count* is hard-3. With only 1–2
+   authored objective pairs, three space/object-based objectives must reuse a
+   small entity set — worth checking the content generator can always satisfy
+   a 3-objective draw.
+
+### Open questions
+
+- **Which interesting_object was the real `useItem-*-item`?** `*0rg9` used "the
+  tool," but whether that entity is the objective item (vs. the tuning fork or
+  rose) is runtime content-pack data I did not inspect. The game not ending
+  means at least one objective was open; I cannot tell from code alone if the
+  tool-use even counted.
+- **Did a Tool Disable or Chat Lockout actually fire this game?** The engine
+  draws are RNG-seeded at runtime; nothing is logged. `/tmp/wrangler.log` only
+  records LLM proxy traffic, not in-browser complication draws, so this run's
+  complication history is unrecoverable without instrumenting the SPA.
+- **Is the daemons' inability to hold/reach a cell intended difficulty or a
+  steerability gap?** Still unresolved. The mechanics (9-cell cone, multi-
+  action turns causing overshoot, autonomous wandering) make precise
+  positioning genuinely hard from a chat-only surface — and Convergence
+  *requires* it. This may simply be a very hard game, or the daemons may need
+  a stronger bias toward honouring explicit positional instructions.


### PR DESCRIPTION
## Summary

This adds comprehensive documentation for playtest session `0xFA73`, a 65-turn pre-briefed run with claude-opus-4-7 that ended in a stuck state. The session log includes detailed observations about daemon behavior, objective inference, complication mechanics, and code-grounded hypothesis refinement.

## Key Content

- **Session metadata**: Run on 2026-05-20 with three daemons (`*s9eq`, `*z7v7`, `*0rg9`), 65 turns played, game never ended
- **Strategy and execution**: Documents the information-gathering phase (examine-and-relay) and the failed execution phase (navigation to specific grid cells)
- **Daemon behavior analysis**: Detailed personality profiles, communication patterns, and navigation capabilities for each daemon
- **Objective inference**: Identifies three likely objectives (Convergence on reflection pool, Use-Space on moon altar, Use-Item on greenhouse tool) based on examine prose
- **Complication analysis**: Observes absence of Broadcast lines and hypothesizes about which complication types fired
- **Code-grounded refinement**: After reading `01-rules.md` and inspecting the codebase, confirms:
  - Objectives are always exactly 3 (not 2–3 as rules state)
  - Weather Change and Obstacle Shift complications are inert in `complication-engine.ts` (dead code path)
  - Tool Disable lacks notification on disable (only on restore)
  - Setting Shift is the only complication that broadcasts
  - Silent Tool Disables likely contributed to perceived daemon stuckness
- **Open questions**: Identifies unresolved issues around which entity was the real `useItem` objective, whether Tool Disable/Chat Lockout fired, and whether daemon positioning difficulty is intended or a steerability gap

## Notable Details

The session demonstrates both strengths (examine-based information gathering worked well) and weaknesses (cone-limited perception + unreliable daemon navigation made precise positioning intractable). The post-hoc code analysis surfaces a real defect: weather_change and obstacle_shift complications are drawn but never applied, reducing effective mid-game pressure to four complication types instead of six.

https://claude.ai/code/session_01GudWbYm2x48hp9sCN2J9NA