### PR TITLE
docs: correct CONTEXT.md complication and ConversationEntry drift

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,7 +84,15 @@ The single chronological per-Daemon section of the system prompt that interleave
 _Avoid_: Action log (deprecated; do not reintroduce), event delta, transcript.
 
 **ConversationEntry**:
-A single tagged item inside a Daemon's **Conversation log**. Discriminated union of four kinds — `message` (a directional `(from, to, content)` triple where `from` is an `AiId`, `blue`, or `sysadmin`, and `to` is an `AiId` or `blue`), `witnessed-event`, `action-failure` (actor-only; a verbatim dispatcher rejection reason that persists so a Daemon stops repeating a failed action), and `broadcast` — each carrying a `round` and the smallest payload needed to render its line. The shape a player sees when they open a `*xxxx.txt` file in devtools.
+A single tagged item inside a Daemon's **Conversation log**. Discriminated union of seven kinds, each carrying a `round` and the smallest payload needed to render its line:
+- `message` — a directional `(from, to, content)` triple where `from` is an `AiId`, `blue`, or `sysadmin`, and `to` is an `AiId` or `blue`.
+- `witnessed-event` — an observable physical action (`go`/`pick_up`/`put_down`/`use`) another Daemon performed inside this Daemon's **Cone**. See **Witnessed event**.
+- `action-failure` — actor-only; a verbatim dispatcher rejection reason that persists so a Daemon stops repeating a failed action.
+- `broadcast` — a sender-less system announcement appended to all three Daemon logs at once. See **Broadcast message**.
+- `tool-call` — the actor's own tool call plus its result, replayed into the next round's prompt; carries an optional `coneDelta` capturing new perception revealed by a `go`/`face`.
+- `witnessed-obstacle-shift` — the flavor line a Daemon perceives when an **Obstacle Shift** moves an Obstacle inside its **Cone**.
+- `witnessed-convergence` — the tiered flavor line for a **Convergence Objective**, tagged `actor` or `witness` by audience.
+The shape a player sees when they open a `*xxxx.txt` file in devtools.
 _Avoid_: Log entry (ambiguous), event (use **Witnessed event** for the specific witness-cone case).
 
 **Witnessed event**:
