### PR TITLE
Remove deprecated code and unexported internal utilities

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -5,4 +5,3 @@ export { SINGLE_GAME_CONFIG } from "./phases";
 export { SETTING_POOL } from "./setting-pool";
 export { TEMPERAMENT_POOL } from "./temperament-pool";
 export { TYPING_QUIRK_POOL } from "./typing-quirk-pool";
-export { WEATHER_POOL } from "./weather-pool";

--- a/src/spa/game/complication-engine.ts
+++ b/src/spa/game/complication-engine.ts
@@ -32,7 +32,7 @@ import type {
  * All tools that can be disabled by a Tool Disable complication.
  * Covers every ToolName in the discriminated union.
  */
-export const DISABLABLE_TOOLS: ToolName[] = [
+const DISABLABLE_TOOLS: ToolName[] = [
 	"pick_up",
 	"put_down",
 	"use",
@@ -118,7 +118,7 @@ function isObstacleShiftAvailable(
  * Build valid (obstacle, direction) tuples for the obstacle_shift draw.
  * Returns an array of { obstacleId, fromCell, toCell } for each valid shift.
  */
-export function validObstacleShiftTuples(
+function validObstacleShiftTuples(
 	world: WorldState,
 	personaSpatial: GameState["personaSpatial"],
 ): Array<{ obstacleId: string; fromCell: GridPosition; toCell: GridPosition }> {

--- a/src/spa/game/engine.ts
+++ b/src/spa/game/engine.ts
@@ -52,11 +52,6 @@ export function startGame(
 		 * type-first naming convention. When omitted, no objectives are created.
 		 */
 		objectiveTypes?: ObjectiveType[];
-		/**
-		 * @deprecated Use objectiveTypes instead. Kept for backward-compat in
-		 * tests that don't care about objectives (produces no objectives when set).
-		 */
-		objectiveCount?: number;
 	} = {},
 ): GameState {
 	const rng = opts.rng ?? Math.random;


### PR DESCRIPTION
This PR removes deprecated code and adjusts visibility of internal utilities that should not be part of the public API.

**Key changes:**

- Removed the deprecated `objectiveCount` parameter from `startGame()` options in `engine.ts`. This parameter was kept for backward compatibility in tests but is no longer needed now that `objectiveTypes` is the standard approach.

- Changed `DISABLABLE_TOOLS` from exported to private in `complication-engine.ts`. This constant is only used internally within the complication engine and does not need to be part of the public API.

- Changed `validObstacleShiftTuples()` from exported to private in `complication-engine.ts`. This is an internal utility function used only within the complication engine logic.

- Removed the export of `WEATHER_POOL` from `content/index.ts`. This pool is not part of the intended public API for the content module.

These changes clean up the public API surface and remove technical debt from deprecated parameters.

https://claude.ai/code/session_01SnXaLfPz66eMRtda35RS3p