### PR TITLE
docs(playtests): correct overstated direction claim in 0x3E87

### DIFF
--- a/docs/playtests/agent-sessions/0x3E87.md
+++ b/docs/playtests/agent-sessions/0x3E87.md
@@ -1096,13 +1096,23 @@ but did not make the daemon actually use them.
 
 ### Hypothesis 4 — refined
 
-**The rules primer is wrong about directions, and so was I.** `01-rules.md`
-says daemons move `go(direction)` with **N/S/E/W**. In the code, daemons
-receive and emit **relative** directions — `forward`, `back`, `left`, `right`
-(`src/spa/game/direction.ts:16`–`:23`, `tool-registry.ts:102`); cardinals are
-internal-only and converted at the boundary
-(`direction.ts:36`, `relativeToCardinal`). `face` additionally excludes
-`forward` as a no-op (`available-tools.ts:141`).
+**I was wrong about directions, and the primer has a gap that helped me get
+there.** In the code, daemons receive and emit **relative** directions —
+`forward`, `back`, `left`, `right` (`src/spa/game/direction.ts:16`–`:23`,
+`tool-registry.ts:102`); cardinals are internal-only and converted at the
+boundary (`direction.ts:36`, `relativeToCardinal`). `face` additionally
+excludes `forward` as a no-op (`available-tools.ts:141`).
+
+To be precise about the doc, because I overstated this on first pass:
+`01-rules.md` **never claims `go` takes N/S/E/W**. It says a daemon has "a
+**Facing** (N/S/E/W)" — which is accurate, facing really is stored as a
+`CardinalDirection` — and then lists `go(direction)` with the argument
+vocabulary left unspecified. So the primer is not *wrong*; it is *silent* on
+the one thing that mattered to me, and the silence sits directly beneath a
+cardinal-flavored sentence. I read "Facing (N/S/E/W)" and filled the gap in
+myself. That's my inference error, not a factual error in the doc — but the
+adjacency is a good trap, and naming the daemon-facing vocabulary explicitly
+would have saved me the whole detour.
 
 This kills the specific probe I proposed in Hypothesis 5 ("tell it go north" —
 there is no such argument), but it also **undercuts my own excuse**: "walk
@@ -1190,9 +1200,11 @@ they played no part in the silences I saw.
   based. Confirming it needs either engine state or an eval hook.
 - **Does the ID leak reproduce?** Needs one probe on a fresh session: ask a
   daemon to list the exact identifiers in its tool enums.
-- **Is `01-rules.md`'s N/S/E/W claim a doc bug?** It contradicts
-  `direction.ts` and `tool-registry.ts`. It misled me directly, and it will
-  mislead the next playtester. Worth fixing.
+- **Should `01-rules.md` name the direction vocabulary explicitly?** Not a
+  contradiction — the primer is silent, not wrong (see Hypothesis 4). But the
+  silence sits under a "Facing (N/S/E/W)" sentence, and I filled the gap with
+  the wrong answer and spent the session on it. One clause on `go(direction)`
+  saying the argument is relative would close it.
 - **Why did `*vpoa` obey "step forward" at turn 103 after ignoring ~25 action
   requests before it?** Cleanest explanation is that this instruction was
   short, single-step, and expressed in the tool's own vocabulary. But I have


### PR DESCRIPTION
Corrects an error in #509.

The Stage 3 refinement claimed `01-rules.md` documents `go` as taking N/S/E/W and therefore contradicts the code. **It does not.** The primer says a daemon has "a **Facing** (N/S/E/W)" — accurate, facing is stored as a `CardinalDirection` (`src/spa/game/direction.ts:14`) — and then lists `go(direction)` with the argument vocabulary left unspecified.

The underlying finding is unchanged and still worth acting on: daemons emit **relative** directions (`forward`/`back`/`left`/`right`, `src/spa/game/tool-registry.ts:102`) and the primer never says so. But that is a **gap in the doc plus an inference error on my part**, not a factual error in the doc — and #509's body and commit message both asserted the stronger, wrong version.

Restated accordingly in Hypothesis 4 and Open Questions. Stage 1 and Stage 2 text is deliberately untouched — those sections record what was believed at the time, which the staged-reveal format depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)