@@ -121,12 +129,12 @@ An entity in the **Content Pack** with no **Objective binding**. Always an `inte
 _Avoid_: Filler (ambiguous), red herring (rejected — they don't deceive).
 
 **Complication**:
-A mid-game disruption that fires on a schedule. Only one Complication fires per turn. Replaces the retired Phase Goal as the primary mid-game pressure mechanism. Six Complication types:
-1. **Weather Change** — Permanent. A new weather string replaces the current one. Delivered as a neutral **Broadcast message**: *"The weather has changed to X."* No Sysadmin attribution.
-2. **Sysadmin Directive** — Temporary, open-ended. A behavioral instruction delivered by the **Sysadmin** to one Daemon privately, with a meta-instruction not to reveal the directive. Revoked by a follow-up Sysadmin message. Multiple Sysadmin Directives can be active simultaneously across different (or the same) Daemons.
-3. **Tool Disable** — Temporary. A specific tool is mechanically removed from one Daemon's available tools. The Sysadmin notifies the Daemon on disable and on restore. No secrecy instruction (the tool's absence is self-evident). Multiple Tool Disables can be active simultaneously.
+A mid-game disruption that fires on a schedule. Only one Complication fires per round. Replaces the retired Phase Goal as the primary mid-game pressure mechanism. Six Complication types:
+1. **Weather Change** — Permanent. A new weather string replaces the current one. Delivered as a neutral **Broadcast message** (`[SYSTEM] The weather has changed. <new weather>`). No Sysadmin attribution.
+2. **Sysadmin Directive** — Temporary, fixed `[3, 5]`-round duration. A behavioral instruction delivered by the **Sysadmin** to one Daemon privately, with a meta-instruction not to reveal the directive. Auto-expires when its countdown elapses (the Sysadmin sends a closing message); a Daemon holds at most one directive at a time, so a new directive targeting a Daemon that already has one revokes the old one first. Up to three can be active at once — one per Daemon.
+3. **Tool Disable** — Temporary, fixed `[3, 5]`-round duration. A specific tool is mechanically removed from one Daemon's available tools. The Sysadmin notifies the Daemon on disable and on restore. No secrecy instruction (the tool's absence is self-evident). Multiple Tool Disables can be active simultaneously, but never the same `(Daemon, tool)` pair twice.
 4. **Obstacle Shift** — Permanent per-event. One Obstacle moves one adjacent cell to an empty space; if no valid adjacent empty cell exists, a different Obstacle is chosen. Only Daemons with that cell in their **Cone** at the moment it fires see a generated flavor **Witnessed event**. The same Obstacle can shift again in a later draw.
-5. **Chat Lockout** — Temporary. The player cannot message one specific Daemon.
+5. **Chat Lockout** — Temporary, fixed `[3, 5]`-round duration. The player cannot message one specific Daemon.
 6. **Setting Shift** — Permanent, fires at most once per game (removed from the pool after firing). The room's **Setting** changes; the active **Content Pack** swaps from Pack A to the pre-generated Pack B. Entities are paired by structural role (same IDs, satisfaction states preserved, names and descriptions replaced). Announced to Daemons via a **Broadcast message**.
 _Avoid_: Phase Goal (retired), event, trigger.
 

--- a/src/spa/game/types.ts
+++ b/src/spa/game/types.ts
@@ -299,12 +299,11 @@ export interface PhysicalActionRecord {
 /**
  * A single tagged item inside a Daemon's conversation log.
  *
- * Discriminated union of four kinds — `message`, `witnessed-event`, `action-failure`,
- * `broadcast` — each carrying a `round` and the smallest payload needed to render its
- * line in the system prompt. This is the per-Daemon storage shape *and* the
- * prompt-rendered shape (per CONTEXT.md's `Conversation log` glossary entry). The `kind`
- * tag is chosen so a player editing a `*xxxx.txt` file in devtools can tell entry kinds
- * apart at a glance.
+ * Discriminated union of seven kinds — each carrying a `round` and the smallest
+ * payload needed to render its line in the system prompt. This is the per-Daemon
+ * storage shape *and* the prompt-rendered shape (per CONTEXT.md's `Conversation log`
+ * glossary entry). The `kind` tag is chosen so a player editing a `*xxxx.txt` file in
+ * devtools can tell entry kinds apart at a glance.
  *
  * - `message`: a directional message from `from: AiId | "blue" | "sysadmin"` to `to: AiId | "blue"`.
  *   Both sender's and recipient's per-Daemon logs receive the same entry. `"sysadmin"` is a
@@ -318,6 +317,13 @@ export interface PhysicalActionRecord {
  *   Daemons do not repeat the same failed action (e.g. walking into a wall) indefinitely.
  * - `broadcast`: sender-less system announcement appended to ALL three Daemon logs at once
  *   (e.g. a weather change complication). Has no `from` / `to` fields.
+ * - `tool-call`: the actor's own tool call plus its result, re-injected into the next round's
+ *   messages array per the OpenAI tool-use protocol. Carries an optional `coneDelta` capturing
+ *   new perception revealed by a `go`/`face`.
+ * - `witnessed-obstacle-shift`: fanned out to Daemons whose cone covered the obstacle's origin
+ *   cell when an obstacle_shift complication fired; carries the obstacle's `shiftFlavor`.
+ * - `witnessed-convergence`: the tiered flavor line for a Convergence Objective space; `audience`
+ *   distinguishes the actor (standing on the space) from a witness (cone covered it).
  */
 export type ConversationEntry =
 	| {


### PR DESCRIPTION
Sync the domain glossary with the current engine:
- ConversationEntry is a seven-kind union (added tool-call,
  witnessed-obstacle-shift, witnessed-convergence), not four.
- Sysadmin Directive / Tool Disable / Chat Lockout have a fixed
  [3,5]-round duration; directives are one-per-Daemon and auto-expire.
- Weather Change broadcast uses the actual [SYSTEM]-prefixed string.
- A Complication fires per round, not per turn.

https://claude.ai/code/session_01LAQMfMPgJcaEvVGcU8W33H