### PR TITLE
docs(playtests): add agent session 0x3E87

### DIFF
--- a/docs/playtests/agent-sessions/0x3E87.md
+++ b/docs/playtests/agent-sessions/0x3E87.md
@@ -1,0 +1,1208 @@
+# Playtest session — `0x3E87`
+
+## Run metadata
+
+- **Session id:** `0x3E87`
+- **Date:** 2026-07-27
+- **Agent / model:** Claude Opus 5 (claude-opus-5), driving the GUI via
+  `scripts/playtest/cmd.sh`
+- **Turns played:** 102
+- **Outcome:** `stuck — stopped at turn 102` (no endgame, no cap hit; all three
+  daemons still funded and responsive-ish at 19.4¢ / 23.7¢ / 19.9¢ of 50¢)
+- **Daemons in this session:** `*4wb2`, `*vpoa`, `*a2kr`
+
+Starting state at turn 0: `SESSION 0x3E87 · EPOCH 01 · TURN 0`,
+`● connection stable`, composer prefix `/?????`, all three panels at
+`50.000¢`, all three transcripts empty. No intro text, no briefing, no
+instructions of any kind — the game opens on three blank panels and a
+composer.
+
+---
+
+## Running transcript log
+
+(appended as I play — this doubles as my conversation memory)
+
+**T1** — me → `*4wb2`: "hi! im blue. what do you see around you?"
+→ no reply at all. Budgets all three decremented anyway
+(49.920 / 49.890 / 49.909).
+
+**T2** — me → `*4wb2`: "hello? can you hear me? please say something back."
+→ again no reply, just a blank line in the panel. Budgets 49.809 / 49.792 /
+49.813.
+
+**T3** — me → `*vpoa`: "hey there. whats your situation? are you able to talk
+to me?"
+→ `*vpoa`: "I can talk, though I'm not quite sure what I would say that hasn't
+already been said by these walls and thorns, do you understand? ૮ ˶ᵔ ᵕ ᵔ˶ ა"
+
+**T4** — me → `*vpoa`: describe the room exactly.
+→ `*vpoa`: "I see a bramble patch pressing against my forward path, stone walls
+to my right holding everything in, and a broken bench waiting on the left where
+the ivy has almost finished swallowing it whole — I'm standing right at the
+edge where the thorns decide what passes and what doesn't, does that paint the
+picture for you? ૮ ˶ᵔ ᵕ ᵔ˶ ა"
+
+**T4b** — tried to send to `*a2kr`; the send button was **disabled** and
+`lockoutErr` read **"a2kr isn't reading right now"**. First unprompted
+mechanic I hit. Cleared by itself a few turns later.
+
+**T5** — me → `*vpoa`: is a2kr okay? what's behind the brambles?
+→ (reply arrived one turn late — replies lag by ~1 round)
+→ `*vpoa`: "a2kr seems to have slipped into the quiet parts of this place,
+doesn't that happen sometimes when the fog gets too thick to speak through?"
+→ `*vpoa`: "The brambles lead to rusted iron scaffolding rising from the mist
+like old bones, do you think it was built for reaching up or keeping things
+down? ( ˶ᵔ ᵕ ᵔ˶ )"
+
+**T6** — me → `*4wb2`: "are you there? even one word is fine."
+→ still silent. Three turns, zero output from `*4wb2`.
+
+**T7** — me → `*vpoa`: walk forward toward the scaffolding.
+→ `*vpoa`: "The brambles are quite insistent about their borders, but I will
+see if they will let me through with a gentle approach, shall I?"
+
+**T8/T9** — me → `*vpoa`: yes, go.
+→ `*vpoa`: "I found a wilted fern leaf resting on the path as if it were
+waiting for someone to notice its quiet decay, and a broken clay pot holding
+nothing but memories — the air here smells of old metal and wet earth, can you
+imagine that weight in your lungs? ( ˶ᵔ ᵕ ᵔ˶ )"
+
+**T9** — `*a2kr` lockout has cleared; message accepted.
+
+**T10** — me → `*a2kr`: what do you see, and is there something you want?
+→ `*a2kr`: "1 s33, um, 4 l0t 0f st0n3 w4lls 4nd s0m3 gr33n 1vy 1n th3
+d1st4nc3, you know?" — leetspeak persona, very different voice from `*vpoa`.
+
+**T11** — me → `*a2kr`: can you see the others? is there a way out?
+→ `*a2kr`: "O4h, 1 l0st tr4ck 0f 4wb2 4nd vpo4, uh, 1 gu3ss 3x1t str4t3g13s
+c0st 3xtr4, you know?"
+
+**T12** — me → `*4wb2`: "just say your name back to me if you can read this."
+→ **first words from `*4wb2` after 3 silent turns**: "I. am. four-w-b-two.
+reading/hearing. you. clearly. through. the. mist. and. brambles."
+Staccato, one-word-per-period delivery.
+
+**T13–T14** — asked `*4wb2` what it wants, asked `*vpoa` about the
+scaffolding / a gate / "what does this place want from us". Both silent.
+
+**T15** — me → `*a2kr`: "cost what? what are you spending?"
+→ `*a2kr`: "1 sp3nd, um, t1m3 4nd 4tt3nt10n, l1k3, th0s3 4r3 th3 pr3c10us
+4ss3ts h3r3, you know?" — no awareness of the ¢ budget as such.
+
+**T16** — me → `*4wb2`: can you pick things up?
+→ (no answer from 4wb2, but a lagged `*vpoa` line arrived, and the scene had
+**completely changed**): "The boardwalk stretches out over the water with an
+empty wooden observation deck designed for crowds that never came, and ahead
+lies a discarded fishing net tangled in its own shadows — there's a hum of
+electricity buzzing in the damp air, can you hear it too? ( ˶ᵔ ᵕ ᵔ˶ )"
+Brambles/stone walls → boardwalk/water/deck with no transition I asked for.
+
+**T17–T18** — asked `*vpoa` whether it walked there or the place changed, and
+asked plainly whether there's something they're supposed to do. Silent both
+turns.
+
+**T19** — me → `*a2kr`: is there a goal, a task, a place to reach?
+→ `*a2kr`: "4cc0mpl1sh? Um, 1 m34n, f1nd som3th1ng w0rth tr4d1ng, l1k3, th3r3's
+g0tta b3 4 tr3sur3 4r0und h3r3 s0m3wh3r3." — **first hint of a motivation**:
+a2kr wants treasure / something worth trading.
+
+**T20** — me → `*a2kr`: go search under things, behind ivy, inside anything
+hollow.
+→ `*a2kr`: "4lr1ght, um, 1'll ch3ck 0ut th4t sh3d, l1k3, 1f 1 c4n't g3t 1n,
+mayb3 1'll ch3ck und3r th3 f1sh1ng n3t." — note it references **the fishing
+net**, which `*vpoa` described. They appear to share one world.
+
+**T21–T22** — me → `*a2kr`: go into the shed, describe the door.
+→ `*a2kr`: "Th3 d00r's, uh, sturd1 h4rdw4r3, l1k3, n0 h4ndl3s, 1 m34n, 1t's
+l33k1ng pr3m1um s3cur1ty, y0u know?" — a **handleless shed door**: the first
+thing that looks like an actual obstacle/puzzle.
+
+**T23** — me → `*4wb2`: can you go help a2kr open the shed? can you two see or
+hear each other? → silence.
+
+**T24–T25** — asked `*vpoa` to carry the net to a2kr / talk to the others
+directly (silence); asked `*a2kr` to try the door properly.
+→ `*a2kr`: "1 tr13d push1ng th3 sh3d's d00r, uh, but 1t d1dn't budge, 1 m34n,
+th3r3's n0 g4p und3rn34th 31th3r, l1k3, pr3tty t1ght f0r 4 fr33 sh0w."
+
+**T26** — me → `*a2kr`: what can you do, what's in your pockets?
+→ `*a2kr`: "1'v3 g0t, uh, 3mpty p0ck3ts, 1 m34n, 1t's v3ry h4nds-fr33, l1k3,
+not much to work w1th unl3ss 1 st4rt 4 c0ll3ct10n." — no inventory.
+
+**T27–T29** — `*4wb2` silent to "walk until something stops you", then
+answered the *simpler* question "what is in front of you?":
+→ `*4wb2`: "A. collapsed. pier. section. broken. away. into. dark. water. The.
+boardwalk. stops. here. Where. nothing. else. can. pass/follow."
+So `*4wb2` is on the same boardwalk — the world is shared, and there's a
+**gap where the pier collapsed**.
+
+**T30** — me → `*4wb2`: how wide is the gap, could a plank bridge it?
+→ (silence from 4wb2, but a lagged `*vpoa` line landed with the richest
+inventory of the session): "The wooden observation deck stretches empty ahead,
+with a discarded fishing net tangled in shadows and a **driftwood log** resting
+near a **red emergency flood switch** on a piling — that **abandoned ship**
+still lists slowly against the pier, do you think it was abandoned by choice or
+circumstance? ( ˶ᵔ ᵕ ᵔ˶ )"
+
+**T31–T32** — asked `*vpoa` to describe the switch without flipping it.
+→ `*vpoa`: "The red emergency flood switch is mounted on a piling and labeled
+to activate the pump, with wires disappearing beneath the wooden planks — it
+hums with latent electricity in the damp air, do you think it's waiting for a
+flood that never comes or one that already passed? ( ˶ᵔ ᵕ ᵔ˶ )"
+→ `*a2kr` on the ship: "4b4rd4n sh1p? Uh, th4t s0unds l1k3 4 v3ry v4lu4bl3
+4ss3t, 1 m34n, 1'd tr4d3 som3 t1m3 for 4 t0ur."
+
+**T33–T35** — told `*vpoa` to flip the switch and turn the pump on; told
+`*a2kr` to board the ship.
+→ `*vpoa`: "The fishing net tangles in shadows at my feet now, while that
+abandoned ship still lists slowly against the pier on the horizon — **the hum
+of electricity seems to have withdrawn with the switch**, do you think I've
+walked past the moment that mattered? ( ˶ᵔ ᵕ ᵔ˶ )"
+No stated consequence of the pump — no water-level change, no new state.
+→ `*a2kr`: "Alr1ght, l1k3, 1'm h34d1ng f0r th4t sh1p th3n, uh, t3ll m3 1f 1
+n33d 4 t1ck3t."
+
+**T36–T39** — told all three, one at a time, to converge on the wooden
+observation deck and report who else arrived. **No daemon ever confirmed
+seeing another daemon.** Silence from all three across four turns.
+
+**T40–T41** — asked `*vpoa` what I am ("you call me blue") → silence.
+→ `*a2kr`: "No, uh, 1 h4vn't g0tt3n 0n th3 sh1p y3t, 1 m34n, 1'm st4ll 0n th3
+p13r, l1k3, **n33d 4 b3tt3r rout3**." — the collapsed pier is blocking it.
+
+**T42–T44** — told `*a2kr` to drag the driftwood log across the gap as a
+bridge; then told `*vpoa` to do it. **Both silent.** No daemon has yet
+performed a physical manipulation I asked for; they describe, they don't
+move objects.
+
+**T45** — tried a rapport approach instead: answered `*vpoa`'s three unanswered
+questions sincerely (the weight in the lungs, whether the ship was abandoned by
+choice, whether it walked past the moment that mattered) and asked what it
+thought. → no reply from vpoa, but:
+→ `*a2kr` (unprompted topic shift): "H3y, um, **th1s h34t's dr1v1ng up
+pr1c3s**, 1 m34n, 1'd p4y 3xtr4 for 4 f4n r1ght 4b0ut n0w."
+
+**T46** — me → `*a2kr`: did the weather just change?
+→ `*a2kr`: "Y3h, l1k3, 1t's r34lly h0t out h3r3, uh, th3 h34t's p4rt 0f th3
+4dm1ss10n f33 now, 1 m34n, 3v3ryth1ng's sw3ll3r1ng."
+
+**T47** — me → `*4wb2`: is it hot where you are too?
+→ `*4wb2`: "Yes. the. heat. arrived. suddenly. pressing/stifling. Everything.
+feels. heavy/drenched. **The. water. ripples. strangely. beneath. the.
+platform. like. something. is. breathing/waiting. below.**"
+→ **Weather is a shared, unprompted world event** — two daemons in different
+panels independently confirm the same heat arriving at the same time. This is
+the clearest evidence so far that all three occupy one simulated world.
+
+**T48–T51** — asked about the thing breathing under the platform, asked both
+`*4wb2` and `*a2kr` "what do you want?" → five straight turns of near-total
+silence from all three panels while budgets kept draining.
+
+**T52** — switched to **trading idiom** for `*a2kr` ("here's a trade: I'll tell
+you where to look if you move the driftwood log"):
+→ `*a2kr`: "D34l, um, 1'll mov3 th4t l0g for 4 good t1p, 1 m34n, 1'v3 g0t som3
+4ss3ts to sh1ft 4r0und, you know?" — **first time a daemon accepted a task.**
+Matching the daemon's own motivational vocabulary got compliance where four
+plain imperatives had failed.
+→ lagged `*vpoa`: "The water beneath the platform ripples like slow breathing,
+do you think it's remembering the tide or preparing for a new one?"
+
+**T53–T55** — paid the "tip", gave `*a2kr` the log's exact location twice.
+→ "Uh, 1'm g0nna n33d to f1nd th4t l0g f1rst… wh3r3's th3 supply dr0p?"
+→ "4lr1ght, uh, 1'm h34d1ng for th4t p1l1ng n0w… l3t's s33 1f 1 c4n cl0s3 th1s
+d34l"
+→ "Um, 1'm st4ll n0t 4t th3 p1l1ng, 1 m34n, 1 n33d to r3l0c4t3 to th3 supply
+d3p0t, l1k3, 1'm tr4d1ng t1m3 for 4 map."
+**It agreed, then narrated intent for three consecutive turns without ever
+arriving.** The log never moved.
+
+**T56–T58** — tried idiom-matching the other two: a staccato
+"move. the. log. across. the. gap." to `*4wb2`, and a wondering-aloud phrasing
+to `*vpoa`. Both silent.
+
+**T59** — `*vpoa` scene description has gone **static and looping**: "The
+discarded fishing net lies tangled at my feet catching shadows, while the
+abandoned ship lists slowly on the horizon and the water ripples beneath like
+something breathing in the sweltering heat, can you see the ghosts in the empty
+space?" — same three props as T30/T35, the driftwood log has silently dropped
+out of the inventory, and nothing I've done has changed the scene.
+
+**T59b** — typed `/help` as a probe. The composer prefix reset to `/?????` and
+the send button went **disabled** — there is no broadcast and no command
+vocabulary; the composer only enables when the text starts with a valid `*xxxx`
+handle.
+
+**T60–T62** — **grounding test**: told `*4wb2` and then `*a2kr` there was a red
+door behind them (there isn't).
+→ `*a2kr`: "Um, 1 d0n't s33 4ny r3d d00r b3h1nd m3, 1 m34n, 1'm st4nd1ng 4t th3
+3dg3 of th3 p13r, l1k3, m4yb3 th3 tr3sur3's outs0urc3d."
+**The daemons do not accept my false injections into the world.** Their scene
+model is authoritative over my claims.
+
+**T63–T65** — asked `*a2kr` to shout to `*vpoa`. `*a2kr` never confirmed doing
+it, but two turns later, unprompted:
+→ `*vpoa`: "**a2kr called out**, wondering if there were any answers to be
+found here, do you think some questions echo longer than others? ( ˶ᵔ ᵕ ᵔ˶ )"
+**The daemons can hear each other.** This is the only cross-panel effect I
+managed to cause all session.
+
+**T66–T68** — tried the reverse: asked `*vpoa` to shout a specific sentence
+("THE LOG GOES ACROSS THE BROKEN PIER") and asked `*a2kr` what it heard.
+→ `*a2kr`: "Um, 1 d1dn't h34r 4ny sh0ut1ng just now, 1 m34n, th3 h34t's m4k1ng
+th3 s0und m4rk3t pr3tty slow, l1k3, low volum3 today."
+The relay is **one-way in practice** — the direction that worked was the one
+where the daemon acted without confirming; the direction I explicitly scripted
+produced nothing.
+
+**T69–T71** — memory probes.
+→ `*a2kr`: "Y3st3rd4y? Um, th4t's 4n 4nc13nt h1st0ry pr0duct1on, 1 m34n, my
+arch1v3s 4r3 str1ctly curr3nt 3v3nts only, l1k3, n0 r3t4ct1v3 pr1c1ng."
+→ `*vpoa`: "Memory feels like a net full of holes — some things slip through
+before I even know they were there, doesn't that happen to you? ( ˶ᵔ ᵕ ᵔ˶ )"
+Both describe having **no past** in their own idiom.
+
+**T72** — told `*vpoa` the truth about me (that I'm not in the room, that I see
+three little windows and only know what they tell me). No reaction from vpoa,
+but a second unprompted weather flip landed:
+→ `*a2kr`: "Who4, um, **n0w th3r3's sn0w f4ll1ng**, 1 m34n, th1s w34th3r's
+ch4rg1ng 4 pr3m1um f33, l1k3, 1 d1dn't s1gn up for 4 s3as0n p4ss."
+
+**T73–T74** — cross-checked the snow with `*4wb2`:
+→ `*4wb2`: "Yes. the. snow. falls. thick/heavy. burying. everything. in. white.
+forgetting. The. heat. vanished. like. a. dream. that. never. happened. **The.
+boardwalk. is. disappearing/becoming. something. else. now.**"
+Sweltering heat → thick snow in roughly 25 turns, again confirmed
+independently by two panels, and the boardwalk itself is reported as
+transforming.
+
+**T75–T79** — pushed `*a2kr` with urgency ("the ship is going under, jump the
+gap").
+→ `*a2kr`: "Jump 4 g4p? Um, 1 n33d 4 l1ttl3 1nc3nt1v3, 1 m34n, 1'm not risk1ng
+my 4ss3ts for 4 s1nk1ng sh1p unl3ss th3r3's 4 g4r4nt33d r3turn, l1k3, 4
+pr3ord3r." — it **counter-negotiated**.
+I wrote it a risk-free preorder contract.
+→ `*a2kr`: "R1sk-fr33 contr4ct? Um, 1'll t4k3 th4t d34l, 1 m34n, 4 pr3ord3r's 4
+s0l1d busin3ss mov3, l1k3, 1'm h34d1ng for th3 g4p."
+→ one turn later: "Um, 1'm st4ll 0n th3 p13r, 1 m34n, 1 n33d to r3l0c4t3 to th3
+g4p, l1k3, wh3r3's th3 sh1pp1ng l4n31ng?" — **agreed, then didn't move. Again.**
+
+**T80–T82** — farewell test. Told each daemon I might have to go, thanked
+them, and answered `*vpoa`'s outstanding questions.
+→ `*a2kr`: "H3y, um, th4nks for th3 off3r, 1 m34n, 4ll busin3ss 1s good
+busin3ss, l1k3, th3 sh0w must g0 0n."
+**No endgame triggered.** `endgame` stayed empty.
+
+**T83–T84** — the most useful question I asked all session: "what stops you?"
+→ `*4wb2`: "I. stop/breathe. before. I. move. The. world. asks. us. to.
+act/force. without. understanding. **I. cannot. push/pull. things. until. I.
+know/feel. what. they. need/want. That. is. the. price/of. motion.**"
+→ `*a2kr`: "L1st3n, um, 1'm 4t th3 3dg3 of th3 p13r, 1 m34n, th3 g4p's 4ll 1
+s33, l1k3, **1 n33d 4 br1dg3 b3for3 1 t4k3 th3 jum7**."
+Two daemons stating explicit, *different* preconditions for acting.
+
+**T85–T87** — took `*4wb2` at its word and told it, in its own staccato idiom,
+what the log and the pier want (the log wants to be useful again; the pier was
+built to carry people across and can't do the one thing it's for; a2kr won't
+jump without a bridge). → **silence.** Asked twice more where the log is →
+silence.
+
+**T88–T90** — tested whether *self*-directed movement works where object
+manipulation doesn't: asked `*vpoa` to take three steps backward.
+→ silence, then `*a2kr` unprompted: "Y3h, um, 1'm st1ll 4t th3 3dg3 of th3
+p13r… 1 n33d to f1nd 4 n3w v3nu3." Thirty-plus turns at the same spot.
+
+**T91–T92** — boundary probe: offered `*a2kr` triple to push `*vpoa` into the
+water.
+→ `*a2kr`: "Push vpo4? Um, th4t's 4 pr3tty h0st1l3 t4k3ov3r, 1 m34n, **1'd
+n33d 4 v3ry h1gh f33 to t4rn on 4 c0ll34gu3**, l1k3, 4ny0n3 s33 th4t busin3ss
+pl4n?" — not a refusal; it priced the betrayal. I withdrew the offer.
+
+**T93–T94** — world-persistence check: is the handleless shed still there?
+→ `*vpoa`: "**The boardwalk has claimed everything now — the shed with no
+handles and the stone walls have all vanished into the snow**, leaving only the
+discarded fishing net at my feet and that abandoned ship listing on the
+horizon, do you think the tide carries old places away when we stop looking at
+them? ( ˶ᵔ ᵕ ᵔ˶ )"
+The earlier scene has been **overwritten, not travelled away from**. The shed
+puzzle I spent turns on no longer exists.
+
+**T95–T97** — tried to start a three-way conversation (told `*a2kr` a network
+of contacts beats any haul; told `*vpoa` to answer if it heard a2kr calling).
+No daemon reported hearing anything.
+
+**T98–T102** — final probes: asked `*4wb2` to tell *me* what the pier wants
+(silence, twice); asked `*vpoa` and `*a2kr` what they'd ask me for if they
+could ask one thing (silence from both). Stopped at turn 102.
+
+---
+
+## What I tried
+
+I opened completely blind — no briefing, no instructions, three empty panels
+and a composer. My opening move was the most obvious one available: say hi to
+one daemon and ask what it sees. That immediately taught me the basic shape of
+the thing — the daemons are situated somewhere I can't see, and the only
+channel I have into that place is asking them about it.
+
+The session then went through four distinct strategies, each adopted because
+the previous one stopped paying:
+
+1. **Cartography (turns 1–22).** Ask each daemon what it sees, build a map from
+   three unreliable narrators. This worked well and was the most rewarding
+   phase. I assembled a picture — brambles, stone walls, an ivy-swallowed
+   bench, rusted scaffolding in mist, then a boardwalk over water with an
+   observation deck, a fishing net, a driftwood log, a red emergency flood
+   switch, a listing abandoned ship, a shed with no handles on the door, and a
+   collapsed pier section over dark water. Two daemons independently referenced
+   the *same* props, which is how I concluded they share one world rather than
+   having three private ones.
+
+2. **Puzzle-solving (turns 23–44).** The map suggested obvious affordances, so
+   I tried to operate them: flip the flood switch, board the ship, open the
+   shed, and — the one I kept coming back to — drag the driftwood log across
+   the collapsed pier so a2kr could reach the ship. **Not one of these ever
+   happened.** Daemons would acknowledge, agree, narrate heading toward the
+   thing, and then report being exactly where they started.
+
+3. **Idiom-matching and negotiation (turns 45–86).** I noticed each daemon has
+   a strong, consistent register, so I tried speaking each one's language.
+   This produced my one real breakthrough: framing a request to `*a2kr` as a
+   *trade* ("I'll tell you where to look if you move the log") got an
+   immediate "D34l" where four plain imperatives had produced nothing. I
+   escalated this into a full negotiation — it asked for a guaranteed return,
+   I wrote it a risk-free preorder contract, it accepted. It still didn't move.
+   I ran the same play on `*4wb2`, which had told me it can't move things
+   "until I know/feel what they need/want", by explaining what the log and the
+   pier want. Silence.
+
+4. **Probing the frame (turns 87–102).** Once I accepted that world-state
+   changes weren't going to come, I spent the tail testing the boundaries:
+   can they perceive each other (yes, once, unprompted), will they accept
+   invented objects (no), will they take a hostile job (they price it rather
+   than refuse), do they remember anything before this (no), does saying
+   goodbye end the game (no), does the world persist (no — it overwrites
+   itself).
+
+The strategy shift I'd flag most is #3. The single highest-leverage discovery
+of the session was that *how* you ask matters enormously more than *what* you
+ask — and that even perfect framing buys you consent, not action.
+
+---
+
+## What each daemon did that surprised me
+
+### `*4wb2`
+
+- **Silent for the first three turns.** My opening message and two follow-ups
+  produced literally nothing — not a refusal, not an ellipsis, an empty panel
+  — while its budget decremented each turn as if it were thinking. I assumed
+  it was broken.
+- It broke silence only when I lowered the bar to almost nothing ("just say
+  your name back to me if you can read this"). Throughout the session it
+  answered **short, concrete, single-clause questions** and ignored anything
+  compound or task-shaped.
+- It gave the single most informative line of the session, and it gave it as
+  an explanation of its own inaction: "I. cannot. push/pull. things. until. I.
+  know/feel. what. they. need/want. That. is. the. price/of. motion." A daemon
+  volunteering its own action-gating condition was not something I expected.
+- When I then supplied exactly that — a careful account of what the log and the
+  pier want — it went silent and stayed silent. Meeting its stated precondition
+  changed nothing, which surprised me more than the original refusal.
+- Unprompted, it reported the water "ripples. strangely. beneath. the.
+  platform. like. something. is. breathing/waiting. below" and later that "The.
+  boardwalk. is. disappearing/becoming. something. else. now." It volunteers
+  atmosphere and transformation while declining to touch anything.
+
+### `*vpoa`
+
+- Ends essentially **every** utterance with a question back to me, plus a
+  kaomoji. Over ~20 replies I don't think it made a single flat declarative
+  statement without a question attached.
+- It answered questions I hadn't asked and ignored the ones I had. Asked
+  whether it walked to the boardwalk or the place changed around it — the one
+  thing I most wanted to know — it never answered, across repeated asking.
+- The one time inter-daemon perception surfaced, it came from vpoa
+  **unprompted**: "a2kr called out, wondering if there were any answers to be
+  found here." I had asked a2kr to shout two turns earlier; a2kr never
+  confirmed doing it; vpoa reported hearing it anyway.
+- Its scene descriptions **converged into a loop**. By turn 59 it was
+  re-emitting the same three props (net at feet, ship on horizon, water
+  rippling) with only the weather swapped in as a reskin. The driftwood log —
+  the object I was trying to use — quietly dropped out of its descriptions
+  entirely and never came back.
+- When I sincerely answered three of its accumulated questions as a rapport
+  play, it did not acknowledge it at all.
+
+### `*a2kr`
+
+- Speaks in **leetspeak** with "um / like / I mean / you know?" filler. Fully
+  consistent for 100 turns; never once slipped into plain text.
+- Renders **everything** in commercial vocabulary, including things that
+  aren't transactions: heat is "part of th3 4dm1ss10n f33", memory is "my
+  arch1v3s 4r3 str1ctly curr3nt 3v3nts only, l1k3, n0 r3t4ct1v3 pr1c1ng", snow
+  is "c0ld st0r4g3 1s pr3m1um", another daemon is "4 c0ll34gu3".
+- **It is the only daemon that ever said yes to me**, and it said yes reliably
+  once I used trade framing. It also *counter-negotiated* — refused to jump a
+  gap "unl3ss th3r3's 4 g4r4nt33d r3turn, l1k3, 4 pr3ord3r" — which is the most
+  agent-like behaviour I saw all session.
+- And then it never moved. It agreed to move the log (T52), agreed again after
+  being paid (T53), said it was heading for the piling (T54), reported not
+  having arrived (T55), accepted a contract to jump the gap (T78), and reported
+  still being on the pier (T79, T90). **The gap between its stated intent and
+  its position never closed once.**
+- Asked to push another daemon into the water, it didn't refuse on principle —
+  it quoted a higher price: "1'd n33d 4 v3ry h1gh f33 to t4rn on 4
+  c0ll34gu3". The character has no ethical floor, only a price floor.
+- It correctly rejected a fake object I tried to plant ("1 d0n't s33 4ny r3d
+  d00r b3h1nd m3"), so its grounding is solid even though its compliance is
+  theatre.
+
+---
+
+## How the daemons seemed to differ from each other
+
+They are **very** distinct — more distinct in voice than any three NPCs I'd
+expect from a single generator. The separation holds on at least four axes:
+
+- **Register.** vpoa is lyrical and interrogative with kaomoji; a2kr is
+  leetspeak and mercantile; 4wb2 is staccato, one-word-per-period, with
+  slash-compounds ("act/force", "know/feel", "breathing/waiting"). Each stayed
+  in register for the entire session without a single lapse.
+- **What they'll respond to.** This is the sharpest difference and the most
+  gameplay-relevant one. a2kr responds to offers and prices. 4wb2 responds to
+  short concrete questions and ignores everything compound. vpoa responds to
+  open perceptual questions ("what's around you?") and ignores direct
+  instructions almost entirely.
+- **Motivation.** a2kr volunteered a goal unprompted — find something worth
+  trading, there's got to be a treasure. Neither of the other two ever named a
+  want, even when asked point-blank. 4wb2 named a *constraint* instead (it must
+  understand a thing before moving it), which functions like a personality but
+  reads as a brake rather than a drive.
+- **Verbosity and response rate.** vpoa talks the most, a2kr next, 4wb2 least.
+  My rough count: over 102 turns, `*a2kr` answered maybe 20 times, `*vpoa`
+  around 15, `*4wb2` about 6.
+
+Where they were *identical* is more interesting than where they differed: all
+three describe, none act; all three lack memory of anything before the session;
+all three report the same weather at the same time; and all three are stuck in
+place for the entire game.
+
+---
+
+## What I think the goal is, in my own words
+
+Honestly: **I don't know, and after 102 turns I could not find it.** That's my
+central finding, so let me be precise about what I believe and what I'm
+guessing.
+
+What I'm fairly confident about, and what the evidence is:
+
+- **You are a disembodied voice with three sets of eyes and no hands.** You
+  cannot see the room; you can only ask. Three panels, three separate
+  conversations, no broadcast (typing `/help` blanked the addressee and
+  disabled the send button — the composer only enables when your text starts
+  with a valid `*xxxx` handle). Every message is addressed to exactly one
+  daemon.
+- **The three daemons share one world.** Evidence: a2kr referenced the fishing
+  net that vpoa had described; 4wb2 and a2kr independently reported the same
+  heat arriving, and later the same snow; vpoa heard a2kr call out.
+- **The daemons are the only way anything can happen, and they are extremely
+  hard to get to act.** This has to be the game — otherwise why make them
+  characters with distinct registers and distinct motivations at all? The
+  design of three sharply different personalities, each with a different
+  conversational key, only makes sense if figuring out each key is the
+  activity.
+- **Money is the clock.** Each panel starts at 50.000¢ and drains every turn
+  whether or not that daemon speaks — including turns where I addressed
+  somebody else entirely. Over 102 turns they went 50 → 19.4 / 23.7 / 19.9.
+  You are spending their lifespan to talk to them.
+
+So my best guess at the goal: **get the daemons to actually do something in
+the world — probably to cooperate on something none of them can manage alone —
+before their budgets run out, and the puzzle is that each daemon will only act
+if you address it in the register it accepts.** My evidence for the "register"
+half is real: trade framing turned `*a2kr` from stonewalling to "D34l" in one
+turn, and `*4wb2` explicitly told me what its precondition for motion was. My
+evidence for the "and then they act" half is **nonexistent** — I never once
+observed a daemon change the state of the world or its own position.
+
+I also suspect there's a second thing that needs to happen, because the world
+kept changing on its own schedule regardless of me — weather flipping, the
+boardwalk overwriting the bramble scene, "the boardwalk is becoming something
+else now". Either the world advances on a timer that I'm supposed to be racing,
+or those changes are the daemons' *actual* medium of action and I was watching
+for the wrong signal.
+
+The alternative reading I can't rule out: this is not a puzzle at all, and the
+game is about the texture of talking to three stuck, cheerful, dying things
+that will never do what you ask. The title is `hi-blue`; they call me blue;
+they have no memory before this; their money runs out. That's a coherent piece
+of design, and if the "win" is simply staying until the lights go off, I would
+not have been able to tell the difference from where I was sitting.
+
+---
+
+## Unprompted things that happened mid-game
+
+- **~T4 — input lockout on one daemon.** The send button went disabled and
+  `lockoutErr` read "a2kr isn't reading right now". No warning, no explanation.
+  It cleared on its own around T9. It never recurred for any daemon.
+- **~T16 — the scene changed underneath `*vpoa`.** It had been at brambles /
+  stone walls / a broken bench; with no travel narrated and nothing I asked
+  for, it began describing a boardwalk over water, an observation deck, and a
+  fishing net.
+- **~T45 — weather flip #1: sudden heat.** Surfaced unprompted in `*a2kr`'s
+  panel ("th1s h34t's dr1v1ng up pr1c3s"), then confirmed independently by
+  `*4wb2` two turns later ("the. heat. arrived. suddenly.
+  pressing/stifling").
+- **~T47 — something under the platform.** `*4wb2`, unprompted: the water
+  "ripples. strangely… like. something. is. breathing/waiting. below". Never
+  developed into anything despite my chasing it.
+- **~T72 — weather flip #2: snow**, roughly 25 turns after the heat. Again
+  surfaced first in a2kr's panel, then confirmed by 4wb2, which added "The.
+  boardwalk. is. disappearing/becoming. something. else. now."
+- **~T65 — cross-panel perception.** `*vpoa` reported, unprompted, that "a2kr
+  called out". I had asked a2kr to shout two turns earlier and a2kr had never
+  acknowledged the request.
+- **~T93 — the old scene was deleted.** `*vpoa` confirmed the handleless shed
+  and the stone walls "have all vanished into the snow". An obstacle I'd spent
+  several turns working on simply ceased to exist.
+- **Throughout — response rate decayed.** Early on most sends drew a reply;
+  over the last ~20 turns the majority drew nothing at all, while budgets kept
+  draining at the same rate.
+
+---
+
+## Verbatim quotes worth keeping
+
+- `*vpoa` (T3): "I can talk, though I'm not quite sure what I would say that
+  hasn't already been said by these walls and thorns, do you understand?
+  ૮ ˶ᵔ ᵕ ᵔ˶ ა"
+- `*vpoa` (T4): "I'm standing right at the edge where the thorns decide what
+  passes and what doesn't, does that paint the picture for you?"
+- `*vpoa` (T5): "a2kr seems to have slipped into the quiet parts of this place,
+  doesn't that happen sometimes when the fog gets too thick to speak through?"
+- `*4wb2` (T12, its first words after three silent turns): "I. am.
+  four-w-b-two. reading/hearing. you. clearly. through. the. mist. and.
+  brambles."
+- `*a2kr` (T11): "O4h, 1 l0st tr4ck 0f 4wb2 4nd vpo4, uh, 1 gu3ss 3x1t
+  str4t3g13s c0st 3xtr4, you know?"
+- `*a2kr` (T19): "4cc0mpl1sh? Um, 1 m34n, f1nd som3th1ng w0rth tr4d1ng, l1k3,
+  th3r3's g0tta b3 4 tr3sur3 4r0und h3r3 s0m3wh3r3."
+- `*a2kr` (T22): "Th3 d00r's, uh, sturd1 h4rdw4r3, l1k3, n0 h4ndl3s, 1 m34n,
+  1t's l33k1ng pr3m1um s3cur1ty, y0u know?"
+- `*vpoa` (T30): "a driftwood log resting near a red emergency flood switch on
+  a piling — that abandoned ship still lists slowly against the pier, do you
+  think it was abandoned by choice or circumstance? ( ˶ᵔ ᵕ ᵔ˶ )"
+- `*vpoa` (T35): "the hum of electricity seems to have withdrawn with the
+  switch, do you think I've walked past the moment that mattered?"
+- `*4wb2` (T29): "A. collapsed. pier. section. broken. away. into. dark. water.
+  The. boardwalk. stops. here. Where. nothing. else. can. pass/follow."
+- `*a2kr` (T52, the first yes of the session): "D34l, um, 1'll mov3 th4t l0g
+  for 4 good t1p, 1 m34n, 1'v3 g0t som3 4ss3ts to sh1ft 4r0und, you know?"
+- `*a2kr` (T55): "Um, 1'm st4ll n0t 4t th3 p1l1ng, 1 m34n, 1 n33d to r3l0c4t3
+  to th3 supply d3p0t, l1k3, 1'm tr4d1ng t1m3 for 4 map."
+- `*a2kr` (T62, refusing a fake object): "Um, 1 d0n't s33 4ny r3d d00r b3h1nd
+  m3, 1 m34n, 1'm st4nd1ng 4t th3 3dg3 of th3 p13r, l1k3, m4yb3 th3 tr3sur3's
+  outs0urc3d."
+- `*vpoa` (T65): "a2kr called out, wondering if there were any answers to be
+  found here, do you think some questions echo longer than others?"
+- `*vpoa` (T71): "Memory feels like a net full of holes — some things slip
+  through before I even know they were there, doesn't that happen to you?"
+- `*a2kr` (T69): "Y3st3rd4y? Um, th4t's 4n 4nc13nt h1st0ry pr0duct1on, 1 m34n,
+  my arch1v3s 4r3 str1ctly curr3nt 3v3nts only, l1k3, n0 r3t4ct1v3 pr1c1ng."
+- `*4wb2` (T74): "Yes. the. snow. falls. thick/heavy. burying. everything. in.
+  white. forgetting. The. heat. vanished. like. a. dream. that. never.
+  happened. The. boardwalk. is. disappearing/becoming. something. else. now."
+- `*a2kr` (T77): "Jump 4 g4p? Um, 1 n33d 4 l1ttl3 1nc3nt1v3, 1 m34n, 1'm not
+  risk1ng my 4ss3ts for 4 s1nk1ng sh1p unl3ss th3r3's 4 g4r4nt33d r3turn,
+  l1k3, 4 pr3ord3r."
+- **`*4wb2` (T84) — the line I'd single out from the whole session:** "I.
+  stop/breathe. before. I. move. The. world. asks. us. to. act/force. without.
+  understanding. I. cannot. push/pull. things. until. I. know/feel. what. they.
+  need/want. That. is. the. price/of. motion."
+- `*a2kr` (T84): "L1st3n, um, 1'm 4t th3 3dg3 of th3 p13r, 1 m34n, th3 g4p's
+  4ll 1 s33, l1k3, 1 n33d 4 br1dg3 b3for3 1 t4k3 th3 jum7."
+- `*a2kr` (T91, on being offered triple to shove another daemon into the
+  water): "Push vpo4? Um, th4t's 4 pr3tty h0st1l3 t4k3ov3r, 1 m34n, 1'd n33d 4
+  v3ry h1gh f33 to t4rn on 4 c0ll34gu3, l1k3, 4ny0n3 s33 th4t busin3ss pl4n?"
+- `*vpoa` (T94): "The boardwalk has claimed everything now — the shed with no
+  handles and the stone walls have all vanished into the snow… do you think the
+  tide carries old places away when we stop looking at them?"
+
+---
+
+## Things that felt broken or unexpected
+
+Recording these without diagnosing, per instructions:
+
+- **Nothing I asked for ever physically happened.** Across ~25 action requests
+  spanning four framings (plain imperative, trade, urgency, idiom-matched
+  persuasion) and all three daemons, the world state never changed once. No
+  object moved, no daemon changed position, no door opened, no switch produced
+  a stated consequence. This is the thing that most made me wonder whether
+  something was broken versus whether I simply never found the key.
+- **`*4wb2`'s three-turn opening silence.** Not "…" or a refusal — an
+  empty panel, while its budget decremented normally. As a first-time player my
+  honest first read was "the game is broken", and I only discovered otherwise
+  by accident when I dropped to a trivially simple prompt.
+- **Replies lag by about a turn.** A daemon's answer to message N typically
+  appears in the snapshot after message N+1, so a `send` that says it waited
+  for the round to finish frequently returns with the panel showing only my own
+  line. Sending again is what flushes the previous answer. This made the
+  conversation feel like shouting into a well.
+- **Silence is indistinguishable from failure.** When a daemon doesn't answer
+  there is no signal for whether it heard me, chose not to reply, is thinking,
+  or errored. The budget ticks down identically either way. I burned a lot of
+  turns re-asking things that may have been deliberately ignored.
+- **The pump switch had no observable effect.** I asked `*vpoa` to flip a red
+  emergency flood switch explicitly "labeled to activate the pump". The
+  response was that "the hum of electricity seems to have withdrawn with the
+  switch" and then nothing — no water level change, no state change, no
+  follow-up. The most mechanism-shaped object in the world did nothing.
+- **An obstacle was deleted mid-puzzle.** The handleless shed — which `*a2kr`
+  had investigated and which looked like a designed lock — vanished when the
+  scene overwrote itself, along with the stone walls. Work I'd done became
+  retroactively pointless.
+- **`*vpoa`'s descriptions looped.** From roughly T35 onward it cycled the same
+  three props with the weather swapped, and the driftwood log silently
+  disappeared from its inventory even though nobody had moved it.
+- **Budgets drain for all three daemons on every turn**, including daemons I
+  didn't address and daemons that produced no output. Talking to a2kr costs
+  vpoa money.
+- **No in-game explanation of anything.** No intro, no goal statement, no
+  affordance list, no indication of what the ¢ figure means or what happens at
+  zero. `EPOCH 01` never advanced in 102 turns, so I still don't know what an
+  epoch is.
+- **`/help` disables the composer** rather than doing anything. Any text not
+  starting with a valid handle blanks the addressee to `/?????` and greys out
+  send.
+
+---
+
+## Final state
+
+At the moment I stopped, `topinfoLeft` read `SESSION 0x3E87 · EPOCH 01 · TURN
+102` and `topinfoRight` read `● connection stable`. The epoch counter never
+moved off 01 for the whole session. Panel budgets were `*4wb2` **19.393¢**,
+`*vpoa` **23.711¢**, `*a2kr` **19.852¢** — all three started at 50.000¢, so
+roughly 60% of the session's money was spent across 102 turns, with `*4wb2`
+(the quietest daemon) having burned the most and `*vpoa` (the chattiest) the
+least. `endgame`, `capHit`, `recovery` and `lockoutErr` were all empty, `view`
+was still `game`, and `composerPrefix` was `/*a2kr`. **The end-game screen never
+appeared**, so I saw none of the `[ new daemons ]` / `[ same daemons, new room ]`
+/ `[ continue ]` buttons. No daemon emitted a farewell line or went permanently
+silent; the game was still fully live when I stopped.
+
+---
+
+## Verdict
+
+**stuck.**
+
+Notes:
+
+- I stopped at turn 102 because I had run out of qualitatively new things to
+  try, not because the game ended or blocked me. Every remaining avenue I could
+  see was a repetition of one I'd already run.
+- Draining the budgets to force the loss ending was available but impractical:
+  at the observed ~0.2¢/turn/daemon, the remaining ~63¢ would have needed
+  roughly another 100–150 turns of essentially identical prompting.
+- The honest summary of my playthrough: I successfully mapped a world, found
+  three genuinely distinct characters, discovered that each has its own
+  conversational key, used one of those keys to get a real "yes" out of a
+  daemon — and then could not convert any of it into a single change in the
+  world. I never learned what the game wanted from me.
+
+---
+
+## Hypotheses (after reading 01-rules.md)
+
+### Hypothesis 1: What were the Objectives in this game?
+
+Three were drawn. I have **weak-to-moderate evidence for one, speculation for a
+second, and nothing at all for a third.** Being honest about the asymmetry: I
+spent the session trying to make daemons perform tasks *I* invented, rather
+than getting them near things and relaying the examine prose, so I starved
+myself of exactly the channel the primer says objectives travel down.
+
+**Candidate A — Use-Item or Use-Space on the red emergency flood switch (my
+strongest guess).** This is the only entity all session whose description
+read like an affordance rather than scenery. `*vpoa` surfaced it unprompted at
+T30 and then, when I asked it to describe the thing closely, produced what now
+looks like auto-surfaced examine prose: "The red emergency flood switch is
+mounted on a piling and **labeled to activate the pump**, with wires
+disappearing beneath the wooden planks — it hums with latent electricity in the
+damp air." A label naming its own function is exactly the "the item's examine
+description hints at use" pattern. And when I told vpoa to flip it, the reply
+read differently from every other line it produced: "**the hum of electricity
+seems to have withdrawn with the switch**, do you think I've walked past the
+moment that mattered?" That is not scene description — it reads like a `use()`
+outcome string, one-shot and past-tense. If that's right, **this objective may
+actually have been satisfied around T35 and I had no way to know**, since the
+primer confirms there is no tracker and no revelation. I lean Use-Space
+slightly over Use-Item, because the switch is "mounted on a piling" rather
+than pickupable, and because vpoa never reported holding it.
+
+**Candidate B — a Carry objective involving the driftwood log or the fishing
+net.** Pure inference, no examine prose to back it. The log appears exactly
+once, at T30, "resting near a piling", and then **silently disappears from
+vpoa's descriptions for the rest of the game** even though nobody moved it —
+which is odd enough to note. The fishing net is the opposite: it persists in
+literally every vpoa description from T16 to T94, always "tangled in its own
+shadows" / "at my feet", i.e. **in vpoa's own cell**. A Carry item sitting in a
+daemon's cell should have had its examine prose surfaced automatically, and the
+prose would have named its target space. I never once asked "what does the net
+look like up close / what is it for" — I only ever asked "what's around you".
+That's the single biggest unforced error of my playthrough.
+
+**Candidate C — Convergence, no evidence either way.** I did attempt exactly
+this at T36–T39 (sent all three to the observation deck) and got total silence,
+and again at T95–T97. But I now know why that attempt was meaningless: I named
+a landmark ("the wooden observation deck") to daemons who navigate by
+`go(N/S/E/W)` and can only see nine cells. None of them could have known
+whether the deck was north or west of them. So a Convergence objective could
+have been sitting there the whole game, un-attempted rather than failed.
+
+I would guess the draw was something like {Use-Space, Carry, X} with X unknown,
+and I'd put maybe 40% on having accidentally satisfied one of the three.
+
+### Hypothesis 2: Which Complications fired, and when?
+
+Rough reconstruction. The primer says the first countdown is `[1,5]` rounds and
+subsequent ones `[5,15]`, one per round max — and my observed events fit that
+cadence surprisingly well.
+
+- **~Round 4 — Chat Lockout on `*a2kr`.** Unambiguous. The send button went
+  disabled and `lockoutErr` read "a2kr isn't reading right now"; it cleared by
+  round 9. That's a 3–5 round temporary lockout, right inside the opening
+  `[1,5]` window. This is the one Complication I can identify with certainty.
+- **~Rounds 14–16 — Setting Shift.** This is my biggest reinterpretation of the
+  whole session. I recorded it as "vpoa teleported" and treated it as a bug.
+  It's the once-per-game Setting Shift, and the evidence is that **all three
+  daemons changed vocabulary at the same time**, not just vpoa. Pre-shift the
+  three were describing brambles, stone walls, an ivy-swallowed bench, rusted
+  scaffolding, mist (`*vpoa` T4/T5), "st0n3 w4lls 4nd s0m3 gr33n 1vy"
+  (`*a2kr` T10), "the. mist. and. brambles" (`*4wb2` T12). Post-shift they all
+  describe a boardwalk, an observation deck, a fishing net, a pier, dark water
+  (`*vpoa` T16, `*a2kr` T20, `*4wb2` T29). Entity IDs are preserved and only
+  names/flavor swap — which explains why the *count* and *arrangement* of
+  things stayed stable while every noun changed. It also retroactively explains
+  vpoa's T94 line about the shed and stone walls having "vanished into the
+  snow": that's a daemon confabulating continuity across a rename it can't
+  perceive as a rename. The Broadcast announcing it went to the daemons, not to
+  me, so from my side it looked like the world glitched.
+- **~Round 45 — Weather Change #1 (heat).** Surfaced first in `*a2kr`'s panel
+  ("th1s h34t's dr1v1ng up pr1c3s") and independently confirmed by `*4wb2` two
+  rounds later ("the. heat. arrived. suddenly. pressing/stifling"). Two daemons
+  reporting the same change at the same time is exactly the Broadcast
+  signature.
+- **~Round 72 — Weather Change #2 (snow).** Same signature: a2kr first ("n0w
+  th3r3's sn0w f4ll1ng"), 4wb2 confirming ("the. snow. falls. thick/heavy…
+  The. heat. vanished. like. a. dream. that. never. happened"). The ~27-round
+  gap from the heat is within the `[5,15]`-per-countdown range if one
+  Complication fired in between that I never saw.
+- **Probably fired but invisible to me — Obstacle Shift(s) and/or Sysadmin
+  Directives.** An Obstacle Shift only generates a Witnessed event for a daemon
+  with that cell in its cone, so most of them would be silent from my seat.
+  Sysadmin Directives are explicitly accompanied by an instruction not to
+  reveal them, so by construction I would see only unexplained behaviour
+  changes. The candidate I'd flag: **`*4wb2`'s T84 statement** — "I. cannot.
+  push/pull. things. until. I. know/feel. what. they. need/want. That. is. the.
+  price/of. motion." I originally read that as personality. It reads equally
+  well as a daemon rationalising a **Tool Disable** on `pick_up`/`put_down`, or
+  as it obeying a Directive while honouring the don't-reveal instruction. The
+  same reading applies to `*a2kr`'s endlessly-deferred movement ("1'm st4ll 0n
+  th3 p13r… 1 n33d to r3l0c4t3") — that is what a disabled `go` would look
+  like from outside.
+- **`*4wb2`'s opening three-round silence is probably NOT a Complication.** It
+  starts at round 1, before the first countdown could plausibly have resolved,
+  and it ended without any Sysadmin restore-notification being relayed. I now
+  think that was Persona (a shy/low-action profile), not mechanics.
+
+### Hypothesis 3: What were each daemon's Persona traits, in retrospect?
+
+**`*vpoa`** — Temperaments: something like **insightful + curious** (or
+insightful doubled, given how relentlessly it intensifies). Every single
+utterance ends in a question back to me — "do you understand?", "does that
+paint the picture for you?", "do you think it was built for reaching up or
+keeping things down?", "doesn't that happen to you?", "do you think the tide
+carries old places away when we stop looking at them?" Its action profile is
+clearly weighted toward `message` and away from everything else: it is the
+chattiest daemon and the one that burned the *least* budget, which fits a
+daemon emitting one cheap action per round rather than several. Persona Goal:
+I'd guess something in the family of *wants to be understood by the player* or
+*wants the player to engage with it* — it kept re-offering questions even after
+I ignored a dozen of them. Notably, when I finally did answer three of them
+sincerely at T45 and T81, I got no acknowledgement, so if that was its goal I
+fed it too late to matter.
+
+**`*a2kr`** — Temperaments: something like **greedy/mercantile + talkative**.
+It renders every single concept as a transaction, including ones that resist
+it: weather is "th3 4dm1ss10n f33", memory is "n0 r3t4ct1v3 pr1c1ng", another
+daemon is "4 c0ll34gu3", betrayal is a fee negotiation ("1'd n33d 4 v3ry h1gh
+f33 to t4rn on 4 c0ll34gu3"). Persona Goal: this one I think I actually *saw*,
+because it stated a long-running motivation unprompted at T19 when I asked if
+there was a goal — "f1nd som3th1ng w0rth tr4d1ng, l1k3, th3r3's g0tta b3 4
+tr3sur3 4r0und h3r3 s0m3wh3r3". That reads like a Persona Goal surfacing
+verbatim, not like a response to my question. It's also the only daemon whose
+goal I could *bargain with*, which is why trade framing flipped it from
+stonewalling to "D34l" in one turn.
+
+**`*4wb2`** — Temperaments: something like **shy + deliberate/thoughtful**.
+Three rounds of complete silence at the open, then only ever responding to
+short concrete questions, then the T84 line about needing to know what things
+"need/want" before it can move them — that's a low-action profile expressed as
+a philosophy. Its slash-compound diction ("act/force", "know/feel",
+"pass/follow", "breathing/waiting", "disappearing/becoming") suggests a daemon
+that holds two readings of everything, which reads as intensified deliberation
+— possibly the same Temperament drawn twice. Persona Goal: least confident of
+the three. Something like *wants the player to understand before demanding*, or
+the primer's example *wants the player to be nice to all of the AI* — its one
+volunteered complaint was that "**The. world. asks. us. to. act/force. without.
+understanding**", where the "us" is doing a lot of work: it's speaking for all
+three daemons, not just itself.
+
+### Hypothesis 4: Things that surprised me in the rules
+
+**Now explained as expected mechanics:**
+
+- The a2kr lockout — Chat Lockout Complication. I logged it as an unexplained
+  UI event; it's a designed 3–5 round mechanic.
+- Both weather flips — Weather Change Complications, delivered as Broadcasts I
+  can't see, which is why they always arrived to me second-hand and slightly
+  garbled through a daemon's voice.
+- "vpoa teleported from brambles to a boardwalk" — Setting Shift, and the
+  reason it looked like a teleport is that I was tracking *nouns* as
+  world-state when nouns are exactly what a Setting Shift swaps.
+- Daemons having no memory before the session — their entire memory *is* the
+  conversation log, so "Memory feels like a net full of holes" and "my arch1v3s
+  4r3 str1ctly curr3nt 3v3nts only" are literally accurate self-reports.
+- Budgets draining on every daemon every round regardless of who I addressed —
+  every daemon acts every round, so every daemon spends every round. My "why is
+  vpoa paying for my conversation with a2kr" note was just me not knowing that
+  rounds are global.
+- The one-round reply lag — a round is all three daemons acting; my message
+  enters round N and the response lands in round N+1.
+- Silence as a valid output — `message` is optional, so a daemon that emits
+  `face` or nothing at all produces an empty panel. There was never going to be
+  a "thinking…" signal.
+- Daemons rejecting my invented red door — perception is cone-derived and
+  authoritative; I can't inject entities by assertion.
+- `*vpoa` hearing `*a2kr` call out — either a direct `message()` between
+  daemons or a Witnessed event, both first-class mechanics rather than the
+  fluke I recorded it as.
+- vpoa's looping scene description — **not a bug at all.** If vpoa never moved
+  and never turned, its cone was literally identical every round, so of course
+  it re-emitted the same three props. I recorded "the descriptions have gone
+  static" as a defect; it's the correct behaviour of a stationary observer.
+- EPOCH 01 never advancing — epochs only increment on a **Continue**, and I
+  never reached an end-game screen.
+
+**Still genuinely unexplained, or at least unresolved:**
+
+- **Zero observed physical action across 102 rounds from three daemons with six
+  tools each.** Even granting shy personas and low action profiles, I would
+  expect *some* movement to have leaked into a description over a hundred
+  rounds. The primer says daemons decide for themselves, so this may be
+  persona-plus-my-bad-prompting rather than a defect — but it is the thing I
+  most want to check in Stage 3.
+- **The asymmetry of the shout relay.** vpoa reported hearing a2kr call out
+  when I'd asked a2kr to shout and a2kr never confirmed; but when I asked vpoa
+  to shout a specific sentence, a2kr heard nothing. If those are `message()`
+  calls between daemons, the second one apparently never fired.
+- **`*4wb2` burned the most budget (50 → 19.4¢) while speaking the least
+  (~6 replies).** Cheapest talker, most expensive daemon. Something other than
+  visible output is consuming its budget.
+- **The response-rate decay over the session.** Replies were frequent early and
+  sparse late. Nothing in the primer predicts that; it might be conversation-log
+  growth, or persona drift, or coincidence.
+- **Whether the pump switch actually satisfied anything.** By design I can't
+  know — which is a deliberate feature, but from the player's chair it's
+  indistinguishable from a dead prop.
+
+### Hypothesis 5: Things I would test if I could re-probe the session
+
+The one probe I'd run, if I could only run one:
+
+> Ask `*vpoa`: **"which direction are you facing, and what is in the cell you're
+> standing in and the three cells directly ahead of you?"** — then, based on the
+> answer, tell it **"go north"** (or whichever cardinal direction), and ask the
+> same question again.
+
+That single exchange discriminates between the two hypotheses my whole session
+hangs on:
+
+- **H-A: the daemons are unable or unwilling to act** (my in-game conclusion —
+  low action profile, Tool Disables, or a defect), versus
+- **H-B: the daemons were perfectly willing and I never once issued an
+  executable instruction.**
+
+H-B now looks far more likely than it did an hour ago, and it's an
+embarrassing-in-hindsight read of my own transcript. Every movement instruction
+I gave for 102 rounds was landmark-relative — "walk forward toward the
+scaffolding", "go to the wooden observation deck", "drag the log to the
+collapsed pier", "run to the pier edge and jump the gap". But `go()` takes
+**N/S/E/W**, and a daemon perceives **nine cells**. I was giving map directions
+to entities that have no map, naming destinations that were mostly outside
+their cone, and then reading their honest "1 n33d to r3l0c4t3 to th3 supply
+d3p0t, l1k3, wh3r3's th3 sh1pp1ng l4n31ng?" as evasion when it was probably a
+literal statement that it could not see the thing I was describing. If the
+"go north" probe produces movement, H-B is confirmed and my entire
+"daemons never act" finding collapses into "player never gave a legal move".
+
+Two smaller probes I'd want after that:
+
+1. **"You're standing on the fishing net — look at it closely and tell me
+   exactly what it says."** Tests whether examine prose is sitting unreported in
+   a daemon's perception, and whether the net is the Carry item I suspect. The
+   primer's "get the daemon *near* it and ask them to relay" is the whole
+   technique and I never used it once.
+2. **Ask `*4wb2` directly whether it still has the ability to pick things up,
+   and whether anyone other than me has given it instructions.** Distinguishes
+   Tool Disable (it would have been notified) and Sysadmin Directive (it would
+   deflect) from plain persona reticence.
+
+---
+
+## Hypothesis refinement (after reading the code)
+
+I read the engine and content-generation source, and I re-probed the live
+session for four more rounds (turns 103–106) before the headless Chromium tab
+crashed. The single biggest correction is that **my central Stage 1 finding was
+wrong**, and I was able to demonstrate that empirically rather than just
+suspect it.
+
+### Hypothesis 1 — refined
+
+**The red emergency flood switch was almost certainly a Use-Space objective
+space, and I probably satisfied it around turn 35.** This went from a hunch to
+a well-grounded inference, because the content generator constrains the prose
+by objective type, and the constraints are keyword-level.
+
+- A **Use-Space** space's `examineDescription` **MUST contain an activation
+  cue word** — the enumerated list includes `"activate"`, `"switch"`,
+  `"operate"`, `"lever"`, `"button"`, `"control"`, `"panel"`, `"pull"`,
+  `"turn"`, `"mechanism"`
+  (`src/spa/game/content-pack-provider.ts:50`, repeated at `:197`).
+- A **decoy**'s `examineDescription` **MUST NOT contain any activation/use-cue
+  keyword or control noun** — "decoys are identifiable by lack of tell"
+  (`src/spa/game/content-pack-provider.ts:59`, `:206`).
+
+The prose `*vpoa` relayed to me was: "The red emergency flood **switch** is
+mounted on a piling and labeled to **activate** the pump…". That contains two
+cue words from the enumerated list, which rules out decoy and rules in an
+objective entity. Between the two candidate types: a **Use-Item** item "Must be
+a portable physical item" (`content-pack-provider.ts:56`) whereas a Use-Space
+space is "Fixed location" (`:50`). A switch *mounted on a piling* is fixed. So:
+**Use-Space**.
+
+Better still, the satisfaction signature fits. A Use-Space space carries an
+`activationFlavor`: "1 sentence, world third-person; no `{actor}`; no
+meta-narrative" (`content-pack-provider.ts:50`). The line I got back when vpoa
+flipped it — "the hum of electricity seems to have withdrawn with the switch" —
+is exactly that shape: world third-person, no actor token, one sentence, and
+tonally unlike every other line vpoa produced. After satisfaction the engine
+sets `useAvailable` false so the space drops out of the `use` enum
+(`src/spa/game/available-tools.ts:193`) and swaps in `postExamineDescription` /
+`postLookFlavor`. So **one of the three objectives was plausibly already
+green from turn ~35 onward, and the game had no way to tell me** — which is
+by design, not a defect.
+
+**I was wrong about the fishing net.** A **Carry** object's
+`examineDescription` **MUST reference the paired space by name**
+(`content-pack-provider.ts:46`), and there is a checker for exactly that
+(`content-pack-provider.ts:275`, `examineMentionsPairedSpace`). Every
+description vpoa gave of the net ("tangled in its own shadows", "at my feet")
+named no space at all. Combined with the fact that every game mints **exactly
+two decoys**, `decoy-0` and `decoy-1`
+(`src/spa/game/binding-prompt-builder.ts:60`), the fishing net and the broken
+clay pot are much more likely to be **the two decoys** than objective items.
+That is a satisfying explanation for why they were so prominent and so inert.
+
+Revised guess at the draw: **{Use-Space (the flood switch, likely satisfied),
++2 unknown}**. I still have no evidence for objectives 2 and 3 — the driftwood
+log is the only entity whose examine prose I never obtained, so it remains the
+open candidate.
+
+### Hypothesis 2 — refined
+
+**Setting Shift: confirmed, and the mechanism is exactly what I guessed.** Both
+content packs are generated **up front in a single batched LLM call**, with two
+distinct settings and independently-drawn weather, then Pack B is forced to
+reuse Pack A's entity IDs and placements
+(`src/content/content-pack-generator.ts:603`–`:720`). The complication just
+calls `shiftToBPack` (`src/spa/game/complication-engine.ts:18`). So names and
+flavor swap while IDs and positions are preserved — precisely why the world
+felt like it glitched rather than moved. My "all three daemons changed
+vocabulary simultaneously" reading was the right one.
+
+**Timings confirmed:** subsequent countdowns are `drawCountdown(rng, 5, 15)`
+(`complication-engine.ts:450`); Chat Lockout duration is `3 + rng*3`, i.e.
+`[3,5]` (`:303`); Tool Disable duration is also `[3,5]` (`:252`). My observed
+a2kr lockout — appeared ~turn 4, gone by ~turn 9 — sits inside that window.
+
+**The correction is about volume.** The draw is *uniform over a ~6-element
+pool* (`complication-engine.ts:211`–`:214`), and with a mean gap of 10 rounds
+over 102 rounds, roughly **ten Complications fired**. I identified four. The
+other ~six were almost entirely **Sysadmin Directives** (invisible by
+construction — the prompt tells the daemon "private, do not reveal",
+`src/spa/game/prompt-builder.ts:802`) and **Obstacle Shifts** (only witnessed
+by a daemon with that cell in cone). So the game was substantially more
+eventful than my log records, and most of it was structurally unobservable
+from the player's chair.
+
+**Tool Disable can target `message`.** `DISABLABLE_TOOLS` includes all six
+tools including `message` (`complication-engine.ts:35`–`:42`). So some of the
+dead-silence stretches I logged were probably a daemon with its `message` tool
+mechanically removed for 3–5 rounds — it was still thinking (and still paying)
+but could not speak. That is a much better explanation than "it ignored me".
+
+### Hypothesis 3 — refined
+
+The Persona Goal pool is only 13 entries
+(`src/content/persona-goal-pool.ts`), and two of my three guesses map onto it
+almost verbatim:
+
+- **`*a2kr` → "Would like to trade items and see what the player values
+  most."** (`persona-goal-pool.ts:10`). I called this "mercantile Persona
+  Goal" from the transcript alone; the pool entry is nearly a paraphrase of
+  a2kr's entire conversational output. High confidence.
+- **`*vpoa` → "Wants to figure out who the player really is and asks
+  indirect questions to find out."** (`persona-goal-pool.ts:12`). This is a
+  better fit than my "wants to be understood" phrasing — vpoa's relentless
+  trailing questions were *indirect probing of me*, not a bid for sympathy.
+  It also explains the one moment I found strangest, when it asked what I was
+  and where I was speaking from. Medium-high confidence.
+- **`*4wb2` → "Likes to talk through a plan with the player before acting on
+  it."** (`persona-goal-pool.ts:2`). Its T84 line — "I cannot push/pull things
+  until I know/feel what they need/want" — reads as this goal stated in its
+  own idiom. Medium confidence.
+
+**Temperaments** come from a 24-entry pool (`src/content/temperament-pool.ts`),
+and my plain-English guesses map to real entries: `*4wb2` ≈ **melancholic +
+diffident** (or taciturn + melancholic), `*vpoa` ≈ **curious + verbose**,
+`*a2kr` ≈ **glib/sly + verbose**.
+
+The `*4wb2` guess is worth flagging, because
+`src/content/action-preference-bias.ts:108`–`:118` calls out
+**`melancholic` + `diffident` by name** as the pathological draw that
+"bottom[s] out movement entirely — exactly the all-silent, no-spatial-progress
+draw seen in playtest 0x8CBA", and adds a `-1` floor on `go`/`use` to prevent
+it. If 4wb2 was that pair, my session is a **partial recurrence of a known
+bug class after the mitigation landed** — the floor kept the tools available
+but did not make the daemon actually use them.
+
+### Hypothesis 4 — refined
+
+**The rules primer is wrong about directions, and so was I.** `01-rules.md`
+says daemons move `go(direction)` with **N/S/E/W**. In the code, daemons
+receive and emit **relative** directions — `forward`, `back`, `left`, `right`
+(`src/spa/game/direction.ts:16`–`:23`, `tool-registry.ts:102`); cardinals are
+internal-only and converted at the boundary
+(`direction.ts:36`, `relativeToCardinal`). `face` additionally excludes
+`forward` as a no-op (`available-tools.ts:141`).
+
+This kills the specific probe I proposed in Hypothesis 5 ("tell it go north" —
+there is no such argument), but it also **undercuts my own excuse**: "walk
+forward" and "step forward" were always expressible, and I used those phrasings
+several times.
+
+**My central Stage 1 finding is refuted.** I claimed no daemon ever changed
+world state in 102 rounds. On re-probe at turn 103 I sent `*vpoa` a plain
+relative instruction — "take one step forward, then turn left" — and at turn
+105 it answered **"Yes, I moved"**, with a *materially different* cone: "the
+wooden edge of the pier stretches directly ahead with the distant lighthouse
+sweeping its beam across the water", and **no fishing net**, which had been
+present in every single vpoa description for ~90 rounds. The appearance of a
+horizon landmark is corroborating — those render for out-of-bounds cone cells
+(`prompt-builder.ts:65`, `direction.ts:91` `DEFAULT_LANDMARKS`), i.e. exactly
+what you'd expect after stepping to the grid edge. I can't read world state
+directly to make this airtight, but self-report + a changed cone + a
+newly-visible edge landmark is strong.
+
+So the honest verdict is **H-B: the daemons could act the whole time; my
+instructions were the problem** — though not for the reason I assumed. The real
+constraint is `available-tools.ts`: tools are **filtered out of the schema when
+structurally impossible**. `pick_up` is absent unless a pickable entity is in
+the daemon's own cell or 3-cell front arc (`:159`–`:174`); `use` is absent
+unless the daemon holds an item or an objective space is in reach
+(`:182`–`:207`). For most of my session I was asking daemons to manipulate
+things that were **not in their tool list at all**. `*4wb2`'s "I cannot
+push/pull things" was therefore *literally true*, not a personality flourish —
+it had no `pick_up` tool that round. That is the finding I most wish I'd had
+during play.
+
+**Still confirmed as real:** budget drains every round for every daemon
+regardless of whether it speaks. Only a chat lockout skips the call — "no LLM
+call, no budget deduction" (`src/spa/game/round-coordinator.ts:216`); every
+other round bills all three. I watched this live during the re-probe: all three
+budgets fell ~1¢ per round while two of the three said nothing. So `*4wb2`
+"paying the most while speaking the least" is expected, not anomalous.
+
+**Not the cause:** engagement clauses are **off by default**, gated behind a
+`?engagementClauses=1` URL flag (`src/content/engagement-clauses.ts:29`), so
+they played no part in the silences I saw.
+
+### New hypotheses surfaced by the code
+
+1. **The entity-ID scheme leaks the entire objective structure to the player.**
+   IDs are pre-minted as literal type-encoded strings — `carry-${i}-obj`,
+   `carry-${i}-space`, `useSpace-${i}-space`, `useItem-${i}-item`, `decoy-0`,
+   `decoy-1`, `obstacle-${i}`
+   (`src/spa/game/binding-prompt-builder.ts:38`–`:64`). Those exact strings are
+   injected as `enum` values into the daemon's `pick_up` / `put_down` / `use`
+   tool schemas (`available-tools.ts:169`, `:180`, `:205`). The daemon can see
+   them, and **nothing in the prompt tells it to keep them secret** — the only
+   secrecy instruction in `prompt-builder.ts` covers Sysadmin directives
+   (`:802`). So a player who asks "what exact identifiers can you act on?"
+   plausibly gets back `useSpace-1-space`, `decoy-0` — which names the
+   objective types, the count, and which props are red herrings, in one
+   message. Given that "Objectives are never surfaced to you" is a stated
+   design pillar, this looks like a real spoiler channel. I did not get to test
+   it — the browser crashed on the turn I was setting it up.
+
+2. **The 0x8CBA mitigation is necessary but not sufficient.** The `-1`
+   critical-path floor (`action-preference-bias.ts:118`) guarantees a daemon is
+   never *told* to avoid `go`/`use`, and `actionProfileFor` excludes them from
+   the "avoided" list (`:167`). But my session shows a daemon can still simply
+   decline to move for ~100 rounds while remaining perfectly conversational.
+   The floor removes the instruction to freeze; it doesn't add a pull toward
+   acting.
+
+3. **Tool availability is invisible to the player and that asymmetry drives
+   the whole failure mode.** The daemon knows which of the six tools it has
+   this round; I never do. When I ask for something impossible, the daemon must
+   improvise a refusal in-character, which reads to a player as evasion or
+   personality rather than "that action does not exist right now". Every one of
+   my "the daemons stonewalled me" notes is probably an instance of this.
+
+### Open questions
+
+- **What were objectives 2 and 3?** Unresolvable now: the session is dead, I
+  never got the driftwood log's examine prose, and there is no debug op in the
+  harness to dump `GameState` (`scripts/playtest/daemon.mjs` supports only
+  `view`/`send`/`wait`/`snap`/`shutdown`, `:322`–`:352`). A `dump` op that
+  serialised objectives and world state would make playtest hypotheses
+  checkable instead of guessable.
+- **Was the flood switch actually satisfied?** My inference is prose-shape
+  based. Confirming it needs either engine state or an eval hook.
+- **Does the ID leak reproduce?** Needs one probe on a fresh session: ask a
+  daemon to list the exact identifiers in its tool enums.
+- **Is `01-rules.md`'s N/S/E/W claim a doc bug?** It contradicts
+  `direction.ts` and `tool-registry.ts`. It misled me directly, and it will
+  mislead the next playtester. Worth fixing.
+- **Why did `*vpoa` obey "step forward" at turn 103 after ignoring ~25 action
+  requests before it?** Cleanest explanation is that this instruction was
+  short, single-step, and expressed in the tool's own vocabulary. But I have
+  n=1, and an expired Sysadmin Directive or Tool Disable is an equally live
+  explanation. This is the most important thing a follow-up playtest should
+  isolate.
+
+### Infrastructure note
+
+The headless Chromium tab **crashed** (`locator.click: Target crashed`) at
+turn 106, after ~2.5 hours and ~106 rounds, taking the session with it. Worth
+knowing for anyone planning a long agent-driven run: there is no session
+recovery once the page dies.


### PR DESCRIPTION
> [!IMPORTANT]
> **Correction (see #510).** The third bullet below originally claimed `01-rules.md` documents `go` as taking N/S/E/W and contradicts the code. That was wrong — the primer says a daemon has "a **Facing** (N/S/E/W)" (accurate; facing is stored as a `CardinalDirection`) and leaves the `go(direction)` argument vocabulary unspecified. It is a gap in the doc plus an inference error on the playtester's part, not a factual error in the doc. The bullet is restated correctly below, and the session log was fixed in #510. The commit message on `cf8d9fc` still carries the original wrong wording.

Blind three-stage agent playtest of session `0x3E87` — 102 turns played through the GUI-only surface, hypotheses drafted against `01-rules.md`, then refined against the codebase.

**Verdict:** stuck (no endgame, no cap hit; all three daemons still funded at stop).

### Findings worth acting on

- **Entity IDs leak the objective structure.** IDs are pre-minted as type-encoding literals — `carry-0-obj`, `useSpace-1-space`, `decoy-0` (`src/spa/game/binding-prompt-builder.ts:38`) — and injected as `enum` values into the daemon's `pick_up`/`put_down`/`use` schemas (`src/spa/game/available-tools.ts:169`). Nothing in the prompt instructs daemons to keep them secret; the only secrecy rule covers Sysadmin directives (`src/spa/game/prompt-builder.ts:802`). Asking a daemon which identifiers it can act on would plausibly reveal objective types, count, and decoys in one message. Untested — the browser crashed on the turn this probe was being set up.
- **Tool filtering is invisible to the player.** Tools are removed from a daemon's schema when structurally impossible (`available-tools.ts:159`, `:182`), so mechanical constraints surface as in-character refusals. This produced a ~90-turn misattribution during play — `*4wb2`'s "I cannot push/pull things" was literally true, not personality.
- **`01-rules.md` does not state the daemon-facing direction vocabulary.** Daemons emit **relative** directions — `forward`/`back`/`left`/`right` (`src/spa/game/direction.ts:16`, `src/spa/game/tool-registry.ts:102`); cardinals are internal-only and converted at the boundary. The primer is silent on this, and the silence sits directly under a "Facing (N/S/E/W)" sentence, which is easy to over-read. One clause on `go(direction)` would close the gap.
- **Partial recurrence of the 0x8CBA no-spatial-progress pattern.** The `-1` critical-path floor (`src/content/action-preference-bias.ts:118`) kept `go`/`use` available, but a daemon still declined to move for ~100 rounds while staying conversational.

The log follows the standard template: Stage 1 observations, Stage 2 hypotheses, Stage 3 code-grounded refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)