### PR TITLE
Add /continuous skill for live handoff docs across sessions

### DIFF
--- a/.claude/hooks/continuous-reminder.sh
+++ b/.claude/hooks/continuous-reminder.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# UserPromptSubmit hook for the /continuous skill.
+# No-op unless a continuity session is active (marker file present).
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+marker="$git_dir/continuous-active"
+[ -f "$marker" ] || exit 0
+token="$(cat "$marker")"
+doc="../html-previews-wt/continuous/$token.html"
+echo "[continuous] Continuity session $token is active. As you work this turn, capture any new task progress, decisions, discovered information, plan changes/dead ends, or user-provided nuance into $doc: rewrite the snapshot section, append to the Decisions & nuance log. Then commit and push the html-previews branch. Read that file first if unsure of its current content."
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/continuous-reminder.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/continuous/SKILL.md
+++ b/.claude/skills/continuous/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: continuous
+description: Maintain a live HTML handoff doc on the html-previews branch, updated every turn as work progresses, so a fresh session can resume the work. Use when the user runs /continuous to start tracking a task, or /continuous <token> to resume one.
+argument-hint: "[token to resume, or blank to start]"
+---
+
+# Continuous handoff
+
+A living handoff doc, published as one HTML file and kept fresh every turn, so a
+fresh session can pick up exactly where this one left off.
+
+Terms: a **continuity token** (e.g. `0x4F9A`) identifies a **continuity doc**;
+`/continuous <token>` resumes it.
+
+## Two modes
+
+- `/continuous` (no token) — **start**. Mint a token, create the doc from the
+  current conversation, arm the per-turn hook, give the user the token + URL.
+- `/continuous <token>` — **resume**. Fetch the doc, rehydrate context, re-arm
+  the hook, continue working. If the token's file does not exist, list what is
+  in `continuous/` and ask the user which token they meant.
+
+## Starting (`/continuous`)
+
+1. Mint a token: `0x` + 4 random uppercase hex chars (e.g. `0x4F9A`). If that
+   file already exists in step 2's worktree, mint another.
+
+2. Set up the publish worktree on the shared `html-previews` branch (the same
+   branch `/html` uses — never merge it in or out of your working branch):
+
+   ```sh
+   git fetch origin html-previews 2>/dev/null
+   if [ ! -d ../html-previews-wt ]; then
+     if git ls-remote --exit-code --heads origin html-previews >/dev/null 2>&1; then
+       git worktree add ../html-previews-wt html-previews
+     else
+       git worktree add --detach ../html-previews-wt
+       git -C ../html-previews-wt checkout --orphan html-previews
+       git -C ../html-previews-wt rm -rf . >/dev/null 2>&1 || true
+     fi
+   fi
+   mkdir -p ../html-previews-wt/continuous
+   ```
+
+3. Write the doc to `../html-previews-wt/continuous/<token>.html` (structure
+   below), seeded from the current conversation.
+
+4. Arm the marker so the per-turn hook activates:
+
+   ```sh
+   echo "<token>" > "$(git rev-parse --git-dir)/continuous-active"
+   ```
+
+5. Commit and push:
+
+   ```sh
+   git -C ../html-previews-wt add continuous/<token>.html
+   git -C ../html-previews-wt commit -m "continuous(<token>): start"
+   git -C ../html-previews-wt push -u origin html-previews
+   ```
+
+6. Give the user the token and this URL:
+
+   `http://htmlpreview.github.io/?http://raw.githubusercontent.com/corvous/hi-blue/html-previews/continuous/<token>.html`
+
+   Tell them they can resume in any new session with `/continuous <token>`.
+
+## The doc
+
+One self-contained HTML file, inline CSS, no build step. Semantic HTML —
+headings, lists, a simple timeline — so a resuming agent reads the raw file
+directly. Three parts:
+
+- **Snapshot** — rewritten on every update, kept tight: the task title, Goal,
+  Status, Open questions, Next steps.
+- **Decisions & nuance** — append-only; never rewrite or delete entries. A
+  timeline of decisions made, information discovered, plan changes/dead ends,
+  and nuance the user gave. One terse entry per item, each tagged with a turn
+  number or short timestamp.
+- **How to resume** — static footer: "Run `/continuous <token>` in a new
+  session."
+
+## Staying current (every turn)
+
+A `UserPromptSubmit` hook re-injects a reminder each turn while the marker
+exists — you do not have to remember on your own, but you MUST act on it.
+
+Whenever a turn produces new task progress, a decision, discovered information,
+a plan change/dead end, or user-provided nuance: update the local doc (rewrite
+the snapshot, append to the log), then commit and push:
+
+```sh
+git -C ../html-previews-wt add continuous/<token>.html
+git -C ../html-previews-wt commit -m "continuous(<token>): update"
+git -C ../html-previews-wt push origin html-previews
+```
+
+Pushing every turn is expected. If a push is rejected, run
+`git -C ../html-previews-wt pull --rebase origin html-previews` and retry. If
+unsure of the doc's current content, read the file first.
+
+## Resuming (`/continuous <token>`)
+
+1. Set up the worktree (step 2 above), then read
+   `../html-previews-wt/continuous/<token>.html`. Missing → list `continuous/`
+   and ask which token.
+2. Append a log entry: `— resumed in a new session —`.
+3. Re-arm the marker (step 4 above).
+4. Continue the conversation naturally — no state-dump summary. A one-line
+   "resumed, caught up" acknowledgement is fine if the user gave no instruction.
+
+## Notes
+
+- Redaction is minimal: scrub only live credentials / API keys. Everything else
+  — decisions, file paths, specifics — is captured. The doc lives in committed
+  git history, so if the user pastes something obviously secret, flag it.
+- Continuity lapses on its own when the session ends; the marker is per-checkout
+  and there is no stop command.
+- Private repo: the user must be signed into GitHub in the same browser for
+  htmlpreview to render the doc.

