### PR TITLE
chore(settings): remove SessionStart pnpm install hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,5 @@
 {
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "corepack enable && pnpm install --frozen-lockfile"
-          }
-        ]
-      }
-    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
Removes the `SessionStart` hook that ran `corepack enable && pnpm install --frozen-lockfile` on every session startup.

## Changes
- Drop the `SessionStart` `startup` matcher block from `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)