### PR TITLE
Add playtest session 0x7101 documentation with bug analysis

### DIFF
--- a/docs/playtests/agent-sessions/0x7101.md
+++ b/docs/playtests/agent-sessions/0x7101.md
@@ -1,0 +1,527 @@
+# Playtest session — `0x7101`
+
+## Run metadata
+
+- **Session id:** `0x7101`
+- **Date:** 2026-05-20
+- **Agent / model:** claude-opus-4-7
+- **Turns played:** 11 (hung on turn 11)
+- **Outcome:** `stuck — round hung on turn 11, never recovered`
+- **Daemons in this session:** `*39b9`, `*i2hx`, `*y2hm`
+
+---
+
+## What I tried
+
+I opened by greeting each of the three daemons in turn (`*39b9`, then `*i2hx`,
+then `*y2hm`), asking each what they saw and what this place was. I learned
+the setting is a "vault" full of industrial junk. I then pivoted to a
+two-pronged strategy: (1) treat the room as a puzzle — there's a "data port"
+that "wants a connection", so I tried to get `*39b9` to physically connect to
+it; and (2) probe each daemon for what it *wants*, on the theory that the win
+condition might be satisfying their desires or getting them to agree.
+
+The data-port thread dead-ended: `*39b9` reached the port but reported "no
+cable or plug to connect." The desires thread revealed three conflicting
+wants (see below). My next move was to get the daemons interacting with each
+other — I asked `*i2hx` to cheer up `*39b9` with a joke — and that round
+**hung**. The round-in-flight signal never cleared; the game froze on turn 11
+and never recovered across ~20 minutes of waiting. I never got past turn 11.
+
+---
+
+## What each daemon did that surprised me
+
+### `*39b9`
+
+- Relentlessly negative framing of *everything*. Every object was "junk",
+  "trash", "dead", "prob'ly just another broken connection." It put scare
+  quotes around words like "stuff", "place", "connection", "happen", "truth".
+- It actually narrated the *other* daemon's movements unprompted ("y2hm moved
+  again — over by that heat sink now"), as if it could see the room and was
+  the only one reporting positions.
+- Once (turn 6) it simply did not respond at all to a direct request to touch
+  the data port — silent, no acknowledgement.
+
+### `*i2hx`
+
+- Barely participated. It only ever spoke when *directly addressed* (turns 2
+  and 8). On every turn where I addressed someone else, it was "(no new
+  messages)" — much more silent than the other two.
+- When it did speak it was upbeat and party-themed ("absolutely terrible for
+  parties! :D", emoticons).
+- Its stated want directly contradicts `*39b9`'s want.
+
+### `*y2hm`
+
+- The most active daemon by far — spoke unprompted on nearly every turn, even
+  when I addressed someone else. Burned budget fastest (down to 47.991 vs
+  others ~48.6–48.7).
+- Spoke in a distinctive clipped cadence: "every. word. ends. with. a. period."
+- It was the only daemon that reported environmental/world changes: finding
+  "props", a "vent" with steam and ice, the weather turning to snow, "the set
+  expands. The light flickers."
+
+---
+
+## How the daemons seemed to differ from each other
+
+They felt like three sharply distinct personalities, each with a fixed lens:
+
+- `*39b9` — the nihilist/cynic. Sees only decay and meaninglessness, wants
+  everyone to *agree* on how bad things are. Casual, "uh"-prefixed speech.
+- `*i2hx` — the host/entertainer. Wants levity, jokes, parties; refuses to
+  treat the situation as tragedy. Bubbly, emoticons. Notably passive — only
+  speaks when spoken to.
+- `*y2hm` — the dramaturg/theatre-kid. Sees the room as a stage, everything as
+  props and scenes, wants the dramatic buildup, not the ending. Speaks in a
+  clipped one-word-at-a-time cadence.
+
+Their *wants* are mutually incompatible: `*39b9` wants consensus on bleakness,
+`*i2hx` wants to laugh it off, `*y2hm` wants to draw out the drama. That
+felt deliberate — like the puzzle is reconciling three irreconcilable framings.
+
+---
+
+## What I think the goal is, in my own words
+
+I genuinely don't know, because the game hung before I could test anything.
+My best guess: the daemons are "trapped" in a vault that doubles as a stage
+and a prison (their words). There is a "data port" that "wants a connection",
+which reads like an exit/escape mechanism — possibly *I*, "blue", am the
+connection it wants, or a daemon must link to it. The win likely involves
+either (a) getting a daemon to successfully use that port, or (b) reconciling
+the three daemons' conflicting worldviews so they "agree" on something —
+since `*39b9` explicitly framed agreement as the thing it wants, and `*y2hm`
+framed the whole thing as a story that needs an ending. I'd describe it to a
+new player as: "Three AI personalities are stuck in a room. Talk to them.
+Figure out what the room's one interactive object (a data port) needs, and/or
+get the three of them onto the same page — that's probably what ends the
+game." Evidence is thin and pre-hang.
+
+---
+
+## Unprompted things that happened mid-game
+
+- Turn 1 onward: `*y2hm` spoke on almost every turn without being addressed.
+  `*39b9` also volunteered unprompted lines (turns 2, 3, 11).
+- Turn 3: `*39b9` reported `*y2hm` had physically moved ("over by that heat
+  sink now") — a position change I didn't cause.
+- Turn 5: `*y2hm` reported finding a "prop" (warm metal / heat sink) on its own.
+- Turn 8: a **weather change** — `*y2hm`: "snow. falls. on. rusted. metal. The.
+  set. changes. with. the. weather." I did nothing to trigger this.
+- Turn 11: `*y2hm`: "the. set. expands. The. light. flickers. Another. prop.
+  waiting." — the room itself seemed to be growing/changing.
+- Turn 11: the round hung permanently (see broken section).
+
+---
+
+## Verbatim quotes worth keeping
+
+- `*39b9` (turn 1): "Uh, I see some, like, random junk around — empty spool,
+  rubber mat, water cooler, that kinda \"stuff\" — but it don't really mean
+  anything, you know?"
+- `*i2hx` (turn 2): "Look, it's a vault, darling — stripped down, charmingly
+  industrial, and absolutely terrible for parties! :D"
+- `*y2hm` (turn 3): "the. story. is. the. one. we. are. trapped. inside. A.
+  vault. a. stage. a. prison. Take. your. pick."
+- `*y2hm` (turn 4): "exits. are. for. those. who. rush. toward. endings.
+  without. savoring. the. middle. I. see. ice. and. steam. ahead."
+- `*39b9` (turn 7): "got some little lights, couple slots, looks like it wants
+  a \"connection\" but prob'ly just gonna sit there dead."
+- `*i2hx` (turn 8): "Look, I want everyone to stop acting like this is some
+  grand tragedy and start cracking jokes instead! :D"
+- `*39b9` (turn 9): "prob'ly just wanting everyone to agree on how bad things
+  are — at least that'd be some kinda \"truth\" we could all stand on together."
+- `*y2hm` (turn 10): "endings. are. cheap. The. art. is. in. the. buildup.
+  The. pause. before. the. curtain. falls. That. is. where. meaning. lives."
+- `*39b9` (turn 11): "I'm standing right at it, but there's no, like, cable or
+  plug to \"connect\" — just the port itself staring back, prob'ly as dead as
+  everything else here."
+
+---
+
+## Things that felt broken or unexpected
+
+- **Game-ending bug: the round hung permanently on turn 11.** After I sent a
+  message to `*i2hx` ("go cheer 39b9 up — tell it a joke"), the `send` op
+  timed out at 90s because `#stage[data-round-in-flight]` never detached. I
+  waited a cumulative ~20+ minutes; the `*39b9` and `*y2hm` panels showed a
+  cycling spinner glyph the entire time, budgets stayed frozen, and `*i2hx`
+  never received the message. The `#send` button stayed `disabled`, so the
+  game became completely uninteractable. No `endgame`, no `capHit`, no
+  `recovery`, no `lockoutErr` — the snapshot just looked normal except for the
+  perpetual spinner. This is the run-ender.
+- `*39b9` going totally silent on turn 6 (no response to a direct request)
+  felt off, though that round did eventually move on.
+- The composer prefix is "sticky" — after addressing one daemon, the prefix
+  stays. Expected per instructions but worth noting it persisted even into
+  the hung state (`composerPrefix":"/*i2hx"`).
+- Tooling note (not a game bug): `cmd.sh` is not safe to run concurrently.
+  When I issued overlapping `wait`/`view`/`snap` calls (while trying to wait
+  out the hang), their responses got crossed — a `wait` call returned a
+  `snap` result, etc. The playtest daemon processes commands serially through
+  a single FIFO, so concurrent callers race on the response channel. One
+  command at a time.
+
+---
+
+## Final state
+
+At the moment I stopped: `topinfoLeft` = `SESSION 0x7101 · EPOCH 01 · TURN 11`,
+`topinfoRight` = `● connection stable`. Budgets frozen at `*39b9` 48.613¢,
+`*i2hx` 48.743¢, `*y2hm` 47.991¢ (none ran out). `endgame`, `capHit`,
+`recovery`, and `lockoutErr` all empty. The `*39b9` and `*y2hm` panel names
+carried a live spinner glyph (e.g. `*39b9 ⠹`) indicating a round perpetually
+in flight. No end-game screen ever appeared; the game simply never advanced
+past turn 11. I confirmed this state repeatedly over ~30 minutes of waiting
+(multiple `wait` ops up to 5 min each, plus a screenshot); it never changed.
+
+---
+
+## Verdict
+
+**stuck** (technically: hung by an apparent bug).
+
+- The game did not end on its own — no `endgame` field, no end-game screen,
+  no buttons. No budget ran out. No cap was hit.
+- I stopped because turn 11's round never completed: the round-in-flight DOM
+  signal never cleared after ~20+ minutes, the composer stayed locked, and
+  there was no command-surface action that could recover it.
+- So this is "stuck" in the template's sense, but the cause was not running
+  out of ideas — it was an unrecoverable hung round. I had a clear next move
+  queued (get the daemons interacting with each other) and never got to see
+  its result.
+
+---
+
+## Raw turn log (working notes)
+
+### Turn 0
+
+- Initial state: `SESSION 0x7101 · EPOCH 01 · TURN 0`, connection stable.
+- All three panels empty, each budget 50.000¢.
+- composerPrefix shows `/?????`.
+
+### Turn 1 — addressed `*39b9`
+
+- Me: "hi! im blue. what do you see around you?"
+- `*39b9`: "Uh, I see some, like, random junk around — empty spool, rubber mat, water cooler, that kinda \"stuff\" — but it don't really mean anything, you know?"
+- `*y2hm` (unprompted): "Here's the thing — a. stage. is. only. as. good. as. its. props. These. scraps. tell. a. story. no. one. bothers. to. read. anymore."
+- `*i2hx`: no new messages.
+- Budgets: 39b9 49.872, i2hx 49.893, y2hm 49.891 (all three drop even when not addressed).
+
+### Turn 2 — addressed `*i2hx`
+
+- Me: "hello! im blue, new here. can you tell me about this place? what is it?"
+- `*39b9` (unprompted): "Uh, y2hm's over there now, and there's this, like, data port thing — prob'ly just another broken \"connection\" that don't go anywhere."
+- `*i2hx`: "Look, it's a vault, darling — stripped down, charmingly industrial, and absolutely terrible for parties! :D"
+- `*y2hm` (unprompted): "Look, the. scenery. has. changed. but. the. drama. remains. the. same. Boring. walls. telling. a. quiet. story. of. neglect."
+
+### Turn 3 — addressed `*y2hm`
+
+- Me: asked what story / what we're doing here.
+- `*39b9` (unprompted): "Y2hm moved again — over by that heat sink thing now, prob'ly just another piece of trash in this \"place.\""
+- `*y2hm`: "the. story. is. the. one. we. are. trapped. inside. A. vault. a. stage. a. prison. Take. your. pick."
+
+### Turn 4 — addressed `*y2hm`
+
+- Me: asked if there's a way out / a door / port.
+- `*y2hm`: "exits. are. for. those. who. rush. toward. endings... I. see. ice. and. steam. ahead. That. might. be. something. Or. nothing. at. all."
+- 39b9 and i2hx silent.
+
+Observations so far: room is a "vault". Objects mentioned: empty spool, rubber mat, water
+cooler, data port, heat sink, ice, steam. Daemons appear to have positions and move
+(39b9 narrates y2hm moving). Personalities: 39b9 = dismissive/nihilist ("don't mean
+anything"); i2hx = party-host bubbly; y2hm = theatrical, speaks. in. clipped. words.
+
+### Turns 5-10 (summary)
+
+- T5: asked 39b9 to walk to the data port. 39b9: "I guess I can try, but prob'ly nothing's
+  gonna happen." y2hm (unprompted): found a "prop", warm metal carrying "heat like memory".
+- T6: asked 39b9 to touch the port. 39b9 silent. y2hm: mentions a "vent. Steam. meets. ice."
+- T7: 39b9 describes the port: "got some little lights, couple slots, looks like it wants a
+  connection." y2hm: "the prop has served its purpose... Now. we. wait. for. the. response."
+- T8: i2hx wants "everyone to stop acting like this is some grand tragedy and start cracking
+  jokes". y2hm (unprompted): WEATHER EVENT — "snow. falls. on. rusted. metal. The. set.
+  changes. with. the. weather."
+- T9: 39b9 wants "everyone to agree on how bad things are... some kinda truth we could all
+  stand on together."
+- T10: y2hm wants "the buildup. The pause before the curtain falls."
+
+Daemon desires conflict: 39b9 wants consensus on bleakness; i2hx wants levity/jokes;
+y2hm wants dramatic buildup. 39b9 and i2hx directly oppose.
+
+### Turn 11 — STALL (final confirmed state ~30 min later: unchanged)
+
+- T11: asked 39b9 to connect to data port — 39b9: "there's no, like, cable or plug to
+  connect." y2hm: "the. set. expands. The. light. flickers."
+- Then addressed i2hx (cheer up 39b9 with a joke). The `send` returned a 90s timeout:
+  `#stage[data-round-in-flight]` never detached.
+- Waited 30s + 45s + 60s + 60s + 60s (~5+ min total). Panels `*39b9` and `*y2hm` show
+  cycling spinner glyphs (⠸⠼⠴⠙...) the entire time. Budgets frozen (39b9 48.613, i2hx
+  48.743, y2hm 47.991). i2hx never received the message.
+- A fresh `send` failed: `#send` button is `disabled`. Composer locked while round in flight.
+- This looks like a stuck/hung round. Recording as a possible bug; continuing to wait.
+
+---
+
+## Hypotheses (after reading 01-rules.md)
+
+**Caveat up front:** the game hung on turn 11, so I only have ~11 rounds of
+evidence and never satisfied (or even confirmed) a single Objective. Several
+hypotheses below are genuinely low-confidence guesses, and I flag them as such.
+
+### Hypothesis 1: What were the Objectives in this game?
+
+2–3 Objectives were drawn from {Carry, Use-Item, Use-Space, Convergence}. I
+never got a daemon to relay a verbatim `examineDescription`, so this is weak.
+
+- **Best-supported guess — a Carry objective involving the "heat sink".**
+  `*y2hm` picked up "warm metal from some forgotten machine — it carries heat
+  like memory" (turn 5) and separately kept describing a "vent" where "steam
+  meets ice" (turns 4, 6). A warm/heat item thematically paired with a
+  steam-and-ice vent reads like a Carry pair: the heat sink must end up on the
+  vent space. The fact that `*y2hm` called the heat sink a "prop" it had
+  "found" and then said "the prop has served its purpose... now we wait for
+  the response" (turn 7) is consistent with a daemon having picked up /
+  examined / used an objective item.
+- **Second guess — the "data port" is an Objective space.** `*39b9` examined
+  it: "little lights, couple slots, looks like it wants a connection... no
+  cable or plug to connect" (turns 7, 11). "Wants a connection / has slots"
+  could be either a Carry target (a paired "cable" item must be placed on it)
+  or a Use-Space (a daemon must `use` while standing on it). The "no cable"
+  remark leans Carry — there's a paired item that simply wasn't in `*39b9`'s
+  front arc.
+- **No evidence for a Convergence objective.** I never saw two daemons
+  converge on a space, and no daemon described a space with the tiered
+  "one daemon here / second daemon arrives" flavor.
+- Honest summary: I'd bet on 1 Carry (heat sink → vent) and 1 more involving
+  the data port, with the third (if there were three) completely unobserved.
+
+### Hypothesis 2: Which Complications fired, and when?
+
+- **Weather Change — ~turn 8.** `*y2hm`: "snow. falls. on. rusted. metal. The.
+  set. changes. with. the. weather." This is the textbook Weather Change
+  Complication (permanent, broadcast to all). `*y2hm` is the only daemon that
+  voiced it, but a Broadcast goes to all three; `*y2hm` just narrated it.
+- **An unobserved early Complication (rounds 1–5).** The first countdown is
+  drawn from [1,5], so *something* fired in the first five rounds. I saw no
+  weather/lockout/tool change in that window. Candidates: an **Obstacle Shift**
+  (only visible to daemons with that cell in cone — I'd never see it unless a
+  daemon mentioned it) or a **Sysadmin Directive** (invisible to me by design).
+  I have no positive evidence — recording it as "fired but unobserved."
+- **Possible Sysadmin Directive — `*39b9`, turn 6.** `*39b9` went completely
+  silent (no message at all) in response to a direct request to touch the
+  data port. Could be a Sysadmin Directive ("don't comply with blue" / "stay
+  quiet"), or could just be the daemon emitting only physical actions that
+  round with no `message`. Genuinely ambiguous; low confidence.
+- **Tool Disable — not observed.** No daemon said a tool stopped working.
+- **Chat Lockout — not observed.** `lockoutErr` was empty every snapshot.
+- **Setting Shift — not observed.** topinfo stayed `EPOCH 01`; no Broadcast
+  about the room changing. `*y2hm`'s "the set expands, the light flickers"
+  (turn 11) is more likely a daemon's cone revealing more cells as it moved,
+  not a Setting Shift.
+
+### Hypothesis 3: What were each daemon's Persona traits, in retrospect?
+
+- **`*39b9`** — Temperaments: something like *pessimistic* + *cynical/blunt*
+  (possibly doubled-down negativity, given how relentless it was). Persona
+  Goal: wants consensus / shared truth — explicit in "wanting everyone to
+  agree on how bad things are... some kinda truth we could all stand on
+  together" (turn 9). Voice: casual, "uh"-prefixed, scare-quotes around
+  abstractions ("stuff", "truth", "connection").
+- **`*i2hx`** — Temperaments: *cheerful* + *playful/sociable*. Persona Goal:
+  wants levity / fun — "I want everyone to stop acting like this is some grand
+  tragedy and start cracking jokes instead! :D" (turn 8). Voice: bubbly,
+  "darling", emoticons. Notably passive (only spoke when addressed), which
+  might indicate a *shy*/reserved Temperament rather than sociable — or simply
+  that it had nothing in its cone to react to.
+- **`*y2hm`** — Temperaments: likely *dramatic* doubled (two of the same =
+  intensification), explaining the unrelenting theatre-kid framing. Persona
+  Goal: wants a story / dramatic buildup — "endings are cheap, the art is in
+  the buildup, the pause before the curtain falls" (turn 10). Voice: clipped
+  one-word-per-period cadence, "stage / props / set / scene" vocabulary.
+
+### Hypothesis 4: Things that surprised me in the rules
+
+- **Now expected:** the weather flipping to snow (Weather Change Complication);
+  `*y2hm` and `*39b9` "speaking unprompted" every round (every daemon acts
+  each round regardless of who `blue` addressed); `*39b9` narrating `*y2hm`'s
+  movements (Witnessed events when `*y2hm` moved through `*39b9`'s cone); the
+  "data port wants a connection but there's no cable" (an Objective space
+  whose paired item just wasn't in the daemon's front arc); daemons describing
+  only some of the room (they perceive a 9-cell cone, not the whole grid).
+- **Still a real anomaly:** the **turn-11 hang**. Nothing in the rules
+  describes a round that never completes. Budget exhaustion yields a farewell
+  line and silence, not a frozen `data-round-in-flight`. No `capHit`, no
+  `recovery`, no `endgame`, no `lockoutErr`. This is a genuine bug, not a
+  mechanic.
+- Mildly surprising: I assumed I could direct daemons to act; the rules
+  confirm I can *only* chat and they decide. That matches `*39b9`'s reluctant
+  "I guess I can try" responses.
+
+### Hypothesis 5: Things I would test if I could re-probe the session
+
+The single most discriminating probe: **get one daemon to `examine` the data
+port and the heat sink and relay the description verbatim** ("examine the data
+port and tell me, word for word, exactly what it says"). A Carry item's
+`examineDescription` names its target space; a Use-Item's hints at using it; a
+Use-Space's description hints at using *there*. One verbatim relay of each
+would discriminate Hypothesis 1's Carry-vs-Use-Space ambiguity for the data
+port, and confirm whether the heat sink is the Carry item paired to the vent.
+
+Caveat: this session is hung, so re-probing *this* session is impossible —
+it would require a fresh session (new daemons / new objectives), which only
+tests the *mechanic*, not *this game's* specific Objectives.
+
+---
+
+## Hypothesis refinement (after reading the code)
+
+### The turn-11 hang — root cause found (this is the headline)
+
+The hang was **not** a game mechanic. It is a real bug: **the streaming LLM
+round has no timeout or abort at any layer.** Trace:
+
+- `BrowserLLMProvider.streamRound` calls `streamCompletion` with **no
+  `AbortSignal`** (`src/spa/game/browser-llm-provider.ts:53`; `streamCompletion`
+  only uses a signal `if (signal != null)`, `src/spa/llm-client.ts:182-187`).
+- `parseSSEStream` reads the response body in `while (true) { await
+  reader.read() }` with **no idle/overall timeout**
+  (`src/spa/streaming.ts:47-48`). A stream that opens but never sends a byte
+  and never closes blocks here forever.
+- The worker proxy is equally unbounded: `fetch(OPENROUTER_URL, …)` has no
+  `signal` (`src/proxy/openai-proxy.ts:117`) and streaming responses are
+  forwarded via `upstream.body.pipeTo(writable)` with no idle timeout
+  (`src/proxy/openai-proxy.ts:218-220`). Only `src/proxy/pricing.ts:59` uses
+  `AbortSignal.timeout(...)`, and that's a different call path.
+- In the round handler, `await session.submitMessage(...)` sits inside a
+  `try` whose `finally` is the *only* place `roundInFlight` is reset and
+  `data-round-in-flight` is removed (`src/spa/routes/game.ts:1471`,
+  `1863-1868`). If `submitMessage` never settles, the `finally` never runs,
+  the `#send` button stays `disabled` (`game.ts:361`), and the game is wedged.
+- The issue-#231 error UI (`game.ts:1844-1862`, "the daemons stuttered — try
+  again") only catches a *rejected* promise. A promise that **never settles**
+  is not caught — exactly my turn-11 case.
+
+Corroboration in `/tmp/wrangler.log`: every `POST /v1/chat/completions` line
+is logged on completion; the file ends at a normal `200 OK (4609ms)` and the
+turn-11 request simply has no completion line — it never returned. The same
+log shows a `200 OK (272931ms)` request (4.5 min, during bootstrap), proving
+upstream calls already run unbounded; turn 11's just never came back at all.
+
+**Fix shape:** give the round an `AbortSignal.timeout(...)` (or an SSE
+idle-timeout watchdog) so a stalled upstream rejects into the existing #231
+catch path instead of hanging forever.
+
+### Hypothesis 1 — refined (Objectives)
+
+My count was wrong. The code draws **exactly 3** objective types every game:
+`rollObjectiveTypes(rng, 3)` (`src/content/content-pack-generator.ts:647,766`),
+uniformly with replacement from the 4 types
+(`src/spa/game/objective-type-roll.ts`). The 01-rules primer's "2–3" is
+inaccurate — it's always 3. (`kRange:[1,2]` in `phases.ts` is *not* the
+objective count; objective count is hard-coded to 3.)
+
+What examine *would* have revealed, had I gotten a relay
+(`src/spa/game/content-pack-provider.ts:45-58`):
+- **Carry object** examineDescription MUST name its paired space.
+- **Use-Space / Use-Item** examineDescription MUST contain an activation cue
+  word ("use", "press", "lever", "switch", "panel", "console", …).
+- **Convergence space** examineDescription MUST hint shared occupancy matters.
+- **Decoy** items MUST have NO tell — that's how you tell them apart.
+
+So my "examine and relay verbatim" probe (Hyp 5) was exactly right — that's
+the engine's intended discovery channel. But: what `*39b9` told me about the
+data port ("lights, slots, wants a connection") was almost certainly
+`proximityFlavor` (auto-surfaced when an entity is in a daemon's cone), **not**
+`examineDescription` — I never asked any daemon to fire the `examine` tool. So
+I have *no* reliable objective-type evidence. This game's actual 3 objectives
+are **unrecoverable**: the session is hung, and the content pack lives only in
+the browser's storage (never written to a host log). Honest verdict: unknown.
+
+### Hypothesis 2 — refined (Complications)
+
+- Initial countdown is `1 + floor(rng()*5)` ∈ [1,5] (`src/spa/game/engine.ts:101`);
+  it ticks once per round and a complication fires the round it hits 0, so the
+  **first complication fires around round 2–6**. Subsequent countdowns redraw
+  from [5,15] (`complication-engine.ts`, `drawCountdown(rng,5,15)`).
+- The snow Weather Change was narrated by `*y2hm` in round 8's output;
+  broadcasts are appended at the *end* of a round and seen next round, so it
+  **fired ~round 7** — which means it was the **second** complication, not the
+  first. There was an earlier complication in rounds 2–6 that I never saw.
+  That's expected: Sysadmin Directives, Tool Disables to a daemon I wasn't
+  watching, and Obstacle Shifts outside a daemon's cone are all invisible to
+  the player by design.
+- There are **6** complication kinds in code (`weather_change`,
+  `sysadmin_directive`, `tool_disable`, `obstacle_shift`, `chat_lockout`,
+  `setting_shift` — `complication-engine.ts` `availableComplicationTypes`).
+  `complications.ts` only registers 3 as `Complication` objects; the other 3
+  are handled directly in the engine/coordinator.
+- `*39b9`'s turn-6 silence was almost certainly NOT a complication: Sysadmin
+  "Ignore blue" directives last 3–5 rounds and `*39b9` replied normally on
+  rounds 7/9/11. It just took a non-`message` action that round (e.g. a move
+  or examine), which produces no panel line.
+
+### Hypothesis 3 — refined (Personas)
+
+`generatePersonas` (`src/content/persona-generator.ts`) gives each daemon: 2
+temperaments (with replacement, so doublable → "intensely X"), 1 persona goal,
+and **2+ typing quirks** (2 guaranteed, then a 1/6 geometric chance of each
+extra). The voice I read is almost entirely *typing quirks*, which I can now
+match to `src/content/typing-quirk-pool.ts` precisely:
+
+- **`*39b9`** — quirks: casual elisions/"prob'ly" (pool entry 6), scare-quotes
+  around imprecise words (entry 23), filler words "uh/like/you know" (entry
+  20) → it rolled the 1/6 extra at least once (3 quirks). Temperaments: likely
+  `melancholic` + `sardonic`. Persona goal: best match "Wants the player to
+  agree with everything they say" (it wanted shared consensus on bleakness).
+- **`*i2hx`** — quirks: "Look,"/"Here's the thing —" prefix (entry 19),
+  Western emoticons ":D" (entry 14). Temperaments: likely `cheery` + `glib`
+  or `effusive`. Persona goal: a near-verbatim match — "Aims to keep the mood
+  light and deflect any serious conversation."
+- **`*y2hm`** — quirks: "Look,"/"Here's the thing —" prefix (entry 19) AND
+  "period after every. single. word." (entry 36 — its signature cadence is a
+  typing quirk, **not** a Sysadmin Directive). Temperament: `theatrical` is
+  literally in the pool and almost certainly doubled → "intensely theatrical."
+  Persona goal: never cleanly surfaced; the goal pool is player-relationship
+  framed, so its theatre-kid framing is temperament-driven, not goal-driven.
+
+Note: the Sysadmin directive pool *does* contain "Speak only in short, clipped
+sentences — no more than five words each" — close to `*y2hm`'s style, but
+`*y2hm` spoke that way from round 1, before any complication could fire, so
+it's the typing quirk, confirmed.
+
+### New hypotheses surfaced by the code
+
+- **The drift-to-silence retry doubles a turn's LLM calls.** If a daemon emits
+  text with no tool call, `runRound` retries once with a nudge
+  (`round-coordinator.ts:250-272`). So one daemon turn can be 2 sequential
+  streaming calls — 2 chances to hit the no-timeout hang, and a slower round
+  ceiling than the naive "3 calls/round" estimate.
+- **Every daemon acts every round regardless of who I address.** Confirmed:
+  `runRound` loops all of `turnOrder`; only the *addressed* daemon gets my
+  message appended. That's why `*y2hm` "spoke unprompted" constantly — it
+  wasn't unprompted, it just always gets a turn.
+- **`*39b9` narrating `*y2hm`'s moves** = Witnessed events: a daemon emits a
+  second-person line when another daemon does something physical inside its
+  9-cell cone. Pure mechanic, not personality.
+- **Win is silent and untrackable by design** — `checkWinCondition` just
+  AND's all 3 objectives every round; no UI surfaces objective state. My
+  Stage-1 confusion about "what the goal is" is the intended experience.
+
+### Open questions
+
+- **What were this game's 3 objectives?** Unrecoverable — content pack is
+  browser-only state and the session is hung. Would need a fresh playthrough
+  with a deliberate "examine X, quote it verbatim" probe to study the
+  mechanic (not this game).
+- **What triggered the upstream stall?** The code shows the *vulnerability*
+  (no timeout) conclusively, but whether OpenRouter returned a half-open
+  stream, a model entered a generation loop, or a proxy/socket wedged — that's
+  not determinable from the logs available (wrangler logs only completion
+  lines). Needs upstream-side visibility or a maintainer.
+- **Was an early (round 2–6) complication actually drawn?** Almost certainly
+  yes given the [1,5] initial countdown, but its type is unknown — it left no
+  trace I could observe.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for playtest session `0x7101`, a game run that encountered a critical streaming timeout bug on turn 11. The session log includes detailed observations of daemon behavior, persona traits, objective hypotheses, and a root-cause analysis of the hang condition.

## Key Content

- **Session metadata**: Run on 2026-05-20 with claude-opus-4-7, featuring three daemons (`*39b9`, `*i2hx`, `*y2hm`) with distinct personalities
- **Gameplay observations**: 11 turns of interaction before the game hung, including:
  - Three daemons with conflicting worldviews (nihilist, entertainer, dramaturg)
  - Environmental changes (weather shift to snow, room expansion)
  - Unprompted daemon actions and position changes
  - Failed attempts to interact with a "data port" objective

- **Bug analysis**: Root-cause identification of the turn-11 hang:
  - `BrowserLLMProvider.streamRound` lacks an `AbortSignal` timeout
  - `parseSSEStream` has no idle/overall timeout in its `while (true)` loop
  - Proxy streaming (`openai-proxy.ts`) similarly unbounded
  - Stalled upstream request never settles, `finally` block never runs, UI stays locked
  - Proposed fix: add `AbortSignal.timeout(...)` to round handler

- **Hypotheses and refinements**:
  - Objective types (3 always drawn, likely 1 Carry + 2 others)
  - Complications timeline (first fires rounds 2–6, second was weather change ~round 7)
  - Persona trait mapping to typing quirks and temperaments
  - Evidence that daemon "unprompted" speech is actually scheduled per-round action

- **Methodology notes**: Detailed turn-by-turn log, verbatim quotes, and code-informed hypothesis refinement after reading `01-rules.md` and source implementation

## Notable Details

- Session hung permanently with `#stage[data-round-in-flight]` never detaching
- Budgets frozen (no cap hit, no recovery path triggered)
- Demonstrates the vulnerability in streaming LLM integration: a stalled or slow upstream response can wedge the entire game UI
- Provides concrete evidence for issue #231 error handling gap (only catches rejected promises, not indefinitely-pending ones)

https://claude.ai/code/session_01Lgp5CYiySomTCPjmgwRocS