--- a/.claude/skills/html/SKILL.md
+++ b/.claude/skills/html/SKILL.md
@@ -5,9 +5,10 @@ description: Build a single static HTML page and give the user a temporary URL t
 
 # HTML Preview (single, temporary)
 
-Previews live on a dedicated `html-previews` branch that holds **only** preview
-`.html` files — never any other repo content. Each preview is its own
-uniquely-named file. Never merge this branch into or out of your working branch.
+Previews live on a dedicated `html-previews` branch that holds preview `.html`
+files (and the `continuous/` folder used by the `/continuous` skill) — never
+other repo content. Each preview is its own uniquely-named file. Never merge
+this branch into or out of your working branch.
 
 When invoked:
 
@@ -54,5 +55,5 @@ Notes:
   for htmlpreview to fetch it.
 - Don't try to spin up a local server — the cloud sandbox isn't reachable from
   the user's browser.
-- The `html-previews` branch is throwaway and only ever contains preview `.html`
-  files. To clean up, delete individual files or the whole branch.
+- The `html-previews` branch is shared with the `/continuous` skill. Don't delete
+  files from it or delete the branch — other skills and sessions rely on it.


### PR DESCRIPTION
## Summary
Introduces a new `/continuous` skill that maintains a live HTML handoff document on the `html-previews` branch, enabling seamless task resumption across sessions. When a user starts or resumes a continuity session, a self-contained HTML doc is kept fresh with every turn's progress, decisions, and context.

## Key Changes

- **New skill: `/continuous`** (`.claude/skills/continuous/SKILL.md`)
  - Two modes: `/continuous` to start a new handoff doc, `/continuous <token>` to resume an existing one
  - Generates a unique token (e.g., `0x4F9A`) to identify each continuity session
  - Publishes a single HTML file to the shared `html-previews` branch with three sections: Snapshot (task status, next steps), Decisions & nuance log (append-only timeline), and resume instructions
  - Provides a public htmlpreview URL for the user to access the live doc

- **Per-turn hook: `continuous-reminder.sh`** (`.claude/hooks/continuous-reminder.sh`)
  - Activates automatically when a continuity session is active (marker file present)
  - Reminds the agent each turn to capture progress, decisions, and context into the handoff doc
  - No-op if no session is active

- **Hook registration** (`.claude/settings.json`)
  - Registers the `continuous-reminder.sh` hook to run on `UserPromptSubmit` events

- **Updated `/html` skill documentation** (`.claude/skills/html/SKILL.md`)
  - Clarifies that the `html-previews` branch is now shared with the `/continuous` skill
  - Warns against deleting files or the branch, as other sessions depend on it

## Implementation Details

- The handoff doc is a self-contained HTML file with inline CSS, readable by both humans and resuming agents
- Continuity is maintained via a git worktree (`html-previews-wt`) on the `html-previews` branch, separate from the working branch
- A marker file (`.git/continuous-active`) tracks whether a session is active; it's per-checkout and lapses naturally when the session ends
- Minimal redaction: only live credentials/API keys are scrubbed; all decisions, file paths, and context are preserved in git history
- The resuming agent reads the HTML file directly to rehydrate context and continue work naturally

https://claude.ai/code/session_012egXp8MTW31hmmsKXvf6a5