### PR TITLE
feat(dev): add local + LAN dev scripts that skip Cloudflare login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,20 @@ The pinned model is `z-ai/glm-4.7` (`src/model.ts`). Daemon system prompts are a
 
 We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/#specification). Squash-merge PR titles are the source of truth — `changelogen` parses them to bump the version and write `CHANGELOG.md`. See `docs/agents/commits.md`.
 
+## Local development
+
+`pnpm dev` runs `wrangler dev`, which fails without a Cloudflare login because
+`RATE_GUARD_KV` is bound in remote mode (`"remote": true` in `wrangler.jsonc`).
+In a sandbox or any environment without `wrangler login`, use:
+
+- **`pnpm dev:local`** — adds `--local` (KV runs in-process, no login) and
+  `--ip 0.0.0.0`. The page is reachable from another device, but in-app API
+  calls still target `localhost`, so the proxy won't work cross-device.
+- **`pnpm dev:lan`** (`scripts/dev-lan.mjs`) — detects the LAN IP, bakes it into
+  `WORKER_BASE_URL`, and serves on `0.0.0.0:8787` for a fully functional app on
+  another device. This sets `WORKER_BASE_URL` off `localhost`, so `__DEV__` is
+  false (no dev inspector / debug footers / BYOK localhost shortcut).
+
 ## Bumping SESSION_SCHEMA_VERSION
 
 When you bump SESSION_SCHEMA_VERSION in

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ corepack enable && pnpm install
 | `pnpm typecheck` | Typecheck |
 | `pnpm test` | Test |
 | `pnpm build` | Build the static SPA into `dist/` |
-| `pnpm dev` | Run the SPA + Worker dev loop via `wrangler dev` (press **b** to open the SPA). SPA edits under `src/spa` re-trigger the build; Worker edits live-reload through Wrangler. |
+| `pnpm dev` | Run the SPA + Worker dev loop via `wrangler dev` (press **b** to open the SPA). SPA edits under `src/spa` re-trigger the build; Worker edits live-reload through Wrangler. Requires a Cloudflare login because `RATE_GUARD_KV` is bound in remote mode. |
+| `pnpm dev:local` | Same loop, but `--local` disables remote bindings (KV runs in-process) so no Cloudflare login is needed, and `--ip 0.0.0.0` exposes it on your LAN for UI preview from another device. In-app API calls still target `localhost`, so the proxy won't work cross-device — use `dev:lan` for that. |
+| `pnpm dev:lan` | Fully functional cross-device dev. Detects your machine's LAN IP, bakes it into `WORKER_BASE_URL` so the SPA's API calls reach the Worker, and serves on `0.0.0.0:8787`. Prints the URL to open on the other device. Note: this turns `__DEV__` off (no dev inspector / debug footers / BYOK localhost shortcut). Both devices must share a network and inbound `8787` must be allowed. |
 | `pnpm smoke` | Run the Playwright integration / smoke suite (see below). |
 | `pnpm release` | Cut a release: bump version, update `CHANGELOG.md`, commit, tag. Push with `git push --follow-tags`. Driven by [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) — see `docs/agents/commits.md`. |
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
 	"scripts": {
 		"build": "node scripts/build-spa.mjs",
 		"dev": "wrangler dev",
+		"dev:local": "wrangler dev --local --ip 0.0.0.0",
+		"dev:lan": "node scripts/dev-lan.mjs",
 		"sandcastle": "npx tsx .sandcastle/main.mts",
 		"lint": "biome ci --error-on-warnings .",
 		"typecheck": "tsgo --noEmit -p tsconfig.json && tsgo --noEmit -p src/proxy/tsconfig.json",

--- a/scripts/dev-lan.mjs
+++ b/scripts/dev-lan.mjs
@@ -1,0 +1,42 @@
+import { spawn } from "node:child_process";
+import { networkInterfaces } from "node:os";
+
+const PORT = 8787;
+
+function detectLanIp() {
+	const candidates = [];
+	for (const addrs of Object.values(networkInterfaces())) {
+		for (const addr of addrs ?? []) {
+			if (addr.family !== "IPv4" || addr.internal) continue;
+			candidates.push(addr.address);
+		}
+	}
+	const preferred = candidates.find((ip) =>
+		/^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(ip),
+	);
+	return preferred ?? candidates[0];
+}
+
+const lanIp = detectLanIp();
+if (!lanIp) {
+	console.error(
+		"Could not detect a LAN IP address — are you connected to a network?",
+	);
+	process.exit(1);
+}
+
+const workerBaseUrl = `http://${lanIp}:${PORT}`;
+console.log(
+	`Serving on all interfaces. Reach it from another device at: ${workerBaseUrl}`,
+);
+
+const child = spawn(
+	"wrangler",
+	["dev", "--local", "--ip", "0.0.0.0", "--port", String(PORT)],
+	{
+		stdio: "inherit",
+		env: { ...process.env, WORKER_BASE_URL: workerBaseUrl },
+	},
+);
+
+child.on("exit", (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Why

`pnpm dev` runs `wrangler dev`, which **fails without a Cloudflare login** because `RATE_GUARD_KV` is bound in remote mode (`"remote": true` in `wrangler.jsonc`). In a sandbox or any environment without `wrangler login`, the dev server exits with:

> You must be logged in to use wrangler dev in remote mode.

## What

Two new scripts that don't require a login:

- **`pnpm dev:local`** — `wrangler dev --local --ip 0.0.0.0`. `--local` disables remote bindings (KV runs in-process, no login); `--ip 0.0.0.0` exposes the UI on the LAN for preview from another device. In-app API calls still target `localhost`, so the proxy won't work cross-device.
- **`pnpm dev:lan`** (`scripts/dev-lan.mjs`) — detects the machine's LAN IP, bakes it into `WORKER_BASE_URL`, and serves on `0.0.0.0:8787` so the app is **fully functional from another device**. Prints the URL to open. Side effect: `__DEV__` goes false (no dev inspector / debug footers / BYOK localhost shortcut), since the base URL is no longer exactly `localhost:8787`.

`pnpm dev` and the committed `wrangler.jsonc` are untouched, so production parity is preserved.

## Docs

Documented both scripts in `README.md` (Commands table) and `AGENTS.md` (new "Local development" section, so agents in a sandbox know to avoid plain `pnpm dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)