### PR TITLE
ci(deploy): provision OPENROUTER_API_KEY worker secret on deploy

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -40,3 +40,7 @@ jobs:
           # `wrangler deploy` runs the `build` block in wrangler.jsonc
           # (`pnpm build`), so no separate build step is required here.
           command: deploy
+          secrets: |
+            OPENROUTER_API_KEY
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
Adds the `secrets:` input to the wrangler deploy step so every deploy re-provisions the Worker's `OPENROUTER_API_KEY` from the repo's Actions secret (set 2026-08-21). Re-keying the Worker is now: rotate the Actions secret, re-run the deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)