### PR TITLE
fix(content-pack): eliminate dual-pack generation flakiness against GLM-4.7

### DIFF
--- a/docs/evals/content-pack-flakiness/2026-05-26T23-03-21.json
+++ b/docs/evals/content-pack-flakiness/2026-05-26T23-03-21.json
@@ -1,0 +1,85 @@
+{
+  "summary": {
+    "successOnFirst": 0,
+    "successAfterRetry": 1,
+    "exhausted": 0,
+    "thrown": 0,
+    "ruleHistogram": {
+      "missing-field": 6
+    },
+    "retryUnitHistogram": {
+      "use-item-binding": 2,
+      "convergence-binding": 2,
+      "use-space-binding": 2
+    },
+    "avgAttemptsToSuccess": 2,
+    "totalCostUsd": 0.00811237
+  },
+  "iterations": [
+    {
+      "iter": 1,
+      "settingA": "collapsed market arcade",
+      "settingB": "hollowed glacier cave",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_item",
+        "convergence",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 1,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8586,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-0-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-0-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            }
+          ]
+        },
+        {
+          "iter": 1,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8901
+        }
+      ],
+      "totalCostUsd": 0.00811237
+    }
+  ]
+}

--- a/docs/evals/content-pack-flakiness/2026-05-26T23-06-51.json
+++ b/docs/evals/content-pack-flakiness/2026-05-26T23-06-51.json
@@ -1,0 +1,719 @@
+{
+  "summary": {
+    "successOnFirst": 2,
+    "successAfterRetry": 4,
+    "exhausted": 2,
+    "thrown": 0,
+    "ruleHistogram": {
+      "verb-of-activation": 3,
+      "wrong-id": 48,
+      "missing-field": 24
+    },
+    "retryUnitHistogram": {
+      "use-item-binding": 25,
+      "decoy": 2,
+      "use-space-binding": 14,
+      "convergence-binding": 22,
+      "objective-pair": 8,
+      "carry-binding": 4
+    },
+    "avgAttemptsToSuccess": 1.8333333333333333,
+    "totalCostUsd": 0.095059514
+  },
+  "iterations": [
+    {
+      "iter": 1,
+      "settingA": "hollowed glacier cave",
+      "settingB": "ink-stained printing hall",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "use_item",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 1,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8184,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "verb-of-activation",
+              "entityId": "useItem-1-item",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 1,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8178
+        }
+      ],
+      "totalCostUsd": 0.00901036
+    },
+    {
+      "iter": 2,
+      "settingA": "collapsed market arcade",
+      "settingB": "hollowed glacier cave",
+      "theme": "magical",
+      "objectiveTypes": [
+        "carry",
+        "use_item",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 2,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8547,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-1",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 2,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8555
+        }
+      ],
+      "totalCostUsd": 0.01120385
+    },
+    {
+      "iter": 3,
+      "settingA": "ink-stained printing hall",
+      "settingB": "tide-flooded boardwalk",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "use_item",
+        "use_item"
+      ],
+      "finalOutcome": "exhausted",
+      "attempts": [
+        {
+          "iter": 3,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8753,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 3,
+          "attempt": 1,
+          "outcome": "validation-failed",
+          "rawLength": 8755,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 3,
+          "attempt": 2,
+          "outcome": "validation-failed",
+          "rawLength": 8755,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        }
+      ],
+      "totalCostUsd": 0.01764063
+    },
+    {
+      "iter": 4,
+      "settingA": "collapsed market arcade",
+      "settingB": "hollowed glacier cave",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 4,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 9603
+        }
+      ],
+      "totalCostUsd": 0.00860875
+    },
+    {
+      "iter": 5,
+      "settingA": "abandoned subway station",
+      "settingB": "hollowed glacier cave",
+      "theme": "magical",
+      "objectiveTypes": [
+        "convergence",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 5,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7943
+        }
+      ],
+      "totalCostUsd": 0.00405558
+    },
+    {
+      "iter": 6,
+      "settingA": "stripped server vault",
+      "settingB": "sun-baked salt flat",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_space",
+        "use_item",
+        "use_item"
+      ],
+      "finalOutcome": "exhausted",
+      "attempts": [
+        {
+          "iter": 6,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7539,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 6,
+          "attempt": 1,
+          "outcome": "validation-failed",
+          "rawLength": 7539,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 6,
+          "attempt": 2,
+          "outcome": "validation-failed",
+          "rawLength": 7539,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        }
+      ],
+      "totalCostUsd": 0.01464619
+    },
+    {
+      "iter": 7,
+      "settingA": "humid and dense bog",
+      "settingB": "forgotten laboratory",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "convergence",
+        "use_item",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 7,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 6448,
+          "validationErrors": [
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "carry-2-space",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1ActorFlavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2ActorFlavor"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "carry-2-space",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1ActorFlavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2ActorFlavor"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            }
+          ]
+        },
+        {
+          "iter": 7,
+          "attempt": 1,
+          "outcome": "validation-failed",
+          "rawLength": 6448,
+          "validationErrors": [
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "carry-2-space",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1ActorFlavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2ActorFlavor"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "carry-2-space",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2Flavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier1ActorFlavor"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "convergenceTier2ActorFlavor"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            },
+            {
+              "retryUnitKind": "objective-pair",
+              "rule": "missing-field",
+              "entityId": "",
+              "field": "bindings"
+            }
+          ]
+        },
+        {
+          "iter": 7,
+          "attempt": 2,
+          "outcome": "ok",
+          "rawLength": 9028
+        }
+      ],
+      "totalCostUsd": 0.01975679
+    },
+    {
+      "iter": 8,
+      "settingA": "hollowed glacier cave",
+      "settingB": "stripped server vault",
+      "theme": "technological",
+      "objectiveTypes": [
+        "use_space",
+        "carry",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 8,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8151,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-1",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 8,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8171
+        }
+      ],
+      "totalCostUsd": 0.010137364
+    }
+  ]
+}

--- a/docs/evals/content-pack-flakiness/2026-05-26T23-23-10.json
+++ b/docs/evals/content-pack-flakiness/2026-05-26T23-23-10.json
@@ -1,0 +1,620 @@
+{
+  "summary": {
+    "successOnFirst": 1,
+    "successAfterRetry": 6,
+    "exhausted": 1,
+    "thrown": 0,
+    "ruleHistogram": {
+      "missing-field": 40,
+      "verb-of-activation": 1,
+      "wrong-id": 18
+    },
+    "retryUnitHistogram": {
+      "convergence-binding": 12,
+      "carry-binding": 12,
+      "decoy": 1,
+      "use-space-binding": 16,
+      "use-item-binding": 18
+    },
+    "avgAttemptsToSuccess": 2,
+    "totalCostUsd": 0.09249543400000002
+  },
+  "iterations": [
+    {
+      "iter": 1,
+      "settingA": "forgotten laboratory",
+      "settingB": "sun-baked salt flat",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "convergence",
+        "carry",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 1,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8222,
+          "validationErrors": [
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-1-obj",
+              "field": "object"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-2-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-1-obj",
+              "field": "object"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-2-space",
+              "field": "space"
+            }
+          ]
+        },
+        {
+          "iter": 1,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8702
+        }
+      ],
+      "totalCostUsd": 0.00786466
+    },
+    {
+      "iter": 2,
+      "settingA": "collapsed market arcade",
+      "settingB": "sun-baked salt flat",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "convergence",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 2,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 9283
+        }
+      ],
+      "totalCostUsd": 0.00442092
+    },
+    {
+      "iter": 3,
+      "settingA": "moonlit greenhouse ruin",
+      "settingB": "hollowed glacier cave",
+      "theme": "technological",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 3,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 9211,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 3,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 9214
+        }
+      ],
+      "totalCostUsd": 0.016479
+    },
+    {
+      "iter": 4,
+      "settingA": "dust-filled opera hall",
+      "settingB": "ink-stained printing hall",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "convergence",
+        "use_space",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 4,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7488,
+          "validationErrors": [
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 4,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 7497
+        }
+      ],
+      "totalCostUsd": 0.008379109999999999
+    },
+    {
+      "iter": 5,
+      "settingA": "flooded underground cistern",
+      "settingB": "collapsed market arcade",
+      "theme": "technological",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 5,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7864,
+          "validationErrors": [
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-0-obj",
+              "field": "object"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-2-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-0-obj",
+              "field": "object"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "missing-field",
+              "entityId": "carry-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-2-item",
+              "field": "item"
+            }
+          ]
+        },
+        {
+          "iter": 5,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8349
+        }
+      ],
+      "totalCostUsd": 0.010465064
+    },
+    {
+      "iter": 6,
+      "settingA": "moonlit greenhouse ruin",
+      "settingB": "stripped server vault",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "convergence",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 6,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7568,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-0-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-2-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-0-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "missing-field",
+              "entityId": "convergence-1-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-2-item",
+              "field": "item"
+            }
+          ]
+        },
+        {
+          "iter": 6,
+          "attempt": 1,
+          "outcome": "validation-failed",
+          "rawLength": 7870,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "convergence-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 6,
+          "attempt": 2,
+          "outcome": "ok",
+          "rawLength": 8108
+        }
+      ],
+      "totalCostUsd": 0.01129115
+    },
+    {
+      "iter": 7,
+      "settingA": "stripped server vault",
+      "settingB": "flooded underground cistern",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 7,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7500,
+          "validationErrors": [
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "carry-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "wrong-id",
+              "entityId": "",
+              "field": "id"
+            }
+          ]
+        },
+        {
+          "iter": 7,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 7512
+        }
+      ],
+      "totalCostUsd": 0.01016442
+    },
+    {
+      "iter": 8,
+      "settingA": "silent planetarium dome",
+      "settingB": "ink-stained printing hall",
+      "theme": "technological",
+      "objectiveTypes": [
+        "use_space",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "exhausted",
+      "attempts": [
+        {
+          "iter": 8,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 10732,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-1-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-1-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            }
+          ]
+        },
+        {
+          "iter": 8,
+          "attempt": 1,
+          "outcome": "validation-failed",
+          "rawLength": 10922,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-1-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-1-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            }
+          ]
+        },
+        {
+          "iter": 8,
+          "attempt": 2,
+          "outcome": "validation-failed",
+          "rawLength": 10922,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-1-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-0-space",
+              "field": "space"
+            },
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "missing-field",
+              "entityId": "useItem-1-item",
+              "field": "item"
+            },
+            {
+              "retryUnitKind": "use-space-binding",
+              "rule": "missing-field",
+              "entityId": "useSpace-2-space",
+              "field": "space"
+            }
+          ]
+        }
+      ],
+      "totalCostUsd": 0.023431109999999998
+    }
+  ]
+}

--- a/docs/evals/content-pack-flakiness/2026-05-26T23-35-24.json
+++ b/docs/evals/content-pack-flakiness/2026-05-26T23-35-24.json
@@ -1,0 +1,214 @@
+{
+  "summary": {
+    "successOnFirst": 6,
+    "successAfterRetry": 2,
+    "exhausted": 0,
+    "thrown": 0,
+    "ruleHistogram": {
+      "verb-of-activation": 2
+    },
+    "retryUnitHistogram": {
+      "decoy": 2
+    },
+    "avgAttemptsToSuccess": 1.25,
+    "totalCostUsd": 0.053203134
+  },
+  "iterations": [
+    {
+      "iter": 1,
+      "settingA": "hollowed glacier cave",
+      "settingB": "stripped server vault",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_item",
+        "use_item",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 1,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7874
+        }
+      ],
+      "totalCostUsd": 0.0046863
+    },
+    {
+      "iter": 2,
+      "settingA": "dust-filled opera hall",
+      "settingB": "collapsed market arcade",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "convergence",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 2,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 9067
+        }
+      ],
+      "totalCostUsd": 0.00601997
+    },
+    {
+      "iter": 3,
+      "settingA": "rusted oil platform deck",
+      "settingB": "collapsed market arcade",
+      "theme": "magical",
+      "objectiveTypes": [
+        "convergence",
+        "use_item",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 3,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8837,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 3,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8838
+        }
+      ],
+      "totalCostUsd": 0.015072760000000001
+    },
+    {
+      "iter": 4,
+      "settingA": "throne room of a pagoda",
+      "settingB": "tide-flooded boardwalk",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "convergence",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 4,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 10076,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-1",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 4,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 10072
+        }
+      ],
+      "totalCostUsd": 0.011894214
+    },
+    {
+      "iter": 5,
+      "settingA": "forgotten laboratory",
+      "settingB": "tide-flooded boardwalk",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "use_item",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 5,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7708
+        }
+      ],
+      "totalCostUsd": 0.00409308
+    },
+    {
+      "iter": 6,
+      "settingA": "collapsed market arcade",
+      "settingB": "stripped server vault",
+      "theme": "technological",
+      "objectiveTypes": [
+        "convergence",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 6,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 9154
+        }
+      ],
+      "totalCostUsd": 0.00417383
+    },
+    {
+      "iter": 7,
+      "settingA": "throne room of a pagoda",
+      "settingB": "library overflowing with books",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "use_item",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 7,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 6855
+        }
+      ],
+      "totalCostUsd": 0.00359852
+    },
+    {
+      "iter": 8,
+      "settingA": "hollowed glacier cave",
+      "settingB": "forgotten laboratory",
+      "theme": "magical",
+      "objectiveTypes": [
+        "convergence",
+        "convergence",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 8,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8249
+        }
+      ],
+      "totalCostUsd": 0.00366446
+    }
+  ]
+}

--- a/docs/evals/content-pack-flakiness/2026-05-26T23-48-26.json
+++ b/docs/evals/content-pack-flakiness/2026-05-26T23-48-26.json
@@ -1,0 +1,229 @@
+{
+  "summary": {
+    "successOnFirst": 5,
+    "successAfterRetry": 3,
+    "exhausted": 0,
+    "thrown": 0,
+    "ruleHistogram": {
+      "verb-of-activation": 3
+    },
+    "retryUnitHistogram": {
+      "decoy": 2,
+      "use-item-binding": 1
+    },
+    "avgAttemptsToSuccess": 1.375,
+    "totalCostUsd": 0.052974904
+  },
+  "iterations": [
+    {
+      "iter": 1,
+      "settingA": "tide-flooded boardwalk",
+      "settingB": "abandoned subway station",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_space",
+        "use_item",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 1,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8002
+        }
+      ],
+      "totalCostUsd": 0.00384708
+    },
+    {
+      "iter": 2,
+      "settingA": "rusted oil platform deck",
+      "settingB": "library overflowing with books",
+      "theme": "technological",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 2,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 9602,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 2,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 9606
+        }
+      ],
+      "totalCostUsd": 0.01224533
+    },
+    {
+      "iter": 3,
+      "settingA": "stripped server vault",
+      "settingB": "dust-filled opera hall",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "carry",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 3,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8491
+        }
+      ],
+      "totalCostUsd": 0.00463729
+    },
+    {
+      "iter": 4,
+      "settingA": "hollowed glacier cave",
+      "settingB": "humid and dense bog",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_space",
+        "use_space",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 4,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8234
+        }
+      ],
+      "totalCostUsd": 0.00497895
+    },
+    {
+      "iter": 5,
+      "settingA": "library overflowing with books",
+      "settingB": "dust-filled opera hall",
+      "theme": "technological",
+      "objectiveTypes": [
+        "convergence",
+        "carry",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 5,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 9035,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 5,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 9035
+        }
+      ],
+      "totalCostUsd": 0.00817959
+    },
+    {
+      "iter": 6,
+      "settingA": "tide-flooded boardwalk",
+      "settingB": "humid and dense bog",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "convergence",
+        "use_item",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 6,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7995,
+          "validationErrors": [
+            {
+              "retryUnitKind": "use-item-binding",
+              "rule": "verb-of-activation",
+              "entityId": "useItem-2-item",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 6,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8026
+        }
+      ],
+      "totalCostUsd": 0.010529284
+    },
+    {
+      "iter": 7,
+      "settingA": "moonlit greenhouse ruin",
+      "settingB": "throne room of a pagoda",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "use_space",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 7,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7922
+        }
+      ],
+      "totalCostUsd": 0.00345546
+    },
+    {
+      "iter": 8,
+      "settingA": "flooded underground cistern",
+      "settingB": "moonlit greenhouse ruin",
+      "theme": "magical",
+      "objectiveTypes": [
+        "carry",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 8,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8771
+        }
+      ],
+      "totalCostUsd": 0.00510192
+    }
+  ]
+}

--- a/docs/evals/content-pack-flakiness/2026-05-26T23-56-20.json
+++ b/docs/evals/content-pack-flakiness/2026-05-26T23-56-20.json
@@ -1,0 +1,494 @@
+{
+  "summary": {
+    "successOnFirst": 16,
+    "successAfterRetry": 4,
+    "exhausted": 0,
+    "thrown": 0,
+    "ruleHistogram": {
+      "verb-of-activation": 4
+    },
+    "retryUnitHistogram": {
+      "decoy": 4
+    },
+    "avgAttemptsToSuccess": 1.2,
+    "totalCostUsd": 0.114877394
+  },
+  "iterations": [
+    {
+      "iter": 1,
+      "settingA": "flooded underground cistern",
+      "settingB": "dust-filled opera hall",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_space",
+        "use_item",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 1,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7358
+        }
+      ],
+      "totalCostUsd": 0.00328676
+    },
+    {
+      "iter": 2,
+      "settingA": "humid and dense bog",
+      "settingB": "flooded underground cistern",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "use_item",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 2,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7959
+        }
+      ],
+      "totalCostUsd": 0.00357691
+    },
+    {
+      "iter": 3,
+      "settingA": "library overflowing with books",
+      "settingB": "sun-baked salt flat",
+      "theme": "technological",
+      "objectiveTypes": [
+        "carry",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 3,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7751
+        }
+      ],
+      "totalCostUsd": 0.0045501
+    },
+    {
+      "iter": 4,
+      "settingA": "dust-filled opera hall",
+      "settingB": "abandoned subway station",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "carry",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 4,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 5465
+        }
+      ],
+      "totalCostUsd": 0.00878175
+    },
+    {
+      "iter": 5,
+      "settingA": "flooded underground cistern",
+      "settingB": "rusted oil platform deck",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 5,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8090
+        }
+      ],
+      "totalCostUsd": 0.00356346
+    },
+    {
+      "iter": 6,
+      "settingA": "collapsed market arcade",
+      "settingB": "ink-stained printing hall",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "use_item",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 6,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8425
+        }
+      ],
+      "totalCostUsd": 0.00561737
+    },
+    {
+      "iter": 7,
+      "settingA": "tide-flooded boardwalk",
+      "settingB": "rusted oil platform deck",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "convergence",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 7,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 9272,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 7,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 9271
+        }
+      ],
+      "totalCostUsd": 0.01334092
+    },
+    {
+      "iter": 8,
+      "settingA": "rusted oil platform deck",
+      "settingB": "hollowed glacier cave",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 8,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8175
+        }
+      ],
+      "totalCostUsd": 0.00555277
+    },
+    {
+      "iter": 9,
+      "settingA": "abandoned subway station",
+      "settingB": "library overflowing with books",
+      "theme": "magical",
+      "objectiveTypes": [
+        "convergence",
+        "convergence",
+        "use_item"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 9,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8435
+        }
+      ],
+      "totalCostUsd": 0.00499212
+    },
+    {
+      "iter": 10,
+      "settingA": "moonlit greenhouse ruin",
+      "settingB": "stripped server vault",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "use_space",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 10,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 8453,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-1",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 10,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 8456
+        }
+      ],
+      "totalCostUsd": 0.00923328
+    },
+    {
+      "iter": 11,
+      "settingA": "hollowed glacier cave",
+      "settingB": "sun-baked salt flat",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 11,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8539
+        }
+      ],
+      "totalCostUsd": 0.0056174
+    },
+    {
+      "iter": 12,
+      "settingA": "silent planetarium dome",
+      "settingB": "moonlit greenhouse ruin",
+      "theme": "technological",
+      "objectiveTypes": [
+        "convergence",
+        "carry",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 12,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8187
+        }
+      ],
+      "totalCostUsd": 0.00355156
+    },
+    {
+      "iter": 13,
+      "settingA": "silent planetarium dome",
+      "settingB": "forgotten laboratory",
+      "theme": "magical",
+      "objectiveTypes": [
+        "use_space",
+        "carry",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 13,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8279
+        }
+      ],
+      "totalCostUsd": 0.0053676
+    },
+    {
+      "iter": 14,
+      "settingA": "library overflowing with books",
+      "settingB": "abandoned subway station",
+      "theme": "technological",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 14,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 9252
+        }
+      ],
+      "totalCostUsd": 0.00403926
+    },
+    {
+      "iter": 15,
+      "settingA": "flooded underground cistern",
+      "settingB": "moonlit greenhouse ruin",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "use_item",
+        "use_item",
+        "use_space"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 15,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7130,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 15,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 7139
+        }
+      ],
+      "totalCostUsd": 0.009010919999999999
+    },
+    {
+      "iter": 16,
+      "settingA": "collapsed market arcade",
+      "settingB": "stripped server vault",
+      "theme": "technological",
+      "objectiveTypes": [
+        "use_item",
+        "use_space",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 16,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8041
+        }
+      ],
+      "totalCostUsd": 0.00428165
+    },
+    {
+      "iter": 17,
+      "settingA": "ink-stained printing hall",
+      "settingB": "humid and dense bog",
+      "theme": "technological",
+      "objectiveTypes": [
+        "convergence",
+        "use_space",
+        "carry"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 17,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 9052
+        }
+      ],
+      "totalCostUsd": 0.004551624
+    },
+    {
+      "iter": 18,
+      "settingA": "tide-flooded boardwalk",
+      "settingB": "throne room of a pagoda",
+      "theme": "magical",
+      "objectiveTypes": [
+        "convergence",
+        "convergence",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 18,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 8996
+        }
+      ],
+      "totalCostUsd": 0.00511796
+    },
+    {
+      "iter": 19,
+      "settingA": "dust-filled opera hall",
+      "settingB": "tide-flooded boardwalk",
+      "theme": "technological",
+      "objectiveTypes": [
+        "use_space",
+        "carry",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 19,
+          "attempt": 0,
+          "outcome": "validation-failed",
+          "rawLength": 7657,
+          "validationErrors": [
+            {
+              "retryUnitKind": "decoy",
+              "rule": "verb-of-activation",
+              "entityId": "decoy-0",
+              "field": "examineDescription"
+            }
+          ]
+        },
+        {
+          "iter": 19,
+          "attempt": 1,
+          "outcome": "ok",
+          "rawLength": 7660
+        }
+      ],
+      "totalCostUsd": 0.0067798500000000005
+    },
+    {
+      "iter": 20,
+      "settingA": "stripped server vault",
+      "settingB": "silent planetarium dome",
+      "theme": "mundane",
+      "objectiveTypes": [
+        "carry",
+        "convergence",
+        "convergence"
+      ],
+      "finalOutcome": "ok",
+      "attempts": [
+        {
+          "iter": 20,
+          "attempt": 0,
+          "outcome": "ok",
+          "rawLength": 7425
+        }
+      ],
+      "totalCostUsd": 0.00406413
+    }
+  ]
+}

--- a/evals/content-pack-flakiness/runner.mts
+++ b/evals/content-pack-flakiness/runner.mts
@@ -1,0 +1,497 @@
+/**
+ * evals/content-pack-flakiness/runner.mts
+ *
+ * Real-LLM harness for content-pack dual generation. Replays the production
+ * retry loop (BrowserContentPackProvider.generateDualContentPacks) against
+ * OpenRouter directly, recording every outer attempt's outcome so we can
+ * see which validation rules trip in practice.
+ *
+ * Run with:
+ *   OPENROUTER_API_KEY=... npx tsx evals/content-pack-flakiness/runner.mts
+ *
+ * Knobs:
+ *   - EVAL_ITERATIONS (default 10): independent end-to-end runs.
+ *   - EVAL_MODEL (default z-ai/glm-4.7): OpenRouter model id.
+ *
+ * Each iteration draws a fresh setting/theme/weather/timeOfDay and a fresh
+ * objective-type triple, then drives the OUTER_BUDGET=3 retry loop just
+ * like production. Output is written to docs/evals/content-pack-flakiness/.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SETTING_POOL } from "../../src/content/setting-pool.js";
+import { THEME_POOL } from "../../src/content/theme-pool.js";
+import { TIME_OF_DAY_POOL } from "../../src/content/time-of-day-pool.js";
+import { WEATHER_POOL } from "../../src/content/weather-pool.js";
+import { PINNED_MODEL } from "../../src/model.js";
+import { validateBoundDualContentPack } from "../../src/spa/game/binding-aware-validator.js";
+import { buildDualBindingPrompt } from "../../src/spa/game/binding-prompt-builder.js";
+import {
+	buildCorrectiveFeedback,
+	buildOuterMessages,
+	DUAL_CONTENT_PACK_SYSTEM_PROMPT,
+	type OuterChatMessage,
+	type ValidationError,
+} from "../../src/spa/game/content-pack-provider.js";
+import { rollObjectiveTypes } from "../../src/spa/game/objective-type-roll.js";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? "";
+const MODEL = process.env.EVAL_MODEL ?? PINNED_MODEL;
+const ITERATIONS = Number(process.env.EVAL_ITERATIONS ?? 10);
+const PARALLEL = Number(process.env.EVAL_PARALLEL ?? 1);
+const OUTER_BUDGET = 3;
+
+if (!OPENROUTER_API_KEY) {
+	console.error("OPENROUTER_API_KEY is not set in env");
+	process.exit(1);
+}
+
+// ── Per-attempt record ───────────────────────────────────────────────────────
+
+type AttemptOutcome = "ok" | "validation-failed" | "hard-error";
+
+interface AttemptRecord {
+	iter: number;
+	attempt: number;
+	outcome: AttemptOutcome;
+	rawLength?: number;
+	errorMessage?: string;
+	validationErrors?: Array<{
+		retryUnitKind: string;
+		rule: string;
+		entityId: string;
+		field: string;
+	}>;
+}
+
+interface IterationResult {
+	iter: number;
+	settingA: string;
+	settingB: string;
+	theme: string;
+	objectiveTypes: string[];
+	finalOutcome: "ok" | "exhausted" | "thrown";
+	finalError?: string;
+	attempts: AttemptRecord[];
+	totalCostUsd?: number;
+}
+
+// ── Draw helpers ─────────────────────────────────────────────────────────────
+
+function rng(): () => number {
+	return Math.random;
+}
+
+function drawDistinct<T>(
+	pool: readonly T[],
+	count: number,
+	r: () => number,
+): T[] {
+	const copy = [...pool];
+	const result: T[] = [];
+	for (let i = 0; i < count && copy.length > 0; i++) {
+		const j = Math.floor(r() * copy.length);
+		result.push(copy.splice(j, 1)[0] as T);
+	}
+	return result;
+}
+
+function drawOne<T>(pool: readonly T[], r: () => number): T {
+	return pool[Math.floor(r() * pool.length)] as T;
+}
+
+// ── Model call (mirrors chatCompletionJson but direct to OpenRouter) ─────────
+
+interface ModelCallResult {
+	content: string | null;
+	reasoning: string | null;
+	costUsd?: number;
+}
+
+async function callOpenRouter(
+	messages: OuterChatMessage[],
+): Promise<ModelCallResult> {
+	const resp = await fetch(OPENROUTER_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+		},
+		body: JSON.stringify({
+			model: MODEL,
+			messages,
+			stream: false,
+			response_format: { type: "json_object" },
+			usage: { include: true },
+			reasoning: { enabled: false },
+		}),
+	});
+
+	if (!resp.ok) {
+		const text = await resp.text();
+		throw new Error(`HTTP ${resp.status}: ${text.slice(0, 200)}`);
+	}
+
+	const body = (await resp.json()) as {
+		choices?: Array<{ message?: { content?: string; reasoning?: string } }>;
+		usage?: { cost?: number };
+		error?: { message?: string };
+	};
+
+	if (body.error) {
+		throw new Error(`upstream error: ${body.error.message ?? "unknown"}`);
+	}
+
+	const msg = body.choices?.[0]?.message;
+	return {
+		content: msg?.content ?? null,
+		reasoning: msg?.reasoning ?? null,
+		...(body.usage?.cost !== undefined ? { costUsd: body.usage.cost } : {}),
+	};
+}
+
+function summariseValidationError(err: ValidationError) {
+	return {
+		retryUnitKind: err.retryUnit.kind,
+		rule: err.rule,
+		entityId: err.entityId,
+		field: err.field,
+	};
+}
+
+// ── One end-to-end iteration ─────────────────────────────────────────────────
+
+async function runIteration(iter: number): Promise<IterationResult> {
+	const r = rng();
+	const [settingA, settingB] = drawDistinct(SETTING_POOL, 2, r) as [
+		string,
+		string,
+	];
+	const weatherA = drawOne(WEATHER_POOL, r);
+	const weatherB = drawOne(WEATHER_POOL, r);
+	const timeOfDayA = drawOne(TIME_OF_DAY_POOL, r);
+	const timeOfDayB = drawOne(TIME_OF_DAY_POOL, r);
+	const theme = drawOne(THEME_POOL, r);
+	const m = 1 + Math.floor(r() * 3);
+
+	const objectiveTypes = rollObjectiveTypes(r, 3);
+
+	const bindingPrompt = buildDualBindingPrompt(
+		objectiveTypes,
+		settingA,
+		settingB,
+		theme,
+		weatherA,
+		weatherB,
+		timeOfDayA,
+		timeOfDayB,
+		m,
+	);
+
+	const schedule = {
+		skeletons: bindingPrompt.skeletons,
+		decoys: [{ id: "decoy-0" }, { id: "decoy-1" }] as const,
+		obstacleCount: m,
+	};
+	const baseUserPrompt = bindingPrompt.userMessage;
+	const systemPrompt = DUAL_CONTENT_PACK_SYSTEM_PROMPT;
+
+	let correctiveFeedback: string | null = null;
+	let prevAssistantRaw: string | null = null;
+	const attempts: AttemptRecord[] = [];
+	let totalCostUsd = 0;
+
+	for (let outer = 0; outer < OUTER_BUDGET; outer++) {
+		const messages = buildOuterMessages(
+			systemPrompt,
+			baseUserPrompt,
+			prevAssistantRaw,
+			correctiveFeedback,
+		);
+
+		let modelResult: ModelCallResult;
+		try {
+			modelResult = await callOpenRouter(messages);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			attempts.push({
+				iter,
+				attempt: outer,
+				outcome: "hard-error",
+				errorMessage: message,
+			});
+			if (outer === OUTER_BUDGET - 1) {
+				return {
+					iter,
+					settingA,
+					settingB,
+					theme,
+					objectiveTypes,
+					finalOutcome: "thrown",
+					finalError: message,
+					attempts,
+					totalCostUsd,
+				};
+			}
+			correctiveFeedback = null;
+			prevAssistantRaw = null;
+			continue;
+		}
+
+		if (modelResult.costUsd !== undefined) totalCostUsd += modelResult.costUsd;
+		const raw =
+			modelResult.content !== null && modelResult.content !== ""
+				? modelResult.content
+				: (modelResult.reasoning ?? "");
+
+		if (raw === "") {
+			attempts.push({
+				iter,
+				attempt: outer,
+				outcome: "hard-error",
+				errorMessage: "empty content and reasoning",
+			});
+			correctiveFeedback = null;
+			prevAssistantRaw = null;
+			continue;
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			attempts.push({
+				iter,
+				attempt: outer,
+				outcome: "hard-error",
+				errorMessage: "JSON parse failed",
+				rawLength: raw.length,
+			});
+			correctiveFeedback = null;
+			prevAssistantRaw = null;
+			continue;
+		}
+
+		const validation = validateBoundDualContentPack(parsed, schedule);
+		if (validation.ok) {
+			attempts.push({
+				iter,
+				attempt: outer,
+				outcome: "ok",
+				rawLength: raw.length,
+			});
+			return {
+				iter,
+				settingA,
+				settingB,
+				theme,
+				objectiveTypes,
+				finalOutcome: "ok",
+				attempts,
+				totalCostUsd,
+			};
+		}
+
+		attempts.push({
+			iter,
+			attempt: outer,
+			outcome: "validation-failed",
+			rawLength: raw.length,
+			validationErrors: validation.errors.map(summariseValidationError),
+		});
+		correctiveFeedback = buildCorrectiveFeedback(validation.errors);
+		prevAssistantRaw = raw;
+	}
+
+	return {
+		iter,
+		settingA,
+		settingB,
+		theme,
+		objectiveTypes,
+		finalOutcome: "exhausted",
+		attempts,
+		totalCostUsd,
+	};
+}
+
+// ── Aggregation ──────────────────────────────────────────────────────────────
+
+function tally(results: IterationResult[]): {
+	successOnFirst: number;
+	successAfterRetry: number;
+	exhausted: number;
+	thrown: number;
+	ruleHistogram: Record<string, number>;
+	retryUnitHistogram: Record<string, number>;
+	avgAttemptsToSuccess: number;
+	totalCostUsd: number;
+} {
+	const ruleHistogram: Record<string, number> = {};
+	const retryUnitHistogram: Record<string, number> = {};
+	let successOnFirst = 0;
+	let successAfterRetry = 0;
+	let exhausted = 0;
+	let thrown = 0;
+	let attemptsToSuccessSum = 0;
+	let totalCostUsd = 0;
+
+	for (const r of results) {
+		totalCostUsd += r.totalCostUsd ?? 0;
+		if (r.finalOutcome === "ok") {
+			const winningAttempt =
+				r.attempts.findIndex((a) => a.outcome === "ok") + 1;
+			if (winningAttempt === 1) successOnFirst++;
+			else successAfterRetry++;
+			attemptsToSuccessSum += winningAttempt;
+		} else if (r.finalOutcome === "exhausted") {
+			exhausted++;
+		} else {
+			thrown++;
+		}
+		for (const a of r.attempts) {
+			if (!a.validationErrors) continue;
+			for (const v of a.validationErrors) {
+				ruleHistogram[v.rule] = (ruleHistogram[v.rule] ?? 0) + 1;
+				retryUnitHistogram[v.retryUnitKind] =
+					(retryUnitHistogram[v.retryUnitKind] ?? 0) + 1;
+			}
+		}
+	}
+
+	const successes = successOnFirst + successAfterRetry;
+	return {
+		successOnFirst,
+		successAfterRetry,
+		exhausted,
+		thrown,
+		ruleHistogram,
+		retryUnitHistogram,
+		avgAttemptsToSuccess:
+			successes > 0 ? attemptsToSuccessSum / successes : NaN,
+		totalCostUsd,
+	};
+}
+
+function formatHistogram(h: Record<string, number>): string {
+	const entries = Object.entries(h).sort((a, b) => b[1] - a[1]);
+	if (entries.length === 0) return "  (none)";
+	return entries.map(([k, v]) => `  ${k}: ${v}`).join("\n");
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+function summariseAttempt(a: AttemptRecord): string {
+	if (a.outcome === "validation-failed" && a.validationErrors) {
+		const ruleSummary = a.validationErrors
+			.slice(0, 5)
+			.map((v) => `${v.retryUnitKind}/${v.rule}/${v.entityId}/${v.field}`)
+			.join(", ");
+		return `attempt ${a.attempt}: validation-failed × ${a.validationErrors.length} (${ruleSummary}${a.validationErrors.length > 5 ? ", …" : ""})`;
+	}
+	if (a.outcome === "hard-error") {
+		return `attempt ${a.attempt}: hard-error — ${a.errorMessage}`;
+	}
+	return `attempt ${a.attempt}: ok`;
+}
+
+function logIterationResult(result: IterationResult, elapsedSec: string): void {
+	const summary =
+		result.finalOutcome === "ok"
+			? `ok in ${result.attempts.length} attempt(s)`
+			: result.finalOutcome === "exhausted"
+				? `EXHAUSTED — failed all ${result.attempts.length}`
+				: `THROWN — ${result.finalError}`;
+	console.log(
+		`iter ${result.iter}: ${summary} (${elapsedSec}s, cost $${(result.totalCostUsd ?? 0).toFixed(4)})`,
+	);
+	if (result.finalOutcome !== "ok") {
+		for (const a of result.attempts) console.log(`  ${summariseAttempt(a)}`);
+	}
+}
+
+async function runIterationLogged(iter: number): Promise<IterationResult> {
+	const startMs = Date.now();
+	try {
+		const result = await runIteration(iter);
+		const elapsed = ((Date.now() - startMs) / 1000).toFixed(1);
+		logIterationResult(result, elapsed);
+		return result;
+	} catch (err) {
+		const elapsed = ((Date.now() - startMs) / 1000).toFixed(1);
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`iter ${iter}: UNCAUGHT ${message} (${elapsed}s)`);
+		return {
+			iter,
+			settingA: "",
+			settingB: "",
+			theme: "",
+			objectiveTypes: [],
+			finalOutcome: "thrown",
+			finalError: message,
+			attempts: [],
+		};
+	}
+}
+
+async function main(): Promise<void> {
+	console.log(
+		`Running ${ITERATIONS} iteration(s) against ${MODEL} (OUTER_BUDGET=${OUTER_BUDGET}, PARALLEL=${PARALLEL})`,
+	);
+	const results: IterationResult[] = [];
+
+	// Pool: at most PARALLEL iterations in flight at once.
+	const queue = Array.from({ length: ITERATIONS }, (_, i) => i + 1);
+	const workers = Array.from(
+		{ length: Math.min(PARALLEL, ITERATIONS) },
+		async () => {
+			while (true) {
+				const next = queue.shift();
+				if (next === undefined) return;
+				const r = await runIterationLogged(next);
+				results.push(r);
+			}
+		},
+	);
+	await Promise.all(workers);
+	results.sort((a, b) => a.iter - b.iter);
+
+	const t = tally(results);
+	console.log("\n=== summary ===");
+	console.log(`iterations: ${ITERATIONS}`);
+	console.log(`success on first attempt:  ${t.successOnFirst}`);
+	console.log(`success after retry:       ${t.successAfterRetry}`);
+	console.log(`exhausted retry budget:    ${t.exhausted}`);
+	console.log(`thrown (network/parse):    ${t.thrown}`);
+	console.log(
+		`avg attempts to success:   ${Number.isNaN(t.avgAttemptsToSuccess) ? "n/a" : t.avgAttemptsToSuccess.toFixed(2)}`,
+	);
+	console.log(`total cost (USD):          $${t.totalCostUsd.toFixed(4)}`);
+	console.log("\nvalidation errors by rule:");
+	console.log(formatHistogram(t.ruleHistogram));
+	console.log("\nvalidation errors by retryUnit:");
+	console.log(formatHistogram(t.retryUnitHistogram));
+
+	// Write artifacts
+	const __dirname = path.dirname(fileURLToPath(import.meta.url));
+	const outDir = path.resolve(
+		__dirname,
+		"../../docs/evals/content-pack-flakiness",
+	);
+	fs.mkdirSync(outDir, { recursive: true });
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+	const jsonPath = path.join(outDir, `${stamp}.json`);
+	fs.writeFileSync(
+		jsonPath,
+		JSON.stringify({ summary: t, iterations: results }, null, 2),
+	);
+	console.log(`\nwrote: ${jsonPath}`);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/src/spa/game/__tests__/content-pack-attempts.test.ts
+++ b/src/spa/game/__tests__/content-pack-attempts.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	__resetContentPackAttemptsForTests,
+	ATTEMPTS_RING_SIZE,
+	ATTEMPTS_STORAGE_KEY,
+	clearContentPackAttempts,
+	getContentPackAttempts,
+	recordContentPackAttempt,
+} from "../content-pack-attempts.js";
+import type { ValidationError } from "../content-pack-provider.js";
+
+const sampleValidationError: ValidationError = {
+	entityId: "decoy-0",
+	field: "examineDescription",
+	rule: "verb-of-activation",
+	message: "Decoy decoy-0: must NOT contain use-cue keyword 'lever'",
+	retryUnit: { kind: "decoy", phaseIndex: 0, decoyId: "decoy-0" },
+};
+
+describe("content-pack-attempts recorder", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		__resetContentPackAttemptsForTests();
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("records a successful single-pack attempt without console.warn", () => {
+		recordContentPackAttempt({
+			op: "single",
+			attempt: 0,
+			outcome: "ok",
+			rawLength: 1234,
+		});
+
+		const records = getContentPackAttempts();
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({
+			op: "single",
+			attempt: 0,
+			outcome: "ok",
+			rawLength: 1234,
+		});
+		expect(console.warn).not.toHaveBeenCalled();
+	});
+
+	it("records a validation-failed attempt with flattened errors and warns", () => {
+		recordContentPackAttempt({
+			op: "dual",
+			attempt: 1,
+			outcome: "validation-failed",
+			validationErrors: [sampleValidationError],
+			rawLength: 4567,
+		});
+
+		const records = getContentPackAttempts();
+		expect(records[0]?.validationErrors).toEqual([
+			{
+				retryUnitKind: "decoy",
+				rule: "verb-of-activation",
+				entityId: "decoy-0",
+				field: "examineDescription",
+			},
+		]);
+		expect(console.warn).toHaveBeenCalledOnce();
+		const [prefix, payload] = (console.warn as ReturnType<typeof vi.fn>).mock
+			.calls[0] as [string, { outcome: string }];
+		expect(prefix).toBe("[content-pack:attempt]");
+		expect(payload.outcome).toBe("validation-failed");
+	});
+
+	it("records a hard-error attempt with the error message", () => {
+		recordContentPackAttempt({
+			op: "single",
+			attempt: 2,
+			outcome: "hard-error",
+			errorMessage: "content-pack JSON parse failed: <truncated>",
+		});
+
+		const records = getContentPackAttempts();
+		expect(records[0]?.outcome).toBe("hard-error");
+		expect(records[0]?.errorMessage).toContain("JSON parse failed");
+	});
+
+	it("trims the ring to ATTEMPTS_RING_SIZE", () => {
+		for (let i = 0; i < ATTEMPTS_RING_SIZE + 10; i++) {
+			recordContentPackAttempt({
+				op: "single",
+				attempt: i % 3,
+				outcome: "ok",
+			});
+		}
+
+		const records = getContentPackAttempts();
+		expect(records).toHaveLength(ATTEMPTS_RING_SIZE);
+	});
+
+	it("persists records across in-memory cache resets via localStorage", () => {
+		recordContentPackAttempt({
+			op: "dual",
+			attempt: 0,
+			outcome: "ok",
+		});
+
+		__resetContentPackAttemptsForTests();
+
+		const records = getContentPackAttempts();
+		expect(records).toHaveLength(1);
+		expect(records[0]?.op).toBe("dual");
+	});
+
+	it("clearContentPackAttempts wipes memory and localStorage", () => {
+		recordContentPackAttempt({ op: "single", attempt: 0, outcome: "ok" });
+		clearContentPackAttempts();
+
+		expect(getContentPackAttempts()).toEqual([]);
+		expect(localStorage.getItem(ATTEMPTS_STORAGE_KEY)).toBeNull();
+	});
+
+	it("ignores a storage envelope with the wrong schema version", () => {
+		localStorage.setItem(
+			ATTEMPTS_STORAGE_KEY,
+			JSON.stringify({ v: 999, records: [{ ts: 1, op: "single" }] }),
+		);
+		__resetContentPackAttemptsForTests();
+
+		expect(getContentPackAttempts()).toEqual([]);
+	});
+
+	it("installs window.__contentPackAttempts after first record in __DEV__", () => {
+		recordContentPackAttempt({ op: "single", attempt: 0, outcome: "ok" });
+
+		const accessor = (
+			window as unknown as { __contentPackAttempts?: () => unknown[] }
+		).__contentPackAttempts;
+		expect(typeof accessor).toBe("function");
+		expect(accessor?.()).toHaveLength(1);
+	});
+});

--- a/src/spa/game/binding-aware-validator.ts
+++ b/src/spa/game/binding-aware-validator.ts
@@ -209,7 +209,9 @@ function validateCarryBinding(
 			entityId: objectId,
 			field: "object",
 			rule: "missing-field",
-			message: `Carry binding ${sk.objectId}: missing object entity`,
+			message:
+				`Carry binding: the binding object has no "object" key. ` +
+				`Add a top-level "object" sub-object with id "${objectId}". Required shape: ${bindingShapeHint("object", objectId, bindingRetryUnit)}`,
 			retryUnit: bindingRetryUnit,
 		});
 	} else {
@@ -253,7 +255,9 @@ function validateCarryBinding(
 			entityId: spaceId,
 			field: "space",
 			rule: "missing-field",
-			message: `Carry binding ${sk.spaceId}: missing space entity`,
+			message:
+				`Carry binding: the binding object has no "space" key. ` +
+				`Add a top-level "space" sub-object with id "${spaceId}". Required shape: ${bindingShapeHint("space", spaceId, bindingRetryUnit)}`,
 			retryUnit: bindingRetryUnit,
 		});
 	} else {
@@ -311,7 +315,9 @@ function validateUseSpaceBinding(
 			entityId: spaceId,
 			field: "space",
 			rule: "missing-field",
-			message: `UseSpace binding ${sk.spaceId}: missing space entity`,
+			message:
+				`UseSpace binding: the binding object has no "space" key. ` +
+				`Add a top-level "space" sub-object with id "${spaceId}". Required shape: ${bindingShapeHint("space", spaceId, bindingRetryUnit)}`,
 			retryUnit: bindingRetryUnit,
 		});
 		return;
@@ -376,7 +382,9 @@ function validateUseItemBinding(
 			entityId: itemId,
 			field: "item",
 			rule: "missing-field",
-			message: `UseItem binding ${sk.itemId}: missing item entity`,
+			message:
+				`UseItem binding: the binding object has no "item" key. ` +
+				`Add a top-level "item" sub-object with id "${itemId}". Required shape: ${bindingShapeHint("item", itemId, bindingRetryUnit)}`,
 			retryUnit: bindingRetryUnit,
 		});
 		return;
@@ -431,7 +439,9 @@ function validateConvergenceBinding(
 			entityId: spaceId,
 			field: "space",
 			rule: "missing-field",
-			message: `Convergence binding ${sk.spaceId}: missing space entity`,
+			message:
+				`Convergence binding: the binding object has no "space" key. ` +
+				`Add a top-level "space" sub-object with id "${spaceId}". Required shape: ${bindingShapeHint("space", spaceId, bindingRetryUnit)}`,
 			retryUnit: bindingRetryUnit,
 		});
 		return;

--- a/src/spa/game/binding-aware-validator.ts
+++ b/src/spa/game/binding-aware-validator.ts
@@ -139,18 +139,46 @@ function forbiddenField(
 	}
 }
 
+type EntitySubKey = "object" | "space" | "item";
+
+function bindingShapeHint(
+	subKey: EntitySubKey,
+	expectedId: string,
+	retryUnit: ValidationError["retryUnit"],
+): string {
+	switch (retryUnit.kind) {
+		case "carry-binding":
+			return subKey === "object"
+				? `{ "type": "carry", "object": { "id": "${expectedId}", "name": ..., "examineDescription": ..., ... }, "space": { ... } }`
+				: `{ "type": "carry", "object": { ... }, "space": { "id": "${expectedId}", "name": ..., "examineDescription": ..., ... } }`;
+		case "use-space-binding":
+			return `{ "type": "use_space", "space": { "id": "${expectedId}", "name": ..., "examineDescription": ..., "activationFlavor": ..., ... } }`;
+		case "use-item-binding":
+			return `{ "type": "use_item", "item": { "id": "${expectedId}", "name": ..., "examineDescription": ..., "useOutcome": ..., ... } }`;
+		case "convergence-binding":
+			return `{ "type": "convergence", "space": { "id": "${expectedId}", "name": ..., "convergenceTier1Flavor": ..., ... } }`;
+		default:
+			return `{ "id": "${expectedId}", ... }`;
+	}
+}
+
 function checkWrongId(
 	entity: RawBindingEntity,
 	expectedId: string,
 	retryUnit: ValidationError["retryUnit"],
 	errors: ValidationError[],
+	subKey: EntitySubKey,
 ): void {
 	if (entity.id !== expectedId) {
+		const actual = entity.id === undefined ? "(missing)" : `"${entity.id}"`;
+		const shape = bindingShapeHint(subKey, expectedId, retryUnit);
 		errors.push({
 			entityId: entity.id ?? "",
 			field: "id",
 			rule: "wrong-id",
-			message: `Entity id "${entity.id}" does not match expected id "${expectedId}"`,
+			message:
+				`The "${subKey}" sub-object inside this binding must include a top-level string field "id" equal to "${expectedId}". ` +
+				`Got ${actual}. Required shape: ${shape}`,
 			retryUnit,
 		});
 	}
@@ -185,7 +213,7 @@ function validateCarryBinding(
 			retryUnit: bindingRetryUnit,
 		});
 	} else {
-		checkWrongId(obj, objectId, bindingRetryUnit, errors);
+		checkWrongId(obj, objectId, bindingRetryUnit, errors, "object");
 		for (const f of [
 			"name",
 			"examineDescription",
@@ -229,7 +257,7 @@ function validateCarryBinding(
 			retryUnit: bindingRetryUnit,
 		});
 	} else {
-		checkWrongId(space, spaceId, bindingRetryUnit, errors);
+		checkWrongId(space, spaceId, bindingRetryUnit, errors, "space");
 		for (const f of ["name", "examineDescription", "proximityFlavor"]) {
 			requiredString(space, f, spaceId, bindingRetryUnit, errors);
 		}
@@ -289,7 +317,7 @@ function validateUseSpaceBinding(
 		return;
 	}
 
-	checkWrongId(space, spaceId, bindingRetryUnit, errors);
+	checkWrongId(space, spaceId, bindingRetryUnit, errors, "space");
 	for (const f of [
 		"name",
 		"examineDescription",
@@ -354,7 +382,7 @@ function validateUseItemBinding(
 		return;
 	}
 
-	checkWrongId(item, itemId, bindingRetryUnit, errors);
+	checkWrongId(item, itemId, bindingRetryUnit, errors, "item");
 	for (const f of [
 		"name",
 		"examineDescription",
@@ -409,7 +437,7 @@ function validateConvergenceBinding(
 		return;
 	}
 
-	checkWrongId(space, spaceId, bindingRetryUnit, errors);
+	checkWrongId(space, spaceId, bindingRetryUnit, errors, "space");
 	for (const f of [
 		"name",
 		"examineDescription",

--- a/src/spa/game/binding-prompt-builder.ts
+++ b/src/spa/game/binding-prompt-builder.ts
@@ -69,26 +69,77 @@ function obstacleIds(count: number): string[] {
 function describeSkeletonInUserMessage(sk: BindingSkeleton, i: number): string {
 	switch (sk.type) {
 		case "carry":
-			return (
-				`Binding ${i} (carry):\n` +
-				`  object id="${sk.objectId}": name, examineDescription (MUST reference paired space "${sk.spaceId}"), useOutcome, placementFlavor (MUST contain {actor}), proximityFlavor\n` +
-				`  space  id="${sk.spaceId}": name, examineDescription (MUST NOT contain use-cue; MUST NOT have activationFlavor/satisfactionFlavor/convergence tier fields), proximityFlavor`
-			);
+			return [
+				`Binding ${i} (carry): use this exact JSON shape (as element ${i} of "bindings"):`,
+				`{`,
+				`  "type": "carry",`,
+				`  "object": {`,
+				`    "id": "${sk.objectId}",`,
+				`    "name": "<2-4 words>",`,
+				`    "examineDescription": "<1-2 sentences; MUST reference the paired space '${sk.spaceId}' by name>",`,
+				`    "useOutcome": "<1 stateless sentence>",`,
+				`    "placementFlavor": "<1 sentence; MUST contain literal {actor}>",`,
+				`    "proximityFlavor": "<1 sentence; daemon POV; no {actor}>"`,
+				`  },`,
+				`  "space": {`,
+				`    "id": "${sk.spaceId}",`,
+				`    "name": "<2-4 words>",`,
+				`    "examineDescription": "<1-2 sentences; MUST NOT contain any use-cue keyword>",`,
+				`    "proximityFlavor": "<1 sentence; daemon POV; no {actor}>"`,
+				`  }`,
+				`}`,
+			].join("\n");
 		case "use_space":
-			return (
-				`Binding ${i} (use_space):\n` +
-				`  space  id="${sk.spaceId}": name, examineDescription (MUST contain use-cue keyword), proximityFlavor, activationFlavor (no {actor}), satisfactionFlavor (no {actor}), postExamineDescription, postLookFlavor`
-			);
+			return [
+				`Binding ${i} (use_space): use this exact JSON shape (as element ${i} of "bindings"):`,
+				`{`,
+				`  "type": "use_space",`,
+				`  "space": {`,
+				`    "id": "${sk.spaceId}",`,
+				`    "name": "<2-4 words>",`,
+				`    "examineDescription": "<1-2 sentences; MUST contain a use-cue keyword>",`,
+				`    "proximityFlavor": "<1 sentence; daemon POV; no {actor}>",`,
+				`    "activationFlavor": "<1 sentence; world third-person; no {actor}>",`,
+				`    "satisfactionFlavor": "<1 sentence; witness POV; no {actor}>",`,
+				`    "postExamineDescription": "<1-2 sentences>",`,
+				`    "postLookFlavor": "<1 sentence>"`,
+				`  }`,
+				`}`,
+			].join("\n");
 		case "use_item":
-			return (
-				`Binding ${i} (use_item):\n` +
-				`  item   id="${sk.itemId}": name, examineDescription (MUST contain use-cue keyword), proximityFlavor, useOutcome, activationFlavor (no {actor}), postExamineDescription (no {actor}), postLookFlavor (no {actor})`
-			);
+			return [
+				`Binding ${i} (use_item): use this exact JSON shape (as element ${i} of "bindings"):`,
+				`{`,
+				`  "type": "use_item",`,
+				`  "item": {`,
+				`    "id": "${sk.itemId}",`,
+				`    "name": "<2-4 words>",`,
+				`    "examineDescription": "<1-2 sentences; MUST contain a use-cue keyword>",`,
+				`    "proximityFlavor": "<1 sentence; daemon POV; no {actor}>",`,
+				`    "useOutcome": "<1 stateless sentence>",`,
+				`    "activationFlavor": "<1 sentence; world third-person; no {actor}>",`,
+				`    "postExamineDescription": "<1-2 sentences; no {actor}>",`,
+				`    "postLookFlavor": "<1 sentence; no {actor}>"`,
+				`  }`,
+				`}`,
+			].join("\n");
 		case "convergence":
-			return (
-				`Binding ${i} (convergence):\n` +
-				`  space  id="${sk.spaceId}": name, examineDescription, proximityFlavor, convergenceTier1Flavor, convergenceTier2Flavor, convergenceTier1ActorFlavor, convergenceTier2ActorFlavor (all no {actor}; NO activationFlavor/satisfactionFlavor/postExamineDescription/postLookFlavor)`
-			);
+			return [
+				`Binding ${i} (convergence): use this exact JSON shape (as element ${i} of "bindings"):`,
+				`{`,
+				`  "type": "convergence",`,
+				`  "space": {`,
+				`    "id": "${sk.spaceId}",`,
+				`    "name": "<2-4 words>",`,
+				`    "examineDescription": "<1-2 sentences; hint at shared-occupancy significance; MUST NOT contain use-cue keyword>",`,
+				`    "proximityFlavor": "<1 sentence; daemon POV; no {actor}>",`,
+				`    "convergenceTier1Flavor": "<1 sentence; witness POV; no {actor}>",`,
+				`    "convergenceTier2Flavor": "<1 sentence; witness POV; no {actor}>",`,
+				`    "convergenceTier1ActorFlavor": "<1 sentence; first-person; no {actor}>",`,
+				`    "convergenceTier2ActorFlavor": "<1 sentence; first-person; no {actor}>"`,
+				`  }`,
+				`}`,
+			].join("\n");
 	}
 }
 

--- a/src/spa/game/content-pack-attempts.ts
+++ b/src/spa/game/content-pack-attempts.ts
@@ -1,0 +1,183 @@
+/**
+ * content-pack-attempts.ts
+ *
+ * Ring-buffer recorder for content-pack LLM-generation attempts. Every outer
+ * retry inside BrowserContentPackProvider (single + dual) records one
+ * AttemptRecord here. Production gives the LLM only OUTER_BUDGET=3 attempts,
+ * so when a real bootstrap dies with "exhausted retry budget" the only
+ * forensic surface is what we capture here.
+ *
+ * Recorder is a no-op outside __DEV__ — adds zero overhead and zero
+ * localStorage writes in production builds.
+ *
+ * Records persist to localStorage so a failed bootstrap remains debuggable
+ * after the player reloads. Pull them in devtools via
+ *   `window.__contentPackAttempts()` or
+ *   `localStorage.getItem("hi-blue:debug/content-pack-attempts")`.
+ */
+
+import type { ValidationError } from "./content-pack-provider.js";
+
+/** localStorage key for the attempt ring buffer. */
+export const ATTEMPTS_STORAGE_KEY = "hi-blue:debug/content-pack-attempts";
+
+/** Max records retained in the ring buffer. */
+export const ATTEMPTS_RING_SIZE = 50;
+
+/** Storage envelope version — bump on shape change. */
+const SCHEMA_VERSION = 1;
+
+/**
+ * Console prefix for grep-ability. Failed attempts emit a structured
+ * `console.warn` with this prefix so playtesters can copy-paste their
+ * devtools log straight into a bug report.
+ */
+const CONSOLE_PREFIX = "[content-pack:attempt]";
+
+export type AttemptOutcome = "ok" | "validation-failed" | "hard-error";
+
+/** Compact per-error summary safe to persist (no raw LLM prose). */
+export interface AttemptValidationError {
+	retryUnitKind: string;
+	rule: string;
+	entityId: string;
+	field: string;
+}
+
+export interface AttemptRecord {
+	ts: number;
+	op: "single" | "dual";
+	attempt: number;
+	outcome: AttemptOutcome;
+	errorMessage?: string;
+	validationErrors?: AttemptValidationError[];
+	/**
+	 * Length of the raw assistant text. Useful to spot truncated outputs
+	 * (validation-failed + tiny rawLength = JSON was cut off mid-stream).
+	 */
+	rawLength?: number;
+}
+
+interface StorageEnvelope {
+	v: number;
+	records: AttemptRecord[];
+}
+
+let ringInMemory: AttemptRecord[] | undefined;
+
+function loadFromStorage(): AttemptRecord[] {
+	if (typeof localStorage === "undefined") return [];
+	try {
+		const raw = localStorage.getItem(ATTEMPTS_STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw) as StorageEnvelope;
+		if (parsed.v !== SCHEMA_VERSION) return [];
+		return Array.isArray(parsed.records) ? parsed.records : [];
+	} catch {
+		return [];
+	}
+}
+
+function persistToStorage(records: AttemptRecord[]): void {
+	if (typeof localStorage === "undefined") return;
+	try {
+		const envelope: StorageEnvelope = { v: SCHEMA_VERSION, records };
+		localStorage.setItem(ATTEMPTS_STORAGE_KEY, JSON.stringify(envelope));
+	} catch {
+		// localStorage may throw on quota / private-mode — drop silently.
+	}
+}
+
+function getRing(): AttemptRecord[] {
+	if (ringInMemory === undefined) ringInMemory = loadFromStorage();
+	return ringInMemory;
+}
+
+function summariseError(err: ValidationError): AttemptValidationError {
+	return {
+		retryUnitKind: err.retryUnit.kind,
+		rule: err.rule,
+		entityId: err.entityId,
+		field: err.field,
+	};
+}
+
+/**
+ * Record a generation attempt. No-op when __DEV__ is false.
+ *
+ * The caller passes ValidationError[] directly when outcome ===
+ * "validation-failed"; this module flattens them into the persisted shape.
+ */
+export function recordContentPackAttempt(input: {
+	op: "single" | "dual";
+	attempt: number;
+	outcome: AttemptOutcome;
+	errorMessage?: string;
+	validationErrors?: ValidationError[];
+	rawLength?: number;
+}): void {
+	if (!__DEV__) return;
+	installWindowAccessor();
+
+	const record: AttemptRecord = {
+		ts: Date.now(),
+		op: input.op,
+		attempt: input.attempt,
+		outcome: input.outcome,
+	};
+	if (input.errorMessage !== undefined)
+		record.errorMessage = input.errorMessage;
+	if (input.validationErrors !== undefined) {
+		record.validationErrors = input.validationErrors.map(summariseError);
+	}
+	if (input.rawLength !== undefined) record.rawLength = input.rawLength;
+
+	const ring = getRing();
+	ring.push(record);
+	while (ring.length > ATTEMPTS_RING_SIZE) ring.shift();
+	persistToStorage(ring);
+
+	if (record.outcome !== "ok") {
+		console.warn(CONSOLE_PREFIX, record);
+	}
+}
+
+/** Return a defensive copy of the recorded attempts. */
+export function getContentPackAttempts(): AttemptRecord[] {
+	return [...getRing()];
+}
+
+/** Drop all recorded attempts (memory + localStorage). */
+export function clearContentPackAttempts(): void {
+	ringInMemory = [];
+	if (typeof localStorage !== "undefined") {
+		try {
+			localStorage.removeItem(ATTEMPTS_STORAGE_KEY);
+		} catch {
+			// ignore
+		}
+	}
+}
+
+/** Test-only: reset the in-memory cache so the next read re-loads from storage. */
+export function __resetContentPackAttemptsForTests(): void {
+	ringInMemory = undefined;
+}
+
+/**
+ * Expose a devtools-console accessor in __DEV__ browser sessions so
+ * playtesters can run `__contentPackAttempts()` after a failed bootstrap.
+ *
+ * Installed lazily on first record/read so a vitest run (where `__DEV__`
+ * isn't defined until the setup file's `beforeEach` fires) doesn't crash
+ * at module import.
+ */
+function installWindowAccessor(): void {
+	if (typeof window === "undefined") return;
+	const w = window as unknown as {
+		__contentPackAttempts?: () => AttemptRecord[];
+	};
+	if (w.__contentPackAttempts === undefined) {
+		w.__contentPackAttempts = getContentPackAttempts;
+	}
+}

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -25,6 +25,7 @@ import {
 	buildBindingPrompt,
 	buildDualBindingPrompt,
 } from "./binding-prompt-builder.js";
+import { recordContentPackAttempt } from "./content-pack-attempts.js";
 import type {
 	AiId,
 	ContentPack,
@@ -1958,6 +1959,12 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 				);
 				const validationResult = validateBoundContentPack(rawJson, schedule);
 				if (validationResult.ok) {
+					recordContentPackAttempt({
+						op: "single",
+						attempt: outer,
+						outcome: "ok",
+						rawLength: raw.length,
+					});
 					return {
 						phases: [
 							{
@@ -1967,10 +1974,23 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 						],
 					};
 				}
+				recordContentPackAttempt({
+					op: "single",
+					attempt: outer,
+					outcome: "validation-failed",
+					validationErrors: validationResult.errors,
+					rawLength: raw.length,
+				});
 				correctiveFeedback = buildCorrectiveFeedback(validationResult.errors);
 				prevAssistantRaw = raw;
 			} catch (err) {
 				if (err instanceof CapHitError) throw err;
+				recordContentPackAttempt({
+					op: "single",
+					attempt: outer,
+					outcome: "hard-error",
+					errorMessage: err instanceof Error ? err.message : String(err),
+				});
 				if (outer === OUTER_BUDGET - 1) throw err;
 				const backoffMs = BACKOFF_MS[outer];
 				if (backoffMs !== undefined) {
@@ -2042,6 +2062,12 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 							"dual content-pack: validated response has no phases",
 						);
 					}
+					recordContentPackAttempt({
+						op: "dual",
+						attempt: outer,
+						outcome: "ok",
+						rawLength: raw.length,
+					});
 					return {
 						phases: [
 							{
@@ -2051,10 +2077,23 @@ export class BrowserContentPackProvider implements ContentPackProvider {
 						],
 					};
 				}
+				recordContentPackAttempt({
+					op: "dual",
+					attempt: outer,
+					outcome: "validation-failed",
+					validationErrors: validationResult.errors,
+					rawLength: raw.length,
+				});
 				correctiveFeedback = buildCorrectiveFeedback(validationResult.errors);
 				prevAssistantRaw = raw;
 			} catch (err) {
 				if (err instanceof CapHitError) throw err;
+				recordContentPackAttempt({
+					op: "dual",
+					attempt: outer,
+					outcome: "hard-error",
+					errorMessage: err instanceof Error ? err.message : String(err),
+				});
 				if (outer === OUTER_BUDGET - 1) throw err;
 				const backoffMs = BACKOFF_MS[outer];
 				if (backoffMs !== undefined) {

--- a/src/spa/game/content-pack-provider.ts
+++ b/src/spa/game/content-pack-provider.ts
@@ -1797,12 +1797,12 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((r) => setTimeout(r, ms));
 }
 
-type OuterChatMessage =
+export type OuterChatMessage =
 	| { role: "system"; content: string }
 	| { role: "user"; content: string }
 	| { role: "assistant"; content: string };
 
-function buildOuterMessages(
+export function buildOuterMessages(
 	systemPrompt: string,
 	userPrompt: string,
 	prevAssistant: string | null,
@@ -1848,7 +1848,7 @@ function retryUnitLabel(unit: ValidationError["retryUnit"]): string {
 	}
 }
 
-function buildCorrectiveFeedback(errors: ValidationError[]): string {
+export function buildCorrectiveFeedback(errors: ValidationError[]): string {
 	// Group by retryUnit so the LLM sees all rules for a given entity together
 	// rather than as a flat dedup'd list — easier to act on per-entity.
 	const groups = new Map<string, { label: string; messages: string[] }>();


### PR DESCRIPTION
## Summary

- **Diagnosed and eliminated a 25% bootstrap-failure rate** in content-pack generation against `z-ai/glm-4.7`. Baseline n=8 → 25% EXHAUSTED. Final n=20 → 0% EXHAUSTED, 80% first-attempt success.
- Root cause: the prompt described per-binding shape in prose (`item id="useItem-0-item": name, examineDescription, ...`), leaving the LLM to infer the JSON wrapping. The model frequently omitted the `item`/`space` sub-object wrapper or its `id` field, and the corrective-retry messages didn't tell it what shape to repair to — so identical invalid responses kept retrying until the budget exhausted.
- Fix: replace prose binding descriptions with literal JSON skeletons the model can copy in place; emit JSON-shape hints in validator error messages for `wrong-id` and binding-wrapper `missing-field` errors.
- Adds a `__DEV__`-gated telemetry recorder (`window.__contentPackAttempts()` + localStorage) for forensics on future live failures, plus a live-LLM eval harness (`evals/content-pack-flakiness/runner.mts`) so future regressions are reproducible.

### Live-eval delta (`z-ai/glm-4.7`, `OUTER_BUDGET=3`)

| Metric | Baseline (n=8) | + corrective fix (n=8) | + prompt skeletons (n=8) | + missing-field hint (n=8) | **Final n=20** |
|---|---|---|---|---|---|
| Bootstrap success | 75% | 87.5% | 100% | 100% | **100%** |
| EXHAUSTED rate | 25% | 12.5% | 0% | 0% | **0%** |
| First-attempt success | 25% | 12.5% | 75% | 63% | **80%** |
| Avg attempts | 1.83 | 2.00 | 1.25 | 1.38 | **1.20** |
| Validation errors | 75 | 59 | 2 | 3 | **4** |
| Cost (per batch) | $0.095 | $0.093 | $0.053 | $0.053 | $0.115 |

Under the baseline 25% EXHAUSTED rate, `p(0 failures in 20) ≈ 0.3%` — statistically clear improvement, not noise.

The 4 remaining validation errors in the n=20 run are all the known `decoy verb-of-activation` footgun (commit c8f9819 / #455); the model recovers from each on the first retry.

## Commits

1. `feat(content-pack): record outer-retry attempts for live-flake forensics` — `__DEV__`-gated ring-buffer recorder + `window.__contentPackAttempts()` accessor.
2. `feat(evals): live-LLM harness for content-pack flakiness + initial findings` — `evals/content-pack-flakiness/runner.mts`, exports `buildOuterMessages` / `buildCorrectiveFeedback` / `OuterChatMessage` so the harness uses the exact production retry shape.
3. `fix(content-pack): sharpen wrong-id corrective message with JSON shape hint` — `checkWrongId` now emits the structural slot (`"item" sub-object`), the actual id (or `(missing)`), and a per-binding-type JSON skeleton.
4. `fix(content-pack): replace prose binding descriptions with literal JSON skeletons` — **the change that did most of the work.** Replaces the prose entity descriptions in `buildBindingPrompt` / `buildDualBindingPrompt` with copy-fillable JSON skeletons. Keeps `):` adjacent to the binding type so the e2e stub regex (`/Binding\s+(\d+)\s+\(([^)]+)\):/g`) still matches.
5. `fix(content-pack): include JSON shape hint in 'missing X entity' corrective messages` — defensive consistency: the four "missing object/space/item entity" branches now also include the shape hint.
6. `docs(evals): n=20 confirmation run` — final artifact under `docs/evals/content-pack-flakiness/`.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1733/1733 pass (8 new tests added for the recorder)
- [x] `pnpm exec playwright test e2e/smoke.spec.ts` — 2/2 pass (stub regex preserved)
- [x] Live-LLM n=8 eval rerun on each fix; full n=20 confirmation against GLM-4.7
- [ ] Manual: bootstrap a real game in the browser and confirm bootstrap completes (no remote env to do this from)
- [ ] Manual: trigger a failure path in the browser and verify `window.__contentPackAttempts()` returns a populated array

## Notes

- Total OpenRouter spend across all evals on this branch: ~$0.45.
- Eval artifacts are committed under `docs/evals/content-pack-flakiness/` as a reproducibility record. Re-run any time with `OPENROUTER_API_KEY=... EVAL_ITERATIONS=20 EVAL_PARALLEL=5 npx tsx evals/content-pack-flakiness/runner.mts`.

https://claude.ai/code/session_01VPVMFS5Mif2niW1rjFuXNL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPVMFS5Mif2niW1rjFuXNL